### PR TITLE
Pre-release polish: AutoDJ Phase 2, EQ UI, sleep timer custom input, SafeArea audit

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -936,6 +936,13 @@ class BottomBar extends StatelessWidget {
                             showModalBottomSheet(
                               context: context,
                               backgroundColor: VelvetColors.surface,
+                              // isScrollControlled lets the sheet
+                              // exceed the default half-screen cap
+                              // — needed because the custom-time
+                              // TextField triggers the soft keyboard
+                              // and the sheet has to grow + resize
+                              // to stay above it.
+                              isScrollControlled: true,
                               builder: (_) => SleepTimerSheet(),
                             );
                           },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,8 +43,11 @@ class MyHttpOverrides extends HttpOverrides {
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await MediaManager().start();
+  // Settings load must come before MediaManager.start() so the audio
+  // handler's _init() can read persisted EQ state when it attaches the
+  // AndroidEqualizer to the player.
   await SettingsManager().load();
+  await MediaManager().start();
   await PlaylistManager().load();
 
   // allow self signed SSL cert

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,10 +23,13 @@ import 'screens/playlists_screen.dart';
 import 'screens/settings_screen.dart';
 import 'screens/share_playlist_dialog.dart';
 
+import 'singletons/auto_dj_manager.dart';
 import 'singletons/media.dart';
 import 'singletons/playlists.dart';
 import 'singletons/settings.dart';
+import 'singletons/sleep_timer.dart';
 import 'theme/velvet_theme.dart';
+import 'widgets/sleep_timer_sheet.dart';
 import 'widgets/waveform_progress.dart';
 
 import 'dart:io';
@@ -49,6 +52,7 @@ Future<void> main() async {
   await SettingsManager().load();
   await MediaManager().start();
   await PlaylistManager().load();
+  await AutoDJManager().load();
 
   // allow self signed SSL cert
   HttpOverrides.global = new MyHttpOverrides();
@@ -915,6 +919,27 @@ class BottomBar extends StatelessWidget {
                                         "Auto DJ Enabled For ${ServerManager().currentServer!.url.toString()}")));
                               }
                             });
+                      }),
+                  StreamBuilder<Duration?>(
+                      stream: SleepTimerManager().remainingStream,
+                      initialData: SleepTimerManager().remaining,
+                      builder: (context, snapshot) {
+                        final active = snapshot.data != null;
+                        return IconButton(
+                          icon: Icon(active
+                              ? Icons.bedtime
+                              : Icons.bedtime_outlined),
+                          color: active
+                              ? VelvetColors.primary
+                              : VelvetColors.appBarTextSecondary,
+                          onPressed: () {
+                            showModalBottomSheet(
+                              context: context,
+                              backgroundColor: VelvetColors.surface,
+                              builder: (_) => SleepTimerSheet(),
+                            );
+                          },
+                        );
                       }),
                 ])
               ])

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io' show Platform;
 
 import 'package:audio_service/audio_service.dart';
 import 'package:just_audio/just_audio.dart';
@@ -8,6 +9,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:uuid/uuid.dart';
 import 'package:http/http.dart' as http;
 import '../objects/server.dart';
+import '../singletons/settings.dart';
 
 /// An [AudioHandler] for playing a list of podcast episodes.
 class AudioPlayerHandler extends BaseAudioHandler
@@ -15,7 +17,18 @@ class AudioPlayerHandler extends BaseAudioHandler
   // ignore: close_sinks
   final BehaviorSubject<List<MediaItem>> _recentSubject =
       BehaviorSubject<List<MediaItem>>();
-  final _player = AudioPlayer();
+  // Android-only: a native equalizer attached to the player's audio
+  // pipeline. just_audio has no iOS/macOS/Linux equivalent, so this
+  // stays null on those platforms and the EQ screen renders an
+  // "Android only" empty state instead.
+  final AndroidEqualizer? equalizer =
+      Platform.isAndroid ? AndroidEqualizer() : null;
+  late final AudioPlayer _player = equalizer != null
+      ? AudioPlayer(
+          audioPipeline:
+              AudioPipeline(androidAudioEffects: [equalizer!]),
+        )
+      : AudioPlayer();
 
   int? get index => _player.currentIndex;
 
@@ -74,6 +87,27 @@ class AudioPlayerHandler extends BaseAudioHandler
       print("### loaded");
     } catch (e) {
       print("Error: $e");
+    }
+    await _applySavedEqualizer();
+  }
+
+  // Apply persisted EQ state to the native equalizer. Best-effort: if
+  // the saved gains array is shorter than the device's actual band
+  // count, leftover bands are left at device default. Wrapped in
+  // try/catch so a flaky audio session never blocks player init.
+  Future<void> _applySavedEqualizer() async {
+    final eq = equalizer;
+    if (eq == null) return;
+    try {
+      await eq.setEnabled(SettingsManager().eqEnabled);
+      final saved = SettingsManager().eqBandGains;
+      if (saved.isEmpty) return;
+      final params = await eq.parameters;
+      for (var i = 0; i < params.bands.length && i < saved.length; i++) {
+        await params.bands[i].setGain(saved[i]);
+      }
+    } catch (e) {
+      print("EQ apply error: $e");
     }
   }
 

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -9,7 +9,9 @@ import 'package:rxdart/rxdart.dart';
 import 'package:uuid/uuid.dart';
 import 'package:http/http.dart' as http;
 import '../objects/server.dart';
+import '../singletons/auto_dj_manager.dart';
 import '../singletons/settings.dart';
+import '../util/camelot.dart';
 
 /// An [AudioHandler] for playing a list of podcast episodes.
 class AudioPlayerHandler extends BaseAudioHandler
@@ -37,6 +39,13 @@ class AudioPlayerHandler extends BaseAudioHandler
   Server? autoDJServer;
 
   var jsonAutoDJIgnoreList;
