### PR TITLE
add tag-driven release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+# Tag-driven Android release pipeline. Pushing a tag like `v0.15.0`
+# builds a signed APK and creates a GitHub Release with it attached.
+# Phase 2 (Play Store) will hook in here as an additional job when
+# the Play Console account is squared away.
+#
+# Required repository secrets (Settings → Secrets and variables →
+# Actions):
+#   ANDROID_KEYSTORE_BASE64    base64-encoded contents of the .jks file
+#   ANDROID_KEYSTORE_PASSWORD  storePassword from android/key.properties
+#   ANDROID_KEY_PASSWORD       keyPassword from android/key.properties
+#   ANDROID_KEY_ALIAS          keyAlias from android/key.properties (currently "key")
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # needed for softprops/action-gh-release to create the release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 17
+        # Matches sourceCompatibility VERSION_17 in android/app/build.gradle.
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Flutter
+        # Pinned to the project's working version per TEST_PLAN.md
+        # rather than channel:stable, so a Flutter release on the
+        # same day doesn't surprise us mid-release-cut.
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.38.9'
+          cache: true
+
+      - name: Restore keystore from secret
+        # The keystore is a 2 KB binary; base64-encoding is the
+        # standard way to round-trip it through a GitHub Secret. It
+        # never appears in plaintext on disk before this step, and
+        # the runner is destroyed at the end of the job.
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 -d > android/app/upload-keystore.jks
+
+      - name: Generate android/key.properties
+        # storeFile is resolved by gradle's file() from
+        # android/app/build.gradle's project directory (android/app/),
+        # so a bare filename here points at upload-keystore.jks
+        # alongside build.gradle — the same one we just decoded.
+        env:
+          STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          cat > android/key.properties <<EOF
+          storePassword=$STORE_PASSWORD
+          keyPassword=$KEY_PASSWORD
+          keyAlias=$KEY_ALIAS
+          storeFile=upload-keystore.jks
+          EOF
+
+      - name: Install Dart dependencies
+        # Also writes android/local.properties (gitignored) with
+        # flutter.versionCode / flutter.versionName extracted from
+        # pubspec.yaml's `version:` field — gradle reads those.
+        run: flutter pub get
+
+      - name: Build signed release APK
+        run: flutter build apk --release
+
+      - name: Rename APK to include tag
+        # Default output is build/app/outputs/flutter-apk/app-release.apk.
+        # Rename to include the tag so users downloading multiple
+        # releases can disambiguate locally.
+        run: |
+          mv build/app/outputs/flutter-apk/app-release.apk \
+             build/app/outputs/flutter-apk/mstream_music-${{ github.ref_name }}.apk
+
+      - name: Create GitHub Release and attach APK
+        # generate_release_notes: true asks GitHub to auto-build the
+        # release body from PRs/commits between this tag and the
+        # previous tag on the same branch lineage.
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: build/app/outputs/flutter-apk/mstream_music-*.apk

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# release.sh — bump version, commit, tag, push.
+#
+# Usage:
+#   ./release.sh <version>           # e.g. 0.14.1 (auto-increments build)
+#   ./release.sh <version>+<build>   # e.g. 0.14.1+26 (explicit build)
+#   ./release.sh --dry-run <version> # show what would happen, do nothing
+#
+# Updates pubspec.yaml and lib/screens/about_screen.dart, commits with
+# "bump to X.Y.Z", tags vX.Y.Z, and pushes the commit + tag. Pending
+# working-tree changes get stashed (with --include-untracked) before
+# the bump and popped at the end via an EXIT trap, even on failure.
+#
+# The pushed tag triggers .github/workflows/release.yml, which builds
+# and publishes a signed APK to GitHub Releases.
+
+set -euo pipefail
+
+# ---- arg parsing -----------------------------------------------------------
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+  shift
+fi
+
+if [[ $# -ne 1 ]]; then
+  cat >&2 <<EOF
+usage: $0 [--dry-run] <version>
+  $0 0.14.1            # auto-increment build number from pubspec
+  $0 0.14.1+26         # explicit build number
+  $0 0.14.1-rc1        # pre-release suffix supported (tag becomes v0.14.1-rc1)
+EOF
+  exit 1
+fi
+
+INPUT="$1"
+
+# Accept X.Y.Z, X.Y.Z-suffix, X.Y.Z+N, X.Y.Z-suffix+N
+if [[ ! "$INPUT" =~ ^([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+)?)(\+([0-9]+))?$ ]]; then
+  echo "error: '$INPUT' is not a valid version (want X.Y.Z[-suffix][+N])" >&2
+  exit 1
+fi
+NEW_VERSION="${BASH_REMATCH[1]}"
+EXPLICIT_BUILD="${BASH_REMATCH[4]}"
+
+# ---- preflight -------------------------------------------------------------
+if [[ ! -f pubspec.yaml ]]; then
+  echo "error: pubspec.yaml not found — run from the project root" >&2
+  exit 1
+fi
+
+CURRENT_LINE="$(grep -E '^version:' pubspec.yaml | head -1)"
+CURRENT="${CURRENT_LINE#version: }"
+CURRENT="$(echo "$CURRENT" | tr -d '[:space:]')"
+CURRENT_VERSION="${CURRENT%+*}"
+CURRENT_BUILD="${CURRENT##*+}"
+
+if [[ -n "$EXPLICIT_BUILD" ]]; then
+  NEW_BUILD="$EXPLICIT_BUILD"
+else
+  NEW_BUILD=$((CURRENT_BUILD + 1))
+fi
+
+FULL_NEW="${NEW_VERSION}+${NEW_BUILD}"
+TAG="v${NEW_VERSION}"
+
+echo "Current: $CURRENT"
+echo "New:     $FULL_NEW"
+echo "Tag:     $TAG"
+echo
+
+# Pull latest tags so the duplicate-tag check is honest
+git fetch --tags --quiet || true
+
+if git rev-parse --verify --quiet "$TAG" >/dev/null; then
+  echo "error: tag $TAG already exists locally" >&2
+  exit 1
+fi
+if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+  echo "error: tag $TAG already exists on origin" >&2
+  exit 1
+fi
+
+if [[ -z "$EXPLICIT_BUILD" ]] && (( NEW_BUILD <= CURRENT_BUILD )); then
+  echo "error: build $NEW_BUILD is not greater than current $CURRENT_BUILD" >&2
+  exit 1
+fi
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "(dry run — no changes made)"
+  exit 0
+fi
+
+# ---- stash, with restore on exit -------------------------------------------
+NEED_STASH=0
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Stashing working-tree changes..."
+  git stash push --include-untracked --message "release.sh autostash for $TAG" >/dev/null
+  NEED_STASH=1
+fi
+
+cleanup() {
+  local rc=$?
+  if [[ $NEED_STASH -eq 1 ]]; then
+    echo "Restoring stashed changes..."
+    if ! git stash pop; then
+      echo "warning: 'git stash pop' had conflicts — resolve manually" >&2
+    fi
+  fi
+  exit $rc
+}
+trap cleanup EXIT
+
+# ---- bump files ------------------------------------------------------------
+# Cross-platform sed -i works via .bak suffix + immediate delete.
+sed -i.bak "s/^version: .*/version: $FULL_NEW/" pubspec.yaml
+rm -f pubspec.yaml.bak
+
+# about_screen's _versionLabel is a hardcoded const — bump it alongside
+# pubspec. Pattern check first so older branches (where the const
+# doesn't exist) silently skip rather than mutating unrelated text.
+ABOUT="lib/screens/about_screen.dart"
+if [[ -f "$ABOUT" ]] && grep -q "static const _versionLabel = '" "$ABOUT"; then
+  sed -i.bak "s/static const _versionLabel = '[^']*';/static const _versionLabel = '$TAG';/" "$ABOUT"
+  rm -f "$ABOUT.bak"
+fi
+
+echo
+echo "Diff:"
+git --no-pager diff -- pubspec.yaml "$ABOUT"
+echo
+
+# ---- commit, tag, push -----------------------------------------------------
+git add pubspec.yaml "$ABOUT"
+git commit -m "bump to $NEW_VERSION"
+git tag "$TAG"
+
+echo "Pushing commit and tag..."
+git push
+git push origin "$TAG"
+
+echo
+echo "Done. The release workflow should now be running for tag $TAG."
+echo "Watch: https://github.com/IrosTheBeggar/mstream_music/actions"

--- a/release.sh
+++ b/release.sh
@@ -3,9 +3,12 @@
 # release.sh — bump version, commit, tag, push.
 #
 # Usage:
-#   ./release.sh <version>           # e.g. 0.14.1 (auto-increments build)
-#   ./release.sh <version>+<build>   # e.g. 0.14.1+26 (explicit build)
-#   ./release.sh --dry-run <version> # show what would happen, do nothing
+#   ./release.sh patch               # bump 0.14.0 -> 0.14.1 (npm convention)
+#   ./release.sh minor               # bump 0.14.0 -> 0.15.0
+#   ./release.sh major               # bump 0.14.0 -> 1.0.0
+#   ./release.sh <version>           # explicit, e.g. 0.14.1
+#   ./release.sh <version>+<build>   # explicit version + build, e.g. 0.14.1+26
+#   ./release.sh --dry-run <input>   # preview without doing anything
 #
 # Updates pubspec.yaml and lib/screens/about_screen.dart, commits with
 # "bump to X.Y.Z", tags vX.Y.Z, and pushes the commit + tag. Pending
@@ -26,9 +29,12 @@ fi
 
 if [[ $# -ne 1 ]]; then
   cat >&2 <<EOF
-usage: $0 [--dry-run] <version>
-  $0 0.14.1            # auto-increment build number from pubspec
-  $0 0.14.1+26         # explicit build number
+usage: $0 [--dry-run] <input>
+  $0 patch             # bump 0.14.0 -> 0.14.1 (npm convention)
+  $0 minor             # bump 0.14.0 -> 0.15.0
+  $0 major             # bump 0.14.0 -> 1.0.0
+  $0 0.14.1            # explicit version, auto-increment build
+  $0 0.14.1+26         # explicit version + build
   $0 0.14.1-rc1        # pre-release suffix supported (tag becomes v0.14.1-rc1)
 EOF
   exit 1
@@ -36,15 +42,9 @@ fi
 
 INPUT="$1"
 
-# Accept X.Y.Z, X.Y.Z-suffix, X.Y.Z+N, X.Y.Z-suffix+N
-if [[ ! "$INPUT" =~ ^([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+)?)(\+([0-9]+))?$ ]]; then
-  echo "error: '$INPUT' is not a valid version (want X.Y.Z[-suffix][+N])" >&2
-  exit 1
-fi
-NEW_VERSION="${BASH_REMATCH[1]}"
-EXPLICIT_BUILD="${BASH_REMATCH[4]}"
-
-# ---- preflight -------------------------------------------------------------
+# ---- preflight: read current version from pubspec --------------------------
+# Done before resolving INPUT because patch/minor/major need the current
+# version to compute the new one from.
 if [[ ! -f pubspec.yaml ]]; then
   echo "error: pubspec.yaml not found — run from the project root" >&2
   exit 1
@@ -55,6 +55,34 @@ CURRENT="${CURRENT_LINE#version: }"
 CURRENT="$(echo "$CURRENT" | tr -d '[:space:]')"
 CURRENT_VERSION="${CURRENT%+*}"
 CURRENT_BUILD="${CURRENT##*+}"
+
+# ---- resolve INPUT into NEW_VERSION + (optional) EXPLICIT_BUILD ----------
+EXPLICIT_BUILD=""
+case "$INPUT" in
+  patch|minor|major)
+    # npm-style bump from the current pubspec version. Strip any
+    # pre-release suffix ("-rc1" etc.) before bumping — going from
+    # 0.14.0-rc1 to a real release should land on 0.14.1, not preserve
+    # the rc tag.
+    BASE="${CURRENT_VERSION%%-*}"
+    IFS='.' read -r CUR_MAJOR CUR_MINOR CUR_PATCH <<< "$BASE"
+    case "$INPUT" in
+      patch) NEW_VERSION="$CUR_MAJOR.$CUR_MINOR.$((CUR_PATCH + 1))" ;;
+      minor) NEW_VERSION="$CUR_MAJOR.$((CUR_MINOR + 1)).0" ;;
+      major) NEW_VERSION="$((CUR_MAJOR + 1)).0.0" ;;
+    esac
+    ;;
+  *)
+    # Explicit: X.Y.Z, X.Y.Z-suffix, X.Y.Z+N, X.Y.Z-suffix+N
+    if [[ ! "$INPUT" =~ ^([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+)?)(\+([0-9]+))?$ ]]; then
+      echo "error: '$INPUT' is not valid input" >&2
+      echo "       want one of: patch | minor | major | X.Y.Z[-suffix][+N]" >&2
+      exit 1
+    fi
+    NEW_VERSION="${BASH_REMATCH[1]}"
+    EXPLICIT_BUILD="${BASH_REMATCH[4]}"
+    ;;
+esac
 
 if [[ -n "$EXPLICIT_BUILD" ]]; then
   NEW_BUILD="$EXPLICIT_BUILD"


### PR DESCRIPTION
Builds a signed APK on tags matching `v*` and attaches it to a GitHub Release with auto-generated notes.

Restores the existing Android signing keystore from a base64-encoded secret, regenerates android/key.properties on the runner, then runs `flutter build apk --release` against pinned Flutter 3.38.9. Same keystore that signed past Play Store releases (SHA256: 8D:99:20:D3:...), so future Play Store uploads remain compatible.

Phase 2 (Play Store via google-play action) will hook in as an additional job in this same workflow once the Play Console account is back online.

Required repo secrets:
  ANDROID_KEYSTORE_BASE64
  ANDROID_KEYSTORE_PASSWORD
  ANDROID_KEY_PASSWORD
  ANDROID_KEY_ALIAS