+
+  // Session-only: the Camelot anchor for harmonic mixing. Locked on
+  // the first DJ-picked song with a recognised key (after that, every
+  // subsequent pick uses the anchor's 6 Camelot neighbours, keeping
+  // the session musically coherent rather than drifting). Reset on
+  // setAutoDJ off or server switch.
+  String? _camelotAnchor;
 
   AudioPlayerHandler() {
     _init();
@@ -221,6 +230,7 @@ class AudioPlayerHandler extends BaseAudioHandler
       case 'setAutoDJ':
         if (autoDJServer == null || autoDJServer != extras?['autoDJServer']) {
           jsonAutoDJIgnoreList = null;
+          _camelotAnchor = null;
         }
         autoDJServer = extras?['autoDJServer'];
 
@@ -287,85 +297,195 @@ class AudioPlayerHandler extends BaseAudioHandler
 
   Future<void> autoDJ(
       {bool autoPlay = false, bool incrementIndex = false}) async {
-    if (autoDJServer == null) {
-      return;
+    if (autoDJServer == null) return;
+
+    // Build per-call ignoreVPaths once (cheap, doesn't change across
+    // retry attempts).
+    final ignoreVPaths = <String>[];
+    autoDJServer!.autoDJPaths.forEach((key, value) {
+      if (value == false) ignoreVPaths.add(key);
+    });
+
+    final mgr = AutoDJManager();
+    Map<String, dynamic>? lastDecoded;
+
+    // BPM/key continuity reads the currently playing item once per
+    // call. If extras don't carry bpm/musicalKey (e.g. a localFile or
+    // a browse hit without metadata), the windows aren't sent and the
+    // server picks freely.
+    final currentItem = (index != null &&
+            index! >= 0 &&
+            index! < queue.value.length)
+        ? queue.value[index!]
+        : null;
+    final rawBpm = currentItem?.extras?['bpm'];
+    final currentBpm = rawBpm is num ? rawBpm.round() : null;
+    final currentKey = currentItem?.extras?['musicalKey'] as String?;
+
+    // If harmonic mixing is on and we have no anchor yet, try to
+    // seed it from the currently playing item's key. Otherwise the
+    // first DJ pick locks the anchor (see _queueAutoDJSong below).
+    if (mgr.harmonicMixingEnabled && _camelotAnchor == null) {
+      final seed = toCamelotCode(currentKey);
+      if (seed != null) _camelotAnchor = seed;
     }
 
-    try {
-      Uri currentUri = Uri.parse(autoDJServer!.url.toString())
-          .resolve('/api/v1/db/random-songs');
-
-      bool flagIt = false;
-      String ignoreVPathString = '[';
-      autoDJServer?.autoDJPaths.forEach((key, value) {
-        if (value == false) {
-          ignoreVPathString += '${flagIt == false ? '' : ','} "$key"';
-          flagIt = true;
+    // Keyword filter is client-side (the server doesn't see it).
+    // Retry up to 5 times if responses get blocked, using the
+    // updated ignoreList from the server so we don't pick the same
+    // rejected track twice. After 5 blocks accept the last response
+    // anyway — mirrors the webapp's fallback so the queue doesn't
+    // stall forever on an over-aggressive filter.
+    for (var attempt = 0; attempt < 5; attempt++) {
+      final payload = <String, dynamic>{
+        'ignoreList': jsonAutoDJIgnoreList ?? [],
+      };
+      if (autoDJServer!.autoDJminRating != null) {
+        payload['minRating'] = autoDJServer!.autoDJminRating;
+      }
+      if (ignoreVPaths.isNotEmpty) {
+        payload['ignoreVPaths'] = ignoreVPaths;
+      }
+      if (mgr.genreFilterEnabled && mgr.genreFilterValues.isNotEmpty) {
+        payload['genres'] = mgr.genreFilterValues;
+        payload['genreMode'] = mgr.genreFilterMode;
+      }
+      if (mgr.bpmContinuityEnabled && currentBpm != null && currentBpm > 0) {
+        payload['bpmRanges'] =
+            _bpmWindows(currentBpm, mgr.bpmTolerance);
+        payload['bpmRangesWide'] =
+            _bpmWindows(currentBpm, mgr.bpmTolerance + 2);
+        // Require tagged tracks so the waterfall doesn't fall back
+        // to BPM-unknown picks when our windows return nothing.
+        payload['requireBpm'] = true;
+      }
+      if (mgr.harmonicMixingEnabled) {
+        if (_camelotAnchor != null) {
+          payload['musicalKeys'] = camelotNeighbours(_camelotAnchor!);
         }
-      });
-      ignoreVPathString += '],';
+        // Always prefer tagged tracks when harmonic mode is on —
+        // even without an anchor, the first pick should be keyed so
+        // we can lock the anchor for the rest of the session.
+        payload['requireMusicalKey'] = true;
+      }
 
-      print(ignoreVPathString);
-
-      String payload = '''{"minRating":${autoDJServer?.autoDJminRating},
-          ${flagIt == true ? '"ignoreVPaths": $ignoreVPathString' : ''}
-          "ignoreList":${json.encode(jsonAutoDJIgnoreList)}}''';
-
-      var res = await http.post(currentUri,
+      Map<String, dynamic> decoded;
+      try {
+        final res = await http.post(
+          Uri.parse(autoDJServer!.url).resolve('/api/v1/db/random-songs'),
           headers: {
             'Content-Type': 'application/json',
-            'x-access-token': autoDJServer?.jwt ?? ''
+            'x-access-token': autoDJServer?.jwt ?? '',
           },
-          body: payload);
-
-      var decoded = jsonDecode(res.body);
-
-      String p = '';
-      decoded['songs'][0]['filepath'].split("/").forEach((element) {
-        if (element.length == 0) {
-          return;
-        }
-        p += "/" + Uri.encodeComponent(element);
-      });
-
-      String lolUrl = autoDJServer!.url.toString() +
-          '/media' +
-          p +
-          '?app_uuid=' +
-          Uuid().v4() +
-          (autoDJServer?.jwt == null ? '' : '&token=' + autoDJServer!.jwt!);
-
-      String? artUrl = decoded['songs'][0]['metadata']['album-art'] != null
-          ? Uri.parse(autoDJServer!.url.toString())
-              .resolve('/album-art/' +
-                  decoded['songs'][0]['metadata']['album-art'] +
-                  '?compress=l&token=' +
-                  (autoDJServer?.jwt ?? ''))
-              .toString()
-          : null;
-
-      MediaItem item = new MediaItem(
-          id: lolUrl,
-          title: decoded['songs'][0]['metadata']['title'] ??
-              decoded['songs'][0]['filepath'].split("/").removeLast(),
-          album: decoded['songs'][0]['metadata']['album'],
-          artist: decoded['songs'][0]['metadata']['artist'],
-          extras: {
-            'path': decoded['songs'][0]['filepath'],
-            'year': decoded['songs'][0]['year'],
-            'artUrl': artUrl,
-          });
+          body: jsonEncode(payload),
+        );
+        if (res.statusCode > 299) return; // server error → bail silently
+        decoded = jsonDecode(res.body) as Map<String, dynamic>;
+      } catch (_) {
+        return; // network error → bail silently (matches old behaviour)
+      }
 
       jsonAutoDJIgnoreList = decoded['ignoreList'];
+      final songs = decoded['songs'] as List?;
+      if (songs == null || songs.isEmpty) return;
 
-      addQueueItem(item);
+      lastDecoded = decoded;
 
-      if (incrementIndex == true) {
-        _player.seek(Duration.zero, index: index! + 1);
+      if (!mgr.isKeywordBlocked(songs[0] as Map<String, dynamic>)) {
+        _queueAutoDJSong(decoded,
+            autoPlay: autoPlay, incrementIndex: incrementIndex);
+        return;
       }
-      if (autoPlay == true) {
-        play();
-      }
-    } catch (err) {}
+      // Otherwise loop — the updated ignoreList means the next call
+      // returns a different candidate.
+    }
+
+    if (lastDecoded != null) {
+      _queueAutoDJSong(lastDecoded,
+          autoPlay: autoPlay, incrementIndex: incrementIndex);
+    }
+  }
+
+  void _queueAutoDJSong(Map<String, dynamic> decoded,
+      {bool autoPlay = false, bool incrementIndex = false}) {
+    final song = decoded['songs'][0] as Map<String, dynamic>;
+    final metadata = (song['metadata'] as Map?) ?? const {};
+    final filepath = song['filepath'] as String;
+
+    String p = '';
+    for (final segment in filepath.split('/')) {
+      if (segment.isEmpty) continue;
+      p += '/' + Uri.encodeComponent(segment);
+    }
+
+    final mediaUrl = autoDJServer!.url +
+        '/media' +
+        p +
+        '?app_uuid=' +
+        Uuid().v4() +
+        (autoDJServer?.jwt == null ? '' : '&token=' + autoDJServer!.jwt!);
+
+    final artUrl = metadata['album-art'] != null
+        ? Uri.parse(autoDJServer!.url)
+            .resolve('/album-art/' +
+                metadata['album-art'] +
+                '?compress=l&token=' +
+                (autoDJServer?.jwt ?? ''))
+            .toString()
+        : null;
+
+    final item = MediaItem(
+      id: mediaUrl,
+      title: metadata['title'] ?? filepath.split('/').last,
+      album: metadata['album'],
+      artist: metadata['artist'],
+      extras: {
+        // Tag with the source server so Share Playlist's multi-server
+        // detection recognises AutoDJ-added songs as shareable.
+        'server': autoDJServer!.localname,
+        'path': filepath,
+        'year': metadata['year'],
+        'artUrl': artUrl,
+        // bpm + musicalKey power the next AutoDJ pick's continuity
+        // payload (see autoDJ() above). 'musical-key' is the wire
+        // shape from the server — we stash it under our camelCase
+        // key for consistency with browser-added items.
+        'bpm': metadata['bpm'],
+        'musicalKey': metadata['musical-key'],
+      },
+    );
+
+    // Lock the Camelot anchor on the first keyed DJ pick of the
+    // session. Subsequent calls in autoDJ() will use the anchor's
+    // neighbours rather than re-deriving from each newly-played
+    // song's key (which would drift across the session).
+    if (AutoDJManager().harmonicMixingEnabled && _camelotAnchor == null) {
+      final code = toCamelotCode(metadata['musical-key'] as String?);
+      if (code != null) _camelotAnchor = code;
+    }
+
+    addQueueItem(item);
+
+    if (incrementIndex == true && index != null) {
+      _player.seek(Duration.zero, index: index! + 1);
+    }
+    if (autoPlay == true) {
+      play();
+    }
+  }
+
+  // BPM continuity windows: one centered on the current tempo, one
+  // at half-tempo, one at double. The server OR-s these together so
+  // a 120-BPM source matches tracks at 112–128, 56–64, or 232–248
+  // (with tolerance=8). Half/double cover the common DJ practice
+  // of mixing across octaves.
+  static List<Map<String, int>> _bpmWindows(int bpm, int tolerance) {
+    final half = (bpm / 2).round();
+    final dbl = bpm * 2;
+    return [
+      {'min': bpm - tolerance, 'max': bpm + tolerance},
+      {'min': half - tolerance, 'max': half + tolerance},
+      {'min': dbl - tolerance, 'max': dbl + tolerance},
+    ];
   }
 }

--- a/lib/objects/metadata.dart
+++ b/lib/objects/metadata.dart
@@ -9,9 +9,16 @@ class MusicMetadata {
   int? year;
   int? rating;
   String? albumArt;
+  // Tempo (BPM) and musical key — populated by the server when a
+  // track is in its library DB. Both nullable since older scans
+  // and untagged files won't have them. Used by AutoDJ's harmonic-
+  // mixing + BPM-continuity modes (see audio_stuff.dart#autoDJ).
+  int? bpm;
+  String? musicalKey;
 
   MusicMetadata(this.artist, this.album, this.title, this.track, this.disc,
-      this.year, this.hash, this.rating, this.albumArt);
+      this.year, this.hash, this.rating, this.albumArt,
+      {this.bpm, this.musicalKey});
 
   MusicMetadata.fromJson(Map<String, dynamic> json)
       : artist = json['artist'],
@@ -22,7 +29,9 @@ class MusicMetadata {
         year = json['year'],
         hash = json['hash'],
         rating = json['rating'],
-        albumArt = json['albumArt'];
+        albumArt = json['albumArt'],
+        bpm = json['bpm'],
+        musicalKey = json['musicalKey'];
 
   Map<String, dynamic> toJson() => {
         'artist': artist,
@@ -34,5 +43,7 @@ class MusicMetadata {
         'hash': hash,
         'rating': rating,
         'albumArt': albumArt,
+        'bpm': bpm,
+        'musicalKey': musicalKey,
       };
 }

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -44,7 +44,9 @@ class AboutScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('About')),
-      body: ListView(
+      body: SafeArea(
+        top: false,
+        child: ListView(
         children: [
           SizedBox(height: 32),
           Center(
@@ -105,6 +107,7 @@ class AboutScreen extends StatelessWidget {
                 onTap: () => _open(context, l.url),
               )),
         ],
+      ),
       ),
     );
   }

--- a/lib/screens/auto_dj.dart
+++ b/lib/screens/auto_dj.dart
@@ -1,246 +1,863 @@
-import 'package:flutter/material.dart';
-import 'package:mstream_music/objects/server.dart';
-import '../singletons/server_list.dart';
-import '../singletons/media.dart';
+// Auto DJ configuration screen.
+//
+// Layout mirrors the webapp's panel:
+//   * Status / enable button at top
+//   * Server picker (if multi-server)
+//   * Sources — per-server vpath toggles
+//   * Filters — min rating (per-server), genre filter (app-level),
+//     keyword filter (app-level)
+//
+// Per-server fields (minRating, autoDJPaths) live on Server objects.
+// App-level filters (genre, keyword) live in AutoDJManager and
+// persist to auto_dj.json. Genre filter is server-side via the
+// `genres`/`genreMode` request fields; keyword filter is client-
+// side, applied in audio_stuff.dart's autoDJ() retry loop.
 
-class AutoDJScreen extends StatelessWidget {
-  setAutoDJ(Server? server) {
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../objects/server.dart';
+import '../singletons/api.dart';
+import '../singletons/auto_dj_manager.dart';
+import '../singletons/media.dart';
+import '../singletons/server_list.dart';
+import '../theme/velvet_theme.dart';
+
+class AutoDJScreen extends StatefulWidget {
+  @override
+  State<AutoDJScreen> createState() => _AutoDJScreenState();
+}
+
+class _AutoDJScreenState extends State<AutoDJScreen> {
+  StreamSubscription<dynamic>? _customStateSub;
+  StreamSubscription<int>? _autoDjMgrSub;
+
+  Server? _autoDJServer;
+
+  // Genre autocomplete cache. Fetched once when the screen mounts
+  // (background) so the picker sheet shows results without waiting.
+  // Re-fetched if the AutoDJ server changes.
+  List<String>? _availableGenres;
+  bool _loadingGenres = false;
+  String? _genreLoadError;
+  Server? _genresLoadedFor;
+
+  final TextEditingController _keywordCtrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    // BehaviorSubject emits seeded value on subscribe, so this fires
+    // immediately with the current state.
+    _customStateSub =
+        MediaManager().audioHandler.customState.listen((event) {
+      final newServer = event?.autoDJState as Server?;
+      if (mounted) {
+        setState(() => _autoDJServer = newServer);
+        _ensureGenresLoaded();
+      }
+    });
+    _autoDjMgrSub = AutoDJManager().changeStream.listen((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _customStateSub?.cancel();
+    _autoDjMgrSub?.cancel();
+    _keywordCtrl.dispose();
+    super.dispose();
+  }
+
+  void _setAutoDJ(Server? server) {
     MediaManager()
         .audioHandler
         .customAction('setAutoDJ', {'autoDJServer': server});
   }
 
+  // Use the AutoDJ server when configured; fall back to the current
+  // server so the genre picker works before AutoDJ is enabled.
+  Server? get _genreFetchTarget =>
+      _autoDJServer ?? ServerManager().currentServer;
+
+  Future<void> _ensureGenresLoaded() async {
+    final server = _genreFetchTarget;
+    if (server == null) return;
+    if (_loadingGenres) return;
+    if (_availableGenres != null && _genresLoadedFor == server) return;
+
+    setState(() {
+      _loadingGenres = true;
+      _genreLoadError = null;
+    });
+    try {
+      final genres = await ApiManager().getGenres(useThisServer: server);
+      if (!mounted) return;
+      setState(() {
+        _availableGenres = genres
+            .map((g) => (g['name'] ?? '').toString())
+            .where((s) => s.isNotEmpty)
+            .toList()
+          ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+        _loadingGenres = false;
+        _genresLoadedFor = server;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loadingGenres = false;
+        _genreLoadError = 'Could not load genres';
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    // Handle No Servers
-    if (ServerManager().serverList.length == 0) {
+    if (ServerManager().serverList.isEmpty) {
       return Scaffold(
-          backgroundColor: Color(0xFF3f3f3f),
-          appBar: AppBar(
-            title: Text("Auto DJ"),
+        appBar: AppBar(title: Text('Auto DJ')),
+        body: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'Add a server first.',
+            style: TextStyle(color: VelvetColors.textSecondary),
           ),
-          body: Container(
-              padding: EdgeInsets.all(40.0),
-              child: ListView(children: [
-                Text('Please add a server'),
-              ])));
+        ),
+      );
     }
 
+    final enabled = _autoDJServer != null;
+
     return Scaffold(
-        backgroundColor: Color(0xFF3f3f3f),
-        appBar: AppBar(
-          title: Text("Auto DJ"),
-        ),
-        body: Container(
-            padding: EdgeInsets.all(40.0),
-            child: ListView(children: [
-              StreamBuilder<dynamic>(
-                  stream: MediaManager().audioHandler.customState,
-                  builder: (context, snapshot) {
-                    final Server? autoDJState =
-                        (snapshot.data?.autoDJState as Server?);
-                    return ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                            backgroundColor: autoDJState == null
-                                ? Colors.green
-                                : Colors.orange.shade900,
-                            textStyle: const TextStyle(fontSize: 20)),
-                        child: autoDJState == null
-                            ? Text('Enable')
-                            : Text('Disable'),
-                        onPressed: () => {
-                              setAutoDJ(autoDJState == null
-                                  ? ServerManager().currentServer
-                                  : null)
-                            });
-                  }),
-              Container(
-                height: 20,
+      appBar: AppBar(title: Text('Auto DJ')),
+      // SafeArea(bottom: true) ensures the last filter section
+      // doesn't get tucked under the system gesture/nav bar on
+      // edge-to-edge devices. AppBar handles the top inset.
+      body: SafeArea(
+        top: false,
+        child: ListView(
+        padding: EdgeInsets.only(bottom: 24),
+        children: [
+          _statusSection(enabled, _autoDJServer),
+          Divider(color: VelvetColors.border, height: 1),
+          if (ServerManager().serverList.length > 1 && enabled) ...[
+            _sectionHeader('Server'),
+            _serverPickerTile(_autoDJServer!),
+            Divider(color: VelvetColors.border, height: 1),
+          ],
+          if (enabled && _autoDJServer!.autoDJPaths.length > 1) ...[
+            _sectionHeader('Sources'),
+            ..._vpathTiles(_autoDJServer!),
+            Divider(color: VelvetColors.border, height: 1),
+          ],
+          _sectionHeader('Continuity'),
+          _bpmContinuitySection(),
+          _harmonicMixingSection(),
+          Divider(color: VelvetColors.border, height: 1),
+          _sectionHeader('Filters'),
+          if (enabled) _minRatingTile(_autoDJServer!),
+          _genreFilterSection(),
+          _keywordFilterSection(),
+        ],
+      ),
+      ),
+    );
+  }
+
+  // ── Continuity: BPM + harmonic mixing ───────────────────────────
+
+  Widget _bpmContinuitySection() {
+    final mgr = AutoDJManager();
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('BPM continuity',
+                        style: TextStyle(
+                            color: VelvetColors.textPrimary, fontSize: 15)),
+                    SizedBox(height: 2),
+                    Text(
+                      'Prefer picks within a tempo window of the current '
+                      'song. Honours half/double-tempo equivalence.',
+                      style: TextStyle(
+                          color: VelvetColors.textSecondary, fontSize: 12),
+                    ),
+                  ],
+                ),
               ),
-              if (ServerManager().serverList.length > 1) ...[
-                StreamBuilder<dynamic>(
-                    stream: MediaManager().audioHandler.customState,
-                    builder: (context, snapshot) {
-                      final Server? autoDJState =
-                          (snapshot.data?.autoDJState as Server?);
-                      if (autoDJState == null) {
-                        return Container();
-                      }
-
-                      return Text('Auto DJ Server: ${autoDJState.url}',
-                          style: TextStyle(fontWeight: FontWeight.bold));
-                    }),
-                StreamBuilder<dynamic>(
-                    stream: MediaManager().audioHandler.customState,
-                    builder: (context, snapshot) {
-                      final Server? autoDJState =
-                          (snapshot.data?.autoDJState as Server?);
-
-                      if (autoDJState == null) {
-                        return Container();
-                      }
-
-                      List<DropdownMenuItem<Server>> lol = [];
-
-                      ServerManager().serverList.forEach((value) {
-                        if (value == autoDJState) {
-                          return;
-                        }
-
-                        lol.add(DropdownMenuItem<Server>(
-                          value: value,
-                          child: Text(value.url.toString()),
-                        ));
-                      });
-
-                      return DropdownButton<Server>(
-                        //value: autoDJState,
-                        hint: Text('Change Server'),
-                        items: lol,
-                        onChanged: (newValue) {
-                          setAutoDJ(newValue);
-                        },
-                      );
-                    }),
+              Switch(
+                value: mgr.bpmContinuityEnabled,
+                onChanged: (v) => mgr.setBpmContinuityEnabled(v),
+                activeThumbColor: VelvetColors.primary,
+              ),
+            ],
+          ),
+          if (mgr.bpmContinuityEnabled) ...[
+            SizedBox(height: 4),
+            Row(
+              children: [
+                Text(
+                  'Tolerance',
+                  style: TextStyle(
+                      color: VelvetColors.textSecondary, fontSize: 13),
+                ),
+                Spacer(),
+                Text(
+                  '± ${mgr.bpmTolerance} BPM',
+                  style: TextStyle(
+                    color: VelvetColors.primary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
               ],
-              Container(
-                height: 20,
+            ),
+            SliderTheme(
+              data: SliderTheme.of(context).copyWith(
+                activeTrackColor: VelvetColors.primary,
+                thumbColor: VelvetColors.primary,
+                overlayColor: VelvetColors.primaryDim,
               ),
-              StreamBuilder<dynamic>(
-                  stream: MediaManager().audioHandler.customState,
-                  builder: (context, snapshot) {
-                    final Server? autoDJState =
-                        (snapshot.data?.autoDJState as Server?);
-                    if (autoDJState == null) {
-                      return Container();
-                    }
+              child: Slider(
+                value: mgr.bpmTolerance.toDouble().clamp(1.0, 20.0),
+                min: 1,
+                max: 20,
+                divisions: 19,
+                onChanged: (v) => mgr.setBpmTolerance(v.round()),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
 
-                    return Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text('Min Rating',
-                              style: TextStyle(fontWeight: FontWeight.bold)),
-                          DropdownButton<int>(
-                            value: autoDJState.autoDJminRating,
-                            items: [
-                              DropdownMenuItem<int>(
-                                value: null,
-                                child: Text('N/A'),
-                              ),
-                              DropdownMenuItem<int>(
-                                value: 1,
-                                child: Text('0.5'),
-                              ),
-                              DropdownMenuItem<int>(
-                                value: 2,
-                                child: Text('1'),
-                              ),
-                              DropdownMenuItem<int>(
-                                value: 3,
-                                child: Text('1.5'),
-                              ),
-                              DropdownMenuItem<int>(
-                                value: 4,
-                                child: Text('2'),
-                              ),
-                              DropdownMenuItem<int>(
-                                value: 5,
-                                child: Text('2.5'),
-                              ),
-                              DropdownMenuItem<int>(
-                                value: 6,
-                                child: Text('3'),
-                              ),
-                              DropdownMenuItem<int>(
-                                value: 7,
-                                child: Text('3.5'),
-                              ),
-                              DropdownMenuItem<int>(
-                                value: 8,
-                                child: Text('4'),
-                              ),
-                              DropdownMenuItem<int>(
-                                value: 9,
-                                child: Text('4.5'),
-                              ),
-                              DropdownMenuItem<int>(
-                                value: 10,
-                                child: Text('5'),
-                              ),
-                            ],
-                            onChanged: (int? newValue) {
-                              autoDJState.autoDJminRating = newValue;
+  Widget _harmonicMixingSection() {
+    final mgr = AutoDJManager();
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Harmonic mixing',
+                    style: TextStyle(
+                        color: VelvetColors.textPrimary, fontSize: 15)),
+                SizedBox(height: 2),
+                Text(
+                  'Prefer picks in keys that mix well with the locked '
+                  'song (Camelot wheel neighbours).',
+                  style: TextStyle(
+                      color: VelvetColors.textSecondary, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+          Switch(
+            value: mgr.harmonicMixingEnabled,
+            onChanged: (v) => mgr.setHarmonicMixingEnabled(v),
+            activeThumbColor: VelvetColors.primary,
+          ),
+        ],
+      ),
+    );
+  }
 
-                              MediaManager()
-                                  .audioHandler
-                                  .customAction('forceAutoDJRefresh');
+  // ── Status / enable button ───────────────────────────────────────
 
-                              ServerManager().callAfterEditServer();
+  Widget _statusSection(bool enabled, Server? autoDJServer) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(20, 20, 20, 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            enabled
+                ? 'Auto DJ is on'
+                : 'Auto DJ is off',
+            style: TextStyle(
+              color: VelvetColors.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          SizedBox(height: 4),
+          Text(
+            enabled
+                ? 'Songs are picked from ${autoDJServer!.url} when the queue runs low.'
+                : "Tap below to start. The current server's library will be used.",
+            style: TextStyle(
+                color: VelvetColors.textSecondary, fontSize: 12),
+          ),
+          SizedBox(height: 14),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor:
+                  enabled ? VelvetColors.error : VelvetColors.primary,
+              foregroundColor: Colors.white,
+              padding: EdgeInsets.symmetric(vertical: 14),
+              shape: RoundedRectangleBorder(
+                borderRadius:
+                    BorderRadius.circular(VelvetColors.radiusSmall),
+              ),
+              textStyle:
+                  TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+            ),
+            onPressed: () => _setAutoDJ(
+                enabled ? null : ServerManager().currentServer),
+            child: Text(enabled ? 'Stop Auto DJ' : 'Start Auto DJ'),
+          ),
+        ],
+      ),
+    );
+  }
 
-                              print(ServerManager()
-                                  .currentServer
-                                  ?.autoDJminRating);
-                              return;
-                            },
-                          )
-                        ]);
-                  }),
-              StreamBuilder<dynamic>(
-                  stream: MediaManager().audioHandler.customState,
-                  builder: (context, snapshot) {
-                    final Server? autoDJState =
-                        (snapshot.data?.autoDJState as Server?);
-                    if (autoDJState == null ||
-                        autoDJState.autoDJPaths.length < 2) {
-                      return Container();
-                    }
+  // ── Server picker (multi-server only, when enabled) ─────────────
 
-                    List<Widget> lol = [
-                      Container(
-                        height: 20,
+  Widget _serverPickerTile(Server autoDJServer) {
+    final otherServers = ServerManager()
+        .serverList
+        .where((s) => s != autoDJServer)
+        .toList();
+    if (otherServers.isEmpty) {
+      return ListTile(
+        contentPadding: EdgeInsets.symmetric(horizontal: 20),
+        title: Text(autoDJServer.url,
+            style: TextStyle(color: VelvetColors.textPrimary)),
+        subtitle: Text('Active source',
+            style: TextStyle(
+                color: VelvetColors.textSecondary, fontSize: 12)),
+      );
+    }
+    return ListTile(
+      contentPadding: EdgeInsets.symmetric(horizontal: 20),
+      title: Text(autoDJServer.url,
+          style: TextStyle(color: VelvetColors.textPrimary)),
+      subtitle: Text('Active source — tap to switch',
+          style:
+              TextStyle(color: VelvetColors.textSecondary, fontSize: 12)),
+      trailing: DropdownButton<Server>(
+        underline: SizedBox.shrink(),
+        hint: Text('Switch', style: TextStyle(color: VelvetColors.primary)),
+        dropdownColor: VelvetColors.surface,
+        items: otherServers
+            .map((s) => DropdownMenuItem(
+                  value: s,
+                  child: Text(s.url,
+                      style: TextStyle(color: VelvetColors.textPrimary)),
+                ))
+            .toList(),
+        onChanged: (newValue) {
+          if (newValue != null) _setAutoDJ(newValue);
+        },
+      ),
+    );
+  }
+
+  // ── Sources (vpath switches) ─────────────────────────────────────
+
+  List<Widget> _vpathTiles(Server autoDJServer) {
+    return autoDJServer.autoDJPaths.entries.map((entry) {
+      return SwitchListTile(
+        contentPadding: EdgeInsets.symmetric(horizontal: 20),
+        title: Text(entry.key,
+            style: TextStyle(color: VelvetColors.textPrimary)),
+        value: entry.value,
+        onChanged: (value) {
+          // Refuse to disable the last enabled vpath — server would
+          // have nothing to draw from.
+          final anyOtherOn = autoDJServer.autoDJPaths.entries
+              .any((e) => e.key != entry.key && e.value);
+          if (!value && !anyOtherOn) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('At least one source is required.')),
+            );
+            return;
+          }
+          setState(() => autoDJServer.autoDJPaths[entry.key] = value);
+          MediaManager()
+              .audioHandler
+              .customAction('forceAutoDJRefresh');
+          ServerManager().callAfterEditServer();
+        },
+        activeThumbColor: VelvetColors.primary,
+      );
+    }).toList();
+  }
+
+  // ── Min Rating ──────────────────────────────────────────────────
+
+  Widget _minRatingTile(Server autoDJServer) {
+    const items = [
+      MapEntry<int?, String>(null, 'Any'),
+      MapEntry<int?, String>(1, '0.5 ★'),
+      MapEntry<int?, String>(2, '1.0 ★'),
+      MapEntry<int?, String>(3, '1.5 ★'),
+      MapEntry<int?, String>(4, '2.0 ★'),
+      MapEntry<int?, String>(5, '2.5 ★'),
+      MapEntry<int?, String>(6, '3.0 ★'),
+      MapEntry<int?, String>(7, '3.5 ★'),
+      MapEntry<int?, String>(8, '4.0 ★'),
+      MapEntry<int?, String>(9, '4.5 ★'),
+      MapEntry<int?, String>(10, '5.0 ★'),
+    ];
+    return ListTile(
+      contentPadding: EdgeInsets.symmetric(horizontal: 20),
+      title: Text('Minimum rating',
+          style: TextStyle(color: VelvetColors.textPrimary)),
+      subtitle: Text('Only pick songs at or above this rating.',
+          style:
+              TextStyle(color: VelvetColors.textSecondary, fontSize: 12)),
+      trailing: DropdownButton<int?>(
+        underline: SizedBox.shrink(),
+        dropdownColor: VelvetColors.surface,
+        value: autoDJServer.autoDJminRating,
+        items: items
+            .map((e) => DropdownMenuItem<int?>(
+                  value: e.key,
+                  child: Text(e.value,
+                      style: TextStyle(color: VelvetColors.textPrimary)),
+                ))
+            .toList(),
+        onChanged: (newValue) {
+          setState(() => autoDJServer.autoDJminRating = newValue);
+          MediaManager().audioHandler.customAction('forceAutoDJRefresh');
+          ServerManager().callAfterEditServer();
+        },
+      ),
+    );
+  }
+
+  // ── Genre Filter ─────────────────────────────────────────────────
+
+  Widget _genreFilterSection() {
+    final mgr = AutoDJManager();
+    final selected = mgr.genreFilterValues;
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Genre filter',
+                        style: TextStyle(
+                            color: VelvetColors.textPrimary, fontSize: 15)),
+                    SizedBox(height: 2),
+                    Text(
+                      'Whitelist plays only matching tracks; '
+                      'blacklist skips them.',
+                      style: TextStyle(
+                          color: VelvetColors.textSecondary, fontSize: 12),
+                    ),
+                  ],
+                ),
+              ),
+              Switch(
+                value: mgr.genreFilterEnabled,
+                onChanged: (v) => mgr.setGenreFilterEnabled(v),
+                activeThumbColor: VelvetColors.primary,
+              ),
+            ],
+          ),
+          if (mgr.genreFilterEnabled) ...[
+            SizedBox(height: 8),
+            SegmentedButton<String>(
+              segments: const [
+                ButtonSegment(value: 'whitelist', label: Text('Whitelist')),
+                ButtonSegment(value: 'blacklist', label: Text('Blacklist')),
+              ],
+              selected: {mgr.genreFilterMode},
+              onSelectionChanged: (set) {
+                if (set.isNotEmpty) {
+                  mgr.setGenreFilterMode(set.first);
+                }
+              },
+              showSelectedIcon: false,
+              style: ButtonStyle(
+                visualDensity: VisualDensity.compact,
+              ),
+            ),
+            SizedBox(height: 12),
+            if (selected.isEmpty)
+              Text(
+                'No genres selected. Tap "Pick genres" to choose.',
+                style:
+                    TextStyle(color: VelvetColors.textTertiary, fontSize: 12),
+              )
+            else
+              Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                children: selected
+                    .map((g) => Chip(
+                          // Cap label width so a long genre like
+                          // "Soundtracks — Film & TV" can't push the
+                          // chip wider than the screen and force an
+                          // overflow within the Wrap row.
+                          label: ConstrainedBox(
+                            constraints: BoxConstraints(maxWidth: 180),
+                            child: Text(
+                              g,
+                              style: TextStyle(
+                                  color: VelvetColors.textPrimary,
+                                  fontSize: 12),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          backgroundColor: VelvetColors.raised,
+                          side: BorderSide(color: VelvetColors.border),
+                          deleteIconColor: VelvetColors.textSecondary,
+                          onDeleted: () => mgr.removeGenre(g),
+                          visualDensity: VisualDensity.compact,
+                        ))
+                    .toList(),
+              ),
+            SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed: _openGenrePicker,
+                icon: Icon(Icons.add, size: 18),
+                label: Text('Pick genres'),
+                style: TextButton.styleFrom(
+                  foregroundColor: VelvetColors.primary,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Future<void> _openGenrePicker() async {
+    await _ensureGenresLoaded();
+    if (!mounted) return;
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: VelvetColors.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (ctx) => _GenrePickerSheet(
+        available: _availableGenres ?? const [],
+        loading: _loadingGenres,
+        error: _genreLoadError,
+      ),
+    );
+  }
+
+  // ── Keyword Filter ───────────────────────────────────────────────
+
+  Widget _keywordFilterSection() {
+    final mgr = AutoDJManager();
+    final words = mgr.keywordFilterWords;
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Keyword filter',
+                        style: TextStyle(
+                            color: VelvetColors.textPrimary, fontSize: 15)),
+                    SizedBox(height: 2),
+                    Text(
+                      'Skip picks whose title, artist, album, or filepath '
+                      'contains any of these words.',
+                      style: TextStyle(
+                          color: VelvetColors.textSecondary, fontSize: 12),
+                    ),
+                  ],
+                ),
+              ),
+              Switch(
+                value: mgr.keywordFilterEnabled,
+                onChanged: (v) => mgr.setKeywordFilterEnabled(v),
+                activeThumbColor: VelvetColors.primary,
+              ),
+            ],
+          ),
+          if (mgr.keywordFilterEnabled) ...[
+            SizedBox(height: 8),
+            if (words.isEmpty)
+              Text(
+                'No keywords. Add words below to start filtering.',
+                style:
+                    TextStyle(color: VelvetColors.textTertiary, fontSize: 12),
+              )
+            else
+              Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                children: words
+                    .map((w) => Chip(
+                          label: ConstrainedBox(
+                            constraints: BoxConstraints(maxWidth: 180),
+                            child: Text(
+                              w,
+                              style: TextStyle(
+                                  color: VelvetColors.textPrimary,
+                                  fontSize: 12),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          backgroundColor: VelvetColors.raised,
+                          side: BorderSide(color: VelvetColors.border),
+                          deleteIconColor: VelvetColors.textSecondary,
+                          onDeleted: () => mgr.removeKeyword(w),
+                          visualDensity: VisualDensity.compact,
+                        ))
+                    .toList(),
+              ),
+            SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _keywordCtrl,
+                    decoration: InputDecoration(
+                      hintText: 'e.g. "live" or "remix"',
+                      isDense: true,
+                    ),
+                    textInputAction: TextInputAction.done,
+                    onSubmitted: (_) => _addKeyword(),
+                  ),
+                ),
+                SizedBox(width: 8),
+                TextButton.icon(
+                  onPressed: _addKeyword,
+                  icon: Icon(Icons.add, size: 18),
+                  label: Text('Add'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: VelvetColors.primary,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Future<void> _addKeyword() async {
+    final w = _keywordCtrl.text.trim();
+    if (w.isEmpty) return;
+    await AutoDJManager().addKeyword(w);
+    _keywordCtrl.clear();
+  }
+
+  // ── Section header (mirrors settings_screen.dart) ───────────────
+
+  Widget _sectionHeader(String label) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(20, 20, 20, 8),
+      child: Text(
+        label.toUpperCase(),
+        style: TextStyle(
+          color: VelvetColors.primary,
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 1.6,
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Genre picker bottom sheet.
+//
+// Search-filtered, checkable list. Tapping toggles immediately
+// through AutoDJManager (no separate "Done" button — the chips on
+// the main screen reflect the live selection state).
+// ─────────────────────────────────────────────────────────────────────
+
+class _GenrePickerSheet extends StatefulWidget {
+  final List<String> available;
+  final bool loading;
+  final String? error;
+  const _GenrePickerSheet({
+    required this.available,
+    required this.loading,
+    this.error,
+  });
+
+  @override
+  State<_GenrePickerSheet> createState() => _GenrePickerSheetState();
+}
+
+class _GenrePickerSheetState extends State<_GenrePickerSheet> {
+  String _query = '';
+  StreamSubscription<int>? _mgrSub;
+
+  @override
+  void initState() {
+    super.initState();
+    // Rebuild when AutoDJManager state changes so checkboxes reflect
+    // toggle taps live.
+    _mgrSub =
+        AutoDJManager().changeStream.listen((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _mgrSub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = AutoDJManager().genreFilterValues.toSet();
+    final q = _query.trim().toLowerCase();
+    final filtered = q.isEmpty
+        ? widget.available
+        : widget.available
+            .where((g) => g.toLowerCase().contains(q))
+            .toList();
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.7,
+      minChildSize: 0.4,
+      maxChildSize: 0.95,
+      expand: false,
+      builder: (context, scrollController) {
+        return Column(
+          children: [
+            // Drag handle
+            Container(
+              margin: EdgeInsets.only(top: 8),
+              height: 4,
+              width: 40,
+              decoration: BoxDecoration(
+                color: VelvetColors.border2,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.fromLTRB(16, 12, 16, 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Pick genres',
+                      style: TextStyle(
+                        color: VelvetColors.textPrimary,
+                        fontSize: 18,
+                        fontWeight: FontWeight.w700,
                       ),
-                      Text('Select Folders',
-                          style: TextStyle(fontWeight: FontWeight.bold))
-                    ];
+                    ),
+                  ),
+                  Text(
+                    '${selected.length} selected',
+                    style: TextStyle(
+                        color: VelvetColors.textSecondary, fontSize: 12),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: TextField(
+                autofocus: false,
+                decoration: InputDecoration(
+                  hintText: 'Search genres…',
+                  prefixIcon: Icon(Icons.search),
+                  isDense: true,
+                ),
+                onChanged: (v) => setState(() => _query = v),
+              ),
+            ),
+            SizedBox(height: 8),
+            Expanded(child: _buildBody(filtered, selected, scrollController)),
+          ],
+        );
+      },
+    );
+  }
 
-                    autoDJState.autoDJPaths.forEach((k, v) {
-                      lol.add(ListTile(
-                        leading: Switch(
-                            value: v,
-                            onChanged: (value) {
-                              bool falseFlag = false;
-                              autoDJState.autoDJPaths.forEach((key, value) {
-                                if (key == k) {
-                                  return;
-                                }
-
-                                if (value == true) {
-                                  falseFlag = true;
-                                }
-                              });
-
-                              if (falseFlag == false) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                        content: Text(
-                                            'You must have 1 folder selected')));
-                                return;
-                              }
-
-                              autoDJState.autoDJPaths[k] = value;
-                              MediaManager()
-                                  .audioHandler
-                                  .customAction('forceAutoDJRefresh');
-                              ServerManager().callAfterEditServer();
-                            }),
-                        title: Text(k),
-                      ));
-                    });
-
-                    return Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: lol);
-                  }),
-            ])));
+  Widget _buildBody(List<String> filtered, Set<String> selected,
+      ScrollController controller) {
+    if (widget.loading) {
+      return Center(
+          child: CircularProgressIndicator(color: VelvetColors.primary));
+    }
+    if (widget.error != null) {
+      return Padding(
+        padding: EdgeInsets.all(16),
+        child: Text(widget.error!,
+            style: TextStyle(color: VelvetColors.error)),
+      );
+    }
+    if (widget.available.isEmpty) {
+      return Padding(
+        padding: EdgeInsets.all(16),
+        child: Text(
+          'No genres found on this server.',
+          style: TextStyle(color: VelvetColors.textSecondary),
+        ),
+      );
+    }
+    if (filtered.isEmpty) {
+      return Padding(
+        padding: EdgeInsets.all(16),
+        child: Text(
+          'No genres match "${_query.trim()}".',
+          style: TextStyle(color: VelvetColors.textSecondary),
+        ),
+      );
+    }
+    return ListView.separated(
+      controller: controller,
+      itemCount: filtered.length,
+      separatorBuilder: (_, __) =>
+          Divider(color: VelvetColors.border, height: 1),
+      itemBuilder: (context, i) {
+        final g = filtered[i];
+        final on = selected.contains(g);
+        return CheckboxListTile(
+          dense: true,
+          value: on,
+          title: Text(g, style: TextStyle(color: VelvetColors.textPrimary)),
+          activeColor: VelvetColors.primary,
+          checkColor: Colors.white,
+          controlAffinity: ListTileControlAffinity.leading,
+          onChanged: (v) async {
+            if (v == true) {
+              await AutoDJManager().addGenre(g);
+            } else {
+              await AutoDJManager().removeGenre(g);
+            }
+          },
+        );
+      },
+    );
   }
 }

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -170,6 +170,11 @@ class Browser extends StatelessWidget {
             'localPath': finalString,
             'year': i.metadata?.year,
             'artUrl': artUrl,
+            // bpm + musicalKey power AutoDJ's BPM-continuity /
+            // harmonic-mixing modes — read off the currently
+            // playing item when computing the next pick's payload.
+            'bpm': i.metadata?.bpm,
+            'musicalKey': i.metadata?.musicalKey,
           });
     }
 
@@ -210,6 +215,8 @@ class Browser extends StatelessWidget {
           'path': i.data,
           'year': i.metadata?.year,
           'artUrl': artUrl,
+          'bpm': i.metadata?.bpm,
+          'musicalKey': i.metadata?.musicalKey,
         });
 
     // TODO: Fire of request for metadata

--- a/lib/screens/downloads.dart
+++ b/lib/screens/downloads.dart
@@ -11,7 +11,7 @@ class DownloadScreen extends StatelessWidget {
         appBar: AppBar(
           title: Text("Downloads"),
         ),
-        body: Column(children: [
+        body: SafeArea(top: false, child: Column(children: [
           // Card(
           //     child: Column(
           //   mainAxisSize: MainAxisSize.min,
@@ -72,6 +72,6 @@ class DownloadScreen extends StatelessWidget {
                               );
                             });
                       })))
-        ]));
+        ])));
   }
 }

--- a/lib/screens/eq_screen.dart
+++ b/lib/screens/eq_screen.dart
@@ -18,6 +18,9 @@
 // Persistence: gains are written to settings.json on onChangeEnd
 // (not on every drag tick) to avoid thrashing the JSON file.
 
+import 'dart:async';
+
+import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 
@@ -34,28 +37,69 @@ class _EqScreenState extends State<EqScreen> {
   AndroidEqualizerParameters? _params;
   bool _loading = true;
   String? _error;
+  StreamSubscription<PlaybackState>? _playbackSub;
 
   @override
   void initState() {
     super.initState();
-    _loadParams();
+    _attemptLoad();
+    // AndroidEqualizer.parameters only resolves once the native
+    // audio session is alive — i.e. something's been queued. If the
+    // user opens this screen with an idle queue, the initial attempt
+    // times out. Watch playback state and retry the moment audio
+    // actually starts, so the user can queue something and come
+    // back without having to navigate out and back in.
+    _playbackSub = MediaManager().audioHandler.playbackState.listen((state) {
+      if (_params == null &&
+          state.processingState != AudioProcessingState.idle) {
+        _attemptLoad();
+      }
+    });
   }
 
-  Future<void> _loadParams() async {
+  @override
+  void dispose() {
+    _playbackSub?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _attemptLoad() async {
     final eq = MediaManager().audioHandler.equalizer;
     if (eq == null) {
+      if (!mounted) return;
       setState(() {
         _loading = false;
         _error = 'Equalizer is only available on Android.';
       });
       return;
     }
+    // Already loaded — nothing to do (guards against the playback
+    // listener firing a duplicate fetch after we've succeeded once).
+    if (_params != null) return;
+
+    if (!mounted) return;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
     try {
-      final p = await eq.parameters;
+      // 3s is plenty when the session is alive (resolves in ms);
+      // when it isn't, the wait would otherwise be unbounded.
+      final p = await eq.parameters.timeout(const Duration(seconds: 3));
       if (!mounted) return;
       setState(() {
         _params = p;
         _loading = false;
+      });
+    } on TimeoutException {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = 'Start a song to configure the EQ.\n\n'
+            "Android's native equalizer initializes with the audio "
+            'session, so we need playback to be active before we can '
+            'read the band layout.';
       });
     } catch (e) {
       if (!mounted) return;

--- a/lib/screens/eq_screen.dart
+++ b/lib/screens/eq_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+// Placeholder stub. The UI agent owns this file and will replace it
+// with the real graphic equalizer (band sliders + presets, reading
+// MediaManager().audioHandler.equalizer and persisting via
+// SettingsManager().setEqBandGains / setEqEnabled). This stub exists
+// only so settings_screen.dart can import EqScreen and the project
+// compiles while the UI work is in flight.
+class EqScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Equalizer')),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'Equalizer UI not yet implemented.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/eq_screen.dart
+++ b/lib/screens/eq_screen.dart
@@ -1,25 +1,309 @@
-import 'package:flutter/material.dart';
+// Graphic equalizer UI for the Android-native AndroidEqualizer that
+// audio_stuff.dart attaches to the player's AudioPipeline.
+//
+// The handler-side plumbing (AndroidEqualizer attach, _applySavedEqualizer
+// on init, SettingsManager.eqEnabled / eqBandGains persistence) was
+// landed by another agent. This screen renders the user-facing
+// controls and writes back via the same persistence hooks.
+//
+// What you get:
+//   * Enable/disable toggle (drives AndroidEqualizer.setEnabled +
+//     SettingsManager.setEqEnabled)
+//   * N vertical sliders, one per band reported by the device's
+//     native equalizer (typically 5 on Samsung, varies by SoC). Each
+//     slider streams its gain via AndroidEqualizerBand.gainStream so
+//     UI stays in sync with audio.
+//   * Reset-to-flat in the AppBar
+//
+// Persistence: gains are written to settings.json on onChangeEnd
+// (not on every drag tick) to avoid thrashing the JSON file.
 
-// Placeholder stub. The UI agent owns this file and will replace it
-// with the real graphic equalizer (band sliders + presets, reading
-// MediaManager().audioHandler.equalizer and persisting via
-// SettingsManager().setEqBandGains / setEqEnabled). This stub exists
-// only so settings_screen.dart can import EqScreen and the project
-// compiles while the UI work is in flight.
-class EqScreen extends StatelessWidget {
+import 'package:flutter/material.dart';
+import 'package:just_audio/just_audio.dart';
+
+import '../singletons/media.dart';
+import '../singletons/settings.dart';
+import '../theme/velvet_theme.dart';
+
+class EqScreen extends StatefulWidget {
+  @override
+  State<EqScreen> createState() => _EqScreenState();
+}
+
+class _EqScreenState extends State<EqScreen> {
+  AndroidEqualizerParameters? _params;
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadParams();
+  }
+
+  Future<void> _loadParams() async {
+    final eq = MediaManager().audioHandler.equalizer;
+    if (eq == null) {
+      setState(() {
+        _loading = false;
+        _error = 'Equalizer is only available on Android.';
+      });
+      return;
+    }
+    try {
+      final p = await eq.parameters;
+      if (!mounted) return;
+      setState(() {
+        _params = p;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = 'Could not initialize equalizer:\n$e';
+      });
+    }
+  }
+
+  Future<void> _setEnabled(bool v) async {
+    final eq = MediaManager().audioHandler.equalizer;
+    if (eq == null) return;
+    await eq.setEnabled(v);
+    await SettingsManager().setEqEnabled(v);
+  }
+
+  // Snapshot the current band gains and write them to settings.json.
+  // Called on slider release (not on every drag tick) so the file
+  // isn't rewritten dozens of times per gesture.
+  Future<void> _persistGains() async {
+    if (_params == null) return;
+    final gains = _params!.bands.map((b) => b.gain).toList();
+    await SettingsManager().setEqBandGains(gains);
+  }
+
+  Future<void> _resetToFlat() async {
+    if (_params == null) return;
+    for (final band in _params!.bands) {
+      await band.setGain(0);
+    }
+    await _persistGains();
+  }
+
+  // 60 → "60", 1000 → "1k", 1500 → "1.5k", 14000 → "14k"
+  String _formatFreq(double hz) {
+    if (hz >= 1000) {
+      final k = hz / 1000;
+      return k == k.roundToDouble()
+          ? '${k.round()}k'
+          : '${k.toStringAsFixed(1)}k';
+    }
+    return '${hz.round()}';
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Equalizer')),
-      body: const Center(
-        child: Padding(
-          padding: EdgeInsets.all(24),
+      appBar: AppBar(
+        title: Text('Equalizer'),
+        actions: [
+          if (_params != null && _params!.bands.isNotEmpty)
+            TextButton(
+              onPressed: _resetToFlat,
+              child: Text(
+                'Reset',
+                style: TextStyle(
+                  color: VelvetColors.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+        ],
+      ),
+      body: SafeArea(top: false, child: _buildBody()),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_loading) {
+      return Center(
+        child: CircularProgressIndicator(color: VelvetColors.primary),
+      );
+    }
+    if (_error != null) {
+      return Padding(
+        padding: EdgeInsets.all(24),
+        child: Center(
           child: Text(
-            'Equalizer UI not yet implemented.',
+            _error!,
             textAlign: TextAlign.center,
+            style: TextStyle(color: VelvetColors.textSecondary),
           ),
         ),
-      ),
+      );
+    }
+    final p = _params!;
+    if (p.bands.isEmpty) {
+      return Padding(
+        padding: EdgeInsets.all(24),
+        child: Center(
+          child: Text(
+            "No EQ bands reported by this device's audio driver.",
+            textAlign: TextAlign.center,
+            style: TextStyle(color: VelvetColors.textSecondary),
+          ),
+        ),
+      );
+    }
+
+    final eq = MediaManager().audioHandler.equalizer!;
+
+    return Column(
+      children: [
+        // Enable/disable — reactive via the equalizer's enabledStream
+        // so external mutations (e.g. settings sync, app restart)
+        // reflect here too. Initial value seeded from the persisted
+        // setting so the switch shows the right state before the
+        // first stream emission.
+        StreamBuilder<bool>(
+          stream: eq.enabledStream,
+          initialData: SettingsManager().eqEnabled,
+          builder: (context, snap) {
+            final on = snap.data ?? false;
+            return SwitchListTile(
+              contentPadding: EdgeInsets.symmetric(horizontal: 20),
+              title: Text(
+                'Equalizer',
+                style: TextStyle(
+                    color: VelvetColors.textPrimary,
+                    fontWeight: FontWeight.w600),
+              ),
+              subtitle: Text(
+                on ? 'On — gains applied to playback' : 'Off — bypass mode',
+                style: TextStyle(
+                    color: VelvetColors.textSecondary, fontSize: 12),
+              ),
+              value: on,
+              onChanged: _setEnabled,
+              activeThumbColor: VelvetColors.primary,
+            );
+          },
+        ),
+        Divider(height: 1, color: VelvetColors.border),
+        // dB range labels above the sliders, aligned to the rail
+        // positions (min on the left, 0 in the middle, max on the
+        // right) so the user can read the absolute span at a glance.
+        Padding(
+          padding: EdgeInsets.fromLTRB(20, 14, 20, 0),
+          child: Row(
+            children: [
+              Text(
+                '${p.minDecibels.toStringAsFixed(0)} dB',
+                style: TextStyle(
+                    color: VelvetColors.textTertiary, fontSize: 10),
+              ),
+              Spacer(),
+              Text(
+                '0 dB',
+                style: TextStyle(
+                    color: VelvetColors.textTertiary, fontSize: 10),
+              ),
+              Spacer(),
+              Text(
+                '+${p.maxDecibels.toStringAsFixed(0)} dB',
+                style: TextStyle(
+                    color: VelvetColors.textTertiary, fontSize: 10),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 8),
+            child: Row(
+              children: p.bands
+                  .map((band) => Expanded(child: _buildBandSlider(band, p)))
+                  .toList(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBandSlider(
+      AndroidEqualizerBand band, AndroidEqualizerParameters p) {
+    return StreamBuilder<double>(
+      stream: band.gainStream,
+      initialData: band.gain,
+      builder: (context, snap) {
+        final gain = (snap.data ?? 0).clamp(p.minDecibels, p.maxDecibels);
+        final sign = gain >= 0 ? '+' : '';
+        return Column(
+          children: [
+            SizedBox(height: 12),
+            // Live gain readout in dB — updates as the user drags.
+            Text(
+              '$sign${gain.toStringAsFixed(1)}',
+              style: TextStyle(
+                color: VelvetColors.textPrimary,
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            Text(
+              'dB',
+              style: TextStyle(
+                  color: VelvetColors.textSecondary, fontSize: 9),
+            ),
+            SizedBox(height: 4),
+            // Vertical slider via RotatedBox. Three-quarter rotation
+            // puts "0" at the top and "max gain" at the top — the
+            // standard graphical-EQ orientation.
+            Expanded(
+              child: RotatedBox(
+                quarterTurns: 3,
+                child: SliderTheme(
+                  data: SliderTheme.of(context).copyWith(
+                    activeTrackColor: VelvetColors.primary,
+                    thumbColor: VelvetColors.primary,
+                    inactiveTrackColor: VelvetColors.border,
+                    overlayColor: VelvetColors.primaryDim,
+                    trackHeight: 4,
+                  ),
+                  child: Slider(
+                    value: gain,
+                    min: p.minDecibels,
+                    max: p.maxDecibels,
+                    // setGain is fire-and-forget per drag tick so
+                    // audio responds immediately; gainStream will
+                    // bring the readout above into sync.
+                    onChanged: (v) {
+                      band.setGain(v);
+                    },
+                    onChangeEnd: (_) => _persistGains(),
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(height: 8),
+            Text(
+              _formatFreq(band.centerFrequency),
+              style: TextStyle(
+                color: VelvetColors.textPrimary,
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            Text(
+              'Hz',
+              style: TextStyle(
+                  color: VelvetColors.textSecondary, fontSize: 9),
+            ),
+            SizedBox(height: 12),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/screens/manage_server.dart
+++ b/lib/screens/manage_server.dart
@@ -144,7 +144,7 @@ class ManageServersScreen extends StatelessWidget {
           ),
           backgroundColor: Color(0xFFFFAB00),
         ),
-        body: Row(children: [
+        body: SafeArea(top: false, child: Row(children: [
           Expanded(
               child: SizedBox(
                   child: StreamBuilder<List<Server>>(
@@ -177,7 +177,7 @@ class ManageServersScreen extends StatelessWidget {
                                               context, index)));
                                 }));
                       })))
-        ]));
+        ])));
   }
 }
 

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -18,9 +18,11 @@ class MeteDataScreen extends StatelessWidget {
         appBar: AppBar(
           title: Text("Song Info"),
         ),
-        body: Container(
-            // padding: EdgeInsets.all(20.0),
-            child: ListView(children: [
+        body: SafeArea(
+            top: false,
+            child: Container(
+                // padding: EdgeInsets.all(20.0),
+                child: ListView(children: [
           if (meta.albumArt != null) ...[Image.network(meta.albumArt!)],
           Container(height: 20),
           if (meta.title != null) ...[
@@ -49,6 +51,6 @@ class MeteDataScreen extends StatelessWidget {
                 padding: EdgeInsets.symmetric(horizontal: 20.0),
                 child: Text(path!))
           ]
-        ])));
+        ]))));
   }
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../singletons/settings.dart';
 import '../singletons/transcode.dart';
 import '../theme/velvet_theme.dart';
+import 'eq_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
   @override
@@ -87,6 +88,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 setState(() {});
               },
             ),
+          ),
+          ListTile(
+            leading: Icon(Icons.equalizer, color: VelvetColors.textSecondary),
+            title: Text('Equalizer'),
+            subtitle: Text(
+              'Tune bass, mids, and treble. Android only.',
+              style: TextStyle(
+                  color: VelvetColors.textSecondary, fontSize: 12),
+            ),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => EqScreen()),
+              );
+            },
           ),
           Divider(color: VelvetColors.border, height: 1),
           _sectionHeader('Browse'),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -15,7 +15,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('Settings')),
-      body: ListView(
+      body: SafeArea(
+        top: false,
+        child: ListView(
         children: [
           _sectionHeader('Appearance'),
           ListTile(
@@ -221,6 +223,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             },
           ),
         ],
+      ),
       ),
     );
   }

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -21,6 +21,38 @@ class ApiManager {
     return _instance;
   }
 
+  /// POST /api/v1/db/genres — returns the server's distinct genre
+  /// list with track counts. Used by the AutoDJ screen to populate
+  /// the genre-picker autocomplete.
+  ///
+  /// Each entry is `{ name: String, track_count: int }`.
+  Future<List<Map<String, dynamic>>> getGenres({
+    Server? useThisServer,
+    List<String>? ignoreVPaths,
+  }) async {
+    final server = useThisServer ?? ServerManager().currentServer;
+    if (server == null) throw Exception('No server selected');
+
+    final body = <String, dynamic>{};
+    if (ignoreVPaths != null && ignoreVPaths.isNotEmpty) {
+      body['ignoreVPaths'] = ignoreVPaths;
+    }
+
+    final response = await http.post(
+      Uri.parse(server.url).resolve('/api/v1/db/genres'),
+      body: jsonEncode(body),
+      headers: {
+        'Content-Type': 'application/json',
+        'x-access-token': server.jwt ?? '',
+      },
+    );
+    if (response.statusCode > 299) {
+      throw Exception('Failed to fetch genres (HTTP ${response.statusCode})');
+    }
+    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+    return List<Map<String, dynamic>>.from(decoded['genres'] ?? []);
+  }
+
   /// POST /api/v1/share — creates a share link for [filepaths] on
   /// [server]. [expiresInDays] null means the link never expires.
   /// Returns the raw server response (notably `playlistId`).
@@ -248,7 +280,9 @@ class ApiManager {
           e['metadata']['year'],
           e['metadata']['hash'],
           e['metadata']['rating'],
-          e['metadata']['album-art']);
+          e['metadata']['album-art'],
+          bpm: e['metadata']['bpm'],
+          musicalKey: e['metadata']['musical-key']);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -290,7 +324,9 @@ class ApiManager {
           e['metadata']['year'],
           e['metadata']['hash'],
           e['metadata']['rating'],
-          e['metadata']['album-art']);
+          e['metadata']['album-art'],
+          bpm: e['metadata']['bpm'],
+          musicalKey: e['metadata']['musical-key']);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -330,7 +366,9 @@ class ApiManager {
           e['metadata']['year'],
           e['metadata']['hash'],
           e['metadata']['rating'],
-          e['metadata']['album-art']);
+          e['metadata']['album-art'],
+          bpm: e['metadata']['bpm'],
+          musicalKey: e['metadata']['musical-key']);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -424,7 +462,9 @@ class ApiManager {
           e['metadata']['year'],
           e['metadata']['hash'],
           e['metadata']['rating'],
-          e['metadata']['album-art']);
+          e['metadata']['album-art'],
+          bpm: e['metadata']['bpm'],
+          musicalKey: e['metadata']['musical-key']);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -502,7 +542,9 @@ class ApiManager {
             inner['year'],
             inner['hash'] ?? '',
             inner['rating'],
-            inner['album-art']);
+            inner['album-art'],
+            bpm: inner['bpm'],
+            musicalKey: inner['musical-key']);
       }
 
       newList.add(newItem);

--- a/lib/singletons/auto_dj_manager.dart
+++ b/lib/singletons/auto_dj_manager.dart
@@ -1,0 +1,204 @@
+// App-level AutoDJ configuration.
+//
+// Filters here apply across whichever server is currently driving
+// AutoDJ — they aren't tied to any specific library. (Per-server
+// fields like minRating + vpath inclusion still live on the Server
+// object since those depend on the library.)
+//
+// Persisted to auto_dj.json next to settings.json. Mirrors the
+// webapp's localStorage namespace structurally — same fields, same
+// defaults (everything off), same caps.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+import 'package:rxdart/rxdart.dart';
+
+class AutoDJManager {
+  AutoDJManager._privateConstructor();
+  static final AutoDJManager _instance = AutoDJManager._privateConstructor();
+  factory AutoDJManager() => _instance;
+
+  static const _filename = 'auto_dj.json';
+
+  // Caps mirror webapp/alpha/auto-dj.js — defence against runaway
+  // payloads to /api/v1/db/random-songs (which Joi-validates max 200
+  // genres / max 50 keywords).
+  static const int maxKeywords = 50;
+  static const int maxGenres = 200;
+
+  // Keyword filter — applied client-side after the server responds.
+  // The server doesn't know about this; we retry the request up to
+  // 5 times if responses get blocked.
+  bool keywordFilterEnabled = false;
+  List<String> keywordFilterWords = [];
+
+  // Genre filter — server-side via the `genres` + `genreMode` fields
+  // on POST /api/v1/db/random-songs.
+  bool genreFilterEnabled = false;
+  String genreFilterMode = 'whitelist'; // 'whitelist' | 'blacklist'
+  List<String> genreFilterValues = [];
+
+  // BPM continuity — prefer next picks within ±tolerance of the
+  // currently playing track's BPM. Server-side via `bpmRanges` (a
+  // tight window) plus `bpmRangesWide` (fallback). Tolerance is in
+  // raw BPM units (1–20, default 8 matching the webapp slider).
+  bool bpmContinuityEnabled = false;
+  int bpmTolerance = 8;
+
+  // Harmonic mixing — prefer keys that mix well with the currently
+  // locked Camelot anchor (which AudioPlayerHandler sets from the
+  // first DJ-picked song of a session). Server-side via
+  // `musicalKeys` (anchor + 5 neighbours).
+  bool harmonicMixingEnabled = false;
+
+  // Single "something changed" stream — the AutoDJ screen subscribes
+  // once and rebuilds on each emit. Cheaper than one stream per field
+  // for the small surface area here.
+  final BehaviorSubject<int> _changeStream = BehaviorSubject<int>.seeded(0);
+  int _tick = 0;
+  Stream<int> get changeStream => _changeStream.stream;
+
+  void _notify() {
+    _tick++;
+    _changeStream.add(_tick);
+  }
+
+  Future<File> get _file async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/$_filename');
+  }
+
+  Future<void> load() async {
+    try {
+      final f = await _file;
+      if (!await f.exists()) return;
+      final raw = await f.readAsString();
+      final m = jsonDecode(raw) as Map<String, dynamic>;
+      keywordFilterEnabled = m['keywordFilterEnabled'] ?? false;
+      keywordFilterWords = List<String>.from(m['keywordFilterWords'] ?? []);
+      genreFilterEnabled = m['genreFilterEnabled'] ?? false;
+      genreFilterMode = m['genreFilterMode'] ?? 'whitelist';
+      genreFilterValues = List<String>.from(m['genreFilterValues'] ?? []);
+      bpmContinuityEnabled = m['bpmContinuityEnabled'] ?? false;
+      bpmTolerance = (m['bpmTolerance'] ?? 8).clamp(1, 20);
+      harmonicMixingEnabled = m['harmonicMixingEnabled'] ?? false;
+      _notify();
+    } catch (_) {
+      // Corrupt or missing — defaults stand.
+    }
+  }
+
+  Future<void> _save() async {
+    final f = await _file;
+    await f.writeAsString(jsonEncode({
+      'keywordFilterEnabled': keywordFilterEnabled,
+      'keywordFilterWords': keywordFilterWords,
+      'genreFilterEnabled': genreFilterEnabled,
+      'genreFilterMode': genreFilterMode,
+      'genreFilterValues': genreFilterValues,
+      'bpmContinuityEnabled': bpmContinuityEnabled,
+      'bpmTolerance': bpmTolerance,
+      'harmonicMixingEnabled': harmonicMixingEnabled,
+    }));
+  }
+
+  // --- Keyword filter ---
+
+  Future<void> setKeywordFilterEnabled(bool v) async {
+    keywordFilterEnabled = v;
+    _notify();
+    await _save();
+  }
+
+  Future<void> addKeyword(String word) async {
+    final trimmed = word.trim();
+    if (trimmed.isEmpty) return;
+    if (keywordFilterWords.contains(trimmed)) return;
+    if (keywordFilterWords.length >= maxKeywords) return;
+    keywordFilterWords.add(trimmed);
+    _notify();
+    await _save();
+  }
+
+  Future<void> removeKeyword(String word) async {
+    keywordFilterWords.remove(word);
+    _notify();
+    await _save();
+  }
+
+  // --- Genre filter ---
+
+  Future<void> setGenreFilterEnabled(bool v) async {
+    genreFilterEnabled = v;
+    _notify();
+    await _save();
+  }
+
+  Future<void> setGenreFilterMode(String mode) async {
+    if (mode != 'whitelist' && mode != 'blacklist') return;
+    genreFilterMode = mode;
+    _notify();
+    await _save();
+  }
+
+  Future<void> addGenre(String genre) async {
+    final trimmed = genre.trim();
+    if (trimmed.isEmpty) return;
+    if (genreFilterValues.contains(trimmed)) return;
+    if (genreFilterValues.length >= maxGenres) return;
+    genreFilterValues.add(trimmed);
+    _notify();
+    await _save();
+  }
+
+  Future<void> removeGenre(String genre) async {
+    genreFilterValues.remove(genre);
+    _notify();
+    await _save();
+  }
+
+  // --- BPM continuity & harmonic mixing ---
+
+  Future<void> setBpmContinuityEnabled(bool v) async {
+    bpmContinuityEnabled = v;
+    _notify();
+    await _save();
+  }
+
+  Future<void> setBpmTolerance(int v) async {
+    bpmTolerance = v.clamp(1, 20);
+    _notify();
+    await _save();
+  }
+
+  Future<void> setHarmonicMixingEnabled(bool v) async {
+    harmonicMixingEnabled = v;
+    _notify();
+    await _save();
+  }
+
+  // Returns true if the song should be skipped per the client-side
+  // keyword filter. Matches webapp behaviour: checks title/artist/
+  // album/filepath joined and lowercased against the keyword list.
+  bool isKeywordBlocked(Map<String, dynamic> song) {
+    if (!keywordFilterEnabled || keywordFilterWords.isEmpty) return false;
+    final meta = (song['metadata'] as Map?) ?? const {};
+    final haystack = [
+      meta['title'] ?? '',
+      meta['artist'] ?? '',
+      meta['album'] ?? '',
+      song['filepath'] ?? '',
+    ].join(' ').toLowerCase();
+    for (final word in keywordFilterWords) {
+      if (haystack.contains(word.toLowerCase())) return true;
+    }
+    return false;
+  }
+
+  void dispose() {
+    _changeStream.close();
+  }
+}

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -59,6 +59,12 @@ class SettingsManager {
   int letterStripThreshold = 25;
   TapBehavior tapBehavior = TapBehavior.addToQueue;
   AppTheme appTheme = AppTheme.velvet;
+  // Android-only equalizer state. Empty gains list means "apply nothing"
+  // (device defaults / flat). Gains are in dB; the valid range and band
+  // count are device-dependent and discovered at runtime via
+  // AndroidEqualizer.parameters.
+  bool eqEnabled = false;
+  List<double> eqBandGains = const [];
 
   late final BehaviorSubject<bool> _albumGridStream =
       BehaviorSubject<bool>.seeded(albumGrid);
@@ -86,6 +92,11 @@ class SettingsManager {
       letterStripThreshold = m['letterStripThreshold'] ?? 25;
       tapBehavior = _readTapBehavior(m);
       appTheme = _readTheme(m);
+      eqEnabled = m['eqEnabled'] ?? false;
+      final rawGains = m['eqBandGains'];
+      eqBandGains = rawGains is List
+          ? rawGains.whereType<num>().map((n) => n.toDouble()).toList()
+          : const [];
       _albumGridStream.add(albumGrid);
       _letterStripStream.add(letterStripThreshold);
       _themeStream.add(appTheme);
@@ -128,6 +139,8 @@ class SettingsManager {
       'letterStripThreshold': letterStripThreshold,
       'tapBehavior': tapBehavior.name,
       'theme': appTheme.name,
+      'eqEnabled': eqEnabled,
+      'eqBandGains': eqBandGains,
     }));
   }
 
@@ -164,6 +177,16 @@ class SettingsManager {
     await _save();
   }
 
+  Future<void> setEqEnabled(bool v) async {
+    eqEnabled = v;
+    await _save();
+  }
+
+  Future<void> setEqBandGains(List<double> v) async {
+    eqBandGains = v;
+    await _save();
+  }
+
   Future<void> resetAll() async {
     TranscodeManager().transcodeOn = false;
     albumGrid = true;
@@ -171,6 +194,8 @@ class SettingsManager {
     letterStripThreshold = 25;
     tapBehavior = TapBehavior.addToQueue;
     appTheme = AppTheme.velvet;
+    eqEnabled = false;
+    eqBandGains = const [];
     _albumGridStream.add(albumGrid);
     _letterStripStream.add(letterStripThreshold);
     _themeStream.add(appTheme);

--- a/lib/singletons/sleep_timer.dart
+++ b/lib/singletons/sleep_timer.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+
+import 'media.dart';
+
+/// Session-only countdown that pauses playback when it fires. Not
+/// persisted — sleep timers shouldn't survive an app restart (waking
+/// up to yesterday's 30-minute timer firing mid-song is hostile).
+class SleepTimerManager {
+  SleepTimerManager._privateConstructor();
+  static final SleepTimerManager _instance =
+      SleepTimerManager._privateConstructor();
+  factory SleepTimerManager() => _instance;
+
+  Timer? _ticker;
+  DateTime? _endsAt;
+
+  // null = inactive. Non-null = remaining time, refreshed every second
+  // so the picker sheet can show a live countdown.
+  final BehaviorSubject<Duration?> _remaining =
+      BehaviorSubject<Duration?>.seeded(null);
+
+  Stream<Duration?> get remainingStream => _remaining.stream;
+  Duration? get remaining => _remaining.value;
+  bool get active => _ticker != null;
+
+  void start(Duration d) {
+    cancel();
+    final ends = DateTime.now().add(d);
+    _endsAt = ends;
+    _remaining.add(d);
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+      final left = ends.difference(DateTime.now());
+      if (left.inMilliseconds <= 0) {
+        _fire();
+      } else {
+        _remaining.add(left);
+      }
+    });
+  }
+
+  void cancel() {
+    _ticker?.cancel();
+    _ticker = null;
+    _endsAt = null;
+    _remaining.add(null);
+  }
+
+  void _fire() {
+    _ticker?.cancel();
+    _ticker = null;
+    _endsAt = null;
+    _remaining.add(null);
+    MediaManager().audioHandler.pause();
+  }
+
+  void dispose() {
+    _ticker?.cancel();
+    _remaining.close();
+  }
+}

--- a/lib/util/camelot.dart
+++ b/lib/util/camelot.dart
@@ -1,0 +1,87 @@
+// Camelot wheel utilities for harmonic-mixing AutoDJ.
+//
+// The Camelot wheel encodes the 24 musical keys (12 major + 12
+// minor) as positions 1–12, with A = minor and B = major. Tracks
+// in keys that are "neighbours" on the wheel mix harmonically:
+// same number (relative major/minor), ±1 same letter (perfect 5th
+// up/down), or ±1 opposite letter (energy-shift mixes).
+//
+// The mStream server's POST /api/v1/db/random-songs accepts Camelot
+// codes ("8A", "12B") in the `musicalKeys` field and expands each
+// internally to the raw key spellings it might find in the library
+// (so "8A" matches songs tagged "8A" or "A minor" or "Amin" or
+// "Am"). The reverse — raw → Camelot — has to happen client-side
+// because the server only accepts codes, not raw keys.
+
+/// Common raw key strings to their Camelot wheel codes. Keys here
+/// are case-sensitive — callers should pass keys verbatim from the
+/// server response. Library tags in practice come back as short
+/// forms like "Am" / "C" / "F#m"; the long forms ("A minor", etc.)
+/// are included for robustness.
+const Map<String, String> _rawKeyToCamelot = {
+  // Minor keys — A side of the wheel
+  'G#m': '1A', 'Abm': '1A', 'G# minor': '1A', 'Ab minor': '1A',
+  'D#m': '2A', 'Ebm': '2A', 'D# minor': '2A', 'Eb minor': '2A',
+  'A#m': '3A', 'Bbm': '3A', 'A# minor': '3A', 'Bb minor': '3A',
+  'Fm': '4A', 'F minor': '4A', 'Fmin': '4A',
+  'Cm': '5A', 'C minor': '5A', 'Cmin': '5A',
+  'Gm': '6A', 'G minor': '6A', 'Gmin': '6A',
+  'Dm': '7A', 'D minor': '7A', 'Dmin': '7A',
+  'Am': '8A', 'A minor': '8A', 'Amin': '8A',
+  'Em': '9A', 'E minor': '9A', 'Emin': '9A',
+  'Bm': '10A', 'B minor': '10A', 'Bmin': '10A',
+  'F#m': '11A', 'Gbm': '11A', 'F# minor': '11A', 'Gb minor': '11A',
+  'C#m': '12A', 'Dbm': '12A', 'C# minor': '12A', 'Db minor': '12A',
+
+  // Major keys — B side of the wheel
+  'B': '1B', 'B major': '1B', 'Bmaj': '1B',
+  'F#': '2B', 'Gb': '2B', 'F# major': '2B', 'Gb major': '2B',
+  'C#': '3B', 'Db': '3B', 'C# major': '3B', 'Db major': '3B',
+  'G#': '4B', 'Ab': '4B', 'G# major': '4B', 'Ab major': '4B',
+  'D#': '5B', 'Eb': '5B', 'D# major': '5B', 'Eb major': '5B',
+  'A#': '6B', 'Bb': '6B', 'A# major': '6B', 'Bb major': '6B',
+  'F': '7B', 'F major': '7B', 'Fmaj': '7B',
+  'C': '8B', 'C major': '8B', 'Cmaj': '8B',
+  'G': '9B', 'G major': '9B', 'Gmaj': '9B',
+  'D': '10B', 'D major': '10B', 'Dmaj': '10B',
+  'A': '11B', 'A major': '11B', 'Amaj': '11B',
+  'E': '12B', 'E major': '12B', 'Emaj': '12B',
+};
+
+final RegExp _camelotRe = RegExp(r'^([1-9]|1[0-2])[AB]$');
+
+/// Returns the Camelot code (e.g. "8A") for [raw], or null if the
+/// raw key isn't recognised. Strings that already look like Camelot
+/// codes pass through unchanged.
+String? toCamelotCode(String? raw) {
+  if (raw == null) return null;
+  final trimmed = raw.trim();
+  if (trimmed.isEmpty) return null;
+  if (_camelotRe.hasMatch(trimmed)) return trimmed;
+  return _rawKeyToCamelot[trimmed];
+}
+
+/// Returns the 6 Camelot codes that mix harmonically with [anchor]:
+/// the anchor itself, ±1 on the same letter (perfect-fifth moves),
+/// the opposite letter at the same number (relative major/minor),
+/// and ±1 on the opposite letter (energy shifts). Wraps around the
+/// 12/1 boundary.
+///
+/// Returns [anchor] alone if it isn't a valid Camelot code.
+List<String> camelotNeighbours(String anchor) {
+  final match = _camelotRe.firstMatch(anchor);
+  if (match == null) return [anchor];
+  final n = int.parse(match.group(1)!);
+  final letter = match.group(2)!;
+  final prev = n == 1 ? 12 : n - 1;
+  final next = n == 12 ? 1 : n + 1;
+  final other = letter == 'A' ? 'B' : 'A';
+  return [
+    '$n$letter',
+    '$prev$letter',
+    '$next$letter',
+    '$n$other',
+    '$prev$other',
+    '$next$other',
+  ];
+}

--- a/lib/widgets/sleep_timer_sheet.dart
+++ b/lib/widgets/sleep_timer_sheet.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+
+import '../singletons/sleep_timer.dart';
+import '../theme/velvet_theme.dart';
+
+class SleepTimerSheet extends StatelessWidget {
+  static const _presets = <int>[15, 30, 45, 60, 90];
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.bedtime, color: VelvetColors.primary),
+                const SizedBox(width: 10),
+                Text(
+                  'Sleep timer',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                    color: VelvetColors.textPrimary,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            StreamBuilder<Duration?>(
+              stream: SleepTimerManager().remainingStream,
+              initialData: SleepTimerManager().remaining,
+              builder: (context, snapshot) {
+                final d = snapshot.data;
+                return Text(
+                  d == null
+                      ? 'Pick a duration to pause playback after.'
+                      : 'Pauses in ${_format(d)}',
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: VelvetColors.textSecondary,
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: _presets
+                  .map((m) => _PresetChip(minutes: m))
+                  .toList(),
+            ),
+            const SizedBox(height: 12),
+            StreamBuilder<Duration?>(
+              stream: SleepTimerManager().remainingStream,
+              initialData: SleepTimerManager().remaining,
+              builder: (context, snapshot) {
+                if (snapshot.data == null) return const SizedBox.shrink();
+                return Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton.icon(
+                    icon: Icon(Icons.close, color: VelvetColors.textSecondary),
+                    label: Text(
+                      'Cancel timer',
+                      style: TextStyle(color: VelvetColors.textSecondary),
+                    ),
+                    onPressed: () {
+                      SleepTimerManager().cancel();
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _format(Duration d) {
+    final m = d.inMinutes;
+    final s = d.inSeconds % 60;
+    return '$m:${s.toString().padLeft(2, '0')}';
+  }
+}
+
+class _PresetChip extends StatelessWidget {
+  final int minutes;
+  const _PresetChip({required this.minutes});
+
+  @override
+  Widget build(BuildContext context) {
+    return ActionChip(
+      label: Text('$minutes min'),
+      backgroundColor: VelvetColors.surface,
+      labelStyle: TextStyle(color: VelvetColors.textPrimary),
+      side: BorderSide(color: VelvetColors.border),
+      onPressed: () {
+        SleepTimerManager().start(Duration(minutes: minutes));
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Sleep timer set for $minutes minutes')),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/sleep_timer_sheet.dart
+++ b/lib/widgets/sleep_timer_sheet.dart
@@ -1,82 +1,162 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../singletons/sleep_timer.dart';
 import '../theme/velvet_theme.dart';
 
-class SleepTimerSheet extends StatelessWidget {
+class SleepTimerSheet extends StatefulWidget {
   static const _presets = <int>[15, 30, 45, 60, 90];
 
   @override
+  State<SleepTimerSheet> createState() => _SleepTimerSheetState();
+}
+
+class _SleepTimerSheetState extends State<SleepTimerSheet> {
+  final TextEditingController _customCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _customCtrl.dispose();
+    super.dispose();
+  }
+
+  void _startMinutes(int minutes) {
+    SleepTimerManager().start(Duration(minutes: minutes));
+    Navigator.of(context).pop();
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Sleep timer set for $minutes minutes')),
+    );
+  }
+
+  void _startCustom() {
+    final raw = _customCtrl.text.trim();
+    final mins = int.tryParse(raw);
+    if (mins == null || mins < 1 || mins > 600) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content: Text('Enter a number between 1 and 600 minutes')),
+      );
+      return;
+    }
+    _startMinutes(mins);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Icon(Icons.bedtime, color: VelvetColors.primary),
-                const SizedBox(width: 10),
-                Text(
-                  'Sleep timer',
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.w600,
-                    color: VelvetColors.textPrimary,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 4),
-            StreamBuilder<Duration?>(
-              stream: SleepTimerManager().remainingStream,
-              initialData: SleepTimerManager().remaining,
-              builder: (context, snapshot) {
-                final d = snapshot.data;
-                return Text(
-                  d == null
-                      ? 'Pick a duration to pause playback after.'
-                      : 'Pauses in ${_format(d)}',
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: VelvetColors.textSecondary,
-                  ),
-                );
-              },
-            ),
-            const SizedBox(height: 16),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: _presets
-                  .map((m) => _PresetChip(minutes: m))
-                  .toList(),
-            ),
-            const SizedBox(height: 12),
-            StreamBuilder<Duration?>(
-              stream: SleepTimerManager().remainingStream,
-              initialData: SleepTimerManager().remaining,
-              builder: (context, snapshot) {
-                if (snapshot.data == null) return const SizedBox.shrink();
-                return Align(
-                  alignment: Alignment.centerRight,
-                  child: TextButton.icon(
-                    icon: Icon(Icons.close, color: VelvetColors.textSecondary),
-                    label: Text(
-                      'Cancel timer',
-                      style: TextStyle(color: VelvetColors.textSecondary),
+    // viewInsets.bottom = on-screen keyboard height (0 when hidden).
+    // Padding here pushes the sheet's content above the keyboard so
+    // the custom-time TextField stays visible while typing.
+    return Padding(
+      padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.bedtime, color: VelvetColors.primary),
+                  const SizedBox(width: 10),
+                  Text(
+                    'Sleep timer',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                      color: VelvetColors.textPrimary,
                     ),
-                    onPressed: () {
-                      SleepTimerManager().cancel();
-                      Navigator.of(context).pop();
-                    },
                   ),
-                );
-              },
-            ),
-          ],
+                ],
+              ),
+              const SizedBox(height: 4),
+              StreamBuilder<Duration?>(
+                stream: SleepTimerManager().remainingStream,
+                initialData: SleepTimerManager().remaining,
+                builder: (context, snapshot) {
+                  final d = snapshot.data;
+                  return Text(
+                    d == null
+                        ? 'Pick a duration to pause playback after.'
+                        : 'Pauses in ${_format(d)}',
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: VelvetColors.textSecondary,
+                    ),
+                  );
+                },
+              ),
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: SleepTimerSheet._presets
+                    .map((m) => _PresetChip(
+                          minutes: m,
+                          onTap: () => _startMinutes(m),
+                        ))
+                    .toList(),
+              ),
+              const SizedBox(height: 16),
+              // Custom-minutes row. TextField + Start; Enter on the
+              // soft keyboard also fires Start. Validation message
+              // shown via a SnackBar so the input row stays tidy.
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _customCtrl,
+                      keyboardType: TextInputType.number,
+                      inputFormatters: [
+                        FilteringTextInputFormatter.digitsOnly,
+                      ],
+                      textInputAction: TextInputAction.done,
+                      onSubmitted: (_) => _startCustom(),
+                      decoration: InputDecoration(
+                        labelText: 'Custom',
+                        hintText: 'minutes (1–600)',
+                        isDense: true,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  TextButton.icon(
+                    onPressed: _startCustom,
+                    icon: Icon(Icons.play_arrow, size: 18),
+                    label: Text('Start'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: VelvetColors.primary,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              StreamBuilder<Duration?>(
+                stream: SleepTimerManager().remainingStream,
+                initialData: SleepTimerManager().remaining,
+                builder: (context, snapshot) {
+                  if (snapshot.data == null) return const SizedBox.shrink();
+                  return Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton.icon(
+                      icon: Icon(Icons.close,
+                          color: VelvetColors.textSecondary),
+                      label: Text(
+                        'Cancel timer',
+                        style: TextStyle(color: VelvetColors.textSecondary),
+                      ),
+                      onPressed: () {
+                        SleepTimerManager().cancel();
+                        Navigator.of(context).pop();
+                      },
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -91,7 +171,8 @@ class SleepTimerSheet extends StatelessWidget {
 
 class _PresetChip extends StatelessWidget {
   final int minutes;
-  const _PresetChip({required this.minutes});
+  final VoidCallback onTap;
+  const _PresetChip({required this.minutes, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -100,13 +181,7 @@ class _PresetChip extends StatelessWidget {
       backgroundColor: VelvetColors.surface,
       labelStyle: TextStyle(color: VelvetColors.textPrimary),
       side: BorderSide(color: VelvetColors.border),
-      onPressed: () {
-        SleepTimerManager().start(Duration(minutes: minutes));
-        Navigator.of(context).pop();
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Sleep timer set for $minutes minutes')),
-        );
-      },
+      onPressed: onTap,
     );
   }
 }


### PR DESCRIPTION
## Summary

Six commits ahead of master, all landed on `release-prep` to be reviewed before cutting the next official release. Three feature additions and one cross-cutting UX pass.

## AutoDJ Phase 2 — continuity controls (`fc27ae2`)

Parity with the webapp's BPM continuity + harmonic mixing toggles.

- New \`lib/util/camelot.dart\` — raw-key (e.g. \`Am\`, \`F#\`) → Camelot code mapping, plus \`camelotNeighbours(anchor)\` returning the 6 harmonically-mixable codes with 12/1 wraparound
- \`MusicMetadata\` gains \`bpm\` + \`musicalKey\` fields, parsed kebab-case off the wire (\`musical-key\` → \`musicalKey\`) at every \`api.dart\` MediaItem build site (5 endpoints)
- Browser's \`_buildFileItem\` passes both through to \`MediaItem.extras\` so AutoDJ can read them off the currently playing track
- \`AutoDJManager\` gains \`bpmContinuityEnabled\`, \`bpmTolerance\` (1–20, default 8), \`harmonicMixingEnabled\` with JSON round-trip in \`auto_dj.json\`
- \`autoDJ()\` reads current track's bpm/musicalKey once per call. With BPM continuity on, sends three OR'd \`bpmRanges\` (normal/half/double tempo) plus \`bpmRangesWide\` fallback with \`requireBpm: true\`. With harmonic mixing on, sends \`musicalKeys\` = anchor + 5 neighbours with \`requireMusicalKey: true\`. Camelot anchor locks on the first DJ pick of a session and resets when \`setAutoDJ\` toggles off or switches servers.
- New \`Continuity\` section in the AutoDJ screen between Sources and Filters, with BPM toggle + tolerance slider + Harmonic toggle.

Same commit also bundles the **sleep timer plumbing** added by another agent (\`SleepTimerManager\`, sheet, BottomBar IconButton) — bundled because their main.dart hunks interleaved with the AutoDJManager load() addition and couldn't be cleanly separated.

## EQ UI — real implementation (\`807b608\`)

The other agent shipped the audio plumbing (\`AndroidEqualizer\` attached to the player's \`AudioPipeline\`, \`SettingsManager.eqEnabled\` / \`eqBandGains\` persistence) with a placeholder \`EqScreen\` stub. This commit fills it in:

- Enable/disable \`SwitchListTile\` bound to \`equalizer.enabledStream\`
- dB range strip showing min / 0 / +max from \`AndroidEqualizerParameters\`
- One vertical slider per band (rotated -90°, classic graphic-EQ orientation) with live gain readout above (\`+3.5 dB\`) and centre frequency label below (\`60\`, \`230\`, \`1k\`, \`14k\`)
- **Reset** action in the AppBar that zeroes all bands
- Persistence: gains write to \`settings.json\` on \`onChangeEnd\` (slider release), not on every drag tick — avoids JSON thrashing
- Graceful fallbacks for non-Android, parameters fetch failure, and zero-band devices

## EQ UI — timeout + auto-retry (\`70468d6\`)

\`AndroidEqualizer.parameters\` only resolves once the native audio session is alive. Opening the EQ with an idle queue used to spin forever.

- 3-second timeout on the parameter fetch
- On timeout, replaces the spinner with \`"Start a song to configure the EQ..."\`
- Subscribes to \`audioHandler.playbackState\`; if processingState leaves \`idle\` while the screen is open, auto-retries the parameter fetch so the bands populate without backing out

## Sleep timer — custom input (\`c6c56d4\`)

The agent's initial sheet exposed five preset chips (15/30/45/60/90 min). This adds custom-duration entry.

- \`SleepTimerSheet\` converted to \`StatefulWidget\`
- New row: TextField (digits-only, 1–600 minutes) + Start button. Soft-keyboard Enter also fires Start
- Validation via SnackBar instead of inline UI clutter
- Sheet wrapped in \`Padding(EdgeInsets.only(bottom: MediaQuery.viewInsets.bottom))\` so the keyboard doesn't shove the input offscreen
- Caller in \`main.dart\` updated to \`isScrollControlled: true\` so the sheet isn't capped at half-screen height when the keyboard appears
- Preset chips and custom-start button share a single \`_startMinutes(int)\` path (consistent toast wording + dismiss behaviour)

## SafeArea audit pass (\`c59c669\`)

Following the same fix applied to AutoDJ for the keyword filter being unreachable under the system gesture/nav bar, swept the other drawer-pushed screens:

| Screen | Bottom content that was at risk |
|---|---|
| About | Discord / GitHub / homepage tappable rows |
| Settings | "Reset to defaults" + Letter-scrubber slider |
| Downloads | Tail of download list |
| Song Info | Long file path text |
| Manage Servers | Tail of server list (FAB was already safe-area-aware) |

Skipped: \`eq_screen\` (centered text, never reaches bottom), \`playlists_screen\` (already has 96px bottom padding for the FAB), Browser/Queue tabs (inside main Scaffold's \`bottomNavigationBar\`), Add Server (already wrapped earlier).

## EQ plumbing (\`90dc502\`)

Landed earlier by another agent; included in this PR's range because release-prep was branched from before it merged to master. Adds \`AndroidEqualizer\` to the audio pipeline, persistence fields, and a placeholder screen.

## Test plan

- [ ] **AutoDJ → Continuity** — toggle BPM continuity, drag tolerance, queue something with BPM tags, let AutoDJ pick → next picks should hover near current tempo
- [ ] **AutoDJ → Harmonic** — play a song with a recognised key, AutoDJ next pick should be in a neighbouring Camelot key. Toggle AutoDJ off → on to reset anchor
- [ ] **AutoDJ chip overflow** — add a long genre, verify chip ellipses don't break the row
- [ ] **AutoDJ keyword filter** — confirm it's reachable above the system gesture bar
- [ ] **EQ with audio playing** — open Settings → Equalizer → bands render immediately, drag sliders, hear change, restart app, gains persist
- [ ] **EQ with idle queue** — open Settings → Equalizer → after 3s, message replaces spinner. Queue + play a song without closing → bands populate
- [ ] **Sleep timer custom** — open sheet, type a number, hit Start. Try invalid input (0, 9999, empty) → SnackBar
- [ ] **SafeArea pass** — About, Settings, Downloads, Song Info, Manage Servers — confirm bottom content is reachable above the system nav bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)