### PR TITLE
Shadertoy shader engine + 9 audio-reactive shaders

### DIFF
--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -1,16 +1,19 @@
 # Native bridge for the projectM visualizer. Produces
 # libvisualizer_bridge.so which exports JNI methods that the Kotlin
 # VisualizerBridge calls — those JNI methods own the EGL context and
-# call into libprojectM-4.so to render frames.
+# delegate per-frame work to an Engine instance (ProjectMEngine or
+# ShaderEngine).
 #
 # libprojectM-4.so itself is prebuilt and lives in jniLibs/<abi>/. We
 # IMPORT it here so CMake can link against it without rebuilding.
+# Shader engine has no external deps beyond GLES/EGL.
 
 cmake_minimum_required(VERSION 3.10)
-project(visualizer_bridge LANGUAGES CXX)
+project(visualizer_bridge LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 99)
 
 # Locate the prebuilt libprojectM-4.so for the current ABI.
 set(PROJECTM_LIB_PATH
@@ -20,10 +23,25 @@ add_library(projectM-4 SHARED IMPORTED)
 set_target_properties(projectM-4 PROPERTIES
     IMPORTED_LOCATION ${PROJECTM_LIB_PATH})
 
-# Our bridge .so.
-add_library(visualizer_bridge SHARED visualizer_bridge.cpp)
+# Vendored KissFFT (BSD-3-Clause) — compiled as part of the bridge so
+# we don't ship a separate .so. -DFIXED_POINT=0 -DKISS_FFT_USE_SINGLE
+# selects the float32 build.
+add_library(visualizer_bridge SHARED
+    visualizer_bridge.cpp
+    projectm_engine.cpp
+    shader_engine.cpp
+    audio_texture.cpp
+    kissfft/kiss_fft.c
+    kissfft/kiss_fftr.c)
 
-target_include_directories(visualizer_bridge PRIVATE include)
+target_include_directories(visualizer_bridge PRIVATE
+    include
+    kissfft)
+
+# KissFFT uses `kiss_fft_scalar` typedef'd to float by default. We
+# silence its log macros (which would otherwise pull in fprintf).
+target_compile_definitions(visualizer_bridge PRIVATE
+    kiss_fft_scalar=float)
 
 target_link_libraries(visualizer_bridge
     PRIVATE

--- a/android/app/src/main/cpp/audio_texture.cpp
+++ b/android/app/src/main/cpp/audio_texture.cpp
@@ -1,0 +1,115 @@
+#include "audio_texture.h"
+
+#include "kissfft/kiss_fftr.h"
+
+#include <android/log.h>
+#include <cmath>
+#include <cstring>
+
+#define LOG_TAG "mstream/viz-bridge"
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+AudioTexture::AudioTexture()
+    : windowed_(FFT_SIZE, 0.0f),
+      hannWindow_(FFT_SIZE, 0.0f),
+      texBytes_(BINS * 2, 0) {
+    // Precompute the Hann window. Used to taper the FFT input so we
+    // don't get spectral leakage from the rectangular edges.
+    for (int i = 0; i < FFT_SIZE; ++i) {
+        hannWindow_[i] =
+            0.5f * (1.0f - std::cos(2.0f * 3.14159265358979f *
+                                     static_cast<float>(i) /
+                                     static_cast<float>(FFT_SIZE - 1)));
+    }
+}
+
+AudioTexture::~AudioTexture() {
+    dispose();
+}
+
+bool AudioTexture::init() {
+    fft_ = kiss_fftr_alloc(FFT_SIZE, 0 /*inverse=false*/, nullptr, nullptr);
+    if (!fft_) {
+        LOGE("kiss_fftr_alloc failed");
+        return false;
+    }
+
+    glGenTextures(1, &tex_);
+    glBindTexture(GL_TEXTURE_2D, tex_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, BINS, 2, 0, GL_RED,
+                  GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    return true;
+}
+
+void AudioTexture::dispose() {
+    if (tex_) {
+        glDeleteTextures(1, &tex_);
+        tex_ = 0;
+    }
+    if (fft_) {
+        kiss_fftr_free(fft_);
+        fft_ = nullptr;
+    }
+}
+
+void AudioTexture::addPcm(const float* samples, std::size_t frameCount) {
+    if (!samples || frameCount == 0) return;
+    // Mix L+R to mono and write into the ring.
+    for (std::size_t i = 0; i < frameCount; ++i) {
+        const float mono = 0.5f * (samples[2 * i] + samples[2 * i + 1]);
+        ring_[ringHead_] = mono;
+        ringHead_ = (ringHead_ + 1) % RING_SIZE;
+    }
+}
+
+GLuint AudioTexture::upload() {
+    if (!tex_ || !fft_) return 0;
+
+    // Pull the most recent FFT_SIZE samples from the ring (in order).
+    // ringHead_ points at the next write slot, so the newest sample is
+    // at (ringHead_ - 1) and the oldest of the FFT window is at
+    // (ringHead_ - FFT_SIZE).
+    const std::size_t start = (ringHead_ + RING_SIZE - FFT_SIZE) % RING_SIZE;
+    for (int i = 0; i < FFT_SIZE; ++i) {
+        const float s = ring_[(start + i) % RING_SIZE];
+        windowed_[i] = s * hannWindow_[i];
+    }
+
+    // Real FFT — outputs FFT_SIZE/2 + 1 complex bins. We use the first
+    // BINS (== FFT_SIZE/2), drop the DC bin convention's mirroring.
+    kiss_fft_cpx out[BINS + 1];
+    kiss_fftr(fft_, windowed_.data(), out);
+
+    // Magnitude → 0..255. Empirical scale to spread typical music
+    // amplitudes across the byte range without aggressive clipping;
+    // shaders can scale up further. log1p compresses dynamic range
+    // similar to what Shadertoy's audio channel does.
+    for (int i = 0; i < BINS; ++i) {
+        const float re = out[i].r;
+        const float im = out[i].i;
+        const float mag = std::sqrt(re * re + im * im);
+        const float compressed = std::log1p(mag * 4.0f) * 0.4f;
+        const float clamped = compressed > 1.0f ? 1.0f : compressed;
+        texBytes_[i] = static_cast<uint8_t>(clamped * 255.0f);
+    }
+
+    // Waveform row — most recent BINS samples mapped from [-1,1] to [0,255].
+    const std::size_t waveStart =
+        (ringHead_ + RING_SIZE - BINS) % RING_SIZE;
+    for (int i = 0; i < BINS; ++i) {
+        const float s = ring_[(waveStart + i) % RING_SIZE];
+        const float n = 0.5f + 0.5f * (s > 1.0f ? 1.0f : (s < -1.0f ? -1.0f : s));
+        texBytes_[BINS + i] = static_cast<uint8_t>(n * 255.0f);
+    }
+
+    glBindTexture(GL_TEXTURE_2D, tex_);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, BINS, 2, GL_RED,
+                     GL_UNSIGNED_BYTE, texBytes_.data());
+    return tex_;
+}

--- a/android/app/src/main/cpp/audio_texture.h
+++ b/android/app/src/main/cpp/audio_texture.h
@@ -1,0 +1,60 @@
+// Builds the 512×2 R8 audio texture that Shadertoy-convention shaders
+// sample via iChannel0. Row 0 (bottom) holds an FFT magnitude
+// spectrum; row 1 (top) holds the recent raw waveform.
+//
+// Sampling convention (Shadertoy):
+//   texture(iChannel0, vec2(freq, 0.25)).r  →  FFT at frequency bin freq
+//   texture(iChannel0, vec2(t,    0.75)).r  →  Waveform sample at offset t
+//
+// PCM in is interleaved stereo. We mix L+R to mono and keep a 2048-
+// sample ring buffer; per upload, we take the most recent 1024 samples,
+// window them, FFT, and write 512 mag bins + 512 waveform samples.
+
+#pragma once
+
+#include <GLES3/gl3.h>
+#include <cstddef>
+#include <vector>
+
+struct kiss_fftr_state;
+typedef struct kiss_fftr_state* kiss_fftr_cfg;
+
+class AudioTexture {
+public:
+    static constexpr int FFT_SIZE = 1024;   // power of 2, real-FFT input
+    static constexpr int BINS = 512;        // FFT_SIZE / 2 — width of texture
+    static constexpr int RING_SIZE = 2048;  // rolling mono buffer
+
+    AudioTexture();
+    ~AudioTexture();
+
+    // Allocates the GL texture + FFT state. Requires a current EGL context.
+    bool init();
+    void dispose();
+
+    // Push interleaved stereo PCM. Frames are L,R pairs. Thread-safe
+    // against `upload()` only at the level of "atomic write index";
+    // we expect the caller (render thread) to call both from the same
+    // thread.
+    void addPcm(const float* samples, std::size_t frameCount);
+
+    // Run FFT on the latest window and upload the texture. Call once
+    // per frame. Returns the GL texture name.
+    GLuint upload();
+
+    GLuint texture() const { return tex_; }
+
+private:
+    GLuint tex_ = 0;
+    kiss_fftr_cfg fft_ = nullptr;
+
+    // Ring buffer of mono samples (L+R mixed, /2). Older samples
+    // overwritten as new ones arrive.
+    float ring_[RING_SIZE]{};
+    std::size_t ringHead_ = 0;
+
+    // Scratch buffers reused per upload.
+    std::vector<float> windowed_;     // FFT_SIZE
+    std::vector<float> hannWindow_;   // FFT_SIZE, precomputed
+    std::vector<uint8_t> texBytes_;   // BINS * 2 (one row of FFT, one of waveform)
+};

--- a/android/app/src/main/cpp/engine.h
+++ b/android/app/src/main/cpp/engine.h
@@ -1,0 +1,37 @@
+// Abstract visualizer engine. Owned by the JNI bridge, called from
+// the Kotlin render thread (with EGL context already current).
+//
+// Concrete engines:
+//   * ProjectMEngine — wraps libprojectM-4.so (Milkdrop presets)
+//   * ShaderEngine   — Shadertoy-style fragment shaders with our own
+//                       FFT pipeline and audio texture
+//
+// All engine methods run on the dedicated render thread. The bridge
+// guarantees the EGL context is current before calling any of them.
+
+#pragma once
+
+#include <cstddef>
+
+class Engine {
+public:
+    virtual ~Engine() = default;
+
+    // Called once after EGL is set up. Return false to abort init.
+    virtual bool init(int width, int height) = 0;
+
+    // Called every frame. Implementations issue GL draw calls; the
+    // bridge handles eglSwapBuffers after this returns.
+    virtual void renderFrame() = 0;
+
+    // Push interleaved stereo PCM into whatever the engine uses for
+    // audio reactivity. Engines are free to ignore.
+    //   samples: interleaved L,R,L,R… in [-1, 1]
+    //   frameCount: number of L/R pairs (so samples has 2*frameCount floats)
+    virtual void addPcm(const float* samples, std::size_t frameCount) = 0;
+
+    // Switch to a new preset/shader. Format is engine-specific:
+    //   ProjectM: .milk file contents
+    //   Shader:   GLSL fragment shader (Shadertoy "mainImage" convention)
+    virtual void loadPreset(const char* data, bool smoothTransition) = 0;
+};

--- a/android/app/src/main/cpp/kissfft/LICENSE
+++ b/android/app/src/main/cpp/kissfft/LICENSE
@@ -1,0 +1,35 @@
+Valid-License-Identifier: BSD-3-Clause
+SPDX-URL: https://spdx.org/licenses/BSD-3-Clause.html
+Usage-Guide:
+  To use the BSD 3-clause "New" or "Revised" License put the following SPDX
+  tag/value pair into a comment according to the placement guidelines in
+  the licensing rules documentation:
+    SPDX-License-Identifier: BSD-3-Clause
+License-Text:
+
+Copyright (c) <year> <owner> . All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/android/app/src/main/cpp/kissfft/_kiss_fft_guts.h
+++ b/android/app/src/main/cpp/kissfft/_kiss_fft_guts.h
@@ -1,0 +1,189 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+/* kiss_fft.h
+   defines kiss_fft_scalar as either short or a float type
+   and defines
+   typedef struct { kiss_fft_scalar r; kiss_fft_scalar i; }kiss_fft_cpx; */
+
+#ifndef _kiss_fft_guts_h
+#define _kiss_fft_guts_h
+
+#include "kiss_fft.h"
+#include "kiss_fft_log.h"
+#include <limits.h>
+
+#define MAXFACTORS 32
+/* e.g. an fft of length 128 has 4 factors
+ as far as kissfft is concerned
+ 4*4*4*2
+ */
+
+struct kiss_fft_state{
+    int nfft;
+    int inverse;
+    int factors[2*MAXFACTORS];
+    kiss_fft_cpx twiddles[1];
+};
+
+/*
+  Explanation of macros dealing with complex math:
+
+   C_MUL(m,a,b)         : m = a*b
+   C_FIXDIV( c , div )  : if a fixed point impl., c /= div. noop otherwise
+   C_SUB( res, a,b)     : res = a - b
+   C_SUBFROM( res , a)  : res -= a
+   C_ADDTO( res , a)    : res += a
+ * */
+#ifdef FIXED_POINT
+#include <stdint.h>
+#if (FIXED_POINT==32)
+# define FRACBITS 31
+# define SAMPPROD int64_t
+#define SAMP_MAX INT32_MAX
+#define SAMP_MIN INT32_MIN
+#else
+# define FRACBITS 15
+# define SAMPPROD int32_t
+#define SAMP_MAX INT16_MAX
+#define SAMP_MIN INT16_MIN
+#endif
+
+#if defined(CHECK_OVERFLOW)
+#  define CHECK_OVERFLOW_OP(a,op,b)  \
+    if ( (SAMPPROD)(a) op (SAMPPROD)(b) > SAMP_MAX || (SAMPPROD)(a) op (SAMPPROD)(b) < SAMP_MIN ) { \
+        KISS_FFT_WARNING("overflow (%d " #op" %d) = %ld", (a),(b),(SAMPPROD)(a) op (SAMPPROD)(b)); }
+#endif
+
+
+#   define smul(a,b) ( (SAMPPROD)(a)*(b) )
+#   define sround( x )  (kiss_fft_scalar)( ( (x) + (1<<(FRACBITS-1)) ) >> FRACBITS )
+
+#   define S_MUL(a,b) sround( smul(a,b) )
+
+#   define C_MUL(m,a,b) \
+      do{ (m).r = sround( smul((a).r,(b).r) - smul((a).i,(b).i) ); \
+          (m).i = sround( smul((a).r,(b).i) + smul((a).i,(b).r) ); }while(0)
+
+#   define DIVSCALAR(x,k) \
+    (x) = sround( smul(  x, SAMP_MAX/k ) )
+
+#   define C_FIXDIV(c,div) \
+    do {    DIVSCALAR( (c).r , div);  \
+        DIVSCALAR( (c).i  , div); }while (0)
+
+#   define C_MULBYSCALAR( c, s ) \
+    do{ (c).r =  sround( smul( (c).r , s ) ) ;\
+        (c).i =  sround( smul( (c).i , s ) ) ; }while(0)
+
+#else  /* not FIXED_POINT*/
+
+#   define S_MUL(a,b) ( (a)*(b) )
+#define C_MUL(m,a,b) \
+    do{ (m).r = (a).r*(b).r - (a).i*(b).i;\
+        (m).i = (a).r*(b).i + (a).i*(b).r; }while(0)
+#   define C_FIXDIV(c,div) /* NOOP */
+#   define C_MULBYSCALAR( c, s ) \
+    do{ (c).r *= (s);\
+        (c).i *= (s); }while(0)
+#endif
+
+#ifndef CHECK_OVERFLOW_OP
+#  define CHECK_OVERFLOW_OP(a,op,b) /* noop */
+#endif
+
+#define  C_ADD( res, a,b)\
+    do { \
+        CHECK_OVERFLOW_OP((a).r,+,(b).r)\
+        CHECK_OVERFLOW_OP((a).i,+,(b).i)\
+        (res).r=(a).r+(b).r;  (res).i=(a).i+(b).i; \
+    }while(0)
+#define  C_SUB( res, a,b)\
+    do { \
+        CHECK_OVERFLOW_OP((a).r,-,(b).r)\
+        CHECK_OVERFLOW_OP((a).i,-,(b).i)\
+        (res).r=(a).r-(b).r;  (res).i=(a).i-(b).i; \
+    }while(0)
+#define C_ADDTO( res , a)\
+    do { \
+        CHECK_OVERFLOW_OP((res).r,+,(a).r)\
+        CHECK_OVERFLOW_OP((res).i,+,(a).i)\
+        (res).r += (a).r;  (res).i += (a).i;\
+    }while(0)
+
+#define C_SUBFROM( res , a)\
+    do {\
+        CHECK_OVERFLOW_OP((res).r,-,(a).r)\
+        CHECK_OVERFLOW_OP((res).i,-,(a).i)\
+        (res).r -= (a).r;  (res).i -= (a).i; \
+    }while(0)
+
+
+#ifdef FIXED_POINT
+#  define KISS_FFT_COS(phase)  floor(.5+SAMP_MAX * cos (phase))
+#  define KISS_FFT_SIN(phase)  floor(.5+SAMP_MAX * sin (phase))
+#  define HALF_OF(x) ((x)>>1)
+#elif defined(USE_SIMD)
+#if defined(HAVE_LASX)
+#define KISS_FFT_COS(phase) ({ \
+    float __cos_val = cosf(phase); \
+    (__m256)(__lasx_xvldrepl_w(&__cos_val, 0)); \
+})
+#define KISS_FFT_SIN(phase) ({ \
+    float __sin_val = sinf(phase); \
+    (__m256)(__lasx_xvldrepl_w(&__sin_val, 0)); \
+})
+#define HALF_OF(x) ((x) * (__m256)(__lasx_xvreplgr2vr_w(0x3F000000))) // 0.5f
+#elif defined(HAVE_LSX)
+#define KISS_FFT_COS(phase) ({ \
+    float __cos_val = cosf(phase); \
+    (__m128)(__lsx_vldrepl_w(&__cos_val, 0)); \
+})
+#define KISS_FFT_SIN(phase) ({ \
+    float __sin_val = sinf(phase); \
+    (__m128)(__lsx_vldrepl_w(&__sin_val, 0)); \
+})
+#define HALF_OF(x) ((x) * (__m128)(__lsx_vreplgr2vr_w(0x3F000000))) // 0.5f
+#else
+#  define KISS_FFT_COS(phase) _mm_set1_ps( cos(phase) )
+#  define KISS_FFT_SIN(phase) _mm_set1_ps( sin(phase) )
+#  define HALF_OF(x) ((x)*_mm_set1_ps(.5))
+#endif
+#else
+#  define KISS_FFT_COS(phase) (kiss_fft_scalar) cos(phase)
+#  define KISS_FFT_SIN(phase) (kiss_fft_scalar) sin(phase)
+#  define HALF_OF(x) ((x)*((kiss_fft_scalar).5))
+#endif
+
+#define  kf_cexp(x,phase) \
+    do{ \
+        (x)->r = KISS_FFT_COS(phase);\
+        (x)->i = KISS_FFT_SIN(phase);\
+    }while(0)
+
+
+/* a debugging function */
+#define pcpx(c)\
+    KISS_FFT_DEBUG("%g + %gi\n",(double)((c)->r),(double)((c)->i))
+
+
+#ifdef KISS_FFT_USE_ALLOCA
+// define this to allow use of alloca instead of malloc for temporary buffers
+// Temporary buffers are used in two case:
+// 1. FFT sizes that have "bad" factors. i.e. not 2,3 and 5
+// 2. "in-place" FFTs.  Notice the quotes, since kissfft does not really do an in-place transform.
+#include <alloca.h>
+#define  KISS_FFT_TMP_ALLOC(nbytes) alloca(nbytes)
+#define  KISS_FFT_TMP_FREE(ptr)
+#else
+#define  KISS_FFT_TMP_ALLOC(nbytes) KISS_FFT_MALLOC(nbytes)
+#define  KISS_FFT_TMP_FREE(ptr) KISS_FFT_FREE(ptr)
+#endif
+
+#endif /* _kiss_fft_guts_h */
+

--- a/android/app/src/main/cpp/kissfft/kiss_fft.c
+++ b/android/app/src/main/cpp/kissfft/kiss_fft.c
@@ -1,0 +1,424 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#include <stdint.h>
+#include "_kiss_fft_guts.h"
+/* The guts header contains all the multiplication and addition macros that are defined for
+ fixed or floating point complex numbers.  It also delares the kf_ internal functions.
+ */
+
+static void kf_bfly2(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m
+        )
+{
+    kiss_fft_cpx * Fout2;
+    kiss_fft_cpx * tw1 = st->twiddles;
+    kiss_fft_cpx t;
+    Fout2 = Fout + m;
+    do{
+        C_FIXDIV(*Fout,2); C_FIXDIV(*Fout2,2);
+
+        C_MUL (t,  *Fout2 , *tw1);
+        tw1 += fstride;
+        C_SUB( *Fout2 ,  *Fout , t );
+        C_ADDTO( *Fout ,  t );
+        ++Fout2;
+        ++Fout;
+    }while (--m);
+}
+
+static void kf_bfly4(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        const size_t m
+        )
+{
+    kiss_fft_cpx *tw1,*tw2,*tw3;
+    kiss_fft_cpx scratch[6];
+    size_t k=m;
+    const size_t m2=2*m;
+    const size_t m3=3*m;
+
+
+    tw3 = tw2 = tw1 = st->twiddles;
+
+    do {
+        C_FIXDIV(*Fout,4); C_FIXDIV(Fout[m],4); C_FIXDIV(Fout[m2],4); C_FIXDIV(Fout[m3],4);
+
+        C_MUL(scratch[0],Fout[m] , *tw1 );
+        C_MUL(scratch[1],Fout[m2] , *tw2 );
+        C_MUL(scratch[2],Fout[m3] , *tw3 );
+
+        C_SUB( scratch[5] , *Fout, scratch[1] );
+        C_ADDTO(*Fout, scratch[1]);
+        C_ADD( scratch[3] , scratch[0] , scratch[2] );
+        C_SUB( scratch[4] , scratch[0] , scratch[2] );
+        C_SUB( Fout[m2], *Fout, scratch[3] );
+        tw1 += fstride;
+        tw2 += fstride*2;
+        tw3 += fstride*3;
+        C_ADDTO( *Fout , scratch[3] );
+
+        if(st->inverse) {
+            Fout[m].r = scratch[5].r - scratch[4].i;
+            Fout[m].i = scratch[5].i + scratch[4].r;
+            Fout[m3].r = scratch[5].r + scratch[4].i;
+            Fout[m3].i = scratch[5].i - scratch[4].r;
+        }else{
+            Fout[m].r = scratch[5].r + scratch[4].i;
+            Fout[m].i = scratch[5].i - scratch[4].r;
+            Fout[m3].r = scratch[5].r - scratch[4].i;
+            Fout[m3].i = scratch[5].i + scratch[4].r;
+        }
+        ++Fout;
+    }while(--k);
+}
+
+static void kf_bfly3(
+         kiss_fft_cpx * Fout,
+         const size_t fstride,
+         const kiss_fft_cfg st,
+         size_t m
+         )
+{
+     size_t k=m;
+     const size_t m2 = 2*m;
+     kiss_fft_cpx *tw1,*tw2;
+     kiss_fft_cpx scratch[5];
+     kiss_fft_cpx epi3;
+     epi3 = st->twiddles[fstride*m];
+
+     tw1=tw2=st->twiddles;
+
+     do{
+         C_FIXDIV(*Fout,3); C_FIXDIV(Fout[m],3); C_FIXDIV(Fout[m2],3);
+
+         C_MUL(scratch[1],Fout[m] , *tw1);
+         C_MUL(scratch[2],Fout[m2] , *tw2);
+
+         C_ADD(scratch[3],scratch[1],scratch[2]);
+         C_SUB(scratch[0],scratch[1],scratch[2]);
+         tw1 += fstride;
+         tw2 += fstride*2;
+
+         Fout[m].r = Fout->r - HALF_OF(scratch[3].r);
+         Fout[m].i = Fout->i - HALF_OF(scratch[3].i);
+
+         C_MULBYSCALAR( scratch[0] , epi3.i );
+
+         C_ADDTO(*Fout,scratch[3]);
+
+         Fout[m2].r = Fout[m].r + scratch[0].i;
+         Fout[m2].i = Fout[m].i - scratch[0].r;
+
+         Fout[m].r -= scratch[0].i;
+         Fout[m].i += scratch[0].r;
+
+         ++Fout;
+     }while(--k);
+}
+
+static void kf_bfly5(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m
+        )
+{
+    kiss_fft_cpx *Fout0,*Fout1,*Fout2,*Fout3,*Fout4;
+    int u;
+    kiss_fft_cpx scratch[13];
+    kiss_fft_cpx * twiddles = st->twiddles;
+    kiss_fft_cpx *tw;
+    kiss_fft_cpx ya,yb;
+    ya = twiddles[fstride*m];
+    yb = twiddles[fstride*2*m];
+
+    Fout0=Fout;
+    Fout1=Fout0+m;
+    Fout2=Fout0+2*m;
+    Fout3=Fout0+3*m;
+    Fout4=Fout0+4*m;
+
+    tw=st->twiddles;
+    for ( u=0; u<m; ++u ) {
+        C_FIXDIV( *Fout0,5); C_FIXDIV( *Fout1,5); C_FIXDIV( *Fout2,5); C_FIXDIV( *Fout3,5); C_FIXDIV( *Fout4,5);
+        scratch[0] = *Fout0;
+
+        C_MUL(scratch[1] ,*Fout1, tw[u*fstride]);
+        C_MUL(scratch[2] ,*Fout2, tw[2*u*fstride]);
+        C_MUL(scratch[3] ,*Fout3, tw[3*u*fstride]);
+        C_MUL(scratch[4] ,*Fout4, tw[4*u*fstride]);
+
+        C_ADD( scratch[7],scratch[1],scratch[4]);
+        C_SUB( scratch[10],scratch[1],scratch[4]);
+        C_ADD( scratch[8],scratch[2],scratch[3]);
+        C_SUB( scratch[9],scratch[2],scratch[3]);
+
+        Fout0->r += scratch[7].r + scratch[8].r;
+        Fout0->i += scratch[7].i + scratch[8].i;
+
+        scratch[5].r = scratch[0].r + S_MUL(scratch[7].r,ya.r) + S_MUL(scratch[8].r,yb.r);
+        scratch[5].i = scratch[0].i + S_MUL(scratch[7].i,ya.r) + S_MUL(scratch[8].i,yb.r);
+
+        scratch[6].r =  S_MUL(scratch[10].i,ya.i) + S_MUL(scratch[9].i,yb.i);
+        scratch[6].i = -S_MUL(scratch[10].r,ya.i) - S_MUL(scratch[9].r,yb.i);
+
+        C_SUB(*Fout1,scratch[5],scratch[6]);
+        C_ADD(*Fout4,scratch[5],scratch[6]);
+
+        scratch[11].r = scratch[0].r + S_MUL(scratch[7].r,yb.r) + S_MUL(scratch[8].r,ya.r);
+        scratch[11].i = scratch[0].i + S_MUL(scratch[7].i,yb.r) + S_MUL(scratch[8].i,ya.r);
+        scratch[12].r = - S_MUL(scratch[10].i,yb.i) + S_MUL(scratch[9].i,ya.i);
+        scratch[12].i = S_MUL(scratch[10].r,yb.i) - S_MUL(scratch[9].r,ya.i);
+
+        C_ADD(*Fout2,scratch[11],scratch[12]);
+        C_SUB(*Fout3,scratch[11],scratch[12]);
+
+        ++Fout0;++Fout1;++Fout2;++Fout3;++Fout4;
+    }
+}
+
+/* perform the butterfly for one stage of a mixed radix FFT */
+static void kf_bfly_generic(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m,
+        int p
+        )
+{
+    int u,k,q1,q;
+    kiss_fft_cpx * twiddles = st->twiddles;
+    kiss_fft_cpx t;
+    int Norig = st->nfft;
+
+    kiss_fft_cpx * scratch = (kiss_fft_cpx*)KISS_FFT_TMP_ALLOC(sizeof(kiss_fft_cpx)*p);
+    if (scratch == NULL){
+        KISS_FFT_ERROR("Memory allocation failed.");
+        return;
+    }
+
+    for ( u=0; u<m; ++u ) {
+        k=u;
+        for ( q1=0 ; q1<p ; ++q1 ) {
+            scratch[q1] = Fout[ k  ];
+            C_FIXDIV(scratch[q1],p);
+            k += m;
+        }
+
+        k=u;
+        for ( q1=0 ; q1<p ; ++q1 ) {
+            int twidx=0;
+            Fout[ k ] = scratch[0];
+            for (q=1;q<p;++q ) {
+                twidx += fstride * k;
+                if (twidx>=Norig) twidx-=Norig;
+                C_MUL(t,scratch[q] , twiddles[twidx] );
+                C_ADDTO( Fout[ k ] ,t);
+            }
+            k += m;
+        }
+    }
+    KISS_FFT_TMP_FREE(scratch);
+}
+
+static
+void kf_work(
+        kiss_fft_cpx * Fout,
+        const kiss_fft_cpx * f,
+        const size_t fstride,
+        int in_stride,
+        int * factors,
+        const kiss_fft_cfg st
+        )
+{
+    kiss_fft_cpx * Fout_beg=Fout;
+    const int p=*factors++; /* the radix  */
+    const int m=*factors++; /* stage's fft length/p */
+    const kiss_fft_cpx * Fout_end = Fout + p*m;
+
+#ifdef _OPENMP
+    // use openmp extensions at the
+    // top-level (not recursive)
+    if (fstride==1 && p<=5 && m!=1)
+    {
+        int k;
+
+        // execute the p different work units in different threads
+#       pragma omp parallel for
+        for (k=0;k<p;++k)
+            kf_work( Fout +k*m, f+ fstride*in_stride*k,fstride*p,in_stride,factors,st);
+        // all threads have joined by this point
+
+        switch (p) {
+            case 2: kf_bfly2(Fout,fstride,st,m); break;
+            case 3: kf_bfly3(Fout,fstride,st,m); break;
+            case 4: kf_bfly4(Fout,fstride,st,m); break;
+            case 5: kf_bfly5(Fout,fstride,st,m); break;
+            default: kf_bfly_generic(Fout,fstride,st,m,p); break;
+        }
+        return;
+    }
+#endif
+
+    if (m==1) {
+        do{
+            *Fout = *f;
+            f += fstride*in_stride;
+        }while(++Fout != Fout_end );
+    }else{
+        do{
+            // recursive call:
+            // DFT of size m*p performed by doing
+            // p instances of smaller DFTs of size m,
+            // each one takes a decimated version of the input
+            kf_work( Fout , f, fstride*p, in_stride, factors,st);
+            f += fstride*in_stride;
+        }while( (Fout += m) != Fout_end );
+    }
+
+    Fout=Fout_beg;
+
+    // recombine the p smaller DFTs
+    switch (p) {
+        case 2: kf_bfly2(Fout,fstride,st,m); break;
+        case 3: kf_bfly3(Fout,fstride,st,m); break;
+        case 4: kf_bfly4(Fout,fstride,st,m); break;
+        case 5: kf_bfly5(Fout,fstride,st,m); break;
+        default: kf_bfly_generic(Fout,fstride,st,m,p); break;
+    }
+}
+
+/*  facbuf is populated by p1,m1,p2,m2, ...
+    where
+    p[i] * m[i] = m[i-1]
+    m0 = n                  */
+static
+void kf_factor(int n,int * facbuf)
+{
+    int p=4;
+    double floor_sqrt;
+    floor_sqrt = floor( sqrt((double)n) );
+
+    /*factor out powers of 4, powers of 2, then any remaining primes */
+    do {
+        while (n % p) {
+            switch (p) {
+                case 4: p = 2; break;
+                case 2: p = 3; break;
+                default: p += 2; break;
+            }
+            if (p > floor_sqrt)
+                p = n;          /* no more factors, skip to end */
+        }
+        n /= p;
+        *facbuf++ = p;
+        *facbuf++ = n;
+    } while (n > 1);
+}
+
+/*
+ *
+ * User-callable function to allocate all necessary storage space for the fft.
+ *
+ * The return value is a contiguous block of memory, allocated with malloc.  As such,
+ * It can be freed with free(), rather than a kiss_fft-specific function.
+ * */
+kiss_fft_cfg kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem )
+{
+    KISS_FFT_ALIGN_CHECK(mem)
+
+    kiss_fft_cfg st=NULL;
+    // check for overflow condition {memneeded > SIZE_MAX}.
+    if (nfft >= (SIZE_MAX - 2*sizeof(struct kiss_fft_state))/sizeof(kiss_fft_cpx))
+        return NULL;
+
+    size_t memneeded = KISS_FFT_ALIGN_SIZE_UP(sizeof(struct kiss_fft_state)
+        + sizeof(kiss_fft_cpx)*(nfft-1)); /* twiddle factors*/
+
+    if ( lenmem==NULL ) {
+        st = ( kiss_fft_cfg)KISS_FFT_MALLOC( memneeded );
+    }else{
+        if (mem != NULL && *lenmem >= memneeded)
+            st = (kiss_fft_cfg)mem;
+        *lenmem = memneeded;
+    }
+    if (st) {
+        int i;
+        st->nfft=nfft;
+        st->inverse = inverse_fft;
+
+        for (i=0;i<nfft;++i) {
+            const double pi=3.141592653589793238462643383279502884197169399375105820974944;
+            double phase = -2*pi*i / nfft;
+            if (st->inverse)
+                phase *= -1;
+            kf_cexp(st->twiddles+i, phase );
+        }
+
+        kf_factor(nfft,st->factors);
+    }
+    return st;
+}
+
+
+void kiss_fft_stride(kiss_fft_cfg st,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int in_stride)
+{
+    if (fin == fout) {
+        //NOTE: this is not really an in-place FFT algorithm.
+        //It just performs an out-of-place FFT into a temp buffer
+        if (fout == NULL){
+            KISS_FFT_ERROR("fout buffer NULL.");
+        return;
+        }
+
+        kiss_fft_cpx * tmpbuf = (kiss_fft_cpx*)KISS_FFT_TMP_ALLOC( sizeof(kiss_fft_cpx)*st->nfft);
+        if (tmpbuf == NULL){
+            KISS_FFT_ERROR("Memory allocation error.");
+        return;
+        }
+
+
+
+        kf_work(tmpbuf,fin,1,in_stride, st->factors,st);
+        memcpy(fout,tmpbuf,sizeof(kiss_fft_cpx)*st->nfft);
+        KISS_FFT_TMP_FREE(tmpbuf);
+    }else{
+        kf_work( fout, fin, 1,in_stride, st->factors,st );
+    }
+}
+
+void kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout)
+{
+    kiss_fft_stride(cfg,fin,fout,1);
+}
+
+
+void kiss_fft_cleanup(void)
+{
+    // nothing needed any more
+}
+
+int kiss_fft_next_fast_size(int n)
+{
+    while(1) {
+        int m=n;
+        while ( (m%2) == 0 ) m/=2;
+        while ( (m%3) == 0 ) m/=3;
+        while ( (m%5) == 0 ) m/=5;
+        if (m<=1)
+            break; /* n is completely factorable by twos, threes, and fives */
+        n++;
+    }
+    return n;
+}

--- a/android/app/src/main/cpp/kissfft/kiss_fft.h
+++ b/android/app/src/main/cpp/kissfft/kiss_fft.h
@@ -1,0 +1,184 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#ifndef KISS_FFT_H
+#define KISS_FFT_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+
+// Define KISS_FFT_SHARED macro to properly export symbols
+#ifdef KISS_FFT_SHARED
+# ifdef _WIN32
+#  ifdef KISS_FFT_BUILD
+#   define KISS_FFT_API __declspec(dllexport)
+#  else
+#   define KISS_FFT_API __declspec(dllimport)
+#  endif
+# else
+#  define KISS_FFT_API __attribute__ ((visibility ("default")))
+# endif
+#else
+# define KISS_FFT_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ATTENTION!
+ If you would like a :
+ -- a utility that will handle the caching of fft objects
+ -- real-only (no imaginary time component ) FFT
+ -- a multi-dimensional FFT
+ -- a command-line utility to perform ffts
+ -- a command-line utility to perform fast-convolution filtering
+
+ Then see kfc.h kiss_fftr.h kiss_fftnd.h fftutil.c kiss_fastfir.c
+  in the tools/ directory.
+*/
+
+/* User may override KISS_FFT_MALLOC and/or KISS_FFT_FREE. */
+#ifdef USE_SIMD
+#ifdef HAVE_LASX
+# include <lasxintrin.h>
+# define kiss_fft_scalar __m256
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC(nbytes) aligned_alloc(32, KISS_FFT_ALIGN_SIZE_UP(nbytes))
+#  define KISS_FFT_ALIGN_CHECK(ptr)
+#  define KISS_FFT_ALIGN_SIZE_UP(size) ((size + 31UL) & ~0x1FUL)
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE free
+# endif
+#elif defined(HAVE_LSX)
+# include <lsxintrin.h>
+# define kiss_fft_scalar __m128
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC(nbytes) aligned_alloc(16, KISS_FFT_ALIGN_SIZE_UP(nbytes))
+#  define KISS_FFT_ALIGN_CHECK(ptr)
+#  define KISS_FFT_ALIGN_SIZE_UP(size) ((size + 15UL) & ~0xFUL)
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE free
+# endif
+#else
+# include <xmmintrin.h>
+# define kiss_fft_scalar __m128
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
+#  define KISS_FFT_ALIGN_CHECK(ptr)
+#  define KISS_FFT_ALIGN_SIZE_UP(size) ((size + 15UL) & ~0xFUL)
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE _mm_free
+# endif
+#endif
+#else
+# define KISS_FFT_ALIGN_CHECK(ptr)
+# define KISS_FFT_ALIGN_SIZE_UP(size) (size)
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC malloc
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE free
+# endif
+#endif
+
+
+#ifdef FIXED_POINT
+#include <stdint.h>
+# if (FIXED_POINT == 32)
+#  define kiss_fft_scalar int32_t
+# else	
+#  define kiss_fft_scalar int16_t
+# endif
+#else
+# ifndef kiss_fft_scalar
+/*  default is float */
+#   define kiss_fft_scalar float
+# endif
+#endif
+
+typedef struct {
+    kiss_fft_scalar r;
+    kiss_fft_scalar i;
+}kiss_fft_cpx;
+
+typedef struct kiss_fft_state* kiss_fft_cfg;
+
+/* 
+ *  kiss_fft_alloc
+ *  
+ *  Initialize a FFT (or IFFT) algorithm's cfg/state buffer.
+ *
+ *  typical usage:      kiss_fft_cfg mycfg=kiss_fft_alloc(1024,0,NULL,NULL);
+ *
+ *  The return value from fft_alloc is a cfg buffer used internally
+ *  by the fft routine or NULL.
+ *
+ *  If lenmem is NULL, then kiss_fft_alloc will allocate a cfg buffer using malloc.
+ *  The returned value should be free()d when done to avoid memory leaks.
+ *  
+ *  The state can be placed in a user supplied buffer 'mem':
+ *  If lenmem is not NULL and mem is not NULL and *lenmem is large enough,
+ *      then the function places the cfg in mem and the size used in *lenmem
+ *      and returns mem.
+ *  
+ *  If lenmem is not NULL and ( mem is NULL or *lenmem is not large enough),
+ *      then the function returns NULL and places the minimum cfg 
+ *      buffer size in *lenmem.
+ * */
+
+kiss_fft_cfg KISS_FFT_API kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem);
+
+/*
+ * kiss_fft(cfg,in_out_buf)
+ *
+ * Perform an FFT on a complex input buffer.
+ * for a forward FFT,
+ * fin should be  f[0] , f[1] , ... ,f[nfft-1]
+ * fout will be   F[0] , F[1] , ... ,F[nfft-1]
+ * Note that each element is complex and can be accessed like
+    f[k].r and f[k].i
+ * */
+void KISS_FFT_API kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout);
+
+/*
+ A more generic version of the above function. It reads its input from every Nth sample.
+ * */
+void KISS_FFT_API kiss_fft_stride(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int fin_stride);
+
+/* If kiss_fft_alloc allocated a buffer, it is one contiguous 
+   buffer and can be simply free()d when no longer needed*/
+#define kiss_fft_free KISS_FFT_FREE
+
+/*
+ Cleans up some memory that gets managed internally. Not necessary to call, but it might clean up 
+ your compiler output to call this before you exit.
+*/
+void KISS_FFT_API kiss_fft_cleanup(void);
+	
+
+/*
+ * Returns the smallest integer k, such that k>=n and k has only "fast" factors (2,3,5)
+ */
+int KISS_FFT_API kiss_fft_next_fast_size(int n);
+
+/* for real ffts, we need an even size */
+#define kiss_fftr_next_fast_size_real(n) \
+        (kiss_fft_next_fast_size( ((n)+1)>>1)<<1)
+
+#ifdef __cplusplus
+} 
+#endif
+
+#endif

--- a/android/app/src/main/cpp/kissfft/kiss_fft_log.h
+++ b/android/app/src/main/cpp/kissfft/kiss_fft_log.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#ifndef kiss_fft_log_h
+#define kiss_fft_log_h
+
+#define ERROR 1
+#define WARNING 2
+#define INFO 3
+#define DEBUG 4
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+#if defined(NDEBUG)
+# define KISS_FFT_LOG_MSG(severity, ...) ((void)0)
+#else
+# define KISS_FFT_LOG_MSG(severity, ...) \
+    fprintf(stderr, "[" #severity "] " __FILE__ ":" TOSTRING(__LINE__) " "); \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n")
+#endif
+
+#define KISS_FFT_ERROR(...) KISS_FFT_LOG_MSG(ERROR, __VA_ARGS__)
+#define KISS_FFT_WARNING(...) KISS_FFT_LOG_MSG(WARNING, __VA_ARGS__)
+#define KISS_FFT_INFO(...) KISS_FFT_LOG_MSG(INFO, __VA_ARGS__)
+#define KISS_FFT_DEBUG(...) KISS_FFT_LOG_MSG(DEBUG, __VA_ARGS__)
+
+
+
+#endif /* kiss_fft_log_h */

--- a/android/app/src/main/cpp/kissfft/kiss_fftr.c
+++ b/android/app/src/main/cpp/kissfft/kiss_fftr.c
@@ -1,0 +1,171 @@
+/*
+ *  Copyright (c) 2003-2004, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#include "kiss_fftr.h"
+#include "_kiss_fft_guts.h"
+
+struct kiss_fftr_state{
+    kiss_fft_cfg substate;
+    kiss_fft_cpx * tmpbuf;
+    kiss_fft_cpx * super_twiddles;
+#ifdef USE_SIMD
+    void * pad;
+#endif
+};
+
+kiss_fftr_cfg kiss_fftr_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem)
+{
+	KISS_FFT_ALIGN_CHECK(mem)
+
+    int i;
+    kiss_fftr_cfg st = NULL;
+    size_t subsize = 0, memneeded;
+
+    if (nfft & 1) {
+        KISS_FFT_ERROR("Real FFT optimization must be even.");
+        return NULL;
+    }
+    nfft >>= 1;
+
+    kiss_fft_alloc (nfft, inverse_fft, NULL, &subsize);
+    memneeded = sizeof(struct kiss_fftr_state) + subsize + sizeof(kiss_fft_cpx) * ( nfft * 3 / 2);
+
+    if (lenmem == NULL) {
+        st = (kiss_fftr_cfg) KISS_FFT_MALLOC (memneeded);
+    } else {
+        if (*lenmem >= memneeded)
+            st = (kiss_fftr_cfg) mem;
+        *lenmem = memneeded;
+    }
+    if (!st)
+        return NULL;
+
+    st->substate = (kiss_fft_cfg) (st + 1); /*just beyond kiss_fftr_state struct */
+    st->tmpbuf = (kiss_fft_cpx *) (((char *) st->substate) + subsize);
+    st->super_twiddles = st->tmpbuf + nfft;
+    kiss_fft_alloc(nfft, inverse_fft, st->substate, &subsize);
+
+    for (i = 0; i < nfft/2; ++i) {
+        double phase =
+            -3.14159265358979323846264338327 * ((double) (i+1) / nfft + .5);
+        if (inverse_fft)
+            phase *= -1;
+        kf_cexp (st->super_twiddles+i,phase);
+    }
+    return st;
+}
+
+void kiss_fftr(kiss_fftr_cfg st,const kiss_fft_scalar *timedata,kiss_fft_cpx *freqdata)
+{
+    /* input buffer timedata is stored row-wise */
+    int k,ncfft;
+    kiss_fft_cpx fpnk,fpk,f1k,f2k,tw,tdc;
+
+    if ( st->substate->inverse) {
+        KISS_FFT_ERROR("kiss fft usage error: improper alloc");
+        return;/* The caller did not call the correct function */
+    }
+
+    ncfft = st->substate->nfft;
+
+    /*perform the parallel fft of two real signals packed in real,imag*/
+    kiss_fft( st->substate , (const kiss_fft_cpx*)timedata, st->tmpbuf );
+    /* The real part of the DC element of the frequency spectrum in st->tmpbuf
+     * contains the sum of the even-numbered elements of the input time sequence
+     * The imag part is the sum of the odd-numbered elements
+     *
+     * The sum of tdc.r and tdc.i is the sum of the input time sequence.
+     *      yielding DC of input time sequence
+     * The difference of tdc.r - tdc.i is the sum of the input (dot product) [1,-1,1,-1...
+     *      yielding Nyquist bin of input time sequence
+     */
+
+    tdc.r = st->tmpbuf[0].r;
+    tdc.i = st->tmpbuf[0].i;
+    C_FIXDIV(tdc,2);
+    CHECK_OVERFLOW_OP(tdc.r ,+, tdc.i);
+    CHECK_OVERFLOW_OP(tdc.r ,-, tdc.i);
+    freqdata[0].r = tdc.r + tdc.i;
+    freqdata[ncfft].r = tdc.r - tdc.i;
+#ifdef USE_SIMD
+#ifdef HAVE_LASX
+    freqdata[0].i = (__m256)(__lasx_xvreplgr2vr_w(0));
+    freqdata[ncfft].i = freqdata[0].i;
+#elif defined(HAVE_LSX)
+    freqdata[0].i = (__m128)(__lsx_vreplgr2vr_w(0));
+    freqdata[ncfft].i = freqdata[0].i;
+#else
+    freqdata[ncfft].i = freqdata[0].i = _mm_set1_ps(0);
+#endif
+#else
+    freqdata[ncfft].i = freqdata[0].i = 0;
+#endif
+
+    for ( k=1;k <= ncfft/2 ; ++k ) {
+        fpk    = st->tmpbuf[k];
+        fpnk.r =   st->tmpbuf[ncfft-k].r;
+        fpnk.i = - st->tmpbuf[ncfft-k].i;
+        C_FIXDIV(fpk,2);
+        C_FIXDIV(fpnk,2);
+
+        C_ADD( f1k, fpk , fpnk );
+        C_SUB( f2k, fpk , fpnk );
+        C_MUL( tw , f2k , st->super_twiddles[k-1]);
+
+        freqdata[k].r = HALF_OF(f1k.r + tw.r);
+        freqdata[k].i = HALF_OF(f1k.i + tw.i);
+        freqdata[ncfft-k].r = HALF_OF(f1k.r - tw.r);
+        freqdata[ncfft-k].i = HALF_OF(tw.i - f1k.i);
+    }
+}
+
+void kiss_fftri(kiss_fftr_cfg st,const kiss_fft_cpx *freqdata,kiss_fft_scalar *timedata)
+{
+    /* input buffer timedata is stored row-wise */
+    int k, ncfft;
+
+    if (st->substate->inverse == 0) {
+        KISS_FFT_ERROR("kiss fft usage error: improper alloc");
+        return;/* The caller did not call the correct function */
+    }
+
+    ncfft = st->substate->nfft;
+
+    st->tmpbuf[0].r = freqdata[0].r + freqdata[ncfft].r;
+    st->tmpbuf[0].i = freqdata[0].r - freqdata[ncfft].r;
+    C_FIXDIV(st->tmpbuf[0],2);
+
+    for (k = 1; k <= ncfft / 2; ++k) {
+        kiss_fft_cpx fk, fnkc, fek, fok, tmp;
+        fk = freqdata[k];
+        fnkc.r = freqdata[ncfft - k].r;
+        fnkc.i = -freqdata[ncfft - k].i;
+        C_FIXDIV( fk , 2 );
+        C_FIXDIV( fnkc , 2 );
+
+        C_ADD (fek, fk, fnkc);
+        C_SUB (tmp, fk, fnkc);
+        C_MUL (fok, tmp, st->super_twiddles[k-1]);
+        C_ADD (st->tmpbuf[k],     fek, fok);
+        C_SUB (st->tmpbuf[ncfft - k], fek, fok);
+#ifdef USE_SIMD
+#ifdef HAVE_LASX
+        __m256 neg_one = (__m256)__lasx_xvreplgr2vr_w(0xBF800000); // -1.0f
+        st->tmpbuf[ncfft - k].i = __lasx_xvfmul_s(st->tmpbuf[ncfft - k].i, neg_one);
+#elif defined(HAVE_LSX)
+        __m128 neg_one = (__m128)__lsx_vreplgr2vr_w(0xBF800000); // -1.0f
+        st->tmpbuf[ncfft - k].i = __lsx_vfmul_s(st->tmpbuf[ncfft - k].i, neg_one);
+#else
+        st->tmpbuf[ncfft - k].i *= _mm_set1_ps(-1.0);
+#endif
+#else
+        st->tmpbuf[ncfft - k].i *= -1;
+#endif
+    }
+    kiss_fft (st->substate, st->tmpbuf, (kiss_fft_cpx *) timedata);
+}

--- a/android/app/src/main/cpp/kissfft/kiss_fftr.h
+++ b/android/app/src/main/cpp/kissfft/kiss_fftr.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2003-2004, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#ifndef KISS_FTR_H
+#define KISS_FTR_H
+
+#include "kiss_fft.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    
+/* 
+ 
+ Real optimized version can save about 45% cpu time vs. complex fft of a real seq.
+
+ 
+ 
+ */
+
+typedef struct kiss_fftr_state *kiss_fftr_cfg;
+
+
+kiss_fftr_cfg KISS_FFT_API kiss_fftr_alloc(int nfft,int inverse_fft,void * mem, size_t * lenmem);
+/*
+ nfft must be even
+
+ If you don't care to allocate space, use mem = lenmem = NULL 
+*/
+
+
+void KISS_FFT_API kiss_fftr(kiss_fftr_cfg cfg,const kiss_fft_scalar *timedata,kiss_fft_cpx *freqdata);
+/*
+ input timedata has nfft scalar points
+ output freqdata has nfft/2+1 complex points
+*/
+
+void KISS_FFT_API kiss_fftri(kiss_fftr_cfg cfg,const kiss_fft_cpx *freqdata,kiss_fft_scalar *timedata);
+/*
+ input freqdata has  nfft/2+1 complex points
+ output timedata has nfft scalar points
+*/
+
+#define kiss_fftr_free KISS_FFT_FREE
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/android/app/src/main/cpp/projectm_engine.cpp
+++ b/android/app/src/main/cpp/projectm_engine.cpp
@@ -1,0 +1,45 @@
+#include "projectm_engine.h"
+
+#include <android/log.h>
+
+#define LOG_TAG "mstream/viz-bridge"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+ProjectMEngine::~ProjectMEngine() {
+    if (pm_) {
+        projectm_destroy(pm_);
+        pm_ = nullptr;
+    }
+}
+
+bool ProjectMEngine::init(int width, int height) {
+    pm_ = projectm_create();
+    if (!pm_) {
+        LOGE("projectm_create failed");
+        return false;
+    }
+    projectm_set_window_size(pm_, width, height);
+    projectm_set_fps(pm_, 60);
+    projectm_set_preset_duration(pm_, 30.0);
+    projectm_set_mesh_size(pm_, 48, 36);
+    LOGI("ProjectMEngine init ok pm=%p %dx%d", (void*)pm_, width, height);
+    return true;
+}
+
+void ProjectMEngine::renderFrame() {
+    if (!pm_) return;
+    projectm_opengl_render_frame(pm_);
+}
+
+void ProjectMEngine::addPcm(const float* samples, std::size_t frameCount) {
+    if (!pm_ || !samples || frameCount == 0) return;
+    projectm_pcm_add_float(pm_, samples,
+                            static_cast<unsigned int>(frameCount),
+                            PROJECTM_STEREO);
+}
+
+void ProjectMEngine::loadPreset(const char* data, bool smoothTransition) {
+    if (!pm_ || !data) return;
+    projectm_load_preset_data(pm_, data, smoothTransition);
+}

--- a/android/app/src/main/cpp/projectm_engine.h
+++ b/android/app/src/main/cpp/projectm_engine.h
@@ -1,0 +1,26 @@
+// Engine wrapping libprojectM-4.so (Milkdrop visualizer).
+//
+// Lifecycle: caller must ensure the EGL context is current before
+// calling init() — projectm_create reads GL state. All subsequent
+// calls (renderFrame, addPcm, loadPreset) also require the context
+// to be current on the same thread.
+
+#pragma once
+
+#include <projectM-4/projectM.h>
+
+#include "engine.h"
+
+class ProjectMEngine : public Engine {
+public:
+    ProjectMEngine() = default;
+    ~ProjectMEngine() override;
+
+    bool init(int width, int height) override;
+    void renderFrame() override;
+    void addPcm(const float* samples, std::size_t frameCount) override;
+    void loadPreset(const char* data, bool smoothTransition) override;
+
+private:
+    projectm_handle pm_ = nullptr;
+};

--- a/android/app/src/main/cpp/shader_engine.cpp
+++ b/android/app/src/main/cpp/shader_engine.cpp
@@ -2,7 +2,7 @@
 
 #include <android/log.h>
 #include <cstring>
-#include <string>
+#include <utility>
 
 #define LOG_TAG "mstream/viz-bridge"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__)
@@ -10,9 +10,8 @@
 
 namespace {
 
-// Vertex shader — a fullscreen triangle. Coordinates chosen so that a
-// single triangle covers the entire viewport without needing a quad
-// (saves us an index buffer).
+// Fullscreen-triangle vertex shader. One triangle covers the entire
+// NDC viewport — saves us an index buffer compared to a quad.
 const char* kVertexShader = R"(#version 300 es
 precision highp float;
 layout(location = 0) in vec2 aPos;
@@ -74,7 +73,28 @@ GLuint compileShader(GLenum kind, const char* src) {
 } // namespace
 
 ShaderEngine::~ShaderEngine() {
-    releaseProgram();
+    // Stop the worker first so it doesn't try to touch GL during
+    // teardown. Worker may have a context-current state that needs
+    // unwinding cleanly.
+    workerShutdown_ = true;
+    {
+        std::lock_guard<std::mutex> lock(queueMutex_);
+        queueCv_.notify_all();
+    }
+    if (worker_.joinable()) worker_.join();
+    teardownSharedContext();
+
+    // Free any program that arrived just before shutdown and never
+    // got adopted by the render thread.
+    {
+        std::lock_guard<std::mutex> lock(resultMutex_);
+        if (pendingProgram_) {
+            glDeleteProgram(pendingProgram_);
+            pendingProgram_ = 0;
+        }
+    }
+
+    if (program_) glDeleteProgram(program_);
     if (vao_) glDeleteVertexArrays(1, &vao_);
     if (vbo_) glDeleteBuffers(1, &vbo_);
     audio_.dispose();
@@ -87,7 +107,7 @@ bool ShaderEngine::init(int width, int height) {
     lastFrameTime_ = startTime_;
     frameCount_ = 0;
 
-    // Fullscreen-triangle VBO/VAO. Three vertices covering NDC.
+    // Fullscreen-triangle VBO/VAO.
     const float verts[] = {
         -1.0f, -1.0f,
          3.0f, -1.0f,
@@ -107,20 +127,104 @@ bool ShaderEngine::init(int width, int height) {
         return false;
     }
 
+    if (!setupSharedContext()) {
+        LOGE("shared EGL context setup failed — compile will fall back to sync");
+        // Fail soft: the engine still works, just synchronously.
+    } else {
+        worker_ = std::thread(&ShaderEngine::workerLoop, this);
+    }
+
     LOGI("ShaderEngine init ok %dx%d", width, height);
     return true;
 }
 
-bool ShaderEngine::compileProgram(const char* fragSource) {
-    GLuint vs = compileShader(GL_VERTEX_SHADER, kVertexShader);
-    if (!vs) return false;
+bool ShaderEngine::setupSharedContext() {
+    EGLDisplay display = eglGetCurrentDisplay();
+    EGLContext mainCtx = eglGetCurrentContext();
+    if (display == EGL_NO_DISPLAY || mainCtx == EGL_NO_CONTEXT) {
+        LOGE("no current EGL display/context — cannot share");
+        return false;
+    }
 
-    std::string fullFrag(kFragPrelude);
-    fullFrag.append(fragSource ? fragSource : "");
-    GLuint fs = compileShader(GL_FRAGMENT_SHADER, fullFrag.c_str());
+    // Choose a config compatible with the main context that also
+    // supports PBuffer surfaces (the worker needs *some* surface to
+    // make its context current, even if it never renders to one).
+    const EGLint configAttrs[] = {
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
+        EGL_SURFACE_TYPE,    EGL_PBUFFER_BIT,
+        EGL_RED_SIZE,   8,
+        EGL_GREEN_SIZE, 8,
+        EGL_BLUE_SIZE,  8,
+        EGL_ALPHA_SIZE, 8,
+        EGL_NONE,
+    };
+    EGLConfig config = nullptr;
+    EGLint numConfigs = 0;
+    if (!eglChooseConfig(display, configAttrs, &config, 1, &numConfigs)
+        || numConfigs < 1) {
+        LOGE("worker eglChooseConfig failed: 0x%x", eglGetError());
+        return false;
+    }
+
+    const EGLint pbAttrs[] = { EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE };
+    workerSurface_ = eglCreatePbufferSurface(display, config, pbAttrs);
+    if (workerSurface_ == EGL_NO_SURFACE) {
+        LOGE("worker eglCreatePbufferSurface failed: 0x%x", eglGetError());
+        return false;
+    }
+
+    const EGLint ctxAttrs[] = { EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE };
+    workerCtx_ = eglCreateContext(display, config, mainCtx, ctxAttrs);
+    if (workerCtx_ == EGL_NO_CONTEXT) {
+        LOGE("worker eglCreateContext (shared) failed: 0x%x", eglGetError());
+        eglDestroySurface(display, workerSurface_);
+        workerSurface_ = EGL_NO_SURFACE;
+        return false;
+    }
+
+    workerDisplay_ = display;
+    return true;
+}
+
+void ShaderEngine::teardownSharedContext() {
+    if (workerDisplay_ == EGL_NO_DISPLAY) return;
+    if (workerCtx_ != EGL_NO_CONTEXT) {
+        eglDestroyContext(workerDisplay_, workerCtx_);
+        workerCtx_ = EGL_NO_CONTEXT;
+    }
+    if (workerSurface_ != EGL_NO_SURFACE) {
+        eglDestroySurface(workerDisplay_, workerSurface_);
+        workerSurface_ = EGL_NO_SURFACE;
+    }
+    workerDisplay_ = EGL_NO_DISPLAY;
+}
+
+ShaderEngine::UniformLocs ShaderEngine::queryUniformLocations(GLuint program) {
+    UniformLocs u;
+    u.time = glGetUniformLocation(program, "iTime");
+    u.timeDelta = glGetUniformLocation(program, "iTimeDelta");
+    u.frame = glGetUniformLocation(program, "iFrame");
+    u.resolution = glGetUniformLocation(program, "iResolution");
+    u.mouse = glGetUniformLocation(program, "iMouse");
+    u.channel0 = glGetUniformLocation(program, "iChannel0");
+    u.channelTime = glGetUniformLocation(program, "iChannelTime[0]");
+    u.channelResolution = glGetUniformLocation(program, "iChannelResolution[0]");
+    u.date = glGetUniformLocation(program, "iDate");
+    u.sampleRate = glGetUniformLocation(program, "iSampleRate");
+    return u;
+}
+
+GLuint ShaderEngine::compileProgramOnCurrentContext(
+        const std::string& fragSource) {
+    GLuint vs = compileShader(GL_VERTEX_SHADER, kVertexShader);
+    if (!vs) return 0;
+
+    std::string full(kFragPrelude);
+    full.append(fragSource);
+    GLuint fs = compileShader(GL_FRAGMENT_SHADER, full.c_str());
     if (!fs) {
         glDeleteShader(vs);
-        return false;
+        return 0;
     }
 
     GLuint p = glCreateProgram();
@@ -139,36 +243,79 @@ bool ShaderEngine::compileProgram(const char* fragSource) {
         glGetProgramInfoLog(p, logLen, nullptr, log.data());
         LOGE("program link error:\n%s", log.c_str());
         glDeleteProgram(p);
-        return false;
+        return 0;
     }
-
-    releaseProgram();
-    program_ = p;
-
-    locTime_ = glGetUniformLocation(p, "iTime");
-    locTimeDelta_ = glGetUniformLocation(p, "iTimeDelta");
-    locFrame_ = glGetUniformLocation(p, "iFrame");
-    locResolution_ = glGetUniformLocation(p, "iResolution");
-    locMouse_ = glGetUniformLocation(p, "iMouse");
-    locChannel0_ = glGetUniformLocation(p, "iChannel0");
-    locChannelTime_ = glGetUniformLocation(p, "iChannelTime[0]");
-    locChannelResolution_ =
-        glGetUniformLocation(p, "iChannelResolution[0]");
-    locDate_ = glGetUniformLocation(p, "iDate");
-    locSampleRate_ = glGetUniformLocation(p, "iSampleRate");
-
-    LOGI("shader program linked ok program=%u", program_);
-    return true;
+    return p;
 }
 
-void ShaderEngine::releaseProgram() {
-    if (program_) {
-        glDeleteProgram(program_);
-        program_ = 0;
+void ShaderEngine::workerLoop() {
+    if (!eglMakeCurrent(workerDisplay_, workerSurface_, workerSurface_,
+                         workerCtx_)) {
+        LOGE("worker eglMakeCurrent failed: 0x%x — exiting worker",
+             eglGetError());
+        return;
     }
+    LOGI("shader compile worker ready");
+
+    while (true) {
+        std::string source;
+        {
+            std::unique_lock<std::mutex> lock(queueMutex_);
+            queueCv_.wait(lock, [this] {
+                return workerShutdown_.load() || hasPendingSource_;
+            });
+            if (workerShutdown_.load()) break;
+            source = std::move(pendingSource_);
+            hasPendingSource_ = false;
+        }
+
+        GLuint newProgram = compileProgramOnCurrentContext(source);
+        if (newProgram == 0) continue;
+
+        // Make sure the program object is fully realized before the
+        // render thread tries to use it from the other context.
+        glFlush();
+
+        // Hand off. If a previous program is still waiting to be
+        // adopted, the render thread missed its window — free it
+        // here so it doesn't leak.
+        GLuint orphan = 0;
+        {
+            std::lock_guard<std::mutex> lock(resultMutex_);
+            orphan = pendingProgram_;
+            pendingProgram_ = newProgram;
+        }
+        if (orphan) glDeleteProgram(orphan);
+    }
+
+    eglMakeCurrent(workerDisplay_, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                    EGL_NO_CONTEXT);
+    LOGI("shader compile worker exited");
+}
+
+void ShaderEngine::adoptPendingProgramIfAny() {
+    GLuint adopt = 0;
+    {
+        std::lock_guard<std::mutex> lock(resultMutex_);
+        if (pendingProgram_ != 0) {
+            adopt = pendingProgram_;
+            pendingProgram_ = 0;
+        }
+    }
+    if (!adopt) return;
+
+    // Free the old current program. Programs are shared between the
+    // worker and render contexts (created via shared context), so
+    // we can delete from either side.
+    if (program_) glDeleteProgram(program_);
+    program_ = adopt;
+    locs_ = queryUniformLocations(program_);
+    LOGI("adopted new shader program=%u", program_);
 }
 
 void ShaderEngine::renderFrame() {
+    adoptPendingProgramIfAny();
+
     if (!program_) {
         // No shader loaded yet — clear to black so the user sees
         // *something* and the surface isn't undefined.
@@ -177,10 +324,8 @@ void ShaderEngine::renderFrame() {
         return;
     }
 
-    // Push the latest audio frame into iChannel0.
     const GLuint audioTex = audio_.upload();
 
-    // Compute timing uniforms.
     auto now = std::chrono::steady_clock::now();
     const float elapsed =
         std::chrono::duration<float>(now - startTime_).count();
@@ -191,35 +336,35 @@ void ShaderEngine::renderFrame() {
     glViewport(0, 0, width_, height_);
     glUseProgram(program_);
 
-    if (locTime_       >= 0) glUniform1f(locTime_, elapsed);
-    if (locTimeDelta_  >= 0) glUniform1f(locTimeDelta_, delta);
-    if (locFrame_      >= 0) glUniform1i(locFrame_, frameCount_);
-    if (locResolution_ >= 0) glUniform3f(locResolution_,
+    if (locs_.time       >= 0) glUniform1f(locs_.time, elapsed);
+    if (locs_.timeDelta  >= 0) glUniform1f(locs_.timeDelta, delta);
+    if (locs_.frame      >= 0) glUniform1i(locs_.frame, frameCount_);
+    if (locs_.resolution >= 0) glUniform3f(locs_.resolution,
         static_cast<float>(width_),
         static_cast<float>(height_),
         static_cast<float>(width_) / static_cast<float>(height_));
-    if (locMouse_      >= 0) glUniform4f(locMouse_, 0.0f, 0.0f, 0.0f, 0.0f);
-    if (locDate_       >= 0) glUniform4f(locDate_, 0.0f, 0.0f, 0.0f, 0.0f);
-    if (locSampleRate_ >= 0) glUniform1f(locSampleRate_, 44100.0f);
+    if (locs_.mouse      >= 0) glUniform4f(locs_.mouse, 0.0f, 0.0f, 0.0f, 0.0f);
+    if (locs_.date       >= 0) glUniform4f(locs_.date, 0.0f, 0.0f, 0.0f, 0.0f);
+    if (locs_.sampleRate >= 0) glUniform1f(locs_.sampleRate, 44100.0f);
 
-    if (locChannelTime_ >= 0) {
+    if (locs_.channelTime >= 0) {
         const float times[4] = { elapsed, elapsed, elapsed, elapsed };
-        glUniform1fv(locChannelTime_, 4, times);
+        glUniform1fv(locs_.channelTime, 4, times);
     }
-    if (locChannelResolution_ >= 0) {
+    if (locs_.channelResolution >= 0) {
         const float res[12] = {
             static_cast<float>(AudioTexture::BINS), 2.0f, 1.0f,
             0.0f, 0.0f, 0.0f,
             0.0f, 0.0f, 0.0f,
             0.0f, 0.0f, 0.0f,
         };
-        glUniform3fv(locChannelResolution_, 4, res);
+        glUniform3fv(locs_.channelResolution, 4, res);
     }
 
-    if (locChannel0_ >= 0) {
+    if (locs_.channel0 >= 0) {
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, audioTex);
-        glUniform1i(locChannel0_, 0);
+        glUniform1i(locs_.channel0, 0);
     }
 
     glBindVertexArray(vao_);
@@ -235,8 +380,27 @@ void ShaderEngine::addPcm(const float* samples, std::size_t frameCount) {
 
 void ShaderEngine::loadPreset(const char* data, bool /*smoothTransition*/) {
     if (!data) return;
-    // We don't currently animate a transition between shaders — the
-    // swap is instant. smoothTransition is accepted for API parity
-    // with ProjectMEngine.
-    compileProgram(data);
+
+    // If the worker thread couldn't be started (shared context
+    // failed), fall back to compiling synchronously on the render
+    // thread — slower but correct.
+    if (!worker_.joinable()) {
+        GLuint newProgram =
+            compileProgramOnCurrentContext(std::string(data));
+        if (newProgram == 0) return;
+        if (program_) glDeleteProgram(program_);
+        program_ = newProgram;
+        locs_ = queryUniformLocations(program_);
+        return;
+    }
+
+    // Queue the source. We only keep the LATEST source — if the user
+    // taps faster than compile time, intermediate selections are
+    // dropped. The worker drains exactly one source per cycle.
+    {
+        std::lock_guard<std::mutex> lock(queueMutex_);
+        pendingSource_ = data;
+        hasPendingSource_ = true;
+    }
+    queueCv_.notify_one();
 }

--- a/android/app/src/main/cpp/shader_engine.cpp
+++ b/android/app/src/main/cpp/shader_engine.cpp
@@ -51,6 +51,37 @@ void main() {
 // === user shader follows ===
 )";
 
+// Present-pass shaders. Same fullscreen-triangle vertex pass but
+// also outputs uv. Fragment samples the offscreen FBO textures and
+// mixes them based on mixT (0 = all old, 1 = all current).
+const char* kPresentVertexShader = R"(#version 300 es
+precision highp float;
+layout(location = 0) in vec2 aPos;
+out vec2 vUv;
+void main() {
+    gl_Position = vec4(aPos, 0.0, 1.0);
+    vUv = (aPos + 1.0) * 0.5;
+}
+)";
+
+const char* kPresentFragmentShader = R"(#version 300 es
+precision highp float;
+in  vec2 vUv;
+out vec4 outColor;
+uniform sampler2D uCurrent;
+uniform sampler2D uOld;
+uniform float uMixT;  // 0 = all old, 1 = all current
+void main() {
+    vec4 cur = texture(uCurrent, vUv);
+    if (uMixT >= 1.0) {
+        outColor = cur;
+        return;
+    }
+    vec4 old = texture(uOld, vUv);
+    outColor = mix(old, cur, uMixT);
+}
+)";
+
 GLuint compileShader(GLenum kind, const char* src) {
     GLuint s = glCreateShader(kind);
     glShaderSource(s, 1, &src, nullptr);
@@ -70,6 +101,54 @@ GLuint compileShader(GLenum kind, const char* src) {
     return s;
 }
 
+GLuint linkProgram(GLuint vs, GLuint fs) {
+    GLuint p = glCreateProgram();
+    glAttachShader(p, vs);
+    glAttachShader(p, fs);
+    glLinkProgram(p);
+    GLint linked = GL_FALSE;
+    glGetProgramiv(p, GL_LINK_STATUS, &linked);
+    if (linked != GL_TRUE) {
+        GLint logLen = 0;
+        glGetProgramiv(p, GL_INFO_LOG_LENGTH, &logLen);
+        std::string log(static_cast<std::size_t>(logLen) + 1, '\0');
+        glGetProgramInfoLog(p, logLen, nullptr, log.data());
+        LOGE("program link error:\n%s", log.c_str());
+        glDeleteProgram(p);
+        return 0;
+    }
+    return p;
+}
+
+// Allocate a color-only RGBA8 texture + FBO at the given size.
+// Returns true on success.
+bool createColorFbo(int w, int h, GLuint* fbo, GLuint* tex) {
+    glGenTextures(1, tex);
+    glBindTexture(GL_TEXTURE_2D, *tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, w, h, 0, GL_RGBA,
+                  GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glGenFramebuffers(1, fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, *fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                            GL_TEXTURE_2D, *tex, 0);
+    const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    if (status != GL_FRAMEBUFFER_COMPLETE) {
+        LOGE("FBO incomplete: 0x%x", status);
+        glDeleteFramebuffers(1, fbo);
+        glDeleteTextures(1, tex);
+        *fbo = 0;
+        *tex = 0;
+        return false;
+    }
+    return true;
+}
+
 } // namespace
 
 ShaderEngine::~ShaderEngine() {
@@ -84,8 +163,6 @@ ShaderEngine::~ShaderEngine() {
     if (worker_.joinable()) worker_.join();
     teardownSharedContext();
 
-    // Free any program that arrived just before shutdown and never
-    // got adopted by the render thread.
     {
         std::lock_guard<std::mutex> lock(resultMutex_);
         if (pendingProgram_) {
@@ -94,6 +171,8 @@ ShaderEngine::~ShaderEngine() {
         }
     }
 
+    teardownOffscreenTargets();
+    if (presentProgram_) glDeleteProgram(presentProgram_);
     if (program_) glDeleteProgram(program_);
     if (vao_) glDeleteVertexArrays(1, &vao_);
     if (vbo_) glDeleteBuffers(1, &vbo_);
@@ -105,9 +184,11 @@ bool ShaderEngine::init(int width, int height) {
     height_ = height;
     startTime_ = std::chrono::steady_clock::now();
     lastFrameTime_ = startTime_;
+    transitionStart_ = startTime_;
     frameCount_ = 0;
 
-    // Fullscreen-triangle VBO/VAO.
+    // Fullscreen-triangle VBO/VAO — shared by the user shader pass
+    // and the present pass.
     const float verts[] = {
         -1.0f, -1.0f,
          3.0f, -1.0f,
@@ -127,6 +208,30 @@ bool ShaderEngine::init(int width, int height) {
         return false;
     }
 
+    if (!setupOffscreenTargets()) {
+        LOGE("offscreen target setup failed");
+        return false;
+    }
+
+    // Compile the present-pass program once at init.
+    {
+        GLuint vs = compileShader(GL_VERTEX_SHADER, kPresentVertexShader);
+        GLuint fs = compileShader(GL_FRAGMENT_SHADER, kPresentFragmentShader);
+        if (!vs || !fs) {
+            if (vs) glDeleteShader(vs);
+            if (fs) glDeleteShader(fs);
+            LOGE("present shader compile failed");
+            return false;
+        }
+        presentProgram_ = linkProgram(vs, fs);
+        glDeleteShader(vs);
+        glDeleteShader(fs);
+        if (!presentProgram_) return false;
+        locPresentCurrent_ = glGetUniformLocation(presentProgram_, "uCurrent");
+        locPresentOld_ = glGetUniformLocation(presentProgram_, "uOld");
+        locPresentMixT_ = glGetUniformLocation(presentProgram_, "uMixT");
+    }
+
     if (!setupSharedContext()) {
         LOGE("shared EGL context setup failed — compile will fall back to sync");
         // Fail soft: the engine still works, just synchronously.
@@ -138,6 +243,36 @@ bool ShaderEngine::init(int width, int height) {
     return true;
 }
 
+bool ShaderEngine::setupOffscreenTargets() {
+    if (!createColorFbo(width_, height_, &fboCurrent_, &texCurrent_)) {
+        return false;
+    }
+    if (!createColorFbo(width_, height_, &fboOld_, &texOld_)) {
+        // Free the first if the second failed.
+        glDeleteFramebuffers(1, &fboCurrent_);
+        glDeleteTextures(1, &texCurrent_);
+        fboCurrent_ = 0;
+        texCurrent_ = 0;
+        return false;
+    }
+    // Initialise both to black so the first frame doesn't sample
+    // undefined memory.
+    glBindFramebuffer(GL_FRAMEBUFFER, fboCurrent_);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glBindFramebuffer(GL_FRAMEBUFFER, fboOld_);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    return true;
+}
+
+void ShaderEngine::teardownOffscreenTargets() {
+    if (fboCurrent_) { glDeleteFramebuffers(1, &fboCurrent_); fboCurrent_ = 0; }
+    if (texCurrent_) { glDeleteTextures(1, &texCurrent_); texCurrent_ = 0; }
+    if (fboOld_) { glDeleteFramebuffers(1, &fboOld_); fboOld_ = 0; }
+    if (texOld_) { glDeleteTextures(1, &texOld_); texOld_ = 0; }
+}
+
 bool ShaderEngine::setupSharedContext() {
     EGLDisplay display = eglGetCurrentDisplay();
     EGLContext mainCtx = eglGetCurrentContext();
@@ -146,9 +281,6 @@ bool ShaderEngine::setupSharedContext() {
         return false;
     }
 
-    // Choose a config compatible with the main context that also
-    // supports PBuffer surfaces (the worker needs *some* surface to
-    // make its context current, even if it never renders to one).
     const EGLint configAttrs[] = {
         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
         EGL_SURFACE_TYPE,    EGL_PBUFFER_BIT,
@@ -227,24 +359,9 @@ GLuint ShaderEngine::compileProgramOnCurrentContext(
         return 0;
     }
 
-    GLuint p = glCreateProgram();
-    glAttachShader(p, vs);
-    glAttachShader(p, fs);
-    glLinkProgram(p);
+    GLuint p = linkProgram(vs, fs);
     glDeleteShader(vs);
     glDeleteShader(fs);
-
-    GLint linked = GL_FALSE;
-    glGetProgramiv(p, GL_LINK_STATUS, &linked);
-    if (linked != GL_TRUE) {
-        GLint logLen = 0;
-        glGetProgramiv(p, GL_INFO_LOG_LENGTH, &logLen);
-        std::string log(static_cast<std::size_t>(logLen) + 1, '\0');
-        glGetProgramInfoLog(p, logLen, nullptr, log.data());
-        LOGE("program link error:\n%s", log.c_str());
-        glDeleteProgram(p);
-        return 0;
-    }
     return p;
 }
 
@@ -272,13 +389,8 @@ void ShaderEngine::workerLoop() {
         GLuint newProgram = compileProgramOnCurrentContext(source);
         if (newProgram == 0) continue;
 
-        // Make sure the program object is fully realized before the
-        // render thread tries to use it from the other context.
         glFlush();
 
-        // Hand off. If a previous program is still waiting to be
-        // adopted, the render thread missed its window — free it
-        // here so it doesn't leak.
         GLuint orphan = 0;
         {
             std::lock_guard<std::mutex> lock(resultMutex_);
@@ -293,7 +405,7 @@ void ShaderEngine::workerLoop() {
     LOGI("shader compile worker exited");
 }
 
-void ShaderEngine::adoptPendingProgramIfAny() {
+bool ShaderEngine::adoptPendingProgramIfAny() {
     GLuint adopt = 0;
     {
         std::lock_guard<std::mutex> lock(resultMutex_);
@@ -302,29 +414,35 @@ void ShaderEngine::adoptPendingProgramIfAny() {
             pendingProgram_ = 0;
         }
     }
-    if (!adopt) return;
+    if (!adopt) return false;
 
-    // Free the old current program. Programs are shared between the
-    // worker and render contexts (created via shared context), so
-    // we can delete from either side.
+    // Capture the current frame into the "old" FBO before swapping
+    // shaders. glBlitFramebuffer is the fastest way to copy texture
+    // contents between two FBOs of the same size.
+    if (program_ && fboCurrent_ && fboOld_) {
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, fboCurrent_);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fboOld_);
+        glBlitFramebuffer(0, 0, width_, height_,
+                           0, 0, width_, height_,
+                           GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    }
+
     if (program_) glDeleteProgram(program_);
     program_ = adopt;
     locs_ = queryUniformLocations(program_);
     LOGI("adopted new shader program=%u", program_);
+
+    // Start the crossfade. If this is the very first preset (no old
+    // program), skip the transition — there's nothing to fade from.
+    transitionStart_ = std::chrono::steady_clock::now();
+    transitioning_ = (fboOld_ != 0);
+    return true;
 }
 
 void ShaderEngine::renderFrame() {
     adoptPendingProgramIfAny();
-
-    if (!program_) {
-        // No shader loaded yet — clear to black so the user sees
-        // *something* and the surface isn't undefined.
-        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-        glClear(GL_COLOR_BUFFER_BIT);
-        return;
-    }
-
-    const GLuint audioTex = audio_.upload();
 
     auto now = std::chrono::steady_clock::now();
     const float elapsed =
@@ -333,39 +451,85 @@ void ShaderEngine::renderFrame() {
         std::chrono::duration<float>(now - lastFrameTime_).count();
     lastFrameTime_ = now;
 
+    // === Pass 1: user shader → fboCurrent_ ===
+    glBindFramebuffer(GL_FRAMEBUFFER, fboCurrent_);
     glViewport(0, 0, width_, height_);
-    glUseProgram(program_);
 
-    if (locs_.time       >= 0) glUniform1f(locs_.time, elapsed);
-    if (locs_.timeDelta  >= 0) glUniform1f(locs_.timeDelta, delta);
-    if (locs_.frame      >= 0) glUniform1i(locs_.frame, frameCount_);
-    if (locs_.resolution >= 0) glUniform3f(locs_.resolution,
-        static_cast<float>(width_),
-        static_cast<float>(height_),
-        static_cast<float>(width_) / static_cast<float>(height_));
-    if (locs_.mouse      >= 0) glUniform4f(locs_.mouse, 0.0f, 0.0f, 0.0f, 0.0f);
-    if (locs_.date       >= 0) glUniform4f(locs_.date, 0.0f, 0.0f, 0.0f, 0.0f);
-    if (locs_.sampleRate >= 0) glUniform1f(locs_.sampleRate, 44100.0f);
+    if (!program_) {
+        // No shader compiled yet — clear the FBO so present has
+        // something defined to sample.
+        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+    } else {
+        const GLuint audioTex = audio_.upload();
 
-    if (locs_.channelTime >= 0) {
-        const float times[4] = { elapsed, elapsed, elapsed, elapsed };
-        glUniform1fv(locs_.channelTime, 4, times);
+        glUseProgram(program_);
+
+        if (locs_.time       >= 0) glUniform1f(locs_.time, elapsed);
+        if (locs_.timeDelta  >= 0) glUniform1f(locs_.timeDelta, delta);
+        if (locs_.frame      >= 0) glUniform1i(locs_.frame, frameCount_);
+        if (locs_.resolution >= 0) glUniform3f(locs_.resolution,
+            static_cast<float>(width_),
+            static_cast<float>(height_),
+            static_cast<float>(width_) / static_cast<float>(height_));
+        if (locs_.mouse      >= 0) glUniform4f(locs_.mouse, 0.0f, 0.0f, 0.0f, 0.0f);
+        if (locs_.date       >= 0) glUniform4f(locs_.date, 0.0f, 0.0f, 0.0f, 0.0f);
+        if (locs_.sampleRate >= 0) glUniform1f(locs_.sampleRate, 44100.0f);
+
+        if (locs_.channelTime >= 0) {
+            const float times[4] = { elapsed, elapsed, elapsed, elapsed };
+            glUniform1fv(locs_.channelTime, 4, times);
+        }
+        if (locs_.channelResolution >= 0) {
+            const float res[12] = {
+                static_cast<float>(AudioTexture::BINS), 2.0f, 1.0f,
+                0.0f, 0.0f, 0.0f,
+                0.0f, 0.0f, 0.0f,
+                0.0f, 0.0f, 0.0f,
+            };
+            glUniform3fv(locs_.channelResolution, 4, res);
+        }
+
+        if (locs_.channel0 >= 0) {
+            glActiveTexture(GL_TEXTURE0);
+            glBindTexture(GL_TEXTURE_2D, audioTex);
+            glUniform1i(locs_.channel0, 0);
+        }
+
+        glBindVertexArray(vao_);
+        glDrawArrays(GL_TRIANGLES, 0, 3);
+        glBindVertexArray(0);
     }
-    if (locs_.channelResolution >= 0) {
-        const float res[12] = {
-            static_cast<float>(AudioTexture::BINS), 2.0f, 1.0f,
-            0.0f, 0.0f, 0.0f,
-            0.0f, 0.0f, 0.0f,
-            0.0f, 0.0f, 0.0f,
-        };
-        glUniform3fv(locs_.channelResolution, 4, res);
+
+    // === Pass 2: present (texCurrent_ ± texOld_) → window surface ===
+    float mixT = 1.0f;
+    if (transitioning_) {
+        const float t = std::chrono::duration<float>(now - transitionStart_)
+                            .count() / kTransitionDuration;
+        if (t >= 1.0f) {
+            transitioning_ = false;
+            mixT = 1.0f;
+        } else {
+            // Smoothstep ease — feels more natural than linear.
+            mixT = t * t * (3.0f - 2.0f * t);
+        }
     }
 
-    if (locs_.channel0 >= 0) {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glViewport(0, 0, width_, height_);
+    glUseProgram(presentProgram_);
+
+    if (locPresentCurrent_ >= 0) {
         glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, audioTex);
-        glUniform1i(locs_.channel0, 0);
+        glBindTexture(GL_TEXTURE_2D, texCurrent_);
+        glUniform1i(locPresentCurrent_, 0);
     }
+    if (locPresentOld_ >= 0) {
+        glActiveTexture(GL_TEXTURE1);
+        glBindTexture(GL_TEXTURE_2D, texOld_);
+        glUniform1i(locPresentOld_, 1);
+    }
+    if (locPresentMixT_ >= 0) glUniform1f(locPresentMixT_, mixT);
 
     glBindVertexArray(vao_);
     glDrawArrays(GL_TRIANGLES, 0, 3);
@@ -381,22 +545,34 @@ void ShaderEngine::addPcm(const float* samples, std::size_t frameCount) {
 void ShaderEngine::loadPreset(const char* data, bool /*smoothTransition*/) {
     if (!data) return;
 
-    // If the worker thread couldn't be started (shared context
-    // failed), fall back to compiling synchronously on the render
-    // thread — slower but correct.
+    // If the worker thread couldn't be started, compile synchronously
+    // on the render thread (slow but correct).
     if (!worker_.joinable()) {
         GLuint newProgram =
             compileProgramOnCurrentContext(std::string(data));
         if (newProgram == 0) return;
+
+        // Snapshot the current frame into the "old" FBO so the
+        // crossfade has something to fade from. Same as the async path.
+        if (program_ && fboCurrent_ && fboOld_) {
+            glBindFramebuffer(GL_READ_FRAMEBUFFER, fboCurrent_);
+            glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fboOld_);
+            glBlitFramebuffer(0, 0, width_, height_,
+                               0, 0, width_, height_,
+                               GL_COLOR_BUFFER_BIT, GL_NEAREST);
+            glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+            glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+        }
+
         if (program_) glDeleteProgram(program_);
         program_ = newProgram;
         locs_ = queryUniformLocations(program_);
+        transitionStart_ = std::chrono::steady_clock::now();
+        transitioning_ = (fboOld_ != 0);
         return;
     }
 
-    // Queue the source. We only keep the LATEST source — if the user
-    // taps faster than compile time, intermediate selections are
-    // dropped. The worker drains exactly one source per cycle.
+    // Async path: queue the source. Only the LATEST source survives.
     {
         std::lock_guard<std::mutex> lock(queueMutex_);
         pendingSource_ = data;

--- a/android/app/src/main/cpp/shader_engine.cpp
+++ b/android/app/src/main/cpp/shader_engine.cpp
@@ -1,0 +1,242 @@
+#include "shader_engine.h"
+
+#include <android/log.h>
+#include <cstring>
+#include <string>
+
+#define LOG_TAG "mstream/viz-bridge"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+namespace {
+
+// Vertex shader — a fullscreen triangle. Coordinates chosen so that a
+// single triangle covers the entire viewport without needing a quad
+// (saves us an index buffer).
+const char* kVertexShader = R"(#version 300 es
+precision highp float;
+layout(location = 0) in vec2 aPos;
+void main() {
+    gl_Position = vec4(aPos, 0.0, 1.0);
+}
+)";
+
+// Prelude prepended to every user fragment shader. Provides the
+// Shadertoy uniforms and the main() entry that delegates to the
+// user's mainImage().
+const char* kFragPrelude = R"(#version 300 es
+precision highp float;
+precision highp int;
+
+uniform float iTime;
+uniform float iTimeDelta;
+uniform int   iFrame;
+uniform vec3  iResolution;
+uniform vec4  iMouse;
+uniform sampler2D iChannel0;
+uniform float iChannelTime[4];
+uniform vec3  iChannelResolution[4];
+uniform vec4  iDate;
+uniform float iSampleRate;
+
+out vec4 outColor;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord);
+
+void main() {
+    vec4 col = vec4(0.0);
+    mainImage(col, gl_FragCoord.xy);
+    outColor = col;
+}
+
+// === user shader follows ===
+)";
+
+GLuint compileShader(GLenum kind, const char* src) {
+    GLuint s = glCreateShader(kind);
+    glShaderSource(s, 1, &src, nullptr);
+    glCompileShader(s);
+    GLint status = GL_FALSE;
+    glGetShaderiv(s, GL_COMPILE_STATUS, &status);
+    if (status != GL_TRUE) {
+        GLint logLen = 0;
+        glGetShaderiv(s, GL_INFO_LOG_LENGTH, &logLen);
+        std::string log(static_cast<std::size_t>(logLen) + 1, '\0');
+        glGetShaderInfoLog(s, logLen, nullptr, log.data());
+        LOGE("shader compile error (%s):\n%s",
+             kind == GL_VERTEX_SHADER ? "vert" : "frag", log.c_str());
+        glDeleteShader(s);
+        return 0;
+    }
+    return s;
+}
+
+} // namespace
+
+ShaderEngine::~ShaderEngine() {
+    releaseProgram();
+    if (vao_) glDeleteVertexArrays(1, &vao_);
+    if (vbo_) glDeleteBuffers(1, &vbo_);
+    audio_.dispose();
+}
+
+bool ShaderEngine::init(int width, int height) {
+    width_ = width;
+    height_ = height;
+    startTime_ = std::chrono::steady_clock::now();
+    lastFrameTime_ = startTime_;
+    frameCount_ = 0;
+
+    // Fullscreen-triangle VBO/VAO. Three vertices covering NDC.
+    const float verts[] = {
+        -1.0f, -1.0f,
+         3.0f, -1.0f,
+        -1.0f,  3.0f,
+    };
+    glGenVertexArrays(1, &vao_);
+    glGenBuffers(1, &vbo_);
+    glBindVertexArray(vao_);
+    glBindBuffer(GL_ARRAY_BUFFER, vbo_);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(verts), verts, GL_STATIC_DRAW);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+    glBindVertexArray(0);
+
+    if (!audio_.init()) {
+        LOGE("audio texture init failed");
+        return false;
+    }
+
+    LOGI("ShaderEngine init ok %dx%d", width, height);
+    return true;
+}
+
+bool ShaderEngine::compileProgram(const char* fragSource) {
+    GLuint vs = compileShader(GL_VERTEX_SHADER, kVertexShader);
+    if (!vs) return false;
+
+    std::string fullFrag(kFragPrelude);
+    fullFrag.append(fragSource ? fragSource : "");
+    GLuint fs = compileShader(GL_FRAGMENT_SHADER, fullFrag.c_str());
+    if (!fs) {
+        glDeleteShader(vs);
+        return false;
+    }
+
+    GLuint p = glCreateProgram();
+    glAttachShader(p, vs);
+    glAttachShader(p, fs);
+    glLinkProgram(p);
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    GLint linked = GL_FALSE;
+    glGetProgramiv(p, GL_LINK_STATUS, &linked);
+    if (linked != GL_TRUE) {
+        GLint logLen = 0;
+        glGetProgramiv(p, GL_INFO_LOG_LENGTH, &logLen);
+        std::string log(static_cast<std::size_t>(logLen) + 1, '\0');
+        glGetProgramInfoLog(p, logLen, nullptr, log.data());
+        LOGE("program link error:\n%s", log.c_str());
+        glDeleteProgram(p);
+        return false;
+    }
+
+    releaseProgram();
+    program_ = p;
+
+    locTime_ = glGetUniformLocation(p, "iTime");
+    locTimeDelta_ = glGetUniformLocation(p, "iTimeDelta");
+    locFrame_ = glGetUniformLocation(p, "iFrame");
+    locResolution_ = glGetUniformLocation(p, "iResolution");
+    locMouse_ = glGetUniformLocation(p, "iMouse");
+    locChannel0_ = glGetUniformLocation(p, "iChannel0");
+    locChannelTime_ = glGetUniformLocation(p, "iChannelTime[0]");
+    locChannelResolution_ =
+        glGetUniformLocation(p, "iChannelResolution[0]");
+    locDate_ = glGetUniformLocation(p, "iDate");
+    locSampleRate_ = glGetUniformLocation(p, "iSampleRate");
+
+    LOGI("shader program linked ok program=%u", program_);
+    return true;
+}
+
+void ShaderEngine::releaseProgram() {
+    if (program_) {
+        glDeleteProgram(program_);
+        program_ = 0;
+    }
+}
+
+void ShaderEngine::renderFrame() {
+    if (!program_) {
+        // No shader loaded yet — clear to black so the user sees
+        // *something* and the surface isn't undefined.
+        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        return;
+    }
+
+    // Push the latest audio frame into iChannel0.
+    const GLuint audioTex = audio_.upload();
+
+    // Compute timing uniforms.
+    auto now = std::chrono::steady_clock::now();
+    const float elapsed =
+        std::chrono::duration<float>(now - startTime_).count();
+    const float delta =
+        std::chrono::duration<float>(now - lastFrameTime_).count();
+    lastFrameTime_ = now;
+
+    glViewport(0, 0, width_, height_);
+    glUseProgram(program_);
+
+    if (locTime_       >= 0) glUniform1f(locTime_, elapsed);
+    if (locTimeDelta_  >= 0) glUniform1f(locTimeDelta_, delta);
+    if (locFrame_      >= 0) glUniform1i(locFrame_, frameCount_);
+    if (locResolution_ >= 0) glUniform3f(locResolution_,
+        static_cast<float>(width_),
+        static_cast<float>(height_),
+        static_cast<float>(width_) / static_cast<float>(height_));
+    if (locMouse_      >= 0) glUniform4f(locMouse_, 0.0f, 0.0f, 0.0f, 0.0f);
+    if (locDate_       >= 0) glUniform4f(locDate_, 0.0f, 0.0f, 0.0f, 0.0f);
+    if (locSampleRate_ >= 0) glUniform1f(locSampleRate_, 44100.0f);
+
+    if (locChannelTime_ >= 0) {
+        const float times[4] = { elapsed, elapsed, elapsed, elapsed };
+        glUniform1fv(locChannelTime_, 4, times);
+    }
+    if (locChannelResolution_ >= 0) {
+        const float res[12] = {
+            static_cast<float>(AudioTexture::BINS), 2.0f, 1.0f,
+            0.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 0.0f,
+        };
+        glUniform3fv(locChannelResolution_, 4, res);
+    }
+
+    if (locChannel0_ >= 0) {
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, audioTex);
+        glUniform1i(locChannel0_, 0);
+    }
+
+    glBindVertexArray(vao_);
+    glDrawArrays(GL_TRIANGLES, 0, 3);
+    glBindVertexArray(0);
+
+    ++frameCount_;
+}
+
+void ShaderEngine::addPcm(const float* samples, std::size_t frameCount) {
+    audio_.addPcm(samples, frameCount);
+}
+
+void ShaderEngine::loadPreset(const char* data, bool /*smoothTransition*/) {
+    if (!data) return;
+    // We don't currently animate a transition between shaders — the
+    // swap is instant. smoothTransition is accepted for API parity
+    // with ProjectMEngine.
+    compileProgram(data);
+}

--- a/android/app/src/main/cpp/shader_engine.cpp
+++ b/android/app/src/main/cpp/shader_engine.cpp
@@ -2,6 +2,8 @@
 
 #include <android/log.h>
 #include <cstring>
+#include <regex>
+#include <sstream>
 #include <utility>
 
 #define LOG_TAG "mstream/viz-bridge"
@@ -33,6 +35,9 @@ uniform int   iFrame;
 uniform vec3  iResolution;
 uniform vec4  iMouse;
 uniform sampler2D iChannel0;
+uniform sampler2D iChannel1;
+uniform sampler2D iChannel2;
+uniform sampler2D iChannel3;
 uniform float iChannelTime[4];
 uniform vec3  iChannelResolution[4];
 uniform vec4  iDate;
@@ -51,9 +56,6 @@ void main() {
 // === user shader follows ===
 )";
 
-// Present-pass shaders. Same fullscreen-triangle vertex pass but
-// also outputs uv. Fragment samples the offscreen FBO textures and
-// mixes them based on mixT (0 = all old, 1 = all current).
 const char* kPresentVertexShader = R"(#version 300 es
 precision highp float;
 layout(location = 0) in vec2 aPos;
@@ -70,13 +72,10 @@ in  vec2 vUv;
 out vec4 outColor;
 uniform sampler2D uCurrent;
 uniform sampler2D uOld;
-uniform float uMixT;  // 0 = all old, 1 = all current
+uniform float uMixT;
 void main() {
     vec4 cur = texture(uCurrent, vUv);
-    if (uMixT >= 1.0) {
-        outColor = cur;
-        return;
-    }
+    if (uMixT >= 1.0) { outColor = cur; return; }
     vec4 old = texture(uOld, vUv);
     outColor = mix(old, cur, uMixT);
 }
@@ -120,8 +119,6 @@ GLuint linkProgram(GLuint vs, GLuint fs) {
     return p;
 }
 
-// Allocate a color-only RGBA8 texture + FBO at the given size.
-// Returns true on success.
 bool createColorFbo(int w, int h, GLuint* fbo, GLuint* tex) {
     glGenTextures(1, tex);
     glBindTexture(GL_TEXTURE_2D, *tex);
@@ -142,19 +139,145 @@ bool createColorFbo(int w, int h, GLuint* fbo, GLuint* tex) {
         LOGE("FBO incomplete: 0x%x", status);
         glDeleteFramebuffers(1, fbo);
         glDeleteTextures(1, tex);
-        *fbo = 0;
-        *tex = 0;
+        *fbo = 0; *tex = 0;
         return false;
     }
     return true;
 }
 
+// === Multi-pass source parsing ===
+//
+// Recognizes lines of two forms (anywhere before the first pass body):
+//
+//   // === channel <target>.<index> = <source>
+//   // === pass: <name> ===
+//
+// Anything after a pass-marker line belongs to that pass until the next
+// pass-marker line or end of file. Single-pass files (no pass markers
+// at all) are treated as if the entire source belongs to one image pass.
+
+struct ParsedShader {
+    std::string commonCode;
+    std::string passCode[ShaderEngine::PASS_COUNT];
+    bool hasPass[ShaderEngine::PASS_COUNT] = {false, false, false, false, false};
+    bool hasCommon = false;
+    // [passIdx][channel] = ChannelSource enum int
+    int channelSrc[ShaderEngine::PASS_COUNT][4] = {{0}};
+};
+
+int passIndexFromName(const std::string& nameLower) {
+    if (nameLower == "image")    return ShaderEngine::PASS_IMAGE;
+    if (nameLower == "buffera")  return ShaderEngine::PASS_BUFFER_A;
+    if (nameLower == "bufferb")  return ShaderEngine::PASS_BUFFER_B;
+    if (nameLower == "bufferc")  return ShaderEngine::PASS_BUFFER_C;
+    if (nameLower == "bufferd")  return ShaderEngine::PASS_BUFFER_D;
+    return -1; // common handled separately
+}
+
+int channelSourceFromString(const std::string& s) {
+    if (s == "audio" || s == "music" || s == "musicstream" || s == "mic")
+        return 1; // CHAN_AUDIO
+    if (s == "buffera") return 2;
+    if (s == "bufferb") return 3;
+    if (s == "bufferc") return 4;
+    if (s == "bufferd") return 5;
+    return 0; // CHAN_NONE
+}
+
+std::string lowerAlnum(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    for (char c : s) {
+        if (c >= 'A' && c <= 'Z') out.push_back(c - 'A' + 'a');
+        else if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) out.push_back(c);
+        // strip whitespace, punctuation
+    }
+    return out;
+}
+
+ParsedShader parseShader(const std::string& source) {
+    ParsedShader out;
+
+    // Quick check: does the source contain `// === pass:` anywhere?
+    if (source.find("=== pass:") == std::string::npos) {
+        // Single-pass — treat whole source as the image pass with
+        // iChannel0 wired to audio (preserves backward compatibility
+        // with our existing single-file shaders).
+        out.hasPass[ShaderEngine::PASS_IMAGE] = true;
+        out.passCode[ShaderEngine::PASS_IMAGE] = source;
+        out.channelSrc[ShaderEngine::PASS_IMAGE][0] = 1; // CHAN_AUDIO
+        return out;
+    }
+
+    // Multi-pass parse: iterate lines, splitting on pass markers.
+    std::istringstream stream(source);
+    std::string line;
+    std::string headerBuf;
+    int curPass = -1;       // -1 = pre-marker zone (or common), -2 = common pass body
+    std::string curBody;
+
+    auto flushCurPass = [&]() {
+        if (curPass == -2) {
+            out.commonCode = curBody;
+            out.hasCommon = true;
+        } else if (curPass >= 0) {
+            out.passCode[curPass] = curBody;
+            out.hasPass[curPass] = true;
+        }
+        curBody.clear();
+    };
+
+    // We also want to capture channel routing lines anywhere before
+    // the first pass marker (those land in the headerBuf via the
+    // initial loop iteration when curPass is -1 and we're not yet in
+    // a pass body).
+    std::regex passMarker(R"(^\s*//\s*===\s*pass\s*:\s*([a-zA-Z]+)\s*===)");
+    std::regex channelMarker(
+        R"(^\s*//\s*===\s*channel\s+([a-zA-Z]+)\s*\.\s*(\d+)\s*=\s*([a-zA-Z]+))");
+
+    while (std::getline(stream, line)) {
+        std::smatch m;
+        if (std::regex_search(line, m, passMarker)) {
+            // flush whatever we were collecting
+            flushCurPass();
+            std::string name = lowerAlnum(m[1].str());
+            if (name == "common") {
+                curPass = -2;
+            } else {
+                int idx = passIndexFromName(name);
+                curPass = (idx >= 0) ? idx : -3;  // -3 = unknown, will be discarded
+                if (idx < 0) LOGE("unknown pass name in source: %s", m[1].str().c_str());
+            }
+            continue;
+        }
+        if (curPass == -1) {
+            // Pre-marker zone: look for routing lines
+            std::smatch cm;
+            if (std::regex_search(line, cm, channelMarker)) {
+                std::string target = lowerAlnum(cm[1].str());
+                int ch = std::stoi(cm[2].str());
+                std::string srcName = lowerAlnum(cm[3].str());
+                int tgtIdx = passIndexFromName(target);
+                int srcEnum = channelSourceFromString(srcName);
+                if (tgtIdx >= 0 && ch >= 0 && ch < 4) {
+                    out.channelSrc[tgtIdx][ch] = srcEnum;
+                }
+            }
+            // Other pre-marker lines are ignored (comments, etc.)
+            continue;
+        }
+        // Accumulate into current pass body
+        curBody.append(line);
+        curBody.push_back('\n');
+    }
+    flushCurPass();
+
+    return out;
+}
+
 } // namespace
 
 ShaderEngine::~ShaderEngine() {
-    // Stop the worker first so it doesn't try to touch GL during
-    // teardown. Worker may have a context-current state that needs
-    // unwinding cleanly.
     workerShutdown_ = true;
     {
         std::lock_guard<std::mutex> lock(queueMutex_);
@@ -165,18 +288,39 @@ ShaderEngine::~ShaderEngine() {
 
     {
         std::lock_guard<std::mutex> lock(resultMutex_);
-        if (pendingProgram_) {
-            glDeleteProgram(pendingProgram_);
-            pendingProgram_ = 0;
-        }
+        if (pendingResult_) { freePassSet(pendingResult_); pendingResult_ = nullptr; }
     }
 
+    clearCurrentSet();
+    releaseAllBufferTargets();
     teardownOffscreenTargets();
+
+    if (blackTex_) glDeleteTextures(1, &blackTex_);
     if (presentProgram_) glDeleteProgram(presentProgram_);
-    if (program_) glDeleteProgram(program_);
     if (vao_) glDeleteVertexArrays(1, &vao_);
     if (vbo_) glDeleteBuffers(1, &vbo_);
     audio_.dispose();
+}
+
+void ShaderEngine::clearCurrentSet() {
+    if (!currentSet_) return;
+    for (int i = 0; i < PASS_COUNT; ++i) {
+        if (currentSet_->hasPass[i] && currentSet_->passes[i].program) {
+            glDeleteProgram(currentSet_->passes[i].program);
+        }
+    }
+    delete currentSet_;
+    currentSet_ = nullptr;
+}
+
+void ShaderEngine::freePassSet(PassSet* set) {
+    if (!set) return;
+    for (int i = 0; i < PASS_COUNT; ++i) {
+        if (set->hasPass[i] && set->passes[i].program) {
+            glDeleteProgram(set->passes[i].program);
+        }
+    }
+    delete set;
 }
 
 bool ShaderEngine::init(int width, int height) {
@@ -187,13 +331,7 @@ bool ShaderEngine::init(int width, int height) {
     transitionStart_ = startTime_;
     frameCount_ = 0;
 
-    // Fullscreen-triangle VBO/VAO — shared by the user shader pass
-    // and the present pass.
-    const float verts[] = {
-        -1.0f, -1.0f,
-         3.0f, -1.0f,
-        -1.0f,  3.0f,
-    };
+    const float verts[] = {-1.0f,-1.0f, 3.0f,-1.0f, -1.0f,3.0f};
     glGenVertexArrays(1, &vao_);
     glGenBuffers(1, &vbo_);
     glBindVertexArray(vao_);
@@ -203,38 +341,40 @@ bool ShaderEngine::init(int width, int height) {
     glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
     glBindVertexArray(0);
 
-    if (!audio_.init()) {
-        LOGE("audio texture init failed");
-        return false;
+    if (!audio_.init()) { LOGE("audio texture init failed"); return false; }
+    if (!setupOffscreenTargets()) { LOGE("offscreen setup failed"); return false; }
+
+    // 1×1 black fallback for unbound iChannels.
+    {
+        const uint8_t black[4] = {0, 0, 0, 255};
+        glGenTextures(1, &blackTex_);
+        glBindTexture(GL_TEXTURE_2D, blackTex_);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 1, 1, 0, GL_RGBA,
+                      GL_UNSIGNED_BYTE, black);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glBindTexture(GL_TEXTURE_2D, 0);
     }
 
-    if (!setupOffscreenTargets()) {
-        LOGE("offscreen target setup failed");
-        return false;
-    }
-
-    // Compile the present-pass program once at init.
+    // Present program.
     {
         GLuint vs = compileShader(GL_VERTEX_SHADER, kPresentVertexShader);
         GLuint fs = compileShader(GL_FRAGMENT_SHADER, kPresentFragmentShader);
         if (!vs || !fs) {
             if (vs) glDeleteShader(vs);
             if (fs) glDeleteShader(fs);
-            LOGE("present shader compile failed");
             return false;
         }
         presentProgram_ = linkProgram(vs, fs);
-        glDeleteShader(vs);
-        glDeleteShader(fs);
+        glDeleteShader(vs); glDeleteShader(fs);
         if (!presentProgram_) return false;
         locPresentCurrent_ = glGetUniformLocation(presentProgram_, "uCurrent");
-        locPresentOld_ = glGetUniformLocation(presentProgram_, "uOld");
-        locPresentMixT_ = glGetUniformLocation(presentProgram_, "uMixT");
+        locPresentOld_     = glGetUniformLocation(presentProgram_, "uOld");
+        locPresentMixT_    = glGetUniformLocation(presentProgram_, "uMixT");
     }
 
     if (!setupSharedContext()) {
-        LOGE("shared EGL context setup failed — compile will fall back to sync");
-        // Fail soft: the engine still works, just synchronously.
+        LOGE("shared EGL setup failed — sync fallback active");
     } else {
         worker_ = std::thread(&ShaderEngine::workerLoop, this);
     }
@@ -244,22 +384,15 @@ bool ShaderEngine::init(int width, int height) {
 }
 
 bool ShaderEngine::setupOffscreenTargets() {
-    if (!createColorFbo(width_, height_, &fboCurrent_, &texCurrent_)) {
-        return false;
-    }
+    if (!createColorFbo(width_, height_, &fboCurrent_, &texCurrent_)) return false;
     if (!createColorFbo(width_, height_, &fboOld_, &texOld_)) {
-        // Free the first if the second failed.
         glDeleteFramebuffers(1, &fboCurrent_);
         glDeleteTextures(1, &texCurrent_);
-        fboCurrent_ = 0;
-        texCurrent_ = 0;
+        fboCurrent_ = 0; texCurrent_ = 0;
         return false;
     }
-    // Initialise both to black so the first frame doesn't sample
-    // undefined memory.
     glBindFramebuffer(GL_FRAMEBUFFER, fboCurrent_);
-    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT);
+    glClearColor(0,0,0,1); glClear(GL_COLOR_BUFFER_BIT);
     glBindFramebuffer(GL_FRAMEBUFFER, fboOld_);
     glClear(GL_COLOR_BUFFER_BIT);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -269,256 +402,356 @@ bool ShaderEngine::setupOffscreenTargets() {
 void ShaderEngine::teardownOffscreenTargets() {
     if (fboCurrent_) { glDeleteFramebuffers(1, &fboCurrent_); fboCurrent_ = 0; }
     if (texCurrent_) { glDeleteTextures(1, &texCurrent_); texCurrent_ = 0; }
-    if (fboOld_) { glDeleteFramebuffers(1, &fboOld_); fboOld_ = 0; }
-    if (texOld_) { glDeleteTextures(1, &texOld_); texOld_ = 0; }
+    if (fboOld_)     { glDeleteFramebuffers(1, &fboOld_); fboOld_ = 0; }
+    if (texOld_)     { glDeleteTextures(1, &texOld_); texOld_ = 0; }
+}
+
+bool ShaderEngine::ensureBufferTarget(int idx) {
+    BufferTarget& bt = bufferTargets_[idx];
+    if (bt.allocated) return true;
+    for (int p = 0; p < 2; ++p) {
+        if (!createColorFbo(width_, height_, &bt.fbo[p], &bt.tex[p])) {
+            // free anything created
+            for (int q = 0; q < p; ++q) {
+                glDeleteFramebuffers(1, &bt.fbo[q]);
+                glDeleteTextures(1, &bt.tex[q]);
+                bt.fbo[q] = 0; bt.tex[q] = 0;
+            }
+            return false;
+        }
+        // Clear to black so first frame doesn't sample undefined memory.
+        glBindFramebuffer(GL_FRAMEBUFFER, bt.fbo[p]);
+        glClearColor(0,0,0,1); glClear(GL_COLOR_BUFFER_BIT);
+    }
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    bt.writeIdx = 0;
+    bt.allocated = true;
+    return true;
+}
+
+void ShaderEngine::releaseAllBufferTargets() {
+    for (int i = 0; i < 4; ++i) {
+        BufferTarget& bt = bufferTargets_[i];
+        if (!bt.allocated) continue;
+        for (int p = 0; p < 2; ++p) {
+            if (bt.fbo[p]) glDeleteFramebuffers(1, &bt.fbo[p]);
+            if (bt.tex[p]) glDeleteTextures(1, &bt.tex[p]);
+            bt.fbo[p] = 0; bt.tex[p] = 0;
+        }
+        bt.allocated = false;
+        bt.writeIdx = 0;
+    }
 }
 
 bool ShaderEngine::setupSharedContext() {
     EGLDisplay display = eglGetCurrentDisplay();
     EGLContext mainCtx = eglGetCurrentContext();
     if (display == EGL_NO_DISPLAY || mainCtx == EGL_NO_CONTEXT) {
-        LOGE("no current EGL display/context — cannot share");
+        LOGE("no current EGL — cannot share");
         return false;
     }
-
-    const EGLint configAttrs[] = {
+    const EGLint cfgAttrs[] = {
         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
         EGL_SURFACE_TYPE,    EGL_PBUFFER_BIT,
-        EGL_RED_SIZE,   8,
-        EGL_GREEN_SIZE, 8,
-        EGL_BLUE_SIZE,  8,
-        EGL_ALPHA_SIZE, 8,
+        EGL_RED_SIZE, 8, EGL_GREEN_SIZE, 8, EGL_BLUE_SIZE, 8, EGL_ALPHA_SIZE, 8,
         EGL_NONE,
     };
-    EGLConfig config = nullptr;
-    EGLint numConfigs = 0;
-    if (!eglChooseConfig(display, configAttrs, &config, 1, &numConfigs)
-        || numConfigs < 1) {
-        LOGE("worker eglChooseConfig failed: 0x%x", eglGetError());
+    EGLConfig cfg;
+    EGLint n = 0;
+    if (!eglChooseConfig(display, cfgAttrs, &cfg, 1, &n) || n < 1) {
+        LOGE("worker eglChooseConfig failed");
         return false;
     }
-
     const EGLint pbAttrs[] = { EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE };
-    workerSurface_ = eglCreatePbufferSurface(display, config, pbAttrs);
-    if (workerSurface_ == EGL_NO_SURFACE) {
-        LOGE("worker eglCreatePbufferSurface failed: 0x%x", eglGetError());
-        return false;
-    }
-
+    workerSurface_ = eglCreatePbufferSurface(display, cfg, pbAttrs);
+    if (workerSurface_ == EGL_NO_SURFACE) return false;
     const EGLint ctxAttrs[] = { EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE };
-    workerCtx_ = eglCreateContext(display, config, mainCtx, ctxAttrs);
+    workerCtx_ = eglCreateContext(display, cfg, mainCtx, ctxAttrs);
     if (workerCtx_ == EGL_NO_CONTEXT) {
-        LOGE("worker eglCreateContext (shared) failed: 0x%x", eglGetError());
         eglDestroySurface(display, workerSurface_);
         workerSurface_ = EGL_NO_SURFACE;
         return false;
     }
-
     workerDisplay_ = display;
     return true;
 }
 
 void ShaderEngine::teardownSharedContext() {
     if (workerDisplay_ == EGL_NO_DISPLAY) return;
-    if (workerCtx_ != EGL_NO_CONTEXT) {
-        eglDestroyContext(workerDisplay_, workerCtx_);
-        workerCtx_ = EGL_NO_CONTEXT;
-    }
-    if (workerSurface_ != EGL_NO_SURFACE) {
-        eglDestroySurface(workerDisplay_, workerSurface_);
-        workerSurface_ = EGL_NO_SURFACE;
-    }
+    if (workerCtx_ != EGL_NO_CONTEXT) eglDestroyContext(workerDisplay_, workerCtx_);
+    if (workerSurface_ != EGL_NO_SURFACE) eglDestroySurface(workerDisplay_, workerSurface_);
+    workerCtx_ = EGL_NO_CONTEXT;
+    workerSurface_ = EGL_NO_SURFACE;
     workerDisplay_ = EGL_NO_DISPLAY;
 }
 
 ShaderEngine::UniformLocs ShaderEngine::queryUniformLocations(GLuint program) {
     UniformLocs u;
-    u.time = glGetUniformLocation(program, "iTime");
-    u.timeDelta = glGetUniformLocation(program, "iTimeDelta");
-    u.frame = glGetUniformLocation(program, "iFrame");
-    u.resolution = glGetUniformLocation(program, "iResolution");
-    u.mouse = glGetUniformLocation(program, "iMouse");
-    u.channel0 = glGetUniformLocation(program, "iChannel0");
-    u.channelTime = glGetUniformLocation(program, "iChannelTime[0]");
+    u.time              = glGetUniformLocation(program, "iTime");
+    u.timeDelta         = glGetUniformLocation(program, "iTimeDelta");
+    u.frame             = glGetUniformLocation(program, "iFrame");
+    u.resolution        = glGetUniformLocation(program, "iResolution");
+    u.mouse             = glGetUniformLocation(program, "iMouse");
+    u.channel[0]        = glGetUniformLocation(program, "iChannel0");
+    u.channel[1]        = glGetUniformLocation(program, "iChannel1");
+    u.channel[2]        = glGetUniformLocation(program, "iChannel2");
+    u.channel[3]        = glGetUniformLocation(program, "iChannel3");
+    u.channelTime       = glGetUniformLocation(program, "iChannelTime[0]");
     u.channelResolution = glGetUniformLocation(program, "iChannelResolution[0]");
-    u.date = glGetUniformLocation(program, "iDate");
-    u.sampleRate = glGetUniformLocation(program, "iSampleRate");
+    u.date              = glGetUniformLocation(program, "iDate");
+    u.sampleRate        = glGetUniformLocation(program, "iSampleRate");
     return u;
 }
 
-GLuint ShaderEngine::compileProgramOnCurrentContext(
-        const std::string& fragSource) {
+GLuint ShaderEngine::compileSingleProgram(const std::string& fragSource) {
     GLuint vs = compileShader(GL_VERTEX_SHADER, kVertexShader);
     if (!vs) return 0;
-
     std::string full(kFragPrelude);
     full.append(fragSource);
     GLuint fs = compileShader(GL_FRAGMENT_SHADER, full.c_str());
-    if (!fs) {
-        glDeleteShader(vs);
-        return 0;
-    }
-
+    if (!fs) { glDeleteShader(vs); return 0; }
     GLuint p = linkProgram(vs, fs);
-    glDeleteShader(vs);
-    glDeleteShader(fs);
+    glDeleteShader(vs); glDeleteShader(fs);
     return p;
 }
 
+ShaderEngine::PassSet* ShaderEngine::compilePassSet(const std::string& source) {
+    ParsedShader parsed = parseShader(source);
+    auto* set = new PassSet();
+    int totalCompiled = 0;
+    for (int i = 0; i < PASS_COUNT; ++i) {
+        if (!parsed.hasPass[i]) continue;
+        std::string passSrc;
+        if (parsed.hasCommon) passSrc = parsed.commonCode + "\n";
+        passSrc += parsed.passCode[i];
+        GLuint prog = compileSingleProgram(passSrc);
+        if (!prog) {
+            LOGE("pass %d compile failed", i);
+            // Free everything and bail
+            freePassSet(set);
+            return nullptr;
+        }
+        Pass& pp = set->passes[i];
+        pp.program = prog;
+        pp.locs = queryUniformLocations(prog);
+        for (int c = 0; c < 4; ++c) {
+            pp.channelSrc[c] = static_cast<ChannelSource>(parsed.channelSrc[i][c]);
+        }
+        set->hasPass[i] = true;
+        ++totalCompiled;
+    }
+    if (totalCompiled == 0 || !set->hasPass[PASS_IMAGE]) {
+        LOGE("PassSet has no image pass — refusing to install");
+        freePassSet(set);
+        return nullptr;
+    }
+    LOGI("PassSet compiled: %d passes", totalCompiled);
+    return set;
+}
+
 void ShaderEngine::workerLoop() {
-    if (!eglMakeCurrent(workerDisplay_, workerSurface_, workerSurface_,
-                         workerCtx_)) {
-        LOGE("worker eglMakeCurrent failed: 0x%x — exiting worker",
-             eglGetError());
+    if (!eglMakeCurrent(workerDisplay_, workerSurface_, workerSurface_, workerCtx_)) {
+        LOGE("worker eglMakeCurrent failed");
         return;
     }
-    LOGI("shader compile worker ready");
-
+    LOGI("shader compile worker ready (multipass)");
     while (true) {
         std::string source;
         {
             std::unique_lock<std::mutex> lock(queueMutex_);
-            queueCv_.wait(lock, [this] {
-                return workerShutdown_.load() || hasPendingSource_;
-            });
+            queueCv_.wait(lock, [this] { return workerShutdown_.load() || hasPendingSource_; });
             if (workerShutdown_.load()) break;
             source = std::move(pendingSource_);
             hasPendingSource_ = false;
         }
-
-        GLuint newProgram = compileProgramOnCurrentContext(source);
-        if (newProgram == 0) continue;
-
+        PassSet* set = compilePassSet(source);
+        if (!set) continue;
         glFlush();
-
-        GLuint orphan = 0;
+        PassSet* orphan = nullptr;
         {
             std::lock_guard<std::mutex> lock(resultMutex_);
-            orphan = pendingProgram_;
-            pendingProgram_ = newProgram;
+            orphan = pendingResult_;
+            pendingResult_ = set;
         }
-        if (orphan) glDeleteProgram(orphan);
+        if (orphan) freePassSet(orphan);
     }
-
-    eglMakeCurrent(workerDisplay_, EGL_NO_SURFACE, EGL_NO_SURFACE,
-                    EGL_NO_CONTEXT);
+    eglMakeCurrent(workerDisplay_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
     LOGI("shader compile worker exited");
 }
 
-bool ShaderEngine::adoptPendingProgramIfAny() {
-    GLuint adopt = 0;
+void ShaderEngine::adoptPendingPassSetIfAny() {
+    PassSet* adopt = nullptr;
     {
         std::lock_guard<std::mutex> lock(resultMutex_);
-        if (pendingProgram_ != 0) {
-            adopt = pendingProgram_;
-            pendingProgram_ = 0;
+        if (pendingResult_) {
+            adopt = pendingResult_;
+            pendingResult_ = nullptr;
         }
     }
-    if (!adopt) return false;
+    if (!adopt) return;
 
-    // Capture the current frame into the "old" FBO before swapping
-    // shaders. glBlitFramebuffer is the fastest way to copy texture
-    // contents between two FBOs of the same size.
-    if (program_ && fboCurrent_ && fboOld_) {
+    // Snapshot current frame for crossfade BEFORE we swap shaders.
+    if (currentSet_ && fboCurrent_ && fboOld_) {
         glBindFramebuffer(GL_READ_FRAMEBUFFER, fboCurrent_);
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fboOld_);
-        glBlitFramebuffer(0, 0, width_, height_,
-                           0, 0, width_, height_,
+        glBlitFramebuffer(0,0,width_,height_, 0,0,width_,height_,
                            GL_COLOR_BUFFER_BIT, GL_NEAREST);
         glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
     }
 
-    if (program_) glDeleteProgram(program_);
-    program_ = adopt;
-    locs_ = queryUniformLocations(program_);
-    LOGI("adopted new shader program=%u", program_);
+    // Release the previous PassSet (programs are GL-shared so this is safe).
+    clearCurrentSet();
+    currentSet_ = adopt;
 
-    // Start the crossfade. If this is the very first preset (no old
-    // program), skip the transition — there's nothing to fade from.
+    // Pre-allocate the buffer targets this PassSet needs. Lazy-alloc
+    // would also work but we do it now so the first frame doesn't
+    // pay the cost.
+    for (int i = 0; i < 4; ++i) {
+        if (currentSet_->hasPass[i]) ensureBufferTarget(i);
+    }
+
     transitionStart_ = std::chrono::steady_clock::now();
     transitioning_ = (fboOld_ != 0);
-    return true;
+
+    int n = 0;
+    for (int i = 0; i < PASS_COUNT; ++i) if (currentSet_->hasPass[i]) ++n;
+    LOGI("adopted PassSet (%d passes)", n);
+}
+
+GLuint ShaderEngine::channelTextureFor(ChannelSource src, int currentPassIdx,
+                                         GLuint audioTex) const {
+    switch (src) {
+        case CHAN_AUDIO: return audioTex;
+        case CHAN_BUFFER_A:
+        case CHAN_BUFFER_B:
+        case CHAN_BUFFER_C:
+        case CHAN_BUFFER_D: {
+            const int bufIdx = static_cast<int>(src) - static_cast<int>(CHAN_BUFFER_A);
+            const BufferTarget& bt = bufferTargets_[bufIdx];
+            if (!bt.allocated) return blackTex_;
+            // Read from the slot we WON'T be writing this frame. If
+            // we're sampling our own buffer (self-feedback), that's
+            // the previous frame's contents. If we're sampling another
+            // buffer that runs before us in render order, it's that
+            // buffer's just-written texture.
+            if (currentPassIdx == bufIdx) {
+                // self-feedback: read the side that's currently the
+                // "previous" frame (not the current write slot).
+                return bt.tex[bt.writeIdx ^ 1];
+            } else {
+                // Reading another buffer: it was just written this
+                // frame to its current write slot, so read from it.
+                return bt.tex[bt.writeIdx];
+            }
+        }
+        case CHAN_NONE:
+        default:
+            return blackTex_;
+    }
+}
+
+void ShaderEngine::renderPass(int idx, const Pass& p, GLuint targetFbo,
+                                float elapsed, float delta, GLuint audioTex) {
+    glBindFramebuffer(GL_FRAMEBUFFER, targetFbo);
+    glViewport(0, 0, width_, height_);
+    glUseProgram(p.program);
+
+    if (p.locs.time       >= 0) glUniform1f(p.locs.time, elapsed);
+    if (p.locs.timeDelta  >= 0) glUniform1f(p.locs.timeDelta, delta);
+    if (p.locs.frame      >= 0) glUniform1i(p.locs.frame, frameCount_);
+    if (p.locs.resolution >= 0) glUniform3f(p.locs.resolution,
+        static_cast<float>(width_),
+        static_cast<float>(height_),
+        static_cast<float>(width_) / static_cast<float>(height_));
+    if (p.locs.mouse      >= 0) glUniform4f(p.locs.mouse, 0,0,0,0);
+    if (p.locs.date       >= 0) glUniform4f(p.locs.date, 0,0,0,0);
+    if (p.locs.sampleRate >= 0) glUniform1f(p.locs.sampleRate, 44100.0f);
+    if (p.locs.channelTime >= 0) {
+        const float t[4] = {elapsed,elapsed,elapsed,elapsed};
+        glUniform1fv(p.locs.channelTime, 4, t);
+    }
+    if (p.locs.channelResolution >= 0) {
+        const float r[12] = {
+            static_cast<float>(width_), static_cast<float>(height_), 1,
+            static_cast<float>(width_), static_cast<float>(height_), 1,
+            static_cast<float>(width_), static_cast<float>(height_), 1,
+            static_cast<float>(width_), static_cast<float>(height_), 1,
+        };
+        glUniform3fv(p.locs.channelResolution, 4, r);
+    }
+
+    // Bind iChannel0..3 textures + sampler uniforms.
+    for (int c = 0; c < 4; ++c) {
+        if (p.locs.channel[c] < 0) continue;
+        // Audio channel resolution differs from buffer; override if needed.
+        GLuint tex;
+        if (p.channelSrc[c] == CHAN_AUDIO) {
+            tex = audioTex;
+        } else {
+            tex = channelTextureFor(p.channelSrc[c], idx, audioTex);
+        }
+        glActiveTexture(GL_TEXTURE0 + c);
+        glBindTexture(GL_TEXTURE_2D, tex);
+        glUniform1i(p.locs.channel[c], c);
+    }
+
+    glBindVertexArray(vao_);
+    glDrawArrays(GL_TRIANGLES, 0, 3);
+    glBindVertexArray(0);
 }
 
 void ShaderEngine::renderFrame() {
-    adoptPendingProgramIfAny();
+    adoptPendingPassSetIfAny();
 
     auto now = std::chrono::steady_clock::now();
-    const float elapsed =
-        std::chrono::duration<float>(now - startTime_).count();
-    const float delta =
-        std::chrono::duration<float>(now - lastFrameTime_).count();
+    const float elapsed = std::chrono::duration<float>(now - startTime_).count();
+    const float delta   = std::chrono::duration<float>(now - lastFrameTime_).count();
     lastFrameTime_ = now;
 
-    // === Pass 1: user shader → fboCurrent_ ===
-    glBindFramebuffer(GL_FRAMEBUFFER, fboCurrent_);
-    glViewport(0, 0, width_, height_);
-
-    if (!program_) {
-        // No shader compiled yet — clear the FBO so present has
-        // something defined to sample.
-        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-        glClear(GL_COLOR_BUFFER_BIT);
+    if (!currentSet_) {
+        // Nothing loaded — keep fboCurrent_ as black, run present anyway.
+        glBindFramebuffer(GL_FRAMEBUFFER, fboCurrent_);
+        glClearColor(0,0,0,1); glClear(GL_COLOR_BUFFER_BIT);
     } else {
         const GLuint audioTex = audio_.upload();
 
-        glUseProgram(program_);
-
-        if (locs_.time       >= 0) glUniform1f(locs_.time, elapsed);
-        if (locs_.timeDelta  >= 0) glUniform1f(locs_.timeDelta, delta);
-        if (locs_.frame      >= 0) glUniform1i(locs_.frame, frameCount_);
-        if (locs_.resolution >= 0) glUniform3f(locs_.resolution,
-            static_cast<float>(width_),
-            static_cast<float>(height_),
-            static_cast<float>(width_) / static_cast<float>(height_));
-        if (locs_.mouse      >= 0) glUniform4f(locs_.mouse, 0.0f, 0.0f, 0.0f, 0.0f);
-        if (locs_.date       >= 0) glUniform4f(locs_.date, 0.0f, 0.0f, 0.0f, 0.0f);
-        if (locs_.sampleRate >= 0) glUniform1f(locs_.sampleRate, 44100.0f);
-
-        if (locs_.channelTime >= 0) {
-            const float times[4] = { elapsed, elapsed, elapsed, elapsed };
-            glUniform1fv(locs_.channelTime, 4, times);
-        }
-        if (locs_.channelResolution >= 0) {
-            const float res[12] = {
-                static_cast<float>(AudioTexture::BINS), 2.0f, 1.0f,
-                0.0f, 0.0f, 0.0f,
-                0.0f, 0.0f, 0.0f,
-                0.0f, 0.0f, 0.0f,
-            };
-            glUniform3fv(locs_.channelResolution, 4, res);
+        // Render every buffer pass that exists, in fixed order A..D.
+        for (int i = 0; i < 4; ++i) {
+            if (!currentSet_->hasPass[i]) continue;
+            BufferTarget& bt = bufferTargets_[i];
+            if (!bt.allocated) continue;
+            renderPass(i, currentSet_->passes[i], bt.fbo[bt.writeIdx],
+                       elapsed, delta, audioTex);
         }
 
-        if (locs_.channel0 >= 0) {
-            glActiveTexture(GL_TEXTURE0);
-            glBindTexture(GL_TEXTURE_2D, audioTex);
-            glUniform1i(locs_.channel0, 0);
+        // Image pass renders into fboCurrent_.
+        if (currentSet_->hasPass[PASS_IMAGE]) {
+            renderPass(PASS_IMAGE, currentSet_->passes[PASS_IMAGE], fboCurrent_,
+                       elapsed, delta, audioTex);
         }
 
-        glBindVertexArray(vao_);
-        glDrawArrays(GL_TRIANGLES, 0, 3);
-        glBindVertexArray(0);
+        // After all passes done this frame, swap each buffer's
+        // ping-pong index — next frame's reads see the texture we
+        // just wrote to.
+        for (int i = 0; i < 4; ++i) {
+            if (currentSet_->hasPass[i] && bufferTargets_[i].allocated) {
+                bufferTargets_[i].writeIdx ^= 1;
+            }
+        }
     }
 
-    // === Pass 2: present (texCurrent_ ± texOld_) → window surface ===
+    // === Present pass: fboCurrent_ (with optional crossfade) → window ===
     float mixT = 1.0f;
     if (transitioning_) {
-        const float t = std::chrono::duration<float>(now - transitionStart_)
-                            .count() / kTransitionDuration;
-        if (t >= 1.0f) {
-            transitioning_ = false;
-            mixT = 1.0f;
-        } else {
-            // Smoothstep ease — feels more natural than linear.
-            mixT = t * t * (3.0f - 2.0f * t);
-        }
+        const float t = std::chrono::duration<float>(now - transitionStart_).count()
+                          / kTransitionDuration;
+        if (t >= 1.0f) { transitioning_ = false; mixT = 1.0f; }
+        else mixT = t * t * (3.0f - 2.0f * t);
     }
-
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glViewport(0, 0, width_, height_);
     glUseProgram(presentProgram_);
-
     if (locPresentCurrent_ >= 0) {
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, texCurrent_);
@@ -530,7 +763,6 @@ void ShaderEngine::renderFrame() {
         glUniform1i(locPresentOld_, 1);
     }
     if (locPresentMixT_ >= 0) glUniform1f(locPresentMixT_, mixT);
-
     glBindVertexArray(vao_);
     glDrawArrays(GL_TRIANGLES, 0, 3);
     glBindVertexArray(0);
@@ -544,35 +776,29 @@ void ShaderEngine::addPcm(const float* samples, std::size_t frameCount) {
 
 void ShaderEngine::loadPreset(const char* data, bool /*smoothTransition*/) {
     if (!data) return;
-
-    // If the worker thread couldn't be started, compile synchronously
-    // on the render thread (slow but correct).
     if (!worker_.joinable()) {
-        GLuint newProgram =
-            compileProgramOnCurrentContext(std::string(data));
-        if (newProgram == 0) return;
-
-        // Snapshot the current frame into the "old" FBO so the
-        // crossfade has something to fade from. Same as the async path.
-        if (program_ && fboCurrent_ && fboOld_) {
+        // Sync fallback if the worker couldn't be set up.
+        PassSet* set = compilePassSet(std::string(data));
+        if (!set) return;
+        // Snapshot for crossfade, then install.
+        if (currentSet_ && fboCurrent_ && fboOld_) {
             glBindFramebuffer(GL_READ_FRAMEBUFFER, fboCurrent_);
             glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fboOld_);
-            glBlitFramebuffer(0, 0, width_, height_,
-                               0, 0, width_, height_,
+            glBlitFramebuffer(0,0,width_,height_, 0,0,width_,height_,
                                GL_COLOR_BUFFER_BIT, GL_NEAREST);
             glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
             glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
         }
-
-        if (program_) glDeleteProgram(program_);
-        program_ = newProgram;
-        locs_ = queryUniformLocations(program_);
+        clearCurrentSet();
+        currentSet_ = set;
+        for (int i = 0; i < 4; ++i) {
+            if (currentSet_->hasPass[i]) ensureBufferTarget(i);
+        }
         transitionStart_ = std::chrono::steady_clock::now();
         transitioning_ = (fboOld_ != 0);
         return;
     }
-
-    // Async path: queue the source. Only the LATEST source survives.
+    // Async: queue source, worker compiles into a PassSet and posts back.
     {
         std::lock_guard<std::mutex> lock(queueMutex_);
         pendingSource_ = data;

--- a/android/app/src/main/cpp/shader_engine.h
+++ b/android/app/src/main/cpp/shader_engine.h
@@ -6,8 +6,14 @@
 //
 // We wrap it with a Shadertoy-style prelude (iTime, iResolution,
 // iChannel0, etc.) and a tiny main() that calls mainImage and writes
-// the result. Compilation happens on loadPreset(); errors are
-// logged but render falls back to the previous program (or no-op).
+// the result.
+//
+// Compilation runs on a dedicated worker thread with its own EGL
+// context that shares resources with the render thread's context.
+// loadPreset returns immediately; the worker compiles + links, and
+// the render thread picks up the new program at the top of the next
+// frame. If the user cycles faster than compile time, the worker
+// drops intermediate sources and only compiles the latest.
 //
 // Audio reactivity: we run a 1024-point FFT on incoming PCM and
 // publish a 512×2 R8 texture bound to iChannel0 — same shape
@@ -15,9 +21,15 @@
 
 #pragma once
 
+#include <EGL/egl.h>
 #include <GLES3/gl3.h>
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
 
 #include "audio_texture.h"
 #include "engine.h"
@@ -33,31 +45,74 @@ public:
     void loadPreset(const char* data, bool smoothTransition) override;
 
 private:
-    bool compileProgram(const char* fragSource);
-    void releaseProgram();
+    // Cached uniform locations for the current program. Recomputed
+    // each time we swap in a new compiled program from the worker.
+    struct UniformLocs {
+        GLint time = -1;
+        GLint timeDelta = -1;
+        GLint frame = -1;
+        GLint resolution = -1;
+        GLint mouse = -1;
+        GLint channel0 = -1;
+        GLint channelTime = -1;
+        GLint channelResolution = -1;
+        GLint date = -1;
+        GLint sampleRate = -1;
+    };
+
+    // Render-thread work: pull any newly-linked program out of the
+    // worker hand-off slot and install it as the current program.
+    void adoptPendingProgramIfAny();
+
+    // Worker thread main loop. Owns workerCtx_; pulls sources off
+    // pendingSources_ and compiles them.
+    void workerLoop();
+
+    // Build vertex+fragment shaders, link a program. Returns 0 on
+    // failure. Safe to call from any thread that has *some* EGL
+    // context current (either the render context or the worker
+    // share context).
+    GLuint compileProgramOnCurrentContext(const std::string& fragSource);
+    static UniformLocs queryUniformLocations(GLuint program);
+
+    // Spawn / tear down the worker. setupSharedContext() must run on
+    // the render thread (it needs the render context current to
+    // create a sharing partner).
+    bool setupSharedContext();
+    void teardownSharedContext();
 
     int width_ = 0;
     int height_ = 0;
 
+    // Active program currently driving the screen.
     GLuint program_ = 0;
+    UniformLocs locs_{};
     GLuint vao_ = 0;
     GLuint vbo_ = 0;
-
-    // Cached uniform locations for the current program.
-    GLint locTime_ = -1;
-    GLint locTimeDelta_ = -1;
-    GLint locFrame_ = -1;
-    GLint locResolution_ = -1;
-    GLint locMouse_ = -1;
-    GLint locChannel0_ = -1;
-    GLint locChannelTime_ = -1;
-    GLint locChannelResolution_ = -1;
-    GLint locDate_ = -1;
-    GLint locSampleRate_ = -1;
 
     std::chrono::steady_clock::time_point startTime_;
     std::chrono::steady_clock::time_point lastFrameTime_;
     int frameCount_ = 0;
 
     AudioTexture audio_;
+
+    // --- Worker thread state ---
+    std::thread worker_;
+    std::mutex queueMutex_;
+    std::condition_variable queueCv_;
+    std::string pendingSource_;   // only the latest queued source survives
+    bool hasPendingSource_ = false;
+    std::atomic<bool> workerShutdown_{false};
+
+    // Hand-off slot from worker → render thread. Non-zero means a
+    // freshly-linked program is ready to adopt. Guarded by
+    // resultMutex_; the worker owns deletion of any program that
+    // gets displaced before the render thread picks it up.
+    std::mutex resultMutex_;
+    GLuint pendingProgram_ = 0;
+
+    // Worker EGL state (shared with the render context).
+    EGLDisplay workerDisplay_ = EGL_NO_DISPLAY;
+    EGLContext workerCtx_ = EGL_NO_CONTEXT;
+    EGLSurface workerSurface_ = EGL_NO_SURFACE;
 };

--- a/android/app/src/main/cpp/shader_engine.h
+++ b/android/app/src/main/cpp/shader_engine.h
@@ -1,0 +1,63 @@
+// Engine that renders Shadertoy-convention fragment shaders.
+//
+// loadPreset() takes a GLSL fragment shader source that defines:
+//
+//     void mainImage(out vec4 fragColor, in vec2 fragCoord);
+//
+// We wrap it with a Shadertoy-style prelude (iTime, iResolution,
+// iChannel0, etc.) and a tiny main() that calls mainImage and writes
+// the result. Compilation happens on loadPreset(); errors are
+// logged but render falls back to the previous program (or no-op).
+//
+// Audio reactivity: we run a 1024-point FFT on incoming PCM and
+// publish a 512×2 R8 texture bound to iChannel0 — same shape
+// Shadertoy itself uses for audio channels.
+
+#pragma once
+
+#include <GLES3/gl3.h>
+#include <chrono>
+#include <memory>
+
+#include "audio_texture.h"
+#include "engine.h"
+
+class ShaderEngine : public Engine {
+public:
+    ShaderEngine() = default;
+    ~ShaderEngine() override;
+
+    bool init(int width, int height) override;
+    void renderFrame() override;
+    void addPcm(const float* samples, std::size_t frameCount) override;
+    void loadPreset(const char* data, bool smoothTransition) override;
+
+private:
+    bool compileProgram(const char* fragSource);
+    void releaseProgram();
+
+    int width_ = 0;
+    int height_ = 0;
+
+    GLuint program_ = 0;
+    GLuint vao_ = 0;
+    GLuint vbo_ = 0;
+
+    // Cached uniform locations for the current program.
+    GLint locTime_ = -1;
+    GLint locTimeDelta_ = -1;
+    GLint locFrame_ = -1;
+    GLint locResolution_ = -1;
+    GLint locMouse_ = -1;
+    GLint locChannel0_ = -1;
+    GLint locChannelTime_ = -1;
+    GLint locChannelResolution_ = -1;
+    GLint locDate_ = -1;
+    GLint locSampleRate_ = -1;
+
+    std::chrono::steady_clock::time_point startTime_;
+    std::chrono::steady_clock::time_point lastFrameTime_;
+    int frameCount_ = 0;
+
+    AudioTexture audio_;
+};

--- a/android/app/src/main/cpp/shader_engine.h
+++ b/android/app/src/main/cpp/shader_engine.h
@@ -1,31 +1,44 @@
-// Engine that renders Shadertoy-convention fragment shaders.
+// Engine that renders Shadertoy-convention fragment shaders, single
+// or multi-pass.
 //
-// loadPreset() takes a GLSL fragment shader source that defines:
+// Single-pass: file is just a `void mainImage(...)` body using the
+// standard Shadertoy uniforms (iTime, iResolution, iChannel0, ...).
+// iChannel0 is wired to our audio texture by default.
 //
-//     void mainImage(out vec4 fragColor, in vec2 fragCoord);
+// Multi-pass: file uses markers to declare passes and channel routing:
 //
-// We wrap it with a Shadertoy-style prelude (iTime, iResolution,
-// iChannel0, etc.) and a tiny main() that calls mainImage and writes
-// the result.
+//   // === channel image.0 = bufferB
+//   // === channel bufferB.0 = bufferA
+//   // === channel bufferB.1 = bufferB
+//   //
+//   // === pass: common ===
+//   <shared code prepended to all other passes>
+//   // === pass: bufferA ===
+//   <bufferA shader>
+//   // === pass: bufferB ===
+//   <bufferB shader>
+//   // === pass: image ===
+//   <image shader>
+//
+// Passes render in fixed order: bufferA, bufferB, bufferC, bufferD,
+// image. Each buffer has ping-pong FBOs so self-feedback works (a
+// buffer reading itself reads last frame's texture; reading another
+// buffer that already rendered this frame reads the just-written
+// texture).
 //
 // Compilation runs on a dedicated worker thread with its own EGL
 // context that shares resources with the render thread's context.
-// loadPreset returns immediately; the worker compiles + links, and
-// the render thread picks up the new program at the top of the next
-// frame. If the user cycles faster than compile time, the worker
-// drops intermediate sources and only compiles the latest.
+// loadPreset returns immediately; the worker compiles all passes
+// into a PassSet, atomically hands it off. If the user cycles
+// faster than compile time, intermediate sources are dropped.
 //
-// Cross-fade between presets: every frame is rendered to a "current"
-// FBO and then a tiny present pass blits to the window surface. On a
-// program swap, the current FBO's contents are copied to an "old"
-// FBO; for the next ~600ms the present pass mixes old → new before
-// reverting to a plain copy. Costs one extra fullscreen quad per
-// frame; the transition itself adds one texture sample during the
-// crossfade window.
+// Cross-fade between presets is unchanged: the image pass renders
+// into fboCurrent_, the present pass copies it to the window
+// surface, and on swap the previous fboCurrent_ is blitted to
+// fboOld_ for a 600ms blend.
 //
-// Audio reactivity: we run a 1024-point FFT on incoming PCM and
-// publish a 512×2 R8 texture bound to iChannel0 — same shape
-// Shadertoy itself uses for audio channels.
+// Audio reactivity: 1024-point FFT on incoming PCM, published as a
+// 512×2 R8 texture bound wherever a channel is routed to "music".
 
 #pragma once
 
@@ -52,75 +65,120 @@ public:
     void addPcm(const float* samples, std::size_t frameCount) override;
     void loadPreset(const char* data, bool smoothTransition) override;
 
+    // Pass slot indices: 0..3 = bufferA..D, 4 = image. Used by the
+    // anonymous-namespace parser in the .cpp; exposed here so it can
+    // refer to them via ShaderEngine::PASS_*.
+    static constexpr int PASS_BUFFER_A = 0;
+    static constexpr int PASS_BUFFER_B = 1;
+    static constexpr int PASS_BUFFER_C = 2;
+    static constexpr int PASS_BUFFER_D = 3;
+    static constexpr int PASS_IMAGE    = 4;
+    static constexpr int PASS_COUNT    = 5;  // image + 4 buffers
+
 private:
-    // Cached uniform locations for the current shader program.
+
+    // Channel input source identifiers. 0 = unbound (sampling returns 0).
+    enum ChannelSource : int {
+        CHAN_NONE    = 0,
+        CHAN_AUDIO   = 1,
+        CHAN_BUFFER_A = 2,
+        CHAN_BUFFER_B = 3,
+        CHAN_BUFFER_C = 4,
+        CHAN_BUFFER_D = 5,
+    };
+
     struct UniformLocs {
         GLint time = -1;
         GLint timeDelta = -1;
         GLint frame = -1;
         GLint resolution = -1;
         GLint mouse = -1;
-        GLint channel0 = -1;
+        GLint channel[4] = {-1, -1, -1, -1};
         GLint channelTime = -1;
         GLint channelResolution = -1;
         GLint date = -1;
         GLint sampleRate = -1;
     };
 
-    // Render-thread work: pull any newly-linked program out of the
-    // worker hand-off slot and install it as the current program.
-    // Returns true if a swap happened (so the caller can start the
-    // transition).
-    bool adoptPendingProgramIfAny();
+    struct Pass {
+        GLuint program = 0;
+        UniformLocs locs{};
+        // Source for each of the 4 iChannel uniforms in this pass.
+        ChannelSource channelSrc[4] = {CHAN_NONE, CHAN_NONE, CHAN_NONE, CHAN_NONE};
+    };
 
-    // Worker thread main loop.
+    // A complete set of compiled passes for one shader preset.
+    struct PassSet {
+        Pass passes[PASS_COUNT];
+        bool hasPass[PASS_COUNT] = {false, false, false, false, false};
+    };
+
+    // Ping-pong FBO+texture pair for a buffer pass.
+    struct BufferTarget {
+        GLuint fbo[2] = {0, 0};
+        GLuint tex[2] = {0, 0};
+        int writeIdx = 0;
+        bool allocated = false;
+    };
+
+    // === Render-thread methods ===
+    void adoptPendingPassSetIfAny();
+    void renderPass(int idx, const Pass& p, GLuint targetFbo,
+                     float elapsed, float delta, GLuint audioTex);
+    GLuint channelTextureFor(ChannelSource src, int currentPassIdx,
+                              GLuint audioTex) const;
+    bool ensureBufferTarget(int idx);
+    void releaseAllBufferTargets();
+    void clearCurrentSet();
+
+    // === Worker-thread methods ===
     void workerLoop();
-
-    // Build vertex+fragment shaders, link a program. Returns 0 on
-    // failure. Safe to call from any thread with *some* EGL context
-    // current (render or shared).
-    GLuint compileProgramOnCurrentContext(const std::string& fragSource);
+    // Compile a complete PassSet from a parsed source. Returns null on failure.
+    // Must be called with a current EGL context.
+    PassSet* compilePassSet(const std::string& source);
     static UniformLocs queryUniformLocations(GLuint program);
+    static GLuint compileSingleProgram(const std::string& fragSource);
+    void freePassSet(PassSet* set);
 
-    // FBO setup for shader-to-texture rendering + cross-fade.
+    // === Bridge between worker and render threads ===
+    PassSet* currentSet_ = nullptr;
+    PassSet* pendingSet_ = nullptr;
+
+    // === Offscreen + present (unchanged from previous design) ===
     bool setupOffscreenTargets();
     void teardownOffscreenTargets();
 
-    // Spawn / tear down the worker.
     bool setupSharedContext();
     void teardownSharedContext();
 
     int width_ = 0;
     int height_ = 0;
 
-    // Active shader program currently driving the offscreen FBO.
-    GLuint program_ = 0;
-    UniformLocs locs_{};
     GLuint vao_ = 0;
     GLuint vbo_ = 0;
 
-    // Present pass: samples the current (and during a transition, the
-    // old) frame texture and writes to the window surface.
+    // Present-pass program (samples fboCurrent_ + optionally fboOld_).
     GLuint presentProgram_ = 0;
     GLint  locPresentCurrent_ = -1;
     GLint  locPresentOld_ = -1;
     GLint  locPresentMixT_ = -1;
 
-    // Offscreen render targets. fboCurrent_ is what the active shader
-    // draws into every frame; fboOld_ is a captured snapshot of the
-    // previous shader's last frame, used during the crossfade.
+    // Final-image FBO (the image pass renders here) + held-old FBO for crossfade.
     GLuint fboCurrent_ = 0;
     GLuint texCurrent_ = 0;
     GLuint fboOld_ = 0;
     GLuint texOld_ = 0;
 
+    // Per-buffer ping-pong targets (only allocated for buffers a preset uses).
+    BufferTarget bufferTargets_[4];
+
+    // 1×1 black fallback texture for unbound channels.
+    GLuint blackTex_ = 0;
+
     std::chrono::steady_clock::time_point startTime_;
     std::chrono::steady_clock::time_point lastFrameTime_;
     int frameCount_ = 0;
 
-    // Crossfade. transitionStart_ + kTransitionDuration == end. While
-    // we're inside this window, the present pass mixes texOld_ →
-    // texCurrent_; once we pass it, the present pass is a plain copy.
     std::chrono::steady_clock::time_point transitionStart_;
     bool transitioning_ = false;
     static constexpr float kTransitionDuration = 0.6f;
@@ -136,7 +194,7 @@ private:
     std::atomic<bool> workerShutdown_{false};
 
     std::mutex resultMutex_;
-    GLuint pendingProgram_ = 0;
+    PassSet* pendingResult_ = nullptr;
 
     EGLDisplay workerDisplay_ = EGL_NO_DISPLAY;
     EGLContext workerCtx_ = EGL_NO_CONTEXT;

--- a/android/app/src/main/cpp/shader_engine.h
+++ b/android/app/src/main/cpp/shader_engine.h
@@ -15,6 +15,14 @@
 // frame. If the user cycles faster than compile time, the worker
 // drops intermediate sources and only compiles the latest.
 //
+// Cross-fade between presets: every frame is rendered to a "current"
+// FBO and then a tiny present pass blits to the window surface. On a
+// program swap, the current FBO's contents are copied to an "old"
+// FBO; for the next ~600ms the present pass mixes old → new before
+// reverting to a plain copy. Costs one extra fullscreen quad per
+// frame; the transition itself adds one texture sample during the
+// crossfade window.
+//
 // Audio reactivity: we run a 1024-point FFT on incoming PCM and
 // publish a 512×2 R8 texture bound to iChannel0 — same shape
 // Shadertoy itself uses for audio channels.
@@ -45,8 +53,7 @@ public:
     void loadPreset(const char* data, bool smoothTransition) override;
 
 private:
-    // Cached uniform locations for the current program. Recomputed
-    // each time we swap in a new compiled program from the worker.
+    // Cached uniform locations for the current shader program.
     struct UniformLocs {
         GLint time = -1;
         GLint timeDelta = -1;
@@ -62,37 +69,61 @@ private:
 
     // Render-thread work: pull any newly-linked program out of the
     // worker hand-off slot and install it as the current program.
-    void adoptPendingProgramIfAny();
+    // Returns true if a swap happened (so the caller can start the
+    // transition).
+    bool adoptPendingProgramIfAny();
 
-    // Worker thread main loop. Owns workerCtx_; pulls sources off
-    // pendingSources_ and compiles them.
+    // Worker thread main loop.
     void workerLoop();
 
     // Build vertex+fragment shaders, link a program. Returns 0 on
-    // failure. Safe to call from any thread that has *some* EGL
-    // context current (either the render context or the worker
-    // share context).
+    // failure. Safe to call from any thread with *some* EGL context
+    // current (render or shared).
     GLuint compileProgramOnCurrentContext(const std::string& fragSource);
     static UniformLocs queryUniformLocations(GLuint program);
 
-    // Spawn / tear down the worker. setupSharedContext() must run on
-    // the render thread (it needs the render context current to
-    // create a sharing partner).
+    // FBO setup for shader-to-texture rendering + cross-fade.
+    bool setupOffscreenTargets();
+    void teardownOffscreenTargets();
+
+    // Spawn / tear down the worker.
     bool setupSharedContext();
     void teardownSharedContext();
 
     int width_ = 0;
     int height_ = 0;
 
-    // Active program currently driving the screen.
+    // Active shader program currently driving the offscreen FBO.
     GLuint program_ = 0;
     UniformLocs locs_{};
     GLuint vao_ = 0;
     GLuint vbo_ = 0;
 
+    // Present pass: samples the current (and during a transition, the
+    // old) frame texture and writes to the window surface.
+    GLuint presentProgram_ = 0;
+    GLint  locPresentCurrent_ = -1;
+    GLint  locPresentOld_ = -1;
+    GLint  locPresentMixT_ = -1;
+
+    // Offscreen render targets. fboCurrent_ is what the active shader
+    // draws into every frame; fboOld_ is a captured snapshot of the
+    // previous shader's last frame, used during the crossfade.
+    GLuint fboCurrent_ = 0;
+    GLuint texCurrent_ = 0;
+    GLuint fboOld_ = 0;
+    GLuint texOld_ = 0;
+
     std::chrono::steady_clock::time_point startTime_;
     std::chrono::steady_clock::time_point lastFrameTime_;
     int frameCount_ = 0;
+
+    // Crossfade. transitionStart_ + kTransitionDuration == end. While
+    // we're inside this window, the present pass mixes texOld_ →
+    // texCurrent_; once we pass it, the present pass is a plain copy.
+    std::chrono::steady_clock::time_point transitionStart_;
+    bool transitioning_ = false;
+    static constexpr float kTransitionDuration = 0.6f;
 
     AudioTexture audio_;
 
@@ -100,18 +131,13 @@ private:
     std::thread worker_;
     std::mutex queueMutex_;
     std::condition_variable queueCv_;
-    std::string pendingSource_;   // only the latest queued source survives
+    std::string pendingSource_;
     bool hasPendingSource_ = false;
     std::atomic<bool> workerShutdown_{false};
 
-    // Hand-off slot from worker → render thread. Non-zero means a
-    // freshly-linked program is ready to adopt. Guarded by
-    // resultMutex_; the worker owns deletion of any program that
-    // gets displaced before the render thread picks it up.
     std::mutex resultMutex_;
     GLuint pendingProgram_ = 0;
 
-    // Worker EGL state (shared with the render context).
     EGLDisplay workerDisplay_ = EGL_NO_DISPLAY;
     EGLContext workerCtx_ = EGL_NO_CONTEXT;
     EGLSurface workerSurface_ = EGL_NO_SURFACE;

--- a/android/app/src/main/cpp/visualizer_bridge.cpp
+++ b/android/app/src/main/cpp/visualizer_bridge.cpp
@@ -1,10 +1,13 @@
-// JNI bridge between Kotlin's VisualizerBridge and libprojectM-4.so.
+// JNI bridge for the visualizer. Owns the EGL context + window
+// surface; delegates the actual rendering to an Engine instance
+// chosen at init time.
 //
-// The Kotlin side owns the Flutter SurfaceTexture and the render
-// thread; this C++ owns the EGL context and the projectm_handle.
-// projectM rendering must happen on the same thread that created
-// the GL context, so the render thread invariably runs Kotlin →
-// JNI → here → projectM.
+// Engines:
+//   0 → ProjectMEngine (Milkdrop, default)
+//   1 → ShaderEngine   (Shadertoy fragment shaders)
+//
+// All native methods run on the Kotlin RenderThread; the EGL context
+// is made current at init and again defensively in each JNI call.
 //
 // JNI naming convention: function names mirror the Kotlin class
 // 'com.example.mstream_music.VisualizerBridge'. Underscore in the
@@ -16,8 +19,12 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <GLES3/gl3.h>
-#include <projectM-4/projectM.h>
 #include <cstdlib>
+#include <memory>
+
+#include "engine.h"
+#include "projectm_engine.h"
+#include "shader_engine.h"
 
 #define LOG_TAG "mstream/viz-bridge"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__)
@@ -25,12 +32,15 @@
 
 namespace {
 
+constexpr jint kEngineProjectM = 0;
+constexpr jint kEngineShader   = 1;
+
 struct BridgeContext {
     EGLDisplay display = EGL_NO_DISPLAY;
     EGLContext context = EGL_NO_CONTEXT;
     EGLSurface surface = EGL_NO_SURFACE;
     ANativeWindow* window = nullptr;
-    projectm_handle pm = nullptr;
+    std::unique_ptr<Engine> engine;
     int width = 0;
     int height = 0;
 };
@@ -104,6 +114,16 @@ void teardownEgl(BridgeContext* ctx) {
     ctx->context = EGL_NO_CONTEXT;
 }
 
+std::unique_ptr<Engine> makeEngine(jint kind) {
+    switch (kind) {
+        case kEngineShader:
+            return std::make_unique<ShaderEngine>();
+        case kEngineProjectM:
+        default:
+            return std::make_unique<ProjectMEngine>();
+    }
+}
+
 } // namespace
 
 extern "C" {
@@ -111,7 +131,7 @@ extern "C" {
 JNIEXPORT jlong JNICALL
 Java_com_example_mstream_1music_VisualizerBridge_nativeInit(
         JNIEnv* env, jobject /*thiz*/, jobject surfaceObj,
-        jint width, jint height) {
+        jint width, jint height, jint engineKind) {
 
     auto* ctx = new BridgeContext();
     ctx->width = width;
@@ -132,21 +152,18 @@ Java_com_example_mstream_1music_VisualizerBridge_nativeInit(
         return 0;
     }
 
-    ctx->pm = projectm_create();
-    if (!ctx->pm) {
-        LOGE("projectm_create failed");
+    ctx->engine = makeEngine(engineKind);
+    if (!ctx->engine || !ctx->engine->init(width, height)) {
+        LOGE("engine init failed (kind=%d)", engineKind);
+        ctx->engine.reset();
         teardownEgl(ctx);
         ANativeWindow_release(ctx->window);
         delete ctx;
         return 0;
     }
-    projectm_set_window_size(ctx->pm, width, height);
-    projectm_set_fps(ctx->pm, 60);
-    projectm_set_preset_duration(ctx->pm, 30.0);
-    projectm_set_mesh_size(ctx->pm, 48, 36);
 
-    LOGI("nativeInit ok: %dx%d ctx=%p pm=%p", width, height, ctx,
-         (void*)ctx->pm);
+    LOGI("nativeInit ok: %dx%d ctx=%p engine=%d", width, height, ctx,
+         engineKind);
     return reinterpret_cast<jlong>(ctx);
 }
 
@@ -154,12 +171,12 @@ JNIEXPORT void JNICALL
 Java_com_example_mstream_1music_VisualizerBridge_nativeRenderFrame(
         JNIEnv* /*env*/, jobject /*thiz*/, jlong ctxPtr) {
     auto* ctx = reinterpret_cast<BridgeContext*>(ctxPtr);
-    if (!ctx || !ctx->pm) return;
+    if (!ctx || !ctx->engine) return;
     // Context should already be current on this thread (set up at
     // init), but re-make-current cheaply guards against any other
     // GL caller stealing it.
     eglMakeCurrent(ctx->display, ctx->surface, ctx->surface, ctx->context);
-    projectm_opengl_render_frame(ctx->pm);
+    ctx->engine->renderFrame();
     eglSwapBuffers(ctx->display, ctx->surface);
 }
 
@@ -168,15 +185,13 @@ Java_com_example_mstream_1music_VisualizerBridge_nativeAddPcm(
         JNIEnv* env, jobject /*thiz*/, jlong ctxPtr,
         jfloatArray samplesArray) {
     auto* ctx = reinterpret_cast<BridgeContext*>(ctxPtr);
-    if (!ctx || !ctx->pm || !samplesArray) return;
+    if (!ctx || !ctx->engine || !samplesArray) return;
     jsize len = env->GetArrayLength(samplesArray);
     if (len <= 0) return;
     jfloat* data = env->GetFloatArrayElements(samplesArray, nullptr);
     if (!data) return;
-    // Treat the input as interleaved stereo; count is per-channel frames.
-    projectm_pcm_add_float(ctx->pm, data,
-                            static_cast<unsigned int>(len / 2),
-                            PROJECTM_STEREO);
+    // Interleaved stereo; frameCount is number of L/R pairs.
+    ctx->engine->addPcm(data, static_cast<std::size_t>(len / 2));
     env->ReleaseFloatArrayElements(samplesArray, data, JNI_ABORT);
 }
 
@@ -185,13 +200,14 @@ Java_com_example_mstream_1music_VisualizerBridge_nativeLoadPresetData(
         JNIEnv* env, jobject /*thiz*/, jlong ctxPtr,
         jstring presetData, jboolean smoothTransition) {
     auto* ctx = reinterpret_cast<BridgeContext*>(ctxPtr);
-    if (!ctx || !ctx->pm || !presetData) return;
+    if (!ctx || !ctx->engine || !presetData) return;
     const char* data = env->GetStringUTFChars(presetData, nullptr);
     if (!data) return;
     eglMakeCurrent(ctx->display, ctx->surface, ctx->surface, ctx->context);
-    projectm_load_preset_data(ctx->pm, data, smoothTransition);
+    ctx->engine->loadPreset(data, smoothTransition);
+    LOGI("loaded preset (%zu bytes)",
+         static_cast<size_t>(env->GetStringUTFLength(presetData)));
     env->ReleaseStringUTFChars(presetData, data);
-    LOGI("loaded preset (%zu bytes)", static_cast<size_t>(env->GetStringUTFLength(presetData)));
 }
 
 JNIEXPORT void JNICALL
@@ -199,10 +215,10 @@ Java_com_example_mstream_1music_VisualizerBridge_nativeDispose(
         JNIEnv* /*env*/, jobject /*thiz*/, jlong ctxPtr) {
     auto* ctx = reinterpret_cast<BridgeContext*>(ctxPtr);
     if (!ctx) return;
-    if (ctx->pm) {
-        projectm_destroy(ctx->pm);
-        ctx->pm = nullptr;
-    }
+    // Engine destructor needs the GL context current to release GL
+    // resources cleanly.
+    eglMakeCurrent(ctx->display, ctx->surface, ctx->surface, ctx->context);
+    ctx->engine.reset();
     teardownEgl(ctx);
     if (ctx->window) {
         ANativeWindow_release(ctx->window);

--- a/android/app/src/main/kotlin/com/example/mstream_music/RealAudioSource.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/RealAudioSource.kt
@@ -1,0 +1,111 @@
+// Captures live audio output via android.media.audiofx.Visualizer and
+// hands chunks of interleaved-stereo Float PCM to a callback. Used by
+// the visualizer's "Real audio" mode.
+//
+// We attach to audio session 0 (system mix) so we get whatever's
+// currently playing through the OS mixer — typically the just_audio
+// stream coming out of mstream_music itself, but if the user's
+// playing music in another app while our visualizer is open, that
+// works too.
+//
+// Android requires the RECORD_AUDIO permission for any Visualizer
+// instance even when capturing your own app's output. The permission
+// flow lives in the Settings screen; this class assumes it has
+// already been granted and fails soft if not.
+
+package com.example.mstream_music
+
+import android.media.audiofx.Visualizer
+import android.util.Log
+
+private const val TAG = "mstream/viz-realaudio"
+
+class RealAudioSource(
+    // Called whenever a fresh waveform chunk arrives. The Float array
+    // is interleaved stereo (L,R,L,R,…) in [-1, 1]; size = 2 *
+    // captureSize. Same shape as what the synthesized source emits.
+    private val onSamples: (FloatArray) -> Unit
+) {
+    private var visualizer: Visualizer? = null
+
+    /**
+     * Returns true if the Visualizer was successfully attached. False
+     * means we couldn't start (permission revoked, session 0 not
+     * accessible on this OS version, etc.) and the caller should
+     * fall back to a synthesized source.
+     */
+    fun start(): Boolean {
+        try {
+            val v = Visualizer(0)
+            // Largest capture size the device supports (typically 1024).
+            val sizeRange = Visualizer.getCaptureSizeRange()
+            v.captureSize = sizeRange[1]
+            val captureSize = v.captureSize
+
+            v.setDataCaptureListener(
+                object : Visualizer.OnDataCaptureListener {
+                    // Note: API 36 dropped the trailing 'd' from
+                    // these method names. If we ever target an older
+                    // SDK that still has *Captured, this will need
+                    // a compileSdk-conditional shim.
+                    override fun onWaveFormDataCapture(
+                        unused: Visualizer,
+                        waveform: ByteArray,
+                        samplingRate: Int
+                    ) {
+                        // Android docs: "8-bit unsigned PCM data,
+                        // where 0x80 (128) represents zero." Map to
+                        // [-1, 1] float and duplicate to stereo so
+                        // the downstream FFT pipeline (which expects
+                        // interleaved stereo) doesn't have to change.
+                        val n = waveform.size
+                        val out = FloatArray(n * 2)
+                        for (i in 0 until n) {
+                            val s = ((waveform[i].toInt() and 0xff) - 128) / 128f
+                            out[i * 2] = s
+                            out[i * 2 + 1] = s
+                        }
+                        onSamples(out)
+                    }
+
+                    override fun onFftDataCapture(
+                        unused: Visualizer,
+                        fft: ByteArray,
+                        samplingRate: Int
+                    ) {
+                        // We do our own FFT in C++ off the waveform;
+                        // ignore the OS-computed FFT.
+                    }
+                },
+                // Capture rate in milliHertz. Use ~30 Hz to match our
+                // synthesized push rate (didn't want to flood the
+                // bridge queue).
+                30_000.coerceAtMost(Visualizer.getMaxCaptureRate()),
+                /* waveform = */ true,
+                /* fft      = */ false
+            )
+            v.enabled = true
+            visualizer = v
+            Log.i(TAG, "Visualizer attached: captureSize=$captureSize")
+            return true
+        } catch (e: Throwable) {
+            // RuntimeException for permission, UnsupportedOperationException
+            // for hardware quirks. Either way, fail soft.
+            Log.w(TAG, "Visualizer setup failed: ${e.message}")
+            release()
+            return false
+        }
+    }
+
+    fun stop() = release()
+
+    private fun release() {
+        try {
+            visualizer?.enabled = false
+        } catch (_: Throwable) {}
+        try {
+            visualizer?.release()
+        } catch (_: Throwable) {}
+        visualizer = null
+    }
+}

--- a/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
@@ -34,7 +34,9 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
     }
 
     // JNI methods — implemented in visualizer_bridge.cpp.
-    private external fun nativeInit(surface: Surface, width: Int, height: Int): Long
+    // engineKind: 0 = ProjectM (Milkdrop), 1 = Shader (Shadertoy fragment shaders).
+    private external fun nativeInit(
+        surface: Surface, width: Int, height: Int, engineKind: Int): Long
     private external fun nativeRenderFrame(ctxPtr: Long)
     private external fun nativeAddPcm(ctxPtr: Long, samples: FloatArray)
     private external fun nativeLoadPresetData(
@@ -98,6 +100,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
     private fun handleCreate(call: MethodCall, result: MethodChannel.Result) {
         val width = (call.argument<Int>("width") ?: 0).coerceAtLeast(1)
         val height = (call.argument<Int>("height") ?: 0).coerceAtLeast(1)
+        val engineKind = call.argument<Int>("engine") ?: 0 // default ProjectM
         val reg = registry
         if (reg == null) {
             result.error("not_attached", "TextureRegistry unavailable", null)
@@ -115,6 +118,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
             surface = surface,
             width = width,
             height = height,
+            engineKind = engineKind,
             initFn = ::nativeInit,
             renderFn = ::nativeRenderFrame,
             addPcmFn = ::nativeAddPcm,
@@ -125,7 +129,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
         renderThread = thread
 
         result.success(entry.id())
-        Log.i(TAG, "create: textureId=${entry.id()} ${width}x${height}")
+        Log.i(TAG, "create: textureId=${entry.id()} ${width}x${height} engine=$engineKind")
     }
 
     private fun handleAddPcm(call: MethodCall, result: MethodChannel.Result) {
@@ -160,7 +164,8 @@ private class RenderThread(
     private val surface: Surface,
     private val width: Int,
     private val height: Int,
-    private val initFn: (Surface, Int, Int) -> Long,
+    private val engineKind: Int,
+    private val initFn: (Surface, Int, Int, Int) -> Long,
     private val renderFn: (Long) -> Unit,
     private val addPcmFn: (Long, FloatArray) -> Unit,
     private val disposeFn: (Long) -> Unit,
@@ -211,7 +216,7 @@ private class RenderThread(
     }
 
     override fun run() {
-        val ctx = initFn(surface, width, height)
+        val ctx = initFn(surface, width, height, engineKind)
         if (ctx == 0L) {
             Log.e(TAG, "nativeInit returned 0 — render thread exiting")
             return

--- a/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
@@ -48,6 +48,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
 
     private var textureEntry: TextureRegistry.SurfaceTextureEntry? = null
     private var renderThread: RenderThread? = null
+    private var realAudio: RealAudioSource? = null
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         registry = binding.textureRegistry
@@ -78,12 +79,38 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
                 renderThread?.resumeRendering()
                 result.success(null)
             }
+            "startRealAudio" -> handleStartRealAudio(result)
+            "stopRealAudio" -> {
+                stopRealAudio()
+                result.success(null)
+            }
             "dispose" -> {
                 teardown()
                 result.success(null)
             }
             else -> result.notImplemented()
         }
+    }
+
+    private fun handleStartRealAudio(result: MethodChannel.Result) {
+        // Already running? No-op success.
+        if (realAudio != null) { result.success(true); return }
+        val rt = renderThread
+        if (rt == null) { result.success(false); return }
+        val src = RealAudioSource { samples -> rt.enqueuePcm(samples) }
+        val ok = src.start()
+        if (ok) {
+            realAudio = src
+            Log.i(TAG, "real audio attached")
+        } else {
+            Log.w(TAG, "real audio failed to attach — Dart should fall back to synthesized")
+        }
+        result.success(ok)
+    }
+
+    private fun stopRealAudio() {
+        realAudio?.stop()
+        realAudio = null
     }
 
     private fun handleLoadPreset(call: MethodCall, result: MethodChannel.Result) {
@@ -147,6 +174,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
     }
 
     private fun teardown() {
+        stopRealAudio()
         renderThread?.shutdown()
         renderThread = null
         textureEntry?.release()

--- a/assets/shaders/01-spectrum-bars.glsl
+++ b/assets/shaders/01-spectrum-bars.glsl
@@ -17,7 +17,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Skew the frequency lookup toward the low end where most music
     // energy lives. Pure linear gives a top-heavy result that looks
     // like nothing's happening on the bass.
-    float freq = pow(bar / numBars, 1.6);
+    //
+    // Note: AudioTexture has 512 bins, so at 44.1 kHz each bin ≈ 43 Hz
+    // and the useful musical range tops out around x = 0.3 (≈ 12 kHz).
+    // The 0.30 max cap below keeps the rightmost bars in lively
+    // frequencies instead of dead air at 15–22 kHz.
+    float freq = pow(bar / numBars, 1.6) * 0.30;
     float amp = texture(iChannel0, vec2(freq, 0.25)).x;
     amp = pow(amp, 1.4) * 1.4;
 

--- a/assets/shaders/01-spectrum-bars.glsl
+++ b/assets/shaders/01-spectrum-bars.glsl
@@ -1,0 +1,43 @@
+// title: Spectrum Bars
+// author: mstream_music
+// license: MIT
+// description: Classic FFT-driven bouncing bars with color cycling.
+//
+// Demonstrates the simplest audio reaction — sample the FFT row of
+// iChannel0 (y near 0.25) at one frequency per bar.
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord / iResolution.xy;
+
+    // 48 bars across the screen.
+    float numBars = 48.0;
+    float bar = floor(uv.x * numBars);
+    float barCenter = (bar + 0.5) / numBars;
+
+    // Skew the frequency lookup toward the low end where most music
+    // energy lives. Pure linear gives a top-heavy result that looks
+    // like nothing's happening on the bass.
+    float freq = pow(bar / numBars, 1.6);
+    float amp = texture(iChannel0, vec2(freq, 0.25)).x;
+    amp = pow(amp, 1.4) * 1.4;
+
+    // Gap between bars.
+    float barWidth = 0.7 / numBars;
+    float dx = abs(uv.x - barCenter);
+    float barMask = smoothstep(barWidth, barWidth - 0.004, dx);
+
+    // Solid below the amplitude line.
+    float fill = step(uv.y, amp);
+
+    // Hue cycles with time and slightly with vertical position so
+    // tall bars get a gradient.
+    vec3 col = 0.5 + 0.5 * cos(
+        iTime * 0.35 + uv.y * 1.6 + vec3(0.0, 2.094, 4.188));
+    col *= fill * barMask;
+
+    // Bright cap on top of each bar.
+    float cap = smoothstep(0.018, 0.0, abs(uv.y - amp)) * barMask;
+    col += cap * vec3(1.0, 1.0, 1.0);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/assets/shaders/02-audio-tunnel.glsl
+++ b/assets/shaders/02-audio-tunnel.glsl
@@ -1,0 +1,40 @@
+// title: Audio Tunnel
+// author: mstream_music
+// license: MIT
+// description: A depth tunnel of rings, scrolling speed and color shift
+//              react to bass / mid / treble FFT bands.
+//
+// Demonstrates the "sample 3 bands" pattern — useful for picking out
+// rhythm sections without doing a full equalizer.
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    float r = length(uv);
+    float a = atan(uv.y, uv.x);
+
+    // Sample three bands. Frequencies are normalized [0..1] into the
+    // FFT row of iChannel0.
+    float bass   = texture(iChannel0, vec2(0.04, 0.25)).x;
+    float mids   = texture(iChannel0, vec2(0.30, 0.25)).x;
+    float treble = texture(iChannel0, vec2(0.70, 0.25)).x;
+
+    // Tunnel rings. log(r) gives even spacing in screen space as
+    // they recede; scroll outward over time, faster with bass.
+    float speed = 0.4 + bass * 1.2;
+    float ring = fract(log(max(r, 0.001)) * 3.0 - iTime * speed);
+    float ringEdge = smoothstep(0.5, 0.42, abs(ring - 0.5));
+
+    // Color mix shifts with the mids; spokes pop on treble hits.
+    vec3 cold = vec3(0.25, 0.55, 1.0);
+    vec3 warm = vec3(1.0, 0.35, 0.55);
+    vec3 col = mix(cold, warm, clamp(mids * 1.5, 0.0, 1.0));
+
+    float spoke = 0.5 + 0.5 * sin(a * 12.0 + iTime * 0.6);
+    col += pow(spoke, 12.0) * treble * vec3(1.0, 0.8, 0.4) * 3.0;
+
+    // Vignette by 1/r so the center stays bright and the edges fall off.
+    col *= ringEdge / max(r * 1.4, 0.18);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/assets/shaders/02-audio-tunnel.glsl
+++ b/assets/shaders/02-audio-tunnel.glsl
@@ -15,9 +15,15 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
     // Sample three bands. Frequencies are normalized [0..1] into the
     // FFT row of iChannel0.
-    float bass   = texture(iChannel0, vec2(0.04, 0.25)).x;
-    float mids   = texture(iChannel0, vec2(0.30, 0.25)).x;
-    float treble = texture(iChannel0, vec2(0.70, 0.25)).x;
+    // AudioTexture has 512 bins, so at 44.1 kHz each bin ≈ 43 Hz:
+    //   x=0.006 → bin 3  → ~130 Hz   (kick / sub bass)
+    //   x=0.06  → bin 31 → ~1.3 kHz  (vocal body / lead)
+    //   x=0.15  → bin 77 → ~3.3 kHz  (presence / cymbal attack)
+    // Previously these were at 0.04 / 0.30 / 0.70 which translated to
+    // low-mid / treble / dead air respectively — fixed.
+    float bass   = texture(iChannel0, vec2(0.006, 0.25)).x;
+    float mids   = texture(iChannel0, vec2(0.060, 0.25)).x;
+    float treble = texture(iChannel0, vec2(0.150, 0.25)).x;
 
     // Tunnel rings. log(r) gives even spacing in screen space as
     // they recede; scroll outward over time, faster with bass.

--- a/assets/shaders/03-plasma-pulse.glsl
+++ b/assets/shaders/03-plasma-pulse.glsl
@@ -14,9 +14,13 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     p.x *= iResolution.x / iResolution.y;
 
     // Average across 16 FFT bins for an overall loudness signal.
+    // AudioTexture has 512 bins; most music energy lives below ~6 kHz
+    // (x = 0.14 in the texture). Spreading samples across the full
+    // x = [0, 1] range puts half the samples in near-silent 11–22 kHz
+    // bins which drags the average down. Cap to x = 0.30.
     float loudness = 0.0;
     for (int i = 0; i < 16; ++i) {
-        float f = (float(i) + 0.5) / 16.0;
+        float f = ((float(i) + 0.5) / 16.0) * 0.30;
         loudness += texture(iChannel0, vec2(f, 0.25)).x;
     }
     loudness *= (1.0 / 16.0);

--- a/assets/shaders/03-plasma-pulse.glsl
+++ b/assets/shaders/03-plasma-pulse.glsl
@@ -1,0 +1,41 @@
+// title: Plasma Pulse
+// author: mstream_music
+// license: MIT
+// description: Classic demoscene plasma. Overall amplitude (averaged
+//              across the FFT) modulates brightness — chill when quiet,
+//              luminous when loud.
+//
+// Demonstrates the "average FFT into a loudness signal" pattern, useful
+// when you want music-reactive intensity without picking specific bands.
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord / iResolution.xy;
+    vec2 p = uv * 2.0 - 1.0;
+    p.x *= iResolution.x / iResolution.y;
+
+    // Average across 16 FFT bins for an overall loudness signal.
+    float loudness = 0.0;
+    for (int i = 0; i < 16; ++i) {
+        float f = (float(i) + 0.5) / 16.0;
+        loudness += texture(iChannel0, vec2(f, 0.25)).x;
+    }
+    loudness *= (1.0 / 16.0);
+
+    // Classic plasma — sum of sines at different rates.
+    float v = 0.0;
+    v += sin(p.x * 3.0 + iTime);
+    v += sin(p.y * 4.0 + iTime * 1.3);
+    v += sin((p.x + p.y) * 2.5 + iTime * 0.7);
+    v += sin(length(p) * 5.0 - iTime * 1.5);
+    v *= 0.25; // back into [-1, 1]
+
+    // Hue from v; saturation full; brightness from loudness.
+    vec3 col;
+    col.r = 0.5 + 0.5 * sin(v * 3.14159 + 0.0);
+    col.g = 0.5 + 0.5 * sin(v * 3.14159 + 2.094);
+    col.b = 0.5 + 0.5 * sin(v * 3.14159 + 4.188);
+
+    col *= 0.35 + loudness * 3.5;
+
+    fragColor = vec4(col, 1.0);
+}

--- a/assets/shaders/04-cyber-fuji.glsl
+++ b/assets/shaders/04-cyber-fuji.glsl
@@ -9,24 +9,73 @@
 //                original) — modulating it would shift the whole
 //                scene vertically via line 106 which uses it as a
 //                world-origin offset.
+//                (3) sun() takes a bass param; its bloom coefficient
+//                is scaled by (1.0 + bass * 0.6) so the sun glow
+//                throbs on bass hits.
+//                (4) grid() takes a bass param; a lateral sway term
+//                sin(iTime*3.0) * bass * 1.2 is added to uv.x so the
+//                retro grid rocks side-to-side on bass hits.
+//                (5) both cloudY base coords get a small bass-driven
+//                offset (opposite signs so the two cloud layers
+//                breathe counter to each other).
+//                (6) converted to multipass: buffer A computes
+//                EMA-smoothed amplitudes for FOUR frequency bands
+//                (bass / low-mid / mid / treble) and packs them
+//                into the RGBA channels of a feedback texture.
+//                Each animation reads its own band so different
+//                musical elements drive different visuals:
+//                  bass     → sun bloom throb (kick drum)
+//                  low-mid  → mountain width (body of song)
+//                  mid      → grid lateral sway (vocals/melody)
+//                  treble   → cloud Y bounce (cymbals/hi-hat)
+//                Asymmetric attack/release smoothing per band so
+//                each modulation snaps on hits but tails out
+//                musically without FFT-bin jitter.
+//                (7) the snow line across the top of Fuji is now
+//                drawn from the live audio waveform (iChannel0 row
+//                0.75) instead of the original static sin wave —
+//                turns the mountain ridge into an oscilloscope.
+//                The texX mapping is intentionally wider than the
+//                snow line itself so the waveform extends past the
+//                mountain at any bulge state (mountain mask clips).
+//                Above the snow line fill, a 1/d glow line is
+//                additively blended for a neon oscilloscope look —
+//                intensity = thickness/(abs(dist)+eps), no smoothstep.
+//                Patterns observed (clean-room) from FabriceNeyret2's
+//                lt23W1 and ncote's 3dGGDy shaders — see notes file.
+//                The behavior pattern of (3)–(5) is inspired by
+//                Chaotnix's fd2GRw fork on Shadertoy (CC-BY-NC-SA
+//                default; we did NOT use their code). Re-implemented
+//                independently from a behavior-only spec in
+//                shader_research/cyber-fuji-reactivity-notes.md.
 //
 // Synthwave / Outrun-style sun + mountains + grid sunset.
+//
+// === channel image.0 = music
+// === channel image.1 = buffera
+// === channel buffera.0 = music
+// === channel buffera.1 = buffera
 
+// === pass: image ===
 
-float sun(vec2 uv, float battery)
+float sun(vec2 uv, float battery, float bass)
 {
  	float val = smoothstep(0.3, 0.29, length(uv));
  	float bloom = smoothstep(0.7, 0.0, length(uv));
-    float cut = 3.0 * sin((uv.y + iTime * 0.2 * (battery + 0.02)) * 100.0) 
+    float cut = 3.0 * sin((uv.y + iTime * 0.2 * (battery + 0.02)) * 100.0)
 				+ clamp(uv.y * 14.0 + 1.0, -6.0, 6.0);
     cut = clamp(cut, 0.0, 1.0);
-    return clamp(val * cut, 0.0, 1.0) + bloom * 0.6;
+    // mstream: bloom coefficient scaled by bass for throbbing glow
+    return clamp(val * cut, 0.0, 1.0) + bloom * (0.6 * (1.0 + bass * 1.0));
 }
 
-float grid(vec2 uv, float battery)
+float grid(vec2 uv, float battery, float bass)
 {
     vec2 size = vec2(uv.y, uv.y * uv.y * 0.2) * 0.01;
-    uv += vec2(0.0, iTime * 4.0 * (battery + 0.05));
+    // mstream: lateral sway proportional to bass — grid rocks left/right.
+    // Slow sin so cycles read as a sway (~2s period), not vibration.
+    float sway = sin(iTime * 3.0) * bass * 1.2;
+    uv += vec2(sway, iTime * 4.0 * (battery + 0.05));
     uv = abs(fract(uv) - 0.5);
  	vec2 lines = smoothstep(size, vec2(0.0), uv);
  	lines += smoothstep(size * 5.0, vec2(0.0), uv) * 0.4 * battery;
@@ -77,10 +126,10 @@ float sdCloud(in vec2 p, in vec2 a1, in vec2 b1, in vec2 a2, in vec2 b2, float w
     float boxH = abs(a2.y - a1.y) * 0.5;
     //float boxVal = sdBox(p - boxCenter, vec2(boxW, boxH)) + w;
     float boxVal = sdBox(p - boxCenter, vec2(0.04, boxH)) + w;
-    
+
     float uniVal1 = opSmoothUnion(lineVal1, boxVal, 0.05);
     float uniVal2 = opSmoothUnion(lineVal2, boxVal, 0.05);
-    
+
     return min(uniVal1, uniVal2);
 }
 
@@ -91,14 +140,17 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     //if (iMouse.x > 1.0 && iMouse.y > 1.0) battery = iMouse.y / iResolution.y;
     //else battery = 0.8;
 
-    // Audio modulation (mstream addition — see file header). bass
-    // is consumed below where the mountain's sdTrapezoid is built.
-    float mstreamBass = 0.0;
-    for (int i = 0; i < 6; i++) {
-        mstreamBass += texture(iChannel0, vec2(float(i) * 0.01 + 0.005, 0.25)).x;
-    }
-    mstreamBass = clamp(mstreamBass * 0.4, 0.0, 1.0);
-    
+    // mstream: read smoothed audio amplitudes from buffer A.
+    //   .r = bass    → sun bloom
+    //   .g = low-mid → mountain width
+    //   .b = mid     → grid sway
+    //   .a = treble  → cloud Y bounce
+    vec4 audio = texture(iChannel1, vec2(0.5, 0.5));
+    float mstreamBass   = audio.r;
+    float mstreamLowMid = audio.g;
+    float mstreamMid    = audio.b;
+    float mstreamTreble = audio.a;
+
     //if (abs(uv.x) < (9.0 / 16.0))
     {
         // Grid
@@ -108,64 +160,92 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
         {
             uv.y = 3.0 / (abs(uv.y + 0.2) + 0.05);
             uv.x *= uv.y * 1.0;
-            float gridVal = grid(uv, battery);
+            float gridVal = grid(uv, battery, mstreamMid);
             col = mix(col, vec3(1.0, 0.5, 1.0), gridVal);
         }
         else
         {
             float fujiD = min(uv.y * 4.5 - 0.5, 1.0);
             uv.y -= battery * 1.1 - 0.51;
-            
+
             vec2 sunUV = uv;
             vec2 fujiUV = uv;
-            
+
             // Sun
             sunUV += vec2(0.75, 0.2);
             //uv.y -= 1.1 - 0.51;
             col = vec3(1.0, 0.2, 1.0);
-            float sunVal = sun(sunUV, battery);
-            
+            float sunVal = sun(sunUV, battery, mstreamBass);
+
             col = mix(col, vec3(1.0, 0.4, 0.1), sunUV.y * 2.0 + 0.2);
             col = mix(vec3(0.0, 0.0, 0.0), col, sunVal);
-            
-            // fuji  —  mstream: width multiplier reacts to bass FFT
-            // so the mountain bulges horizontally on hits.
-            float mstreamWidthMul = 1.0 + mstreamBass * 0.25;
+
+            // fuji  —  mstream: width multiplier reacts to smoothed
+            // low-mid energy so the mountain bulges with the body of
+            // the song rather than just kicks.
+            float mstreamWidthMul = 1.0 + mstreamLowMid * 0.4;
             float fujiVal = sdTrapezoid( uv  + vec2(-0.75+sunUV.y * 0.0, 0.5), (1.75 + pow(uv.y * uv.y, 2.1)) * mstreamWidthMul, 0.2, 0.5);
-            float waveVal = uv.y + sin(uv.x * 20.0 + iTime * 2.0) * 0.05 + 0.2;
+            // mstream: snow line traces the live audio waveform, with a
+            // 1/d glow line drawn on top (neon oscilloscope style).
+            // iChannel0 row y=0.75 is the time-domain waveform (512 samples,
+            // centered at 0.5). Map a WIDER range than the snow line so
+            // the waveform extends past the mountain at any bulge state
+            // (step(fujiVal,0) mask clips it cleanly to the mountain shape).
+            // Box-blur over 7 samples for a continuous line shape.
+            float texX = (uv.x - 0.25);  // uv.x ∈ [0.25, 1.25] → texX ∈ [0, 1]
+            float audioWave = 0.0;
+            for (int i = -3; i <= 3; i++) {
+                audioWave += texture(iChannel0, vec2(clamp(texX + float(i) * 0.005, 0.0, 1.0), 0.75)).x;
+            }
+            audioWave /= 7.0;
+            // waveVal is a signed altitude relative to the wave line.
+            // Positive above the line (snow fill), abs(waveVal) is the
+            // distance from the line itself (oscilloscope render).
+            float waveVal = uv.y + (audioWave - 0.5) * 0.15 + 0.2;
             float wave_width = smoothstep(0.0,0.01,(waveVal));
-            
+
             // fuji color
             col = mix( col, mix(vec3(0.0, 0.0, 0.25), vec3(1.0, 0.0, 0.5), fujiD), step(fujiVal, 0.0));
             // fuji top snow
             col = mix( col, vec3(1.0, 0.5, 1.0), wave_width * step(fujiVal, 0.0));
+            // mstream: 1/d glow line traced ON the waveform boundary.
+            // intensity = thickness / (abs(dist) + eps), capped at 4.0,
+            // additively blended over the snow fill so the line reads
+            // as a bright neon glow rather than a flat strip.
+            // Pattern reference: 3dGGDy by ncote — see
+            // shader_research/cyber-fuji-reactivity-notes.md.
+            float lineGlow = 0.004 / (abs(waveVal) + 0.001);
+            lineGlow = min(lineGlow, 4.0);
+            col += vec3(1.0, 1.0, 1.0) * lineGlow * step(fujiVal, 0.0);
             // fuji outline
             col = mix( col, vec3(1.0, 0.5, 1.0), 1.0-smoothstep(0.0,0.01,abs(fujiVal)) );
             //col = mix( col, vec3(1.0, 1.0, 1.0), 1.0-smoothstep(0.03,0.04,abs(fujiVal)) );
             //col = vec3(1.0, 1.0, 1.0) *(1.0-smoothstep(0.03,0.04,abs(fujiVal)));
-            
+
             // horizon color
             col += mix( col, mix(vec3(1.0, 0.12, 0.8), vec3(0.0, 0.0, 0.2), clamp(uv.y * 3.5 + 3.0, 0.0, 1.0)), step(0.0, fujiVal) );
-            
+
             // cloud
             vec2 cloudUV = uv;
             cloudUV.x = mod(cloudUV.x + iTime * 0.1, 4.0) - 2.0;
             float cloudTime = iTime * 0.5;
-            float cloudY = -0.5;
-            float cloudVal1 = sdCloud(cloudUV, 
-                                     vec2(0.1 + sin(cloudTime + 140.5)*0.1,cloudY), 
-                                     vec2(1.05 + cos(cloudTime * 0.9 - 36.56) * 0.1, cloudY), 
-                                     vec2(0.2 + cos(cloudTime * 0.867 + 387.165) * 0.1,0.25+cloudY), 
+            // mstream: cloud Y bounces with treble (positive offset on this layer)
+            float cloudY = -0.5 + mstreamTreble * 0.3;
+            float cloudVal1 = sdCloud(cloudUV,
+                                     vec2(0.1 + sin(cloudTime + 140.5)*0.1,cloudY),
+                                     vec2(1.05 + cos(cloudTime * 0.9 - 36.56) * 0.1, cloudY),
+                                     vec2(0.2 + cos(cloudTime * 0.867 + 387.165) * 0.1,0.25+cloudY),
                                      vec2(0.5 + cos(cloudTime * 0.9675 - 15.162) * 0.09, 0.25+cloudY), 0.075);
-            cloudY = -0.6;
-            float cloudVal2 = sdCloud(cloudUV, 
-                                     vec2(-0.9 + cos(cloudTime * 1.02 + 541.75) * 0.1,cloudY), 
-                                     vec2(-0.5 + sin(cloudTime * 0.9 - 316.56) * 0.1, cloudY), 
-                                     vec2(-1.5 + cos(cloudTime * 0.867 + 37.165) * 0.1,0.25+cloudY), 
+            // mstream: second cloud layer bounces counter-direction (treble)
+            cloudY = -0.6 - mstreamTreble * 0.3;
+            float cloudVal2 = sdCloud(cloudUV,
+                                     vec2(-0.9 + cos(cloudTime * 1.02 + 541.75) * 0.1,cloudY),
+                                     vec2(-0.5 + sin(cloudTime * 0.9 - 316.56) * 0.1, cloudY),
+                                     vec2(-1.5 + cos(cloudTime * 0.867 + 37.165) * 0.1,0.25+cloudY),
                                      vec2(-0.6 + sin(cloudTime * 0.9675 + 665.162) * 0.09, 0.25+cloudY), 0.075);
-            
+
             float cloudVal = min(cloudVal1, cloudVal2);
-            
+
             //col = mix(col, vec3(1.0,1.0,0.0), smoothstep(0.0751, 0.075, cloudVal));
             col = mix(col, vec3(0.0, 0.0, 0.2), 1.0 - smoothstep(0.075 - 0.0001, 0.075, cloudVal));
             col += vec3(1.0, 1.0, 1.0)*(1.0 - smoothstep(0.0,0.01,abs(cloudVal - 0.075)));
@@ -178,5 +258,73 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     }
     //else fragColor = vec4(0.0);
 
-    
+
+}
+
+// === pass: buffera ===
+// Four-band smoothed audio extractor with self-feedback.
+//
+// IMPORTANT: our AudioTexture uses BINS=512 (Shadertoy convention),
+// so at a 44.1 kHz sample rate each bin ≈ 43 Hz. The useful musical
+// spectrum (under ~6 kHz) is therefore packed into x ∈ [0, 0.27].
+// Earlier versions of this pass sampled out at x=0.5–0.75 expecting
+// 256 bins and were reading dead-air frequencies above 10 kHz.
+//
+// Reads:
+//   iChannel0 = music   (raw FFT, row 0; waveform row 1)
+//   iChannel1 = buffera (previous frame's smoothed values, self-feedback)
+//
+// Writes:
+//   .r = smoothed bass    (~85-515 Hz;     bins 2-12)
+//   .g = smoothed low-mid (~600-1300 Hz;   bins 14-30)
+//   .b = smoothed mid     (~1.5-3.7 kHz;   bins 35-85)
+//   .a = smoothed treble  (~4.3-10.7 kHz;  bins 100-250)
+//   Same vec4 is written to every pixel — image pass samples one.
+//
+// Asymmetric attack/release smoothing applied vec4-wise:
+//   attack  ≈ 0.15 (snappy onsets)
+//   release ≈ 0.50 (musical decay, not too dragging)
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    // Sample 6 bins per band, averaged, then scaled to ~fit [0,1].
+    // x coords below match the BINS=512 layout (see header comment).
+    // Pre-scale per band. Sum-of-6-bins approach means raw values can
+    // easily reach 1.5-3.0 on energetic music, so multipliers need to
+    // stay small or every channel saturates at 1.0 (= constant = no
+    // animation). Diagnostic confirmed all 4 channels were clamping;
+    // these factors aim for peak values in [0.6, 0.9] range, leaving
+    // dynamic-range headroom for the smoothing envelope to swing in.
+    float rawBass = 0.0;
+    for (int i = 0; i < 6; i++) {
+        rawBass += texture(iChannel0, vec2(0.004 + float(i) * 0.004, 0.25)).x;
+    }
+    rawBass = clamp(rawBass * 0.25, 0.0, 1.0);
+
+    float rawLowMid = 0.0;
+    for (int i = 0; i < 6; i++) {
+        rawLowMid += texture(iChannel0, vec2(0.028 + float(i) * 0.006, 0.25)).x;
+    }
+    rawLowMid = clamp(rawLowMid * 0.35, 0.0, 1.0);
+
+    float rawMid = 0.0;
+    for (int i = 0; i < 6; i++) {
+        rawMid += texture(iChannel0, vec2(0.070 + float(i) * 0.020, 0.25)).x;
+    }
+    rawMid = clamp(rawMid * 0.5, 0.0, 1.0);
+
+    float rawTreble = 0.0;
+    for (int i = 0; i < 6; i++) {
+        rawTreble += texture(iChannel0, vec2(0.20 + float(i) * 0.060, 0.25)).x;
+    }
+    rawTreble = clamp(rawTreble * 0.6, 0.0, 1.0);
+
+    vec4 raw  = vec4(rawBass, rawLowMid, rawMid, rawTreble);
+    vec4 prev = texture(iChannel1, vec2(0.5, 0.5));
+
+    // Asymmetric smoothing vec4-wise: 0.15 attack (raw > prev), 0.5 release.
+    // step(prev, raw) is 1 when raw >= prev (rising), else 0.
+    vec4 coeff = mix(vec4(0.5), vec4(0.15), step(prev, raw));
+    vec4 smoothed = clamp(mix(raw, prev, coeff), vec4(0.0), vec4(1.0));
+
+    fragColor = smoothed;
 }

--- a/assets/shaders/04-cyber-fuji.glsl
+++ b/assets/shaders/04-cyber-fuji.glsl
@@ -2,12 +2,16 @@
 // author: Jan Mróz (jaszunio15), uploaded to Shadertoy by kaiware007
 // source: https://www.shadertoy.com/view/Wt33Wf
 // license: CC BY 3.0 — https://creativecommons.org/licenses/by/3.0/
-// modifications: header rewritten for our metadata convention; shader body unchanged.
+// modifications: (1) header rewritten for our metadata convention.
+//                (2) `battery` (line ~87 in mainImage) was a constant
+//                1.0 in the original; we now derive it from the bass
+//                FFT bins of iChannel0, ranging ~0.55..1.10. Since
+//                `battery` already drives sun pulse rate, grid scroll
+//                speed, and the final luminance mix, this single
+//                substitution makes the whole scene react to music
+//                without otherwise touching the source.
 //
-// Synthwave / Outrun-style sun + mountains + grid sunset. Visually
-// striking but not audio-reactive in the original — driven entirely
-// by iTime. Our engine still exposes iChannel0 if anyone wants to
-// extend it later.
+// Synthwave / Outrun-style sun + mountains + grid sunset.
 
 
 float sun(vec2 uv, float battery)
@@ -84,7 +88,16 @@ float sdCloud(in vec2 p, in vec2 a1, in vec2 b1, in vec2 a2, in vec2 b2, float w
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
     vec2 uv = (2.0 * fragCoord.xy - iResolution.xy)/iResolution.y;
-    float battery = 1.0;
+    // Audio modulation (mstream addition — see file header).
+    // Average a handful of low FFT bins for a bass-energy signal,
+    // then map it onto `battery` which the rest of the shader uses
+    // as its master "intensity" parameter.
+    float bassEnergy = 0.0;
+    for (int i = 0; i < 6; i++) {
+        bassEnergy += texture(iChannel0, vec2(float(i) * 0.01 + 0.005, 0.25)).x;
+    }
+    bassEnergy = clamp(bassEnergy * 0.4, 0.0, 1.0);
+    float battery = 0.55 + bassEnergy * 0.55;
     //if (iMouse.x > 1.0 && iMouse.y > 1.0) battery = iMouse.y / iResolution.y;
     //else battery = 0.8;
     

--- a/assets/shaders/04-cyber-fuji.glsl
+++ b/assets/shaders/04-cyber-fuji.glsl
@@ -1,0 +1,169 @@
+// title: Cyber Fuji 2020
+// author: Jan Mróz (jaszunio15), uploaded to Shadertoy by kaiware007
+// source: https://www.shadertoy.com/view/Wt33Wf
+// license: CC BY 3.0 — https://creativecommons.org/licenses/by/3.0/
+// modifications: header rewritten for our metadata convention; shader body unchanged.
+//
+// Synthwave / Outrun-style sun + mountains + grid sunset. Visually
+// striking but not audio-reactive in the original — driven entirely
+// by iTime. Our engine still exposes iChannel0 if anyone wants to
+// extend it later.
+
+
+float sun(vec2 uv, float battery)
+{
+ 	float val = smoothstep(0.3, 0.29, length(uv));
+ 	float bloom = smoothstep(0.7, 0.0, length(uv));
+    float cut = 3.0 * sin((uv.y + iTime * 0.2 * (battery + 0.02)) * 100.0) 
+				+ clamp(uv.y * 14.0 + 1.0, -6.0, 6.0);
+    cut = clamp(cut, 0.0, 1.0);
+    return clamp(val * cut, 0.0, 1.0) + bloom * 0.6;
+}
+
+float grid(vec2 uv, float battery)
+{
+    vec2 size = vec2(uv.y, uv.y * uv.y * 0.2) * 0.01;
+    uv += vec2(0.0, iTime * 4.0 * (battery + 0.05));
+    uv = abs(fract(uv) - 0.5);
+ 	vec2 lines = smoothstep(size, vec2(0.0), uv);
+ 	lines += smoothstep(size * 5.0, vec2(0.0), uv) * 0.4 * battery;
+    return clamp(lines.x + lines.y, 0.0, 3.0);
+}
+
+float dot2(in vec2 v ) { return dot(v,v); }
+
+float sdTrapezoid( in vec2 p, in float r1, float r2, float he )
+{
+    vec2 k1 = vec2(r2,he);
+    vec2 k2 = vec2(r2-r1,2.0*he);
+    p.x = abs(p.x);
+    vec2 ca = vec2(p.x-min(p.x,(p.y<0.0)?r1:r2), abs(p.y)-he);
+    vec2 cb = p - k1 + k2*clamp( dot(k1-p,k2)/dot2(k2), 0.0, 1.0 );
+    float s = (cb.x<0.0 && ca.y<0.0) ? -1.0 : 1.0;
+    return s*sqrt( min(dot2(ca),dot2(cb)) );
+}
+
+float sdLine( in vec2 p, in vec2 a, in vec2 b )
+{
+    vec2 pa = p-a, ba = b-a;
+    float h = clamp( dot(pa,ba)/dot(ba,ba), 0.0, 1.0 );
+    return length( pa - ba*h );
+}
+
+float sdBox( in vec2 p, in vec2 b )
+{
+    vec2 d = abs(p)-b;
+    return length(max(d,vec2(0))) + min(max(d.x,d.y),0.0);
+}
+
+float opSmoothUnion(float d1, float d2, float k){
+	float h = clamp(0.5 + 0.5 * (d2 - d1) /k,0.0,1.0);
+    return mix(d2, d1 , h) - k * h * ( 1.0 - h);
+}
+
+float sdCloud(in vec2 p, in vec2 a1, in vec2 b1, in vec2 a2, in vec2 b2, float w)
+{
+	//float lineVal1 = smoothstep(w - 0.0001, w, sdLine(p, a1, b1));
+    float lineVal1 = sdLine(p, a1, b1);
+    float lineVal2 = sdLine(p, a2, b2);
+    vec2 ww = vec2(w*1.5, 0.0);
+    vec2 left = max(a1 + ww, a2 + ww);
+    vec2 right = min(b1 - ww, b2 - ww);
+    vec2 boxCenter = (left + right) * 0.5;
+    //float boxW = right.x - left.x;
+    float boxH = abs(a2.y - a1.y) * 0.5;
+    //float boxVal = sdBox(p - boxCenter, vec2(boxW, boxH)) + w;
+    float boxVal = sdBox(p - boxCenter, vec2(0.04, boxH)) + w;
+    
+    float uniVal1 = opSmoothUnion(lineVal1, boxVal, 0.05);
+    float uniVal2 = opSmoothUnion(lineVal2, boxVal, 0.05);
+    
+    return min(uniVal1, uniVal2);
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+    vec2 uv = (2.0 * fragCoord.xy - iResolution.xy)/iResolution.y;
+    float battery = 1.0;
+    //if (iMouse.x > 1.0 && iMouse.y > 1.0) battery = iMouse.y / iResolution.y;
+    //else battery = 0.8;
+    
+    //if (abs(uv.x) < (9.0 / 16.0))
+    {
+        // Grid
+        float fog = smoothstep(0.1, -0.02, abs(uv.y + 0.2));
+        vec3 col = vec3(0.0, 0.1, 0.2);
+        if (uv.y < -0.2)
+        {
+            uv.y = 3.0 / (abs(uv.y + 0.2) + 0.05);
+            uv.x *= uv.y * 1.0;
+            float gridVal = grid(uv, battery);
+            col = mix(col, vec3(1.0, 0.5, 1.0), gridVal);
+        }
+        else
+        {
+            float fujiD = min(uv.y * 4.5 - 0.5, 1.0);
+            uv.y -= battery * 1.1 - 0.51;
+            
+            vec2 sunUV = uv;
+            vec2 fujiUV = uv;
+            
+            // Sun
+            sunUV += vec2(0.75, 0.2);
+            //uv.y -= 1.1 - 0.51;
+            col = vec3(1.0, 0.2, 1.0);
+            float sunVal = sun(sunUV, battery);
+            
+            col = mix(col, vec3(1.0, 0.4, 0.1), sunUV.y * 2.0 + 0.2);
+            col = mix(vec3(0.0, 0.0, 0.0), col, sunVal);
+            
+            // fuji
+            float fujiVal = sdTrapezoid( uv  + vec2(-0.75+sunUV.y * 0.0, 0.5), 1.75 + pow(uv.y * uv.y, 2.1), 0.2, 0.5);
+            float waveVal = uv.y + sin(uv.x * 20.0 + iTime * 2.0) * 0.05 + 0.2;
+            float wave_width = smoothstep(0.0,0.01,(waveVal));
+            
+            // fuji color
+            col = mix( col, mix(vec3(0.0, 0.0, 0.25), vec3(1.0, 0.0, 0.5), fujiD), step(fujiVal, 0.0));
+            // fuji top snow
+            col = mix( col, vec3(1.0, 0.5, 1.0), wave_width * step(fujiVal, 0.0));
+            // fuji outline
+            col = mix( col, vec3(1.0, 0.5, 1.0), 1.0-smoothstep(0.0,0.01,abs(fujiVal)) );
+            //col = mix( col, vec3(1.0, 1.0, 1.0), 1.0-smoothstep(0.03,0.04,abs(fujiVal)) );
+            //col = vec3(1.0, 1.0, 1.0) *(1.0-smoothstep(0.03,0.04,abs(fujiVal)));
+            
+            // horizon color
+            col += mix( col, mix(vec3(1.0, 0.12, 0.8), vec3(0.0, 0.0, 0.2), clamp(uv.y * 3.5 + 3.0, 0.0, 1.0)), step(0.0, fujiVal) );
+            
+            // cloud
+            vec2 cloudUV = uv;
+            cloudUV.x = mod(cloudUV.x + iTime * 0.1, 4.0) - 2.0;
+            float cloudTime = iTime * 0.5;
+            float cloudY = -0.5;
+            float cloudVal1 = sdCloud(cloudUV, 
+                                     vec2(0.1 + sin(cloudTime + 140.5)*0.1,cloudY), 
+                                     vec2(1.05 + cos(cloudTime * 0.9 - 36.56) * 0.1, cloudY), 
+                                     vec2(0.2 + cos(cloudTime * 0.867 + 387.165) * 0.1,0.25+cloudY), 
+                                     vec2(0.5 + cos(cloudTime * 0.9675 - 15.162) * 0.09, 0.25+cloudY), 0.075);
+            cloudY = -0.6;
+            float cloudVal2 = sdCloud(cloudUV, 
+                                     vec2(-0.9 + cos(cloudTime * 1.02 + 541.75) * 0.1,cloudY), 
+                                     vec2(-0.5 + sin(cloudTime * 0.9 - 316.56) * 0.1, cloudY), 
+                                     vec2(-1.5 + cos(cloudTime * 0.867 + 37.165) * 0.1,0.25+cloudY), 
+                                     vec2(-0.6 + sin(cloudTime * 0.9675 + 665.162) * 0.09, 0.25+cloudY), 0.075);
+            
+            float cloudVal = min(cloudVal1, cloudVal2);
+            
+            //col = mix(col, vec3(1.0,1.0,0.0), smoothstep(0.0751, 0.075, cloudVal));
+            col = mix(col, vec3(0.0, 0.0, 0.2), 1.0 - smoothstep(0.075 - 0.0001, 0.075, cloudVal));
+            col += vec3(1.0, 1.0, 1.0)*(1.0 - smoothstep(0.0,0.01,abs(cloudVal - 0.075)));
+        }
+
+        col += fog * fog * fog;
+        col = mix(vec3(col.r, col.r, col.r) * 0.5, col, battery * 0.7);
+
+        fragColor = vec4(col,1.0);
+    }
+    //else fragColor = vec4(0.0);
+
+    
+}

--- a/assets/shaders/04-cyber-fuji.glsl
+++ b/assets/shaders/04-cyber-fuji.glsl
@@ -3,13 +3,12 @@
 // source: https://www.shadertoy.com/view/Wt33Wf
 // license: CC BY 3.0 — https://creativecommons.org/licenses/by/3.0/
 // modifications: (1) header rewritten for our metadata convention.
-//                (2) `battery` (line ~87 in mainImage) was a constant
-//                1.0 in the original; we now derive it from the bass
-//                FFT bins of iChannel0, ranging ~0.55..1.10. Since
-//                `battery` already drives sun pulse rate, grid scroll
-//                speed, and the final luminance mix, this single
-//                substitution makes the whole scene react to music
-//                without otherwise touching the source.
+//                (2) the mountain's sdTrapezoid width is multiplied
+//                by (1.0 + bass * 0.25) so it bulges horizontally
+//                on bass hits. `battery` stays constant at 1.0 (the
+//                original) — modulating it would shift the whole
+//                scene vertically via line 106 which uses it as a
+//                world-origin offset.
 //
 // Synthwave / Outrun-style sun + mountains + grid sunset.
 
@@ -88,18 +87,17 @@ float sdCloud(in vec2 p, in vec2 a1, in vec2 b1, in vec2 a2, in vec2 b2, float w
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
     vec2 uv = (2.0 * fragCoord.xy - iResolution.xy)/iResolution.y;
-    // Audio modulation (mstream addition — see file header).
-    // Average a handful of low FFT bins for a bass-energy signal,
-    // then map it onto `battery` which the rest of the shader uses
-    // as its master "intensity" parameter.
-    float bassEnergy = 0.0;
-    for (int i = 0; i < 6; i++) {
-        bassEnergy += texture(iChannel0, vec2(float(i) * 0.01 + 0.005, 0.25)).x;
-    }
-    bassEnergy = clamp(bassEnergy * 0.4, 0.0, 1.0);
-    float battery = 0.55 + bassEnergy * 0.55;
+    float battery = 1.0;
     //if (iMouse.x > 1.0 && iMouse.y > 1.0) battery = iMouse.y / iResolution.y;
     //else battery = 0.8;
+
+    // Audio modulation (mstream addition — see file header). bass
+    // is consumed below where the mountain's sdTrapezoid is built.
+    float mstreamBass = 0.0;
+    for (int i = 0; i < 6; i++) {
+        mstreamBass += texture(iChannel0, vec2(float(i) * 0.01 + 0.005, 0.25)).x;
+    }
+    mstreamBass = clamp(mstreamBass * 0.4, 0.0, 1.0);
     
     //if (abs(uv.x) < (9.0 / 16.0))
     {
@@ -130,8 +128,10 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
             col = mix(col, vec3(1.0, 0.4, 0.1), sunUV.y * 2.0 + 0.2);
             col = mix(vec3(0.0, 0.0, 0.0), col, sunVal);
             
-            // fuji
-            float fujiVal = sdTrapezoid( uv  + vec2(-0.75+sunUV.y * 0.0, 0.5), 1.75 + pow(uv.y * uv.y, 2.1), 0.2, 0.5);
+            // fuji  —  mstream: width multiplier reacts to bass FFT
+            // so the mountain bulges horizontally on hits.
+            float mstreamWidthMul = 1.0 + mstreamBass * 0.25;
+            float fujiVal = sdTrapezoid( uv  + vec2(-0.75+sunUV.y * 0.0, 0.5), (1.75 + pow(uv.y * uv.y, 2.1)) * mstreamWidthMul, 0.2, 0.5);
             float waveVal = uv.y + sin(uv.x * 20.0 + iTime * 2.0) * 0.05 + 0.2;
             float wave_width = smoothstep(0.0,0.01,(waveVal));
             

--- a/assets/shaders/05-hex-marching.glsl
+++ b/assets/shaders/05-hex-marching.glsl
@@ -2,12 +2,16 @@
 // author: mrange (Shadertoy)
 // source: https://www.shadertoy.com/view/NdKyDw
 // license: CC0 (Public Domain dedication)
-// modifications: repackaged into our multipass format; pass sources unchanged.
+// modifications: (1) repackaged into our multipass format.
+//                (2) image pass gains an iChannel1 = music route and
+//                samples the bass FFT to add a brightness pulse on
+//                beats. Original buffer pass sources untouched.
 //
 // Multipass: bufferA computes hex marching geometry, bufferB does a feedback
 // pass sampling itself + bufferA, image samples bufferB for the final frame.
 //
 // === channel image.0 = bufferb
+// === channel image.1 = music
 // === channel bufferb.0 = buffera
 // === channel bufferb.1 = bufferb
 //
@@ -22,6 +26,17 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   vec3 col = pcol.xyz;
   col = clamp(col, 0.0, 1.0);
   col *= smoothstep(0.0, 2.0, TIME);
+
+  // mstream addition: brightness pulses on bass hits. Sample a few
+  // low FFT bins from the music channel (iChannel1) and use them as
+  // a multiplier on the otherwise time-only output.
+  float bass = 0.0;
+  for (int i = 0; i < 4; i++) {
+    bass += texture(iChannel1, vec2(float(i) * 0.015 + 0.005, 0.25)).x;
+  }
+  bass = clamp(bass * 0.5, 0.0, 1.0);
+  col *= 1.0 + bass * 0.8;
+
   col = sqrt(col);
   fragColor = vec4(col, 1.0);
 }

--- a/assets/shaders/05-hex-marching.glsl
+++ b/assets/shaders/05-hex-marching.glsl
@@ -1,0 +1,294 @@
+// title: Hex marching
+// author: mrange (Shadertoy)
+// source: https://www.shadertoy.com/view/NdKyDw
+// license: CC0 (Public Domain dedication)
+// modifications: repackaged into our multipass format; pass sources unchanged.
+//
+// Multipass: bufferA computes hex marching geometry, bufferB does a feedback
+// pass sampling itself + bufferA, image samples bufferB for the final frame.
+//
+// === channel image.0 = bufferb
+// === channel bufferb.0 = buffera
+// === channel bufferb.1 = bufferb
+//
+// === pass: image ===
+// License CC0: Hex Marching
+//  Results from saturday afternoon tinkering
+#define TIME iTime
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 q = fragCoord/iResolution.xy;
+
+  vec4 pcol = texture(iChannel0, q);
+  vec3 col = pcol.xyz;
+  col = clamp(col, 0.0, 1.0);
+  col *= smoothstep(0.0, 2.0, TIME);
+  col = sqrt(col);
+  fragColor = vec4(col, 1.0);
+}
+// === pass: buffera ===
+// License CC0: Hex Marching
+#define RESOLUTION  iResolution
+#define TIME        iTime
+#define PI          3.141592654
+#define TAU         (2.0*PI)
+#define ROT(a)      mat2(cos(a), sin(a), -sin(a), cos(a))
+#define BPM         30.0
+
+const float planeDist = 1.0-0.2;
+
+// License: WTFPL, author: sam hocevar, found: https://stackoverflow.com/a/17897228/418488
+const vec4 hsv2rgb_K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+vec3 hsv2rgb(vec3 c) {
+  vec3 p = abs(fract(c.xxx + hsv2rgb_K.xyz) * 6.0 - hsv2rgb_K.www);
+  return c.z * mix(hsv2rgb_K.xxx, clamp(p - hsv2rgb_K.xxx, 0.0, 1.0), c.y);
+}
+// License: WTFPL, author: sam hocevar, found: https://stackoverflow.com/a/17897228/418488
+//  Macro version of above to enable compile-time constants
+#define HSV2RGB(c)  (c.z * mix(hsv2rgb_K.xxx, clamp(abs(fract(c.xxx + hsv2rgb_K.xyz) * 6.0 - hsv2rgb_K.www) - hsv2rgb_K.xxx, 0.0, 1.0), c.y))
+
+
+// License: Unknown, author: Unknown, found: don't remember
+vec4 alphaBlend(vec4 back, vec4 front) {
+  float w = front.w + back.w*(1.0-front.w);
+  vec3 xyz = (front.xyz*front.w + back.xyz*back.w*(1.0-front.w))/w;
+  return w > 0.0 ? vec4(xyz, w) : vec4(0.0);
+}
+
+// License: Unknown, author: Unknown, found: don't remember
+vec3 alphaBlend(vec3 back, vec4 front) {
+  return mix(back, front.xyz, front.w);
+}
+
+// License: Unknown, author: Unknown, found: don't remember
+float tanh_approx(float x) {
+  //  Found this somewhere on the interwebs
+  //  return tanh(x);
+  float x2 = x*x;
+  return clamp(x*(27.0 + x2)/(27.0+9.0*x2), -1.0, 1.0);
+}
+
+// License: Unknown, author: Unknown, found: don't remember
+float hash(float co) {
+  return fract(sin(co*12.9898) * 13758.5453);
+}
+
+vec3 offset(float z) {
+  float a = z;
+  vec2 p = -0.15*(vec2(cos(a), sin(a*sqrt(2.0))) + vec2(cos(a*sqrt(0.75)), sin(a*sqrt(0.5))));
+  return vec3(p, z);
+}
+
+vec3 doffset(float z) {
+  float eps = 0.05;
+  return 0.5*(offset(z + eps) - offset(z - eps))/(2.0*eps);
+}
+
+vec3 ddoffset(float z) {
+  float eps = 0.05;
+  return 0.5*(doffset(z + eps) - doffset(z - eps))/(2.0*eps);
+}
+
+// License: CC0, author: Mårten Rånge, found: https://github.com/mrange/glsl-snippets
+vec2 toPolar(vec2 p) {
+  return vec2(length(p), atan(p.y, p.x));
+}
+
+// License: CC0, author: Mårten Rånge, found: https://github.com/mrange/glsl-snippets
+vec2 toRect(vec2 p) {
+  return vec2(p.x*cos(p.y), p.x*sin(p.y));
+}
+
+// License: MIT OR CC-BY-NC-4.0, author: mercury, found: https://mercury.sexy/hg_sdf/
+float mod1(inout float p, float size) {
+  float halfsize = size*0.5;
+  float c = floor((p + halfsize)/size);
+  p = mod(p + halfsize, size) - halfsize;
+  return c;
+}
+
+vec2 hextile(inout vec2 p) {
+  // See Art of Code: Hexagonal Tiling Explained!
+  // https://www.youtube.com/watch?v=VmrIDyYiJBA
+  const vec2 sz       = vec2(1.0, sqrt(3.0));
+  const vec2 hsz      = 0.5*sz;
+
+  vec2 p1 = mod(p, sz)-hsz;
+  vec2 p2 = mod(p - hsz, sz)-hsz;
+  vec2 p3 = dot(p1, p1) < dot(p2, p2) ? p1 : p2;
+  vec2 n = ((p3 - p + hsz)/sz);
+  p = p3;
+
+  n -= vec2(0.5);
+  // Rounding to make hextile 0,0 well behaved
+  return round(n*2.0)*0.5;
+}
+
+vec4 effect(vec2 p, float aa, float h) {
+  vec2 hhn = hextile(p);
+  const float w = 0.02;
+  vec2 pp = toPolar(p);
+  float a = pp.y;
+  float hn = mod1(pp.y, TAU/6.0);
+  vec2 hp = toRect(pp);
+  float hd = hp.x-(w*10.0);
+  
+  float x = hp.x-0.5*w;
+  float n = mod1(x, w);
+  float d = abs(x)-(0.5*w-aa);
+  
+  float h0 = hash(10.0*(hhn.x+hhn.y)+2.0*h+n);
+  float h1 = fract(8667.0*h0);
+  float cut = mix(-0.5, 0.999, 0.5+0.5*sin(TIME+TAU*h0));
+  const float coln = 6.0;
+  float t = smoothstep(aa, -aa, d)*smoothstep(cut, cut-0.005, sin(a+2.0*(h1-0.5)*TIME+h1*TAU))*exp(-150.0*abs(x));
+  vec3 col = hsv2rgb(vec3(floor(h0*coln)/coln, 0.8, 1.0))*t*1.75;
+
+  t = mix(0.9, 1.0, t);
+  t *= smoothstep(aa, -aa, -hd);
+  if (hd < 0.0) {
+    col = vec3(0.0);
+    t = 15.*dot(p, p);
+  }
+  return vec4(col, t);
+}
+
+vec4 plane(vec3 ro, vec3 rd, vec3 pp, vec3 npp, vec3 off, float n) {
+  float h0 = hash(n);
+  float h1 = fract(8667.0*h0);
+
+  vec3 hn;
+  vec2 p  = (pp-off*vec3(1.0, 1.0, 0.0)).xy;
+  p *= ROT(TAU*h0);
+  p.x -= 0.25*h1*(pp.z-ro.z);
+  const float z = 1.0;
+  p /= z;
+  float aa = distance(pp,npp)*sqrt(1.0/3.0)/z;
+  vec4 col = effect(p, aa, h1);
+
+  return col;
+}
+
+vec3 skyColor(vec3 ro, vec3 rd) {
+  return vec3(0.0);
+}
+
+vec3 color(vec3 ww, vec3 uu, vec3 vv, vec3 ro, vec2 p) {
+  float lp = length(p);
+  vec2 np = p + 2.0/RESOLUTION.y;
+  float rdd = (2.-0.5*tanh_approx(lp));  // Playing around with rdd can give interesting distortions
+//  float rdd = 2.;
+  
+  vec3 rd = normalize(p.x*uu + p.y*vv + rdd*ww);
+  vec3 nrd = normalize(np.x*uu + np.y*vv + rdd*ww);
+
+  const int furthest = 5;
+  const int fadeFrom = max(furthest-2, 0);
+
+  const float fadeDist = planeDist*float(furthest - fadeFrom);
+  float nz = floor(ro.z / planeDist);
+
+  vec3 skyCol = skyColor(ro, rd);
+
+
+  vec4 acol = vec4(0.0);
+  const float cutOff = 0.95;
+  bool cutOut = false;
+
+  float maxpd = 0.0;
+
+  // Steps from nearest to furthest plane and accumulates the color 
+  for (int i = 1; i <= furthest; ++i) {
+    float pz = planeDist*nz + planeDist*float(i);
+
+    float pd = (pz - ro.z)/rd.z;
+
+    if (pd > 0.0 && acol.w < cutOff) {
+      vec3 pp = ro + rd*pd;
+      maxpd = pd;
+      vec3 npp = ro + nrd*pd;
+
+      vec3 off = offset(pp.z);
+
+      vec4 pcol = plane(ro, rd, pp, npp, off, nz+float(i));
+
+      float nz = pp.z-ro.z;
+      float fadeIn = smoothstep(planeDist*float(furthest), planeDist*float(fadeFrom), nz);
+      float fadeOut = smoothstep(0.0, planeDist*0.1, nz);
+//      pcol.xyz = mix(skyCol, pcol.xyz, fadeIn);
+      pcol.w *= fadeOut*fadeIn;
+      pcol = clamp(pcol, 0.0, 1.0);
+
+      acol = alphaBlend(pcol, acol);
+    } else {
+      cutOut = true;
+      acol.w = acol.w > cutOff ? 1.0 : acol.w;
+      break;
+    }
+
+  }
+
+  vec3 col = alphaBlend(skyCol, acol);
+// To debug cutouts due to transparency  
+//  col += cutOut ? vec3(1.0, -1.0, 0.0) : vec3(0.0);
+  return col;
+}
+
+vec3 effect(vec2 p, vec2 q) {
+  float tm  = planeDist*TIME*BPM/60.0;
+  vec3 ro   = offset(tm);
+  vec3 dro  = doffset(tm);
+  vec3 ddro = ddoffset(tm);
+
+  vec3 ww = normalize(dro);
+  vec3 uu = normalize(cross(normalize(vec3(0.0,1.0,0.0)+ddro), ww));
+  vec3 vv = cross(ww, uu);
+
+  vec3 col = color(ww, uu, vv, ro, p);
+  
+  return col;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 q = fragCoord/RESOLUTION.xy;
+  vec2 p = -1. + 2. * q;
+  p.x *= RESOLUTION.x/RESOLUTION.y;
+
+  vec3 col = effect(p, q);
+  
+  fragColor = vec4(col, 1.0);
+}
+// === pass: bufferb ===
+// License CC0: Hex Marching
+#define RESOLUTION  iResolution
+#define TIME        iTime
+#define ROT(a)      mat2(cos(a), sin(a), -sin(a), cos(a))
+
+const mat2 brot = ROT(2.399);
+//  simplyfied version of Dave Hoskins blur
+vec3 dblur(vec2 q,float rad) {
+  vec3 acc=vec3(0);
+  const float m = 0.002;
+  vec2 pixel=vec2(m*RESOLUTION.y/RESOLUTION.x,m);
+  vec2 angle=vec2(0,rad);
+  rad=1.;
+  const int iter = 30;
+  for (int j=0; j<iter; ++j) {  
+    rad += 1./rad;
+    angle*=brot;
+    vec4 col=texture(iChannel1,q+pixel*(rad-1.)*angle);
+    acc+=col.xyz;
+  }
+  return acc*(1.0/float(iter));
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 q = fragCoord/RESOLUTION.xy;
+  vec2 p = -1.0+2.0*q;
+  vec4 pcol = texture(iChannel0,q);
+  vec3 bcol = dblur(q, .75);
+  
+  vec3 col = pcol.xyz;
+  col += vec3(0.9, .8, 1.2)*mix(0.5, 0.66, length(p))*(0.05+bcol);
+  
+  fragColor = vec4(col, 1.0);
+}

--- a/assets/shaders/05-hex-marching.glsl
+++ b/assets/shaders/05-hex-marching.glsl
@@ -30,11 +30,13 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   // mstream addition: brightness pulses on bass hits. Sample a few
   // low FFT bins from the music channel (iChannel1) and use them as
   // a multiplier on the otherwise time-only output.
+  // AudioTexture has 512 bins (~43 Hz/bin @ 44.1 kHz); these 4 samples
+  // cover bins ~2–7 ≈ 85–300 Hz, the kick/sub-bass range.
   float bass = 0.0;
   for (int i = 0; i < 4; i++) {
-    bass += texture(iChannel1, vec2(float(i) * 0.015 + 0.005, 0.25)).x;
+    bass += texture(iChannel1, vec2(float(i) * 0.004 + 0.004, 0.25)).x;
   }
-  bass = clamp(bass * 0.5, 0.0, 1.0);
+  bass = clamp(bass * 0.7, 0.0, 1.0);
   col *= 1.0 + bass * 0.8;
 
   col = sqrt(col);

--- a/assets/shaders/06-4d-beats.glsl
+++ b/assets/shaders/06-4d-beats.glsl
@@ -1,0 +1,87 @@
+// title: 4D Beats
+// author: mrange (Mårten Rånge)
+// source: https://www.shadertoy.com/view/tfK3Dy
+// license: CC0 (Public Domain dedication)
+// modifications: repackaged into our single-pass format; engine
+//                wires iChannel0 to our audio texture by default.
+//
+// Beat-driven 4D grid visualization by mrange, animated by audio FFT.
+
+// CC0: 4D Beats
+// Continuing experiments with yesterday's grid structure
+// Note: Music may require clicking play/stop to initialize
+// Shader animation depends on audio timestamp - static without music
+// BPM: 114
+
+// Variant here: https://www.shadertoy.com/view/WfG3WV
+
+// One thing that bothers me abit about these minishaders is that it's
+//  harder for me to reference where I found tricks and inspiritation. 
+//  Normal shaders I just copy the function and put a comment on it. 
+//  So here is an incomplete list of shader devs that were source of 
+//   tricks and inspiration for the minishaders (alphabetical sorting)
+//   @byt3_m3chanic
+//   @FabriceNeyrat2
+//   @iq
+//   @shane
+//   @XorDev
+
+void mainImage(out vec4 O, vec2 C) {
+  vec4 o,p,P,U=vec4(1,2,3,0);
+  
+  // Musical timing: beat-synced animation
+  //  floor(T)+sqrt(F) gives the beat synchronized speed-up
+  //  floor(T)+F*F also works
+  float i,z,d,k,T=iChannelTime[0]*1.9,F=fract(T),t=floor(T)+sqrt(F);
+  
+  // 2D rotation matrix that spins based on musical beats
+  mat2 R=mat2(cos(t*.1+11.*U.wxzw));
+  
+  // Raymarching loop
+  for(vec3 r=iResolution;++i<77.;z+=.8*d+1e-3)
+    
+    // Create ray from camera through current pixel
+    //  Extend to 4D because why not?
+    p=vec4(z*normalize(vec3(C-.5*r.xy,r.y)),.2),
+    
+    // Move camera back in Z
+    p.z-=3.,
+    
+    p.xw*=R,  // Rotate in XW plane
+    p.yw*=R,  // Rotate in YW plane  
+    p.zw*=R,  // Rotate in ZW plane
+    
+    // @mla inversion
+    //  Makes the boring grid more interesting
+    p*=k=9./dot(p,p),
+    
+    // Offset by time to move grid
+    //  Store P for coloring later
+    P=p-=.5*t,
+    
+    // Fold space: move to unit cell of infinite lattice
+    //  abs here in to avoid doing it for each individual box edge
+    p=abs(p-round(p)),
+    
+    // Distance field
+    d=abs(
+     min(
+       min(
+           // Cross pattern centered in each unit cell
+           min(min(length(p.xz),length(p.yz)), length(p.xy))
+           // 4D sphere at the center of each unit cell
+         , length(p)-.2
+         )
+         // Box edges: thin walls along each axis
+       , min(p.w,min(p.x,min(p.z,p.y)))+.05)
+       )/k,
+    
+    // Color calculation based on depth and inversion factor
+    p=1.+sin(P.z+log2(k)+U.wxyw),
+    
+    // Accumulate color: brightness scales with inversion + beat fade
+    o+=U*exp(.7*k-6.*F)+p.w*p/max(d,1e-3);
+    
+  // Tanh tone mapping, divide by .9 to get a slight clipping effect
+  O=tanh(o/1e4)/.9;
+}

--- a/assets/shaders/07-neonwave-sunrise.glsl
+++ b/assets/shaders/07-neonwave-sunrise.glsl
@@ -1,0 +1,397 @@
+// title: Neonwave sunrise
+// author: mrange (Mårten Rånge)
+// source: https://www.shadertoy.com/view/7dyyRy
+// license: CC0 (Public Domain dedication)
+// modifications: repackaged into our single-pass format; engine
+//                wires iChannel0 to our audio texture by default.
+//
+// Synthwave sunrise — neon sun + reflective water, music-reactive.
+
+// CC0 - Neonwave sunrise
+//  Inspired by a tweet by I wanted to create something that looked
+//  a bit like the tweet. This is the result.
+
+#define RESOLUTION    iResolution
+#define TIME          iTime
+#define PI            3.141592654
+#define TAU           (2.0*PI)
+
+#define SHOW_FFT
+
+
+// License: WTFPL, author: sam hocevar, found: https://stackoverflow.com/a/17897228/418488
+const vec4 hsv2rgb_K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+vec3 hsv2rgb(vec3 c) {
+  vec3 p = abs(fract(c.xxx + hsv2rgb_K.xyz) * 6.0 - hsv2rgb_K.www);
+  return c.z * mix(hsv2rgb_K.xxx, clamp(p - hsv2rgb_K.xxx, 0.0, 1.0), c.y);
+}
+// License: WTFPL, author: sam hocevar, found: https://stackoverflow.com/a/17897228/418488
+//  Macro version of above to enable compile-time constants
+#define HSV2RGB(c)  (c.z * mix(hsv2rgb_K.xxx, clamp(abs(fract(c.xxx + hsv2rgb_K.xyz) * 6.0 - hsv2rgb_K.www) - hsv2rgb_K.xxx, 0.0, 1.0), c.y))
+
+// License: Unknown, author: Unknown, found: don't remember
+vec4 alphaBlend(vec4 back, vec4 front) {
+  float w = front.w + back.w*(1.0-front.w);
+  vec3 xyz = (front.xyz*front.w + back.xyz*back.w*(1.0-front.w))/w;
+  return w > 0.0 ? vec4(xyz, w) : vec4(0.0);
+}
+
+// License: Unknown, author: Unknown, found: don't remember
+vec3 alphaBlend(vec3 back, vec4 front) {
+  return mix(back, front.xyz, front.w);
+}
+
+// License: Unknown, author: Unknown, found: don't remember
+float tanh_approx(float x) {
+  //  Found this somewhere on the interwebs
+  //  return tanh(x);
+  float x2 = x*x;
+  return clamp(x*(27.0 + x2)/(27.0+9.0*x2), -1.0, 1.0);
+}
+
+// License: Unknown, author: Unknown, found: don't remember
+float hash(float co) {
+  return fract(sin(co*12.9898) * 13758.5453);
+}
+
+// License: Unknown, author: Unknown, found: don't remember
+float hash(vec2 p) {
+  float a = dot (p, vec2 (127.1, 311.7));
+  return fract(sin(a)*43758.5453123);
+}
+
+// Value noise: https://iquilezles.org/articles/morenoise
+float vnoise(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+    
+  vec2 u = f*f*(3.0-2.0*f);
+//  vec2 u = f;
+
+  float a = hash(i + vec2(0.0,0.0));
+  float b = hash(i + vec2(1.0,0.0));
+  float c = hash(i + vec2(0.0,1.0));
+  float d = hash(i + vec2(1.0,1.0));
+  
+  float m0 = mix(a, b, u.x);
+  float m1 = mix(c, d, u.x);
+  float m2 = mix(m0, m1, u.y);
+  
+  return m2;
+}
+
+// License: MIT, author: Inigo Quilez, found: https://iquilezles.org/www/articles/spherefunctions/spherefunctions.htm
+vec2 raySphere(vec3 ro, vec3 rd, vec4 sph) {
+  vec3 oc = ro - sph.xyz;
+  float b = dot( oc, rd );
+  float c = dot( oc, oc ) - sph.w*sph.w;
+  float h = b*b - c;
+  if( h<0.0 ) return vec2(-1.0);
+  h = sqrt( h );
+  return vec2(-b - h, -b + h);
+}
+
+// License: MIT OR CC-BY-NC-4.0, author: mercury, found: https://mercury.sexy/hg_sdf/
+float mod1(inout float p, float size) {
+  float halfsize = size*0.5;
+  float c = floor((p + halfsize)/size);
+  p = mod(p + halfsize, size) - halfsize;
+  return c;
+}
+
+// License: MIT OR CC-BY-NC-4.0, author: mercury, found: https://mercury.sexy/hg_sdf/
+vec2 mod2(inout vec2 p, vec2 size) {
+  vec2 c = floor((p + size*0.5)/size);
+  p = mod(p + size*0.5,size) - size*0.5;
+  return c;
+}
+
+// License: Unknown, author: Unknown, found: don't remember
+vec2 hash2(vec2 p) {
+  p = vec2(dot (p, vec2 (127.1, 311.7)), dot (p, vec2 (269.5, 183.3)));
+  return fract(sin(p)*43758.5453123);
+}
+
+float hifbm(vec2 p) {
+  const float aa = 0.5;
+  const float pp = 2.0-0.;
+
+  float sum = 0.0;
+  float a   = 1.0;
+  
+  for (int i = 0; i < 5; ++i) {
+    sum += a*vnoise(p);
+    a *= aa;
+    p *= pp;
+  }
+  
+  return sum;
+}
+
+float lofbm(vec2 p) {
+  const float aa = 0.5;
+  const float pp = 2.0-0.;
+
+  float sum = 0.0;
+  float a   = 1.0;
+  
+  for (int i = 0; i < 2; ++i) {
+    sum += a*vnoise(p);
+    a *= aa;
+    p *= pp;
+  }
+  
+  return sum;
+}
+
+float hiheight(vec2 p) {
+  return hifbm(p)-1.8;
+}
+
+float loheight(vec2 p) {
+  return lofbm(p)-2.15;
+}
+
+vec4 plane(vec3 ro, vec3 rd, vec3 pp, vec3 npp, vec3 off, float n) {
+  float h = hash(n);
+  float s = mix(0.05, 0.25, h);
+
+  vec3 hn;
+  vec2 p = (pp-off*2.0*vec3(1.0, 1.0, 0.0)).xy;
+
+  const vec2 stp = vec2(0.5, 0.33); 
+  float he    = hiheight(vec2(p.x, pp.z)*stp);
+  float lohe  = loheight(vec2(p.x, pp.z)*stp);
+
+  float d = p.y-he;
+  float lod = p.y - lohe;
+
+  float aa = distance(pp, npp)*sqrt(1.0/3.0);
+  float t = smoothstep(aa, -aa, d);
+
+  float df = exp(-0.1*(distance(ro, pp)-2.));  
+  vec3 acol = hsv2rgb(vec3(mix(0.9, 0.6, df), 0.9, mix(1.0, 0.0, df)));
+  vec3 gcol = hsv2rgb(vec3(0.6, 0.5, tanh_approx(exp(-mix(2.0, 8.0, df)*lod))));
+  
+  vec3 col = vec3(0.0);
+  col += acol;
+  col += 0.5*gcol;
+  
+  return vec4(col, t);
+}
+
+vec3 stars(vec2 sp, float hh) {
+  const vec3 scol0 = HSV2RGB(vec3(0.85, 0.8, 1.0));
+  const vec3 scol1 = HSV2RGB(vec3(0.65, 0.5, 1.0));
+  vec3 col = vec3(0.0);
+  
+  const float m = 6.0;
+
+  for (float i = 0.0; i < m; ++i) {
+    vec2 pp = sp+0.5*i;
+    float s = i/(m-1.0);
+    vec2 dim  = vec2(mix(0.05, 0.003, s)*PI);
+    vec2 np = mod2(pp, dim);
+    vec2 h = hash2(np+127.0+i);
+    vec2 o = -1.0+2.0*h;
+    float y = sin(sp.x);
+    pp += o*dim*0.5;
+    pp.y *= y;
+    float l = length(pp);
+  
+    float h1 = fract(h.x*1667.0);
+    float h2 = fract(h.x*1887.0);
+    float h3 = fract(h.x*2997.0);
+
+    vec3 scol = mix(8.0*h2, 0.25*h2*h2, s)*mix(scol0, scol1, h1*h1);
+
+    vec3 ccol = col + exp(-(mix(6000.0, 2000.0, hh)/mix(2.0, 0.25, s))*max(l-0.001, 0.0))*scol;
+    ccol *= mix(0.125, 1.0, smoothstep(1.0, 0.99, sin(0.25*TIME+TAU*h.y)));
+    col = h3 < y ? ccol : col;
+  }
+  
+  return col;
+}
+
+vec3 toSpherical(vec3 p) {
+  float r   = length(p);
+  float t   = acos(p.z/r);
+  float ph  = atan(p.y, p.x);
+  return vec3(r, t, ph);
+}
+
+const vec3 lpos   = 1E6*vec3(0., -0.15, 1.0);
+const vec3 ldir   = normalize(lpos);
+
+vec4 moon(vec3 ro, vec3 rd) {
+  const vec4 mdim   = vec4(1E5*vec3(0., 0.4, 1.0), 20000.0);
+  const vec3 mcol0  = HSV2RGB(vec3(0.75, 0.7, 1.0));
+  const vec3 mcol3  = HSV2RGB(vec3(0.75, 0.55, 1.0));
+
+  vec2 md     = raySphere(ro, rd, mdim);
+  vec3 mpos   = ro + rd*md.x;
+  vec3 mnor   = normalize(mpos-mdim.xyz);
+  float mdif  = max(dot(ldir, mnor), 0.0);
+  float mf    = smoothstep(0.0, 10000.0, md.y - md.x);
+  float mfre  = 1.0+dot(rd, mnor); 
+  float imfre = 1.0-mfre;
+
+  vec3 col = vec3(0.0);
+  col += mdif*mcol0*4.0;
+
+#if defined(SHOW_FFT)
+  vec3 fcol = vec3(0.0);
+  vec2 msp    = toSpherical(-mnor.zxy).yz;
+  vec2 omsp   = msp;
+  float msf   = sin(msp.x);
+  msp.x       -= PI*0.5;
+  const float mszy = (TAU/(4.0))*0.125; 
+  float msny  = mod1(msp.y, mszy);
+  msp.y *= msf;
+
+  const int limit = 1;
+  for (int i = -limit; i <= limit; ++i) {
+    vec2 pp     = msp+vec2(0.0, mszy*float(i));
+    float d0    = abs(pp.y);
+    vec2 cp     = vec2(0.055*abs(msny-float(i)), 0.25);
+    float fft   = texture(iChannel0, cp).x;
+    float d1    = length(pp)-0.05*fft;
+    float h     =mix(0.66, 0.99, fft);
+    vec3 mcol1  = hsv2rgb(vec3(h, 0.55, 1.0));
+    vec3 mcol2  = hsv2rgb(vec3(h, 0.85, 1.0));
+    fcol += mcol1*0.5*tanh_approx(0.0025/max(d0, 0.0))*imfre*pow(msf, mix(100.0, 10.0, fft));
+    fcol += mcol2*5.0*tanh_approx(0.00025/(max(d1, 0.0)*max(d1, 0.0)))*imfre*msf;
+  }
+  float d0   = abs(msp.x);
+  fcol += mcol3*0.5*tanh_approx(0.0025/max(d0, 0.0))*imfre;
+  
+  const float start = 18.0;
+  col += fcol*smoothstep(start, start+6.0+2.0*abs(omsp.y), TIME);
+
+#endif
+
+  return vec4(col, mf);
+}
+
+
+vec3 skyColor(vec3 ro, vec3 rd) {
+  const vec3 acol   = HSV2RGB(vec3(0.6, 0.9, 0.075));
+  const vec3 lpos   = 1E6*vec3(0., -0.15, 1.0);
+  const vec3 lcol   = HSV2RGB(vec3(0.75, 0.8, 1.0));
+
+  vec2 sp     = toSpherical(rd.xzy).yz;
+
+  float lf    = pow(max(dot(ldir, rd), 0.0), 80.0);
+  float li    = 0.02*mix(1.0, 10.0, lf)/(abs((rd.y+0.055))+0.025);
+  float lz    = step(-0.055, rd.y);
+
+  vec4 mcol   = moon(ro, rd);
+
+  vec3 col = vec3(0.0);
+  col += stars(sp, 0.25)*smoothstep(0.5, 0.0, li)*lz;  
+  col  = mix(col, mcol.xyz, mcol.w);
+  col += smoothstep(-0.4, 0.0, (sp.x-PI*0.5))*acol;
+  col += tanh(lcol*li);
+  return col;
+}
+
+vec3 color(vec3 ww, vec3 uu, vec3 vv, vec3 ro, vec2 p) {
+  float lp = length(p);
+  vec2 np = p + 2.0/RESOLUTION.y;
+//  float rdd = (2.0-1.0*tanh_approx(lp));  // Playing around with rdd can give interesting distortions
+  float rdd = 2.0;
+  vec3 rd = normalize(p.x*uu + p.y*vv + rdd*ww);
+  vec3 nrd = normalize(np.x*uu + np.y*vv + rdd*ww);
+
+  const float planeDist = 1.0;
+  const int furthest = 12;
+  const int fadeFrom = max(furthest-2, 0);
+
+  const float fadeDist = planeDist*float(fadeFrom);
+  const float maxDist  = planeDist*float(furthest);
+  float nz = floor(ro.z / planeDist);
+
+  vec3 skyCol = skyColor(ro, rd);
+
+
+  vec4 acol = vec4(0.0);
+  const float cutOff = 0.95;
+  bool cutOut = false;
+
+  // Steps from nearest to furthest plane and accumulates the color 
+  for (int i = 1; i <= furthest; ++i) {
+    float pz = planeDist*nz + planeDist*float(i);
+
+    float pd = (pz - ro.z)/rd.z;
+
+    vec3 pp = ro + rd*pd;
+    
+    if (pp.y < 0. && pd > 0.0 && acol.w < cutOff) {
+      vec3 npp = ro + nrd*pd;
+
+      vec3 off = vec3(0.0);
+
+      vec4 pcol = plane(ro, rd, pp, npp, off, nz+float(i));
+
+      float nz = pp.z-ro.z;
+      float fadeIn = smoothstep(maxDist, fadeDist, pd);
+      pcol.xyz = mix(skyCol, pcol.xyz, fadeIn);
+//      pcol.w *= fadeOut;
+      pcol = clamp(pcol, 0.0, 1.0);
+
+      acol = alphaBlend(pcol, acol);
+    } else {
+      cutOut = true;
+      acol.w = acol.w > cutOff ? 1.0 : acol.w;
+      break;
+    }
+
+  }
+
+  vec3 col = alphaBlend(skyCol, acol);
+// To debug cutouts due to transparency  
+//  col += cutOut ? vec3(1.0, -1.0, 0.0) : vec3(0.0);
+  return col;
+}
+
+vec3 effect(vec2 p, vec2 q) {
+  float tm= TIME*0.25;
+  vec3 ro = vec3(0.0, 0.0, tm);
+  vec3 dro= normalize(vec3(0.0, 0.09, 1.0));  
+  vec3 ww = normalize(dro);
+  vec3 uu = normalize(cross(normalize(vec3(0.0,1.0,0.0)), ww));
+  vec3 vv = normalize(cross(ww, uu));
+
+  vec3 col = color(ww, uu, vv, ro, p);
+  
+  return col;
+}
+
+// License: Unknown, author: nmz (twitter: @stormoid), found: https://www.shadertoy.com/view/NdfyRM
+float sRGB(float t) { return mix(1.055*pow(t, 1./2.4) - 0.055, 12.92*t, step(t, 0.0031308)); }
+// License: Unknown, author: nmz (twitter: @stormoid), found: https://www.shadertoy.com/view/NdfyRM
+vec3 sRGB(in vec3 c) { return vec3 (sRGB(c.x), sRGB(c.y), sRGB(c.z)); }
+
+// License: Unknown, author: Matt Taylor (https://github.com/64), found: https://64.github.io/tonemapping/
+vec3 aces_approx(vec3 v) {
+  v = max(v, 0.0);
+  v *= 0.6f;
+  float a = 2.51f;
+  float b = 0.03f;
+  float c = 2.43f;
+  float d = 0.59f;
+  float e = 0.14f;
+  return clamp((v*(a*v+b))/(v*(c*v+d)+e), 0.0f, 1.0f);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 q = fragCoord/RESOLUTION.xy;
+  vec2 p = -1. + 2. * q;
+  p.x *= RESOLUTION.x/RESOLUTION.y;
+  vec3 col = vec3(0.0);
+  col = effect(p, q);
+  col *= smoothstep(0.0, 8.0, TIME-abs(q.y));
+  col = aces_approx(col);
+  col = sRGB(col);
+  fragColor = vec4(col, 1.0);
+}

--- a/assets/shaders/08-neonwave-sunset.glsl
+++ b/assets/shaders/08-neonwave-sunset.glsl
@@ -1,0 +1,399 @@
+// title: Neonwave Sunset
+// author: mrange (Mårten Rånge)
+// source: https://www.shadertoy.com/view/7dtcRj
+// license: CC0 (Public Domain dedication)
+// modifications: repackaged into our single-pass format; engine
+//                wires iChannel0 to our audio texture by default.
+//
+// Synthwave sunset companion to Neonwave sunrise, music-reactive.
+
+// License CC0: Neon Sunset
+//  Code is hackish but I thought it looked good enough to share
+//  The music from GTA III - RISE FM, the best radio channel in GTA III IMHO
+#define LAYERS            5.0
+#define PI                3.141592654
+#define TAU               (2.0*PI)
+#define TIME              iTime
+#define TTIME             (TAU*TIME)
+#define RESOLUTION        iResolution
+#define ROT(a)            mat2(cos(a), sin(a), -sin(a), cos(a))
+
+// License: Unknown, author: nmz (twitter: @stormoid), found: https://www.shadertoy.com/view/NdfyRM
+float sRGB(float t) { return mix(1.055*pow(t, 1./2.4) - 0.055, 12.92*t, step(t, 0.0031308)); }
+// License: Unknown, author: nmz (twitter: @stormoid), found: https://www.shadertoy.com/view/NdfyRM
+vec3 sRGB(in vec3 c) { return vec3 (sRGB(c.x), sRGB(c.y), sRGB(c.z)); }
+
+// License: Unknown, author: Matt Taylor (https://github.com/64), found: https://64.github.io/tonemapping/
+vec3 aces_approx(vec3 v) {
+  v = max(v, 0.0);
+  v *= 0.6f;
+  float a = 2.51f;
+  float b = 0.03f;
+  float c = 2.43f;
+  float d = 0.59f;
+  float e = 0.14f;
+  return clamp((v*(a*v+b))/(v*(c*v+d)+e), 0.0f, 1.0f);
+}
+
+// License: Unknown, author: Unknown, found: don't remember
+float hash(float co) {
+  return fract(sin(co*12.9898) * 13758.5453);
+}
+
+
+// License: Unknown, author: Unknown, found: don't remember
+vec2 hash2(vec2 p) {
+  p = vec2(dot (p, vec2 (127.1, 311.7)), dot (p, vec2 (269.5, 183.3)));
+  return fract(sin(p)*43758.5453123);
+}
+
+// License: CC BY-NC-SA 3.0, author: Stephane Cuillerdier - Aiekick/2015 (twitter:@aiekick), found: https://www.shadertoy.com/view/Mt3GW2
+vec3 blackbody(float Temp) {
+  vec3 col = vec3(255.);
+  col.x = 56100000. * pow(Temp,(-3. / 2.)) + 148.;
+  col.y = 100.04 * log(Temp) - 623.6;
+  if (Temp > 6500.) col.y = 35200000. * pow(Temp,(-3. / 2.)) + 184.;
+  col.z = 194.18 * log(Temp) - 1448.6;
+  col = clamp(col, 0., 255.)/255.;
+  if (Temp < 1000.) col *= Temp/1000.;
+  return col;
+}
+
+// License: WTFPL, author: sam hocevar, found: https://stackoverflow.com/a/17897228/418488
+const vec4 hsv2rgb_K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+vec3 hsv2rgb(vec3 c) {
+  vec3 p = abs(fract(c.xxx + hsv2rgb_K.xyz) * 6.0 - hsv2rgb_K.www);
+  return c.z * mix(hsv2rgb_K.xxx, clamp(p - hsv2rgb_K.xxx, 0.0, 1.0), c.y);
+}
+#define HSV2RGB(c)  (c.z * mix(hsv2rgb_K.xxx, clamp(abs(fract(c.xxx + hsv2rgb_K.xyz) * 6.0 - hsv2rgb_K.www) - hsv2rgb_K.xxx, 0.0, 1.0), c.y))
+
+// License: Unknown, author: Unknown, found: don't remember
+float tanh_approx(float x) {
+//  return tanh(x);
+  float x2 = x*x;
+  return clamp(x*(27.0 + x2)/(27.0+9.0*x2), -1.0, 1.0);
+}
+
+float circle(vec2 p, float r) {
+  return length(p) - r;
+}
+
+// License: MIT, author: Inigo Quilez, found: https://iquilezles.org/articles/smin
+float pmin(float a, float b, float k) {
+    float h = clamp( 0.5+0.5*(b-a)/k, 0.0, 1.0 );
+    return mix( b, a, h ) - k*h*(1.0-h);
+}
+
+// License: MIT OR CC-BY-NC-4.0, author: mercury, found: https://mercury.sexy/hg_sdf/
+float mod1(inout float p, float size) {
+  float halfsize = size*0.5;
+  float c = floor((p + halfsize)/size);
+  p = mod(p + halfsize, size) - halfsize;
+  return c;
+}
+
+// License: MIT OR CC-BY-NC-4.0, author: mercury, found: https://mercury.sexy/hg_sdf/
+vec2 mod2(inout vec2 p, vec2 size) {
+  vec2 c = floor((p + size*0.5)/size);
+  p = mod(p + size*0.5,size) - size*0.5;
+  return c;
+}
+
+// License: MIT, author: Inigo Quilez, found: https://iquilezles.org/articles/intersectors
+float rayPlane(vec3 ro, vec3 rd, vec4 p) {
+  return -(dot(ro,p.xyz)+p.w)/dot(rd,p.xyz);
+}
+
+vec3 toSpherical(vec3 p) {
+  float r   = length(p);
+  float t   = acos(p.z/r);
+  float ph  = atan(p.y, p.x);
+  return vec3(r, t, ph);
+}
+
+float sun(vec2 p) {
+  const float ch = 0.0125;
+  vec2 sp = p;
+  float d0 = circle(sp, 0.5);
+  float d = d0;
+  return d;
+}
+
+float segmentx(vec2 p) {
+  float d0 = abs(p.y);
+  float d1 = length(p);
+  return p.x > 0.0 ? d0 : d1;
+}
+
+float segmentx(vec2 p, float l) {
+  float hl = 0.5*l;
+  p.x = abs(p.x);
+  float d0 = abs(p.y);
+  float d1 = length(p-vec2(hl, 0.0));
+  return p.x > hl ? d1 : d0;
+}
+
+float synth(vec2 p, float aa, out float h, out float db) {
+  const float z = 75.0;
+  p.y -= -70.0;
+  const float st = 0.04;
+  p.x = abs(p.x);
+  p.x -= 20.0-3.5;
+  p.x += st*20.0;
+  p /= z;
+  float n = mod1(p.x, st);
+  float dib = 1E6;
+  const int around = 0;
+  for (int i = -around; i <=around ;++i) {
+    float fft = texture(iChannel0, vec2((n+float(i))*st, 0.25)).x; 
+    fft *= fft;
+    if (i == 0) h = fft;
+    float dibb = segmentx((p-vec2(st*float(i), 0.0)).yx, fft+0.05)-st*0.4;
+    dib = min(dib, dibb);
+  }
+  
+  float d = dib;
+  db = abs(p.y)*z;
+  return smoothstep(aa, -aa, d*z);
+}
+
+vec3 road(vec3 ro, vec3 rd, vec3 nrd, float glare, vec4 pl, out float pt) {
+  const float szoom   = 0.5;
+  const float bsz     = 25.0;
+  const float sm      = 1.0;
+  float off = abs(pl.w);
+  float t = rayPlane(ro, rd, pl);
+  pt = t;
+
+  vec3 p  = ro+rd*t;
+  vec3 np = ro+nrd*t;
+
+  vec2 pp   = p.xz;
+  vec2 npp  = np.xz;
+  vec2 opp  = pp;
+
+  float aa  = length(npp-pp)*sqrt(0.5);
+  pp.y += -60.0*TIME;
+
+  vec3 gcol = vec3(0.0);
+
+  float dr = abs(pp.x)-off;
+  vec2 cp = pp;
+  mod1(cp.y, 6.0*off);
+  vec2 sp = pp;
+  sp.x = abs(sp.x);
+  mod1(sp.y, off);
+  float dcl = segmentx(cp.yx, 1.5*off);
+  float dsl = segmentx((sp-vec2(0.95*off, 0.0)).yx, off*0.5);
+
+  vec2 mp = pp;
+  mod2(mp, vec2(off*0.5));
+    
+  vec2 dp = abs(mp);
+  float d = dp.x;
+  d = pmin(d, dp.y, sm);
+  d = max(d, -dr);
+  d = min(d, dcl); 
+  d = min(d, dsl); 
+  vec2 s2 = sin(TIME+2.0*p.xz/off);
+  float m = mix(0.75, 0.9, tanh_approx(s2.x+s2.y));
+  m *= m;
+  m *= m;
+  m *= m;
+  vec3 hsv = vec3(0.4+mix(0.5, 0.0, m), tanh_approx(0.15*mix(30.0, 10.0, m)*d), 1.0);
+  float fo = exp(-0.04*max(abs(t)-off*2., 0.0));
+  vec3 bcol = hsv2rgb(hsv);
+  gcol += 2.0*bcol*exp(-0.1*mix(30.0, 10.0, m)*d)*fo;
+
+  float sh;
+  float sdb;
+  float sd =synth(opp, aa,sh, sdb)*smoothstep(aa, -aa, -dr);
+  sh = tanh_approx(sh);
+  sdb *= 0.075;
+  sdb *= sdb;
+  sdb += 0.05;
+  vec3 scol = sd*(sdb)*pow(tanh(vec3(0.1)+bcol), mix(vec3(1.0), vec3(1.5, 0.5, 0.5), smoothstep(0.4, 0.5, sh)));
+  gcol += scol;
+
+
+  gcol = t > 0.0 ? gcol : vec3(0.0);
+  return gcol+scol;
+}
+
+vec3 stars(vec2 sp, float hh) {
+  vec3 col = vec3(0.0);
+  
+  const float m = LAYERS;
+  hh = tanh_approx(20.0*hh);
+
+  for (float i = 0.0; i < m; ++i) {
+    vec2 pp = sp+0.5*i;
+    float s = i/(m-1.0);
+    vec2 dim  = vec2(mix(0.05, 0.003, s)*PI);
+    vec2 np = mod2(pp, dim);
+    vec2 h = hash2(np+127.0+i);
+    vec2 o = -1.0+2.0*h;
+    float y = sin(sp.x);
+    pp += o*dim*0.5;
+    pp.y *= y;
+    float l = length(pp);
+  
+    float h1 = fract(h.x*1667.0);
+    float h2 = fract(h.x*1887.0);
+    float h3 = fract(h.x*2997.0);
+
+    vec3 scol = mix(8.0*h2, 0.25*h2*h2, s)*blackbody(mix(3000.0, 22000.0, h1*h1));
+
+    vec3 ccol = col + exp(-(mix(6000.0, 2000.0, hh)/mix(2.0, 0.25, s))*max(l-0.001, 0.0))*scol;
+    ccol *= mix(0.125, 1.0, smoothstep(1.0, 0.99, sin(0.25*TIME+TAU*h.y)));
+    col = h3 < y ? ccol : col;
+  }
+  
+  return col;
+}
+
+vec3 meteorite(vec2 sp) {
+  const float period = 3.0;
+  float mtime = mod(TIME, period);
+  float ntime = floor(TIME/period);
+  float h0 = hash(ntime+123.4);
+  float h1 = fract(1667.0*h0);
+  float h2 = fract(9967.0*h0);
+  vec2 mp = sp;
+  mp.x += -1.0;
+  mp.y += -0.5*h1;
+  mp.y += PI*0.5;
+  mp *= ROT(PI+mix(-PI/4.0, PI/4.0, h0));
+  float m = mtime/period;
+  mp.x += mix(-1.0, 2.0, m);
+  
+  float d0 = length(mp);
+  float d1 = segmentx(mp);
+  
+  vec3 col = vec3(0.0);
+  
+  col += 0.5*exp(-4.0*max(d0, 0.0))*exp(-1000.0*max(d1, 0.0));
+  col *= 2.0*HSV2RGB(vec3(0.8, 0.5, 1.0));
+  float fl = smoothstep(-0.5, 0.5, sin(12.0*TTIME));
+  col += mix(1.0, 0.5, fl)*exp(-mix(100.0, 150.0, fl)*max(d0, 0.0));
+  
+  col = h2 > 0.8 ? col: vec3(0.0);
+  return col;
+}
+
+vec3 skyGrid(vec2 sp) {
+  const float m = 1.0;
+
+  const vec2 dim = vec2(1.0/12.0*PI);
+  float y = sin(sp.x);
+  vec2 pp = sp;
+  vec2 np = mod2(pp, dim*vec2(1.0/floor(1.0/y), 1.0));
+
+  vec3 col = vec3(0.0);
+
+  float d = min(abs(pp.x), abs(pp.y*y));
+  
+  float aa = 2.0/RESOLUTION.y;
+  
+  col += 0.25*vec3(0.5, 0.5, 1.0)*exp(-2000.0*max(d-0.00025, 0.0));
+  
+  return col;
+}
+
+
+vec3 sunset(vec2 sp, vec2 nsp) {
+  const float szoom   = 0.5;
+  float aa = length(nsp-sp)*sqrt(0.5);
+  sp -= vec2(vec2(0.5, -0.5)*PI);
+  sp /= szoom;
+  sp = sp.yx;
+  sp.y += 0.22;
+  sp.y = -sp.y;
+  float ds = sun(sp)*szoom;
+  
+  vec3 bscol = hsv2rgb(vec3(fract(0.7-0.25*(sp.y)), 1.0, 1.0));
+  vec3 gscol = 0.75*sqrt(bscol)*exp(-50.0*max(ds, 0.0));
+  vec3 scol = mix(gscol, bscol, smoothstep(aa, -aa, ds));
+  return scol;
+}
+
+vec3 glow(vec3 ro, vec3 rd, vec2 sp, vec3 lp) {
+  float ld = max(dot(normalize(lp-ro), rd),0.0);
+  float y = -0.5+sp.x/PI;
+  y = max(abs(y)-0.02, 0.0)+0.1*smoothstep(0.5, PI, abs(sp.y));
+  float ci = pow(ld, 10.0)*2.0*exp(-25.0*y);
+  float h = 0.65;
+  vec3 col = hsv2rgb(vec3(h, 0.75, 0.35*exp(-15.0*y)))+HSV2RGB(vec3(0.8, 0.75, 0.5))*ci;
+  return col;
+}
+
+
+
+vec3 neonSky(vec3 ro, vec3 rd, vec3 nrd, out float gl) {
+  const vec3 lp       = 500.0*vec3(0.0, 0.25, -1.0);
+  const vec3 skyCol   = HSV2RGB(vec3(0.8, 0.75, 0.05));
+
+
+  float glare = pow(abs(dot(rd, normalize(lp))), 20.0);
+  
+  vec2 sp   = toSpherical(rd.xzy).yz;
+  vec2 nsp  = toSpherical(nrd.xzy).yz;
+  vec3 grd  = rd;
+  grd.xy *= ROT(0.025*TIME);
+  vec2 spp = toSpherical(grd).yz;
+
+  float gm = 1.0/abs(rd.y)*mix(0.005, 2.0, glare);
+  vec3 col = skyCol*gm;
+  float ig = 1.0-glare;
+  col += glow(ro, rd, sp, lp);
+  if (rd.y > 0.0) {
+    col += sunset(sp, nsp);
+    col += stars(sp, 0.0)*ig;
+    col += skyGrid(spp)*ig;
+    col += meteorite(sp)*ig;
+  }
+  gl = glare;
+  return col;
+}
+
+vec3 color(vec3 ro, vec3 rd, vec3 nrd) {
+  const float off1  = -20.0;
+  const vec4 pl1    = vec4(normalize(vec3(0.0, 1.0, 0.15)), -off1);
+  float glare;
+  vec3 col = neonSky(ro, rd, nrd, glare);
+  if (rd.y < 0.0) {
+    float t;
+    col += road(ro, rd, nrd, glare, pl1, t);
+  }
+  return col;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 q = fragCoord/RESOLUTION.xy; 
+  vec2 p = -1.0 + 2.0*q;
+  p.x *= RESOLUTION.x/RESOLUTION.y;
+  float aa = 2.0/RESOLUTION.y;
+  vec3 ro = vec3(0.0, 0.0, 10.0);
+  vec3 la = vec3(0.0, 2.0, 0.0);
+  vec3 up = vec3(0.0, 1.0, 0.0);
+
+  vec3 ww = normalize(la - ro);
+  vec3 uu = normalize(cross(up, ww ));
+  vec3 vv = normalize(cross(ww,uu));
+  const float fov = tan(TAU/6.0);
+  vec2 np = p + vec2(aa); 
+  vec3 rd = normalize(-p.x*uu + p.y*vv + fov*ww);
+  vec3 nrd = normalize(-np.x*uu + np.y*vv + fov*ww);
+
+
+  vec3 col = vec3(0.1);
+  col = color(ro, rd, nrd);
+//  col += synth(p, np);
+  col *= smoothstep(0.0, 4.0, TIME);
+  col = aces_approx(col);
+  col = sRGB(col); 
+
+
+  fragColor = vec4(col, 1.0);
+}
+

--- a/assets/shaders/09-mountainbytes.glsl
+++ b/assets/shaders/09-mountainbytes.glsl
@@ -1,0 +1,766 @@
+// title: MountainBytes — Phosphorescent Purple Pixel Peaks
+// author: mrange (Mårten Rånge); music by Virgill
+// source: https://www.shadertoy.com/view/lX2GzD
+// license: CC0 (Public Domain dedication)
+// modifications: repackaged into our multipass format. Original is
+//                a MountainBytes 2024 4KiB demo (demozoo #338637).
+//                Channel routing below; buffer passes are pure
+//                generators (no inputs); the Common section is
+//                prepended to every pass by the engine. image.2 is
+//                routed to our audio texture (was the demo music).
+//
+// === channel image.0 = buffera
+// === channel image.1 = bufferb
+// === channel image.2 = music
+
+// === pass: common ===
+// ----------------------------------------------
+// CC0: Phosphorescent Purple Pixel Peaks
+// ----------------------------------------------
+//  `----- - --- ---------?\___/?\/zS!?\___/?\/-o
+//                mrange & virgill              |
+//  `----- - --- ------ -----\___/?\/!?\___/?\/-o
+//                                              |
+//   release: Phosphorescent Purple Pixel Peaks |
+//      type: Windows 4k intro                  |
+//      date: 17.02.2024                        |
+//     party: Mountainbytes 2024                |
+//                                              |
+//                                              |
+//  code: mrange                                |
+//  music: Virgill                              |
+//                                              |
+//                                              |
+// mrange - So, in this release, I set out to   |
+// whip up a terrain marcher in a snug 4KiB     |
+// space. Started with your usual terrain,      |
+// thinking, "Let's give it a synthwave twist." |
+// Now, my previous attempts at a synthwave-    |
+// style terrain marcher were kinda meh, but    |
+// guess what? Lightning struck, and I managed  |
+// to sculpt some visually pleasing mountains.  |
+//                                              |
+// They're not a perfect match for the synthwave|
+// vibe, but hey, check out these transparent,  |
+// glowing ice cream peaks. Cool, right?        |
+//                                              |
+// Big shoutout to Virgill for dropping another |
+// killer tune that totally catches the vibe.   |
+// Sadly, we had to ditch some funky sound      |
+// effects this time around—blame it on the     |
+// space crunch. Fingers crossed, next time,    |
+// we'll pack in the funk.                      |
+//                                              |
+// Oh, and a quick nod to sointu by our main    |
+// man Pestis. This nifty tool churns out tunes |
+// that sound fantastic, and even a music novice|
+// like me could tinker around with its         |
+// user-friendly tracker.                       |
+//                                              |
+// We're banking on you having a blast with our |
+// creation, hoping it dishes out that feel-good|
+// synthwave goodness. Cheers!                  |
+//                                              |
+//                                         _  .:!
+//  <----- ----- -  -   -     - ----- ----\/----'
+
+#define TIME        iTime
+#define RESOLUTION  iResolution
+
+const float 
+  pi        = acos(-1.)
+;
+
+const vec3 
+  Units     = vec3(0, 1, 1E-2)
+;
+
+mat2 rot(float a) {
+  float c=cos(a),s=sin(a);
+  return mat2(c,s,-s,c);
+}
+
+// License: Unknown, author: Unknown, found: don't remember
+float hash2(vec2 co) {
+  return fract(sin(dot(co.xy ,vec2(12.9898,58.233))) * 13758.5453);
+}
+
+
+// License: MIT, author: Inigo Quilez, found: https://www.shadertoy.com/view/lsf3WH
+//  Value noise function
+float vnoise(vec2 p) {
+ vec2 i = floor(p);
+ vec2 f = fract(p);
+    
+ vec2 u = f*f*(3.-2.*f);
+
+ float a = hash2(i);
+ float b = hash2(i+Units.yx);
+ float c = hash2(i+Units.xy);
+ float d = hash2(i+Units.yy);
+   
+ float m0 = mix(a, b, u.x);
+ float m1 = mix(c, d, u.x);
+ float m2 = mix(m0, m1, u.y);
+    
+ return m2;
+}
+
+
+// License: MIT, author: Inigo Quilez, found: https://iquilezles.org/articles/fbm/
+//  Scales and rotates and aggregates multiple layers of value noise
+//  to create something that looks like mountains
+vec3 fbm(vec2 p, int ii) {
+  vec2 np = p;
+  vec2 cp = p;
+  float nh = 0.0;
+  float na = 1.0;
+  float ns = 0.0;
+  for (int i = 0; i < ii; ++i) {
+    nh += na*vnoise(np);
+    np += 123.4;
+    np *= 2.11*rot(1.);
+    ns += na;
+    na *= 0.5;
+  }
+  
+  nh /= ns;
+
+  return vec3(nh);
+}
+
+
+// === pass: buffera ===
+// ----------------------------------------------
+// CC0: Phosphorescent Purple Pixel Peaks
+// ----------------------------------------------
+//  `----- - --- ---------?\___/?\/zS!?\___/?\/-o
+//                mrange & virgill              |
+//  `----- - --- ------ -----\___/?\/!?\___/?\/-o
+//                                              |
+//   release: Phosphorescent Purple Pixel Peaks |
+//      type: Windows 4k intro                  |
+//      date: 17.02.2024                        |
+//     party: Mountainbytes 2024                |
+//                                              |
+//                                              |
+//  code: mrange                                |
+//  music: Virgill                              |
+//                                              |
+//                                              |
+// mrange - So, in this release, I set out to   |
+// whip up a terrain marcher in a snug 4KiB     |
+// space. Started with your usual terrain,      |
+// thinking, "Let's give it a synthwave twist." |
+// Now, my previous attempts at a synthwave-    |
+// style terrain marcher were kinda meh, but    |
+// guess what? Lightning struck, and I managed  |
+// to sculpt some visually pleasing mountains.  |
+//                                              |
+// They're not a perfect match for the synthwave|
+// vibe, but hey, check out these transparent,  |
+// glowing ice cream peaks. Cool, right?        |
+//                                              |
+// Big shoutout to Virgill for dropping another |
+// killer tune that totally catches the vibe.   |
+// Sadly, we had to ditch some funky sound      |
+// effects this time around—blame it on the     |
+// space crunch. Fingers crossed, next time,    |
+// we'll pack in the funk.                      |
+//                                              |
+// Oh, and a quick nod to sointu by our main    |
+// man Pestis. This nifty tool churns out tunes |
+// that sound fantastic, and even a music novice|
+// like me could tinker around with its         |
+// user-friendly tracker.                       |
+//                                              |
+// We're banking on you having a blast with our |
+// creation, hoping it dishes out that feel-good|
+// synthwave goodness. Cheers!                  |
+//                                              |
+//                                         _  .:!
+//  <----- ----- -  -   -     - ----- ----\/----'
+
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 q = fragCoord/RESOLUTION.xy;
+  vec2 p = -1. + 2. * q;
+  p.x *= RESOLUTION.x/RESOLUTION.y;
+
+  // High resolution FBM
+  //  Used for normal computation and raymarching of the detailed mountain
+  vec3 col = fbm(p, 6);
+  
+  fragColor = vec4(col, 1.0);
+}
+// === pass: bufferb ===
+// ----------------------------------------------
+// CC0: Phosphorescent Purple Pixel Peaks
+// ----------------------------------------------
+//  `----- - --- ---------?\___/?\/zS!?\___/?\/-o
+//                mrange & virgill              |
+//  `----- - --- ------ -----\___/?\/!?\___/?\/-o
+//                                              |
+//   release: Phosphorescent Purple Pixel Peaks |
+//      type: Windows 4k intro                  |
+//      date: 17.02.2024                        |
+//     party: Mountainbytes 2024                |
+//                                              |
+//                                              |
+//  code: mrange                                |
+//  music: Virgill                              |
+//                                              |
+//                                              |
+// mrange - So, in this release, I set out to   |
+// whip up a terrain marcher in a snug 4KiB     |
+// space. Started with your usual terrain,      |
+// thinking, "Let's give it a synthwave twist." |
+// Now, my previous attempts at a synthwave-    |
+// style terrain marcher were kinda meh, but    |
+// guess what? Lightning struck, and I managed  |
+// to sculpt some visually pleasing mountains.  |
+//                                              |
+// They're not a perfect match for the synthwave|
+// vibe, but hey, check out these transparent,  |
+// glowing ice cream peaks. Cool, right?        |
+//                                              |
+// Big shoutout to Virgill for dropping another |
+// killer tune that totally catches the vibe.   |
+// Sadly, we had to ditch some funky sound      |
+// effects this time around—blame it on the     |
+// space crunch. Fingers crossed, next time,    |
+// we'll pack in the funk.                      |
+//                                              |
+// Oh, and a quick nod to sointu by our main    |
+// man Pestis. This nifty tool churns out tunes |
+// that sound fantastic, and even a music novice|
+// like me could tinker around with its         |
+// user-friendly tracker.                       |
+//                                              |
+// We're banking on you having a blast with our |
+// creation, hoping it dishes out that feel-good|
+// synthwave goodness. Cheers!                  |
+//                                              |
+//                                         _  .:!
+//  <----- ----- -  -   -     - ----- ----\/----'
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 q = fragCoord/RESOLUTION.xy;
+  vec2 p = -1. + 2. * q;
+  p.x *= RESOLUTION.x/RESOLUTION.y;
+
+  // Low resolution FBM
+  //  Used for snow normal computation and inner glowing mountains
+  vec3 col = fbm(p, 4);
+  
+  fragColor = vec4(col, 1.0);
+}
+// === pass: image ===
+// ----------------------------------------------
+// CC0: Phosphorescent Purple Pixel Peaks
+// ----------------------------------------------
+//  `----- - --- ---------?\___/?\/zS!?\___/?\/-o
+//                mrange & virgill              |
+//  `----- - --- ------ -----\___/?\/!?\___/?\/-o
+//                                              |
+//   release: Phosphorescent Purple Pixel Peaks |
+//      type: Windows 4k intro                  |
+//      date: 17.02.2024                        |
+//     party: Mountainbytes 2024                |
+//                                              |
+//                                              |
+//  code: mrange                                |
+//  music: Virgill                              |
+//                                              |
+//                                              |
+// mrange - So, in this release, I set out to   |
+// whip up a terrain marcher in a snug 4KiB     |
+// space. Started with your usual terrain,      |
+// thinking, "Let's give it a synthwave twist." |
+// Now, my previous attempts at a synthwave-    |
+// style terrain marcher were kinda meh, but    |
+// guess what? Lightning struck, and I managed  |
+// to sculpt some visually pleasing mountains.  |
+//                                              |
+// They're not a perfect match for the synthwave|
+// vibe, but hey, check out these transparent,  |
+// glowing ice cream peaks. Cool, right?        |
+//                                              |
+// Big shoutout to Virgill for dropping another |
+// killer tune that totally catches the vibe.   |
+// Sadly, we had to ditch some funky sound      |
+// effects this time around—blame it on the     |
+// space crunch. Fingers crossed, next time,    |
+// we'll pack in the funk.                      |
+//                                              |
+// Oh, and a quick nod to sointu by our main    |
+// man Pestis. This nifty tool churns out tunes |
+// that sound fantastic, and even a music novice|
+// like me could tinker around with its         |
+// user-friendly tracker.                       |
+//                                              |
+// We're banking on you having a blast with our |
+// creation, hoping it dishes out that feel-good|
+// synthwave goodness. Cheers!                  |
+//                                              |
+//                                         _  .:!
+//  <----- ----- -  -   -     - ----- ----\/----'
+
+// Some commented they don't enjoy the flashes
+//  This is fair and it's not very synthwave-y
+//  So I included this option to drop them
+// #define IDONTLIKETHEFLASHING
+
+#define hifbm iChannel0
+#define lofbm iChannel1
+
+const float 
+  tau       = 2.*pi
+, max_dist  = 14.
+, near_dist = 10.
+, tolerance = 1E-3
+, eps1      = 1E-1
+, path_a    = .2
+, path_b    = 3.
+, minh      = .5
+, maxh      = 2.5
+, wl        = .3
+, innerAdj  = .25
+, ch        = .0175
+, ibpm      = 6./9.
+, per       = 32.*ibpm
+, stp       = 66.
+, lp        = .33*tau/stp
+, fof       = log(20.)
+, rnd       = 123.4
+, period    = 92.
+;
+
+const vec3
+  sunCol0    = vec3(.3  , .1 , 1)
+, sunCol1    = vec3(.1  , .7 , 1)
+, gridCol0   = vec3(.8  , .1 , 1)
+, gridCol1   = vec3(.1  , .5 , 1)
+, roadGlow   = vec3(1   , .3 , .2)*2E-5
+, bikeFlash  = vec3(.5  , .1 , .2)*5E-4
+, skyCol     = gridCol0/3.
+, innerGlow  = sunCol1*8.
+, absorbCol  = -4.*vec3(.5, 2., 1.)
+, sunDir     = normalize(vec3(0., .2, -1.))
+, upDir      = Units.xyx
+;
+
+const vec4 
+  planet = vec4(1.25,.5,-1,.45)*1E5
+;
+  
+const int
+  lo_max_iter = 10
+, hi_max_iter = 90
+;
+
+float g_time;
+float g_beat;
+float g_part;
+
+vec2 segment(vec2 p) {
+  float d0 = length(p);
+  return vec2(p.y>0.?d0:abs(p.x), d0);
+}
+
+// License: MIT, author: Inigo Quilez, found: https://www.iquilezles.org/www/articles/spherefunctions/spherefunctions.htm
+float raySphere(vec3 ro, vec3 rd, vec4 sph) {
+  vec3 oc = ro - sph.xyz;
+  float b = dot(oc, rd);
+  float c = dot(oc, oc) - sph.w*sph.w;
+  float h = b*b - c;
+  return h>0. ? -b - sqrt(h) :  -1.;
+}
+
+// Camera path
+vec3 cam_path(float z) {
+  return vec3(sin(z*path_a)*path_b, 1.-.4*cos(z*lp), -z);
+}
+
+// Derivate of Camera path, used to determine which direction camera points in
+vec3 dcam_path(float z) {
+  return (cam_path(z+eps1) - cam_path(z-eps1))/(2.*eps1);
+}
+
+// Derivate of Derivate of Camera path, used to determine camera tilt
+vec3 ddcam_path(float z) {
+  return (dcam_path(z+eps1) - dcam_path(z-eps1))/(2.*eps1); 
+}
+
+// License: Unknown, author: Unknown, found: don't remember
+float hash1(float co) {
+  return fract(sin(co*12.9898) * 13758.5453);
+}
+
+// Diffuse lighting
+float dif(vec3 n, vec3 ld) {
+  return max(dot(n, ld),0.);
+}
+
+// Fake fresnel effect (more reflective at "edges")
+float fre(vec3 rd, vec3 n, float pwr) {
+  return pow(1.+dot(rd,n), pwr);
+}
+
+// License: MIT OR CC-BY-NC-4.0, author: mercury, found: https://mercury.sexy/hg_sdf/
+float mod1(inout float p, float size) {
+  float halfsize = .5*size;
+  float c = floor((p + halfsize)/size);
+  p = mod(p + halfsize, size) - halfsize;
+  return c;
+}
+
+
+// License: MIT, author: Inigo Quilez, found: https://www.iquilezles.org/www/articles/smin/smin.htm
+//  Soft max function, used in the sun for example to round the edges
+float pmax(float a, float b, float k) {
+  float h = clamp(.5+.5*(a-b)/k, 0., 1.);
+  return mix(b, a, h) + k*h*(1.-h);
+}
+
+// Height function for mountains
+float hf(sampler2D sampler, vec2 p) {
+  vec3 cam = cam_path(p.y);
+  float f = abs(cam.x+p.x);
+  // Global height function
+  float g = mix(minh, maxh*(.5-.5*cos(lp*p.y)), smoothstep(.3, 2.-.5*sin(lp*p.y), f));
+  p *= .125;
+  p += .5;
+  vec2 n = fract(.5*floor(p));
+  p = fract(p);
+  p.x = n.x == 0. ? p.x : 1.-p.x;
+  p.y = n.y == 0. ? p.y : 1.-p.y;
+  // Combine global height function and mountain FBM
+  return mix(wl-1E-2, g*texture(sampler, p).x, g_part > 1. ?smoothstep(.06, .12, f) : 1.);
+}
+
+// Raymarches against height function
+float rayMarch(sampler2D sampler, vec3 ro, vec3 rd, int maxi, float initt, float yadj, float sgn, float wlt) {
+  float t = initt;
+  float stp = .9;
+  float lastt;
+
+  int i;
+
+  for (i = 0; i < maxi; ++i) {
+    if (t > max_dist) {
+      break;
+    }
+    vec3 p = ro+rd*t;
+    if (p.y < wl) {
+      return wlt;
+    }
+
+    float h = hf(sampler, p.xz)-yadj;
+    float d = sgn*(p.y - h);
+
+    if (d < tolerance) {
+      // If we have an intercept we just step back a bit and tries again
+      //  To reduce the potentiel overshoots
+      if (stp >= .125) {
+        stp *= .5;
+        t = lastt;
+      } else {
+        break;
+      }
+    }
+    lastt = t;
+
+    t += max(stp*d, tolerance);
+  }
+
+  return t;
+}
+
+vec3 normal(sampler2D sampler, vec2 p) {
+   return normalize(vec3(
+      hf(sampler, p - Units.zx) - hf(sampler, p + Units.zx)
+    , 2.*Units.z
+    , hf(sampler, p - Units.xz) - hf(sampler, p + Units.xz)
+   ));
+}
+
+float lorayMarch(vec3 ro, vec3 rd, float initt, float yadj, float sgn, float wlt) {
+  return rayMarch(lofbm, ro, rd, lo_max_iter, initt, yadj, sgn, wlt);
+}
+
+vec3 lonormal(vec2 p) {
+  return normal(lofbm, p);
+}
+
+float hirayMarch(vec3 ro, vec3 rd, float initt, float wlt) {
+  return rayMarch(hifbm, ro, rd, hi_max_iter, initt, 0., 1., wlt);
+}
+
+vec3 hinormal(vec2 p) {
+  return normal(hifbm, p);
+}
+
+float sun(vec2 p) {
+  p.y += -.2;
+  float d0 = length(p) - .5;
+  float d2 = p.y;
+  mod1(p.y, ch*6.);
+  float d1 = abs(p.y) -  ch;
+  return pmax(d0, -max(d1, d2), ch);
+}
+
+// The sky
+vec3 skyRender(vec3 ro, vec3 rd) {
+  vec2 sp   = rd.xy*2.;
+  float ds = sun(sp);
+
+  vec3 bscol = mix(sunCol0, sunCol1, clamp(1.4*sp.y, 0., 1.));
+  bscol*=sqrt(bscol*2.);
+
+  // The Sun
+  vec3 col = 1E-2/max(abs(ds), 1E-2)*bscol;
+  col += bscol*smoothstep(3E-3, 0.0, ds);
+
+  float gd = rd.y+5E-3;
+
+  float t = 1.;
+  if (g_part > 2.) {
+      // The City
+      col += 1E-3/max(abs(sp.x*(sp.y*sp.y+1.)), 2E-3)*(0.5+2.*g_beat)*sunCol1;
+      for (float i = 0.; i < 4.; ++i) {
+        vec2 cp = sp;
+        cp *= 1.+.1*i;
+        float cn = mod1(cp.x, .015);
+        float ch = hash1(cn+rnd*i)*smoothstep(32., 4., abs(cn));
+        t = min(t, mix((i+1.)*.125, 1., step(.2*ch, cp.y)));
+      }
+    col *= t;
+  }
+
+  float 
+    si = raySphere(ro, rd, planet)
+  ;
+  
+  vec3 
+    spos = ro+rd*si
+  , sn = normalize(spos-planet.xyz+Units.xyx*5E3*sin(1E3*spos.y/1E5))
+  , sr = reflect(rd, sn)
+  ;
+
+  if (si > 0.) {
+    // The Planet
+    float 
+        sdif = dif(sn, sunDir)
+      , sspe = 4.*pow(dif(sr, sunDir), 80.)*fre(rd, sn, 4.)
+      ;
+    col = sunCol0*sdif+sunCol1*sspe;
+  }
+  
+  float at = g_time-48.;
+  if (at > 0.) {
+    // The Rocket
+    vec2 rp = rd.xy-vec2(-.4-.2*rd.y*rd.y, 5E-3*(at*at-1.));
+    vec2 dr = segment(rp);
+    float rfo = smoothstep(.4, .0, dr.y);
+    col += 1E-3*(sunCol0)/max(abs(dr.x), 2E-4*(2.-rfo))*rfo;
+    col += 3E-3*sunCol1/abs(dr.y)*hash1(floor(g_time*20.));
+  }
+
+  col *= step(0., gd);
+  // The horizon
+  col += 1E-2/max(sqrt(abs(gd))*(75E-2*rd.x*rd.x+75E-4), 5E-4*(1.+30.*rd.x*rd.x))*(1.+.5*g_beat)*skyCol;
+   
+  return col;
+}
+
+// The ground
+vec3 groundRender(vec3 rd, vec3 pp, float pt) {
+  
+  float 
+      gfre  = fre(rd, upDir, 1.)
+    , rp    = pp.x
+    ;
+  rp += cam_path(pp.z).x;    
+
+  // The grid
+  vec2 ggp    = pp.xz;
+  float gcf   = .5+.5*(sin(ggp.x)*sin(ggp.y));
+  ggp         *= 3.;
+  ggp         -= round(ggp);
+  ggp         = abs(ggp);  
+  float ggd   = min(ggp.x, ggp.y) ;
+
+  vec3 gcol = mix(gridCol0, gridCol1, gcf);
+  gcol *= sqrt(gcol)*1E-2;
+
+  float fo = exp(-.5*max(pt-2., 0.));
+  float sm = .025*smoothstep(.6, 1., gfre)+1E-3;
+  float bp = abs(rp)-5E-2;
+  float cp = abs(rp)-25E-3;
+  float cs = sign(rp);
+
+  vec3 pcol = gcol/max(ggd, sm);
+  sm *= 1E-4;
+  if (g_part > 1.) {
+    // The road
+    pcol *= step(0., bp);
+    pcol += roadGlow/max((rp*rp), sm)*smoothstep(.25, .5, sin(20.*pp.z));
+    pcol += .25/max(bp*bp, sm)*roadGlow;
+  }
+
+  float off = pp.z+g_time*3.;
+  float noff = mod1(off, 10.);
+  float hoff = hash1(noff);
+  float ht = hash1(floor(g_time*10.));
+  off += 3.*cs*(hoff-.5);
+  
+  vec2 cp2 = vec2(cp,off);
+  if (g_part > 2.) {
+    // The motorbikes
+    pcol += step(0., off)/max(cp*cp, sm)*smoothstep(2., 0., off)*(cs > 0. ? roadGlow.xzy : roadGlow.zyx)*.25;
+    pcol += ht*ht/max(dot(cp2, cp2), sm)*bikeFlash;
+  }
+  pcol *= fo;
+  return pcol;
+}
+
+vec3 sceneRender(vec3 ro, vec3 rd) {
+  vec3 sky = skyRender(ro, rd);
+
+  float pt = -(ro.y-wl)/rd.y;
+  // Intersect the mountains
+  float gt = hirayMarch(ro, rd, 1E-2, pt);
+
+  vec3 col = vec3(0);
+
+  float ft = max(gt-near_dist, 0.)/(max_dist-near_dist);
+  float fm = exp(-ft*fof);
+
+  vec3 gp = ro+rd*gt;
+  vec3 gn = hinormal(gp.xz);
+  vec3 sn = lonormal(gp.xz);
+  float sdif = dif(sn, sunDir);
+  if (pt > 0. && pt <= gt) {
+    // Hit the ground
+    vec3 pp = ro+pt*rd;
+    vec3 pr = reflect(rd, upDir);
+    float pfre = fre(rd, upDir, 2.);
+    // To find the reflection
+    float pgt = hirayMarch(pp, pr, 5E-2, max_dist); 
+  
+    if (pgt < max_dist) {
+      pfre *= .125*smoothstep(2., 4., pgt);
+    }
+
+    // The ground
+    col = groundRender(rd, pp, pt);
+    // The reflection
+    col += skyRender(pp, pr)*pfre;
+  } else if (gt < max_dist) {
+    // The mountains
+    vec3 gr = reflect(rd, gn);
+    vec3 grr = refract(rd, gn, 1.-.025);
+    vec3 sr = reflect(rd, sn);
+
+    // Ray march the inner mountains
+    float nlt = lorayMarch(gp, grr, eps1, innerAdj, 1., max_dist);
+    float rpt = -(gp.y-wl)/grr.y;
+
+    // Compute inner grid
+    vec3 rpp = gp+grr*rpt;
+    vec3 groundCol = groundRender(grr, rpp, rpt+gt); 
+    vec3 nlp = gp+grr*nlt;
+
+    float gfre = fre(rd, gn, 8.);
+    float sfre = fre(rd, sn, 2.);
+
+    float sspe = pow(dif(sr, sunDir), 40.);
+    float gspe = pow(dif(gr, sunDir), 100.);
+    if (gp.y > mix(.2, .5, .5+.5*sin(gp.z+1.23*gp.x))+.6/max(sqrt(gn.y), .1)) {
+      // The snow
+      col += sfre*sspe;
+      col += sfre*gspe;
+      col += sdif*sqrt(sunCol1);
+      col += -.125*abs(sn.x*sn.y);
+      col += sqrt(skyCol)/sn.y;
+    } else {
+      if (rpt > 0.) {
+        // The inner grid
+        col += .5*exp(rpt*absorbCol)*groundCol;
+      }
+
+      if (nlt < max_dist) {
+        // Raymarch through the inner mountain
+        float flt = lorayMarch(nlp, grr, 5E-2, innerAdj, -1., max_dist);
+        if (flt >= max_dist) {
+          flt = rpt-nlt;
+        }
+        
+        // The inner glow
+        col = mix(col, innerGlow*exp((1.5-.5*g_beat)*nlt*absorbCol), exp(.25*flt)-1.);
+      }
+      col += gfre*.5*skyRender(gp, gr);
+    }
+  } else {
+    // Sky
+    col = sky;
+  }
+
+  // Apply glow
+  col = mix(sky, col, fm);
+
+  return col;
+}
+
+vec3 effect(vec2 p) {
+  g_time = mod(TIME, period);
+  float lt = g_time + .25*ibpm;
+  float ct = mod(lt, per);
+  float nt = floor(lt/per);
+  g_part   = nt;
+  // Beats that control mountain and city flashes
+  g_beat   = exp(-2.*mod(ct+ibpm, 2.*ibpm))*mod(nt, 2.);
+
+  float pt  = ct+stp*nt;
+  vec3 ro   = cam_path(pt);
+  vec3 dro  = dcam_path(pt);
+  vec3 ddro = ddcam_path(pt);
+  dro.zy *= rot(-.11);
+
+  vec3 ww = normalize(dro);
+  vec3 uu = normalize(cross(upDir+2.*ddro, ww));
+  vec3 vv = cross(ww, uu);
+  vec3 rd = normalize(p.x*uu + p.y*vv + 2.*ww);
+
+  vec3 col = sceneRender(ro, rd);
+  // Go black if beyond last part
+  col *= g_part < 4. ? 1. : 0.;
+  float sf = 4.*dot(sunDir, rd);
+
+#ifdef IDONTLIKETHEFLASHING
+  col *= 1.0-exp(-4.*ct);
+  float ft = ct - 31.75*ibpm;
+  if (ft > 0.)
+    col *= exp(-16.*ft);
+#else
+  col += sf*exp(-6.*ct)*sunCol1;
+  float ft = ct - 31.75*ibpm;
+  if (ft > 0.)
+    col += sf*exp(-16.*ft)*sunCol1;
+#endif
+  col = tanh(col)-3E-2*(length(p)+.125);
+  // Fade in
+  col *= smoothstep(0., .25*per, g_time-4.+sf);
+  col *= 1.25;
+  col = sqrt(col);
+  return col;
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord) {
+  vec2 q = fragCoord/RESOLUTION.xy;
+  vec2 p = -1.+2.*q;
+  p.x *= RESOLUTION.x/RESOLUTION.y;
+  vec3 col = effect(p);
+  fragColor = vec4(col,1.0);
+}

--- a/lib/native/visualizer_bridge.dart
+++ b/lib/native/visualizer_bridge.dart
@@ -9,14 +9,25 @@ import 'package:flutter/services.dart';
 class VisualizerBridge {
   static const _channel = MethodChannel('mstream/visualizer');
 
-  /// Asks Kotlin to allocate a SurfaceTexture + EGL context + projectM
-  /// handle at [width] × [height]. Returns the Flutter texture id (to
-  /// hand to a [Texture] widget) on success, or `null` on failure.
-  static Future<int?> create({required int width, required int height}) async {
+  /// Engine identifiers — matches the enum in native/visualizer_bridge.cpp.
+  static const int engineProjectM = 0;
+  static const int engineShader = 1;
+
+  /// Asks Kotlin to allocate a SurfaceTexture + EGL context + visualizer
+  /// engine at [width] × [height]. [engine] picks which renderer:
+  /// `engineProjectM` (default, Milkdrop) or `engineShader` (Shadertoy
+  /// fragment shaders). Returns the Flutter texture id (to hand to a
+  /// [Texture] widget) on success, or `null` on failure.
+  static Future<int?> create({
+    required int width,
+    required int height,
+    int engine = engineProjectM,
+  }) async {
     try {
       final id = await _channel.invokeMethod<int>('create', {
         'width': width,
         'height': height,
+        'engine': engine,
       });
       return id;
     } on PlatformException catch (e) {

--- a/lib/native/visualizer_bridge.dart
+++ b/lib/native/visualizer_bridge.dart
@@ -87,6 +87,32 @@ class VisualizerBridge {
     }
   }
 
+  /// Asks Kotlin to attach an `AndroidVisualizer` to audio session 0
+  /// and start streaming waveform samples into the render thread's
+  /// PCM queue. Returns true on success, false if Visualizer creation
+  /// failed (commonly because RECORD_AUDIO was revoked or the OS
+  /// doesn't allow session-0 capture). Callers should fall back to
+  /// synthesized PCM on false.
+  static Future<bool> startRealAudio() async {
+    try {
+      final ok = await _channel.invokeMethod<bool>('startRealAudio');
+      return ok == true;
+    } on PlatformException catch (e) {
+      // ignore: avoid_print
+      print('VisualizerBridge.startRealAudio failed: ${e.code} ${e.message}');
+      return false;
+    }
+  }
+
+  /// Stops the AndroidVisualizer if it's attached.
+  static Future<void> stopRealAudio() async {
+    try {
+      await _channel.invokeMethod('stopRealAudio');
+    } on PlatformException {
+      // ignore
+    }
+  }
+
   /// Tears down the render thread, EGL context, and projectM handle.
   /// Call from VisualizerScreen.dispose().
   static Future<void> dispose() async {

--- a/lib/native/visualizer_presets.dart
+++ b/lib/native/visualizer_presets.dart
@@ -1,9 +1,15 @@
-// Loads Milkdrop .milk presets bundled as Flutter assets and pushes
-// them into the running visualizer via [VisualizerBridge.loadPreset].
+// Loads visualizer presets bundled as Flutter assets and pushes them
+// into the running native engine via [VisualizerBridge.loadPreset].
 //
-// First call lists the assets/presets/ directory (via the asset
-// manifest), caches the list, and keeps the order stable so
-// [random] and [next] are deterministic within a session.
+// Engine-aware:
+//   ProjectM (Milkdrop)  → reads `assets/presets/*.milk`
+//   Shadertoy fragment   → reads `assets/shaders/*.glsl`
+//
+// Each engine's catalog is cached separately after first listing.
+// Adding/removing a preset = drop a file in/out of the matching
+// assets directory and rebuild — no code changes needed. Each shader
+// file starts with metadata comments (// title:, // author:, //
+// license:) so we can surface attribution in the UI later.
 
 import 'dart:math';
 
@@ -11,54 +17,85 @@ import 'package:flutter/services.dart';
 
 import 'visualizer_bridge.dart';
 
+/// Which preset library a [VisualizerPresets] call targets. Mirrors the
+/// engine kind used at bridge construction time — the catalog must
+/// match whatever the native side was built for.
+enum VisualizerPresetKind { milkdrop, shader }
+
 class VisualizerPresets {
   VisualizerPresets._();
   static final VisualizerPresets _instance = VisualizerPresets._();
   factory VisualizerPresets() => _instance;
 
-  List<String>? _paths;
-  int _cursor = 0;
+  final Map<VisualizerPresetKind, List<String>?> _paths = {};
+  final Map<VisualizerPresetKind, int> _cursors = {};
   final Random _rng = Random();
 
-  /// Asset paths under `assets/presets/`. Cached after first read.
-  /// Uses Flutter 3.10+'s binary AssetManifest API.
-  Future<List<String>> _list() async {
-    final cached = _paths;
+  String _directoryFor(VisualizerPresetKind kind) {
+    switch (kind) {
+      case VisualizerPresetKind.milkdrop:
+        return 'assets/presets/';
+      case VisualizerPresetKind.shader:
+        return 'assets/shaders/';
+    }
+  }
+
+  String _extensionFor(VisualizerPresetKind kind) {
+    switch (kind) {
+      case VisualizerPresetKind.milkdrop:
+        return '.milk';
+      case VisualizerPresetKind.shader:
+        return '.glsl';
+    }
+  }
+
+  /// Asset paths bundled for [kind]. Cached after first read.
+  Future<List<String>> _list(VisualizerPresetKind kind) async {
+    final cached = _paths[kind];
     if (cached != null) return cached;
     try {
       final manifest = await AssetManifest.loadFromAssetBundle(rootBundle);
+      final dir = _directoryFor(kind);
+      final ext = _extensionFor(kind);
       final found = manifest
           .listAssets()
-          .where((k) => k.startsWith('assets/presets/') && k.endsWith('.milk'))
+          .where((k) => k.startsWith(dir) && k.endsWith(ext))
           .toList()
         ..sort();
-      _paths = found;
+      _paths[kind] = found;
       // ignore: avoid_print
-      print('VisualizerPresets: found ${found.length} preset(s)');
+      print('VisualizerPresets[${kind.name}]: found ${found.length}');
       return found;
     } catch (e) {
       // ignore: avoid_print
-      print('VisualizerPresets: manifest read failed: $e');
-      _paths = const [];
+      print('VisualizerPresets[${kind.name}]: manifest read failed: $e');
+      _paths[kind] = const [];
       return const [];
     }
   }
 
-  /// Load a random preset into the running visualizer. No-op if no
-  /// presets are bundled or if no visualizer instance is alive.
-  Future<void> loadRandom({bool smooth = true}) async {
-    final paths = await _list();
+  /// Load a random preset of the given kind into the running engine.
+  /// No-op if nothing is bundled.
+  Future<void> loadRandom(
+    VisualizerPresetKind kind, {
+    bool smooth = true,
+  }) async {
+    final paths = await _list(kind);
     if (paths.isEmpty) return;
     final pick = paths[_rng.nextInt(paths.length)];
     await _loadByPath(pick, smooth: smooth);
   }
 
-  /// Advance to the next preset in the (sorted) list. Wraps around.
-  Future<void> loadNext({bool smooth = true}) async {
-    final paths = await _list();
+  /// Advance to the next preset in the sorted list, wrapping around.
+  Future<void> loadNext(
+    VisualizerPresetKind kind, {
+    bool smooth = true,
+  }) async {
+    final paths = await _list(kind);
     if (paths.isEmpty) return;
-    _cursor = (_cursor + 1) % paths.length;
-    await _loadByPath(paths[_cursor], smooth: smooth);
+    final next = ((_cursors[kind] ?? -1) + 1) % paths.length;
+    _cursors[kind] = next;
+    await _loadByPath(paths[next], smooth: smooth);
   }
 
   Future<void> _loadByPath(String assetPath, {required bool smooth}) async {

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -107,6 +107,31 @@ class _SettingsScreenState extends State<SettingsScreen> {
             },
           ),
           ListTile(
+            title: Text('Visualizer engine'),
+            subtitle: Text(
+              _visualizerEngineSubtitle(SettingsManager().visualizerEngine),
+              style: TextStyle(
+                  color: VelvetColors.textSecondary, fontSize: 12),
+            ),
+            trailing: DropdownButton<VisualizerEngine>(
+              value: SettingsManager().visualizerEngine,
+              underline: SizedBox.shrink(),
+              dropdownColor: VelvetColors.surface,
+              style: TextStyle(color: VelvetColors.textPrimary, fontSize: 14),
+              items: VisualizerEngine.values
+                  .map((e) => DropdownMenuItem(
+                        value: e,
+                        child: Text(e.label),
+                      ))
+                  .toList(),
+              onChanged: (v) async {
+                if (v == null) return;
+                await SettingsManager().setVisualizerEngine(v);
+                if (mounted) setState(() {});
+              },
+            ),
+          ),
+          ListTile(
             title: Text('Visualizer audio source'),
             subtitle: Text(
               _visualizerSourceSubtitle(
@@ -260,6 +285,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
       case AppTheme.light:
         return 'Light body with a dark app bar and amber accents — '
             "matches the older shipped theme.";
+    }
+  }
+
+  String _visualizerEngineSubtitle(VisualizerEngine e) {
+    switch (e) {
+      case VisualizerEngine.milkdrop:
+        return 'Milkdrop presets via projectM (default). Richer effects, '
+            'heavier on the GPU.';
+      case VisualizerEngine.shader:
+        return 'Shadertoy-style fragment shaders. Lighter, modular — '
+            'drop .glsl files in assets/shaders/ to extend the catalog.';
     }
   }
 

--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -4,8 +4,10 @@
 // Android device without an EGL context).
 
 import 'dart:io' show Platform;
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../native/projectm_controller.dart';
 import '../native/visualizer_bridge.dart';
@@ -39,14 +41,36 @@ class _VisualizerScreenState extends State<VisualizerScreen>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    // Full-immersive landscape for the visualizer. Hides status +
+    // navigation bars so the shader uses every pixel; locks the
+    // device to landscape because most Shadertoy/Milkdrop content
+    // is composed for that aspect.
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.landscapeLeft,
+      DeviceOrientation.landscapeRight,
+    ]);
     if (Platform.isAndroid) {
-      WidgetsBinding.instance.addPostFrameCallback((_) => _bringUpBridge());
+      // Wait for the orientation change to settle before sampling the
+      // physical size for the GL surface — a postFrameCallback alone
+      // can fire while the screen is still portrait. 250ms is plenty
+      // on every device I've tested and the user only sees black
+      // during the gap.
+      Future.delayed(const Duration(milliseconds: 250), () {
+        if (mounted) _bringUpBridge();
+      });
     }
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    // Restore the app chrome before the parent route reappears.
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+    ]);
     VisualizerAudio().stop();
     VisualizerBridge.dispose();
     super.dispose();
@@ -86,12 +110,15 @@ class _VisualizerScreenState extends State<VisualizerScreen>
     if (_bringingUp || !mounted) return;
     _bringingUp = true;
 
-    // Size the GL surface to the screen's pixel dimensions so the
-    // visualizer renders at full resolution.
+    // Size the GL surface to the screen's pixel dimensions in
+    // landscape — we force landscape orientation in initState but
+    // the orientation change may not have fully propagated by the
+    // time we read physicalSize. max/min collapses both states to
+    // the right landscape dimensions regardless.
     final view = View.of(context);
     final size = view.physicalSize;
-    final w = size.width.round().clamp(64, 4096);
-    final h = size.height.round().clamp(64, 4096);
+    final w = math.max(size.width, size.height).round().clamp(64, 4096);
+    final h = math.min(size.width, size.height).round().clamp(64, 4096);
 
     final id = await VisualizerBridge.create(
       width: w,
@@ -119,13 +146,10 @@ class _VisualizerScreenState extends State<VisualizerScreen>
   @override
   Widget build(BuildContext context) {
     final supported = Platform.isAndroid;
+    // No AppBar — the visualizer is fullscreen + immersive. Long-press
+    // exits (the bottom overlay still tells the user how).
     return Scaffold(
       backgroundColor: Colors.black,
-      appBar: AppBar(
-        title: Text('Visualizer'),
-        backgroundColor: Colors.black,
-        elevation: 0,
-      ),
       body: GestureDetector(
         behavior: HitTestBehavior.opaque,
         // Tap when rendering = next preset (so the user can cycle).

--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -27,6 +27,13 @@ class _VisualizerScreenState extends State<VisualizerScreen>
   // Tracks whether we've parked the bridge so didChangeAppLifecycleState
   // doesn't double-pause / double-resume.
   bool _backgroundPaused = false;
+  // Snapshot at bringup so engine swaps via Settings only take effect
+  // next time the visualizer opens — no half-swapped GL state.
+  late final VisualizerEngine _engine =
+      SettingsManager().visualizerEngine;
+  VisualizerPresetKind get _presetKind => _engine == VisualizerEngine.shader
+      ? VisualizerPresetKind.shader
+      : VisualizerPresetKind.milkdrop;
 
   @override
   void initState() {
@@ -86,7 +93,11 @@ class _VisualizerScreenState extends State<VisualizerScreen>
     final w = size.width.round().clamp(64, 4096);
     final h = size.height.round().clamp(64, 4096);
 
-    final id = await VisualizerBridge.create(width: w, height: h);
+    final id = await VisualizerBridge.create(
+      width: w,
+      height: h,
+      engine: _engine.nativeKind,
+    );
     if (!mounted) return;
     setState(() {
       _textureId = id;
@@ -97,10 +108,11 @@ class _VisualizerScreenState extends State<VisualizerScreen>
     // a bridge there's nothing on the receiving end to consume PCM.
     if (id != null) {
       VisualizerAudio().start();
-      // Pick a random Milkdrop preset on bringup. Without this projectM
-      // falls back to its idle preset (still nice, but every session
-      // looks the same).
-      await VisualizerPresets().loadRandom(smooth: false);
+      // Pick a random preset matching the active engine. ProjectM
+      // falls back to its idle preset if we don't load one (still
+      // looks fine); ShaderEngine clears to black so loading is
+      // essential.
+      await VisualizerPresets().loadRandom(_presetKind, smooth: false);
     }
   }
 
@@ -121,7 +133,7 @@ class _VisualizerScreenState extends State<VisualizerScreen>
         // switch). Long-press always closes — escape hatch.
         onTap: () {
           if (_textureId != null) {
-            VisualizerPresets().loadNext();
+            VisualizerPresets().loadNext(_presetKind);
           } else {
             Navigator.of(context).maybePop();
           }

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -41,6 +41,35 @@ enum TapBehavior {
   }
 }
 
+/// Which rendering engine the visualizer screen uses. Milkdrop is the
+/// projectM Cream-of-the-Crop pack; Shadertoy is our Shadertoy-style
+/// fragment shader catalog (drop .glsl files in assets/shaders/ to
+/// extend). Persisted so the choice survives app restart.
+enum VisualizerEngine {
+  milkdrop,
+  shader;
+
+  String get label {
+    switch (this) {
+      case VisualizerEngine.milkdrop:
+        return 'Milkdrop';
+      case VisualizerEngine.shader:
+        return 'Shaders';
+    }
+  }
+
+  /// Wire kind passed across the MethodChannel to the native bridge.
+  /// Must match the enum in visualizer_bridge.cpp.
+  int get nativeKind {
+    switch (this) {
+      case VisualizerEngine.milkdrop:
+        return 0;
+      case VisualizerEngine.shader:
+        return 1;
+    }
+  }
+}
+
 /// Where the visualizer screen pulls its frame-driving audio data
 /// from. `synthesized` (the default) generates fake PCM from playback
 /// position — no permissions, works on every platform. `real` taps
@@ -94,6 +123,10 @@ class SettingsManager {
   // through the permission flow.
   VisualizerAudioSource visualizerAudioSource =
       VisualizerAudioSource.synthesized;
+  // Visualizer rendering engine. Milkdrop is the default — it's the
+  // richer engine and the one we shipped first. Shader engine is the
+  // lighter alternative driven by the bundled .glsl catalog.
+  VisualizerEngine visualizerEngine = VisualizerEngine.milkdrop;
 
   late final BehaviorSubject<bool> _albumGridStream =
       BehaviorSubject<bool>.seeded(albumGrid);
@@ -127,6 +160,7 @@ class SettingsManager {
           ? rawGains.whereType<num>().map((n) => n.toDouble()).toList()
           : const [];
       visualizerAudioSource = _readVisualizerAudioSource(m);
+      visualizerEngine = _readVisualizerEngine(m);
       _albumGridStream.add(albumGrid);
       _letterStripStream.add(letterStripThreshold);
       _themeStream.add(appTheme);
@@ -153,6 +187,16 @@ class SettingsManager {
       }
     }
     return VisualizerAudioSource.synthesized;
+  }
+
+  VisualizerEngine _readVisualizerEngine(Map<String, dynamic> m) {
+    final str = m['visualizerEngine'];
+    if (str is String) {
+      for (final v in VisualizerEngine.values) {
+        if (v.name == str) return v;
+      }
+    }
+    return VisualizerEngine.milkdrop;
   }
 
   /// Reads tapBehavior, with one-shot migration from the old boolean
@@ -182,6 +226,7 @@ class SettingsManager {
       'eqEnabled': eqEnabled,
       'eqBandGains': eqBandGains,
       'visualizerAudioSource': visualizerAudioSource.name,
+      'visualizerEngine': visualizerEngine.name,
     }));
   }
 
@@ -233,6 +278,11 @@ class SettingsManager {
     await _save();
   }
 
+  Future<void> setVisualizerEngine(VisualizerEngine v) async {
+    visualizerEngine = v;
+    await _save();
+  }
+
   Future<void> resetAll() async {
     TranscodeManager().transcodeOn = false;
     albumGrid = true;
@@ -243,6 +293,7 @@ class SettingsManager {
     eqEnabled = false;
     eqBandGains = const [];
     visualizerAudioSource = VisualizerAudioSource.synthesized;
+    visualizerEngine = VisualizerEngine.milkdrop;
     _albumGridStream.add(albumGrid);
     _letterStripStream.add(letterStripThreshold);
     _themeStream.add(appTheme);

--- a/lib/singletons/visualizer_audio.dart
+++ b/lib/singletons/visualizer_audio.dart
@@ -1,12 +1,15 @@
 // Drives the visualizer's audio input. Two strategies — picked by
 // [SettingsManager.visualizerAudioSource]:
 //
-//   * synthesized (default) — generates fake PCM from a low-frequency
-//     beat + carrier, modulated by playback state. No permissions, works
-//     on every device with the visualizer.
-//   * real — captures the actual audio output via an AndroidVisualizer
-//     tap. Requires RECORD_AUDIO. NOT IMPLEMENTED YET — falls through
-//     to synthesized for now.
+//   * synthesized (default) — generates broadband PCM from a few
+//     overlapping sweeps + low-amplitude pink-ish noise + a 2 Hz
+//     beat envelope. No permissions, works everywhere; designed so
+//     the spectrum analyzer shaders look populated across the whole
+//     frequency range even when nothing's playing.
+//   * real — taps the OS audio output via android.media.audiofx.
+//     Visualizer on session 0. Requires RECORD_AUDIO. Falls back to
+//     synthesized if the OS refuses the capture (revoked permission,
+//     session 0 locked down by the device, etc.).
 
 import 'dart:async';
 import 'dart:math';
@@ -23,21 +26,20 @@ class VisualizerAudio {
 
   static const _sampleRate = 44100.0;
   static const _samplesPerTick = 512;
-  static const _tickHz = 30; // 30 Hz push rate keeps FFT fed without flooding
+  static const _tickHz = 30;
 
   Timer? _timer;
   StreamSubscription<bool>? _playbackSub;
   bool _playing = false;
   int _frame = 0;
+  bool _realAttached = false;
+  bool _active = false;
 
-  void start() {
-    if (_timer != null) return;
+  Future<void> start() async {
+    if (_active) return;
+    _active = true;
     _frame = 0;
 
-    // Mirror the actual transport so the visualizer is loud when music
-    // is playing and quiet when paused. The visualizer should still
-    // render *something* even when paused (a low hum), so it never
-    // looks frozen.
     final initial = MediaManager().audioHandler.playbackState.value;
     _playing = initial.playing;
     _playbackSub = MediaManager()
@@ -47,6 +49,21 @@ class VisualizerAudio {
         .distinct()
         .listen((p) => _playing = p);
 
+    // If the user opted into real audio AND we can actually attach
+    // the Visualizer, hand off to Kotlin entirely — no need for the
+    // synthesized timer. If Visualizer attach fails (permission
+    // revoked or OS quirk), silently fall back to synthesized so
+    // the user still sees something.
+    if (SettingsManager().visualizerAudioSource == VisualizerAudioSource.real) {
+      final ok = await VisualizerBridge.startRealAudio();
+      if (ok) {
+        _realAttached = true;
+        return;
+      }
+      // ignore: avoid_print
+      print('VisualizerAudio: real-audio attach failed; using synthesized');
+    }
+
     _timer = Timer.periodic(
       Duration(milliseconds: (1000 / _tickHz).round()),
       (_) => _tick(),
@@ -54,6 +71,12 @@ class VisualizerAudio {
   }
 
   void stop() {
+    if (!_active) return;
+    _active = false;
+    if (_realAttached) {
+      VisualizerBridge.stopRealAudio();
+      _realAttached = false;
+    }
     _timer?.cancel();
     _timer = null;
     _playbackSub?.cancel();
@@ -61,43 +84,54 @@ class VisualizerAudio {
   }
 
   void _tick() {
-    final samples = _generate();
-    VisualizerBridge.addPcm(samples);
+    VisualizerBridge.addPcm(_generate());
   }
 
-  // Interleaved stereo Float32 PCM, in [-1, 1]. The "music" here is a
-  // 220 Hz carrier modulated by a 2 Hz beat (120 BPM equivalent), with
-  // a touch of low harmonic added so the FFT has something to chew on
-  // across bands. Amplitude is scaled to 0.6 when playing, 0.1 when
-  // paused — a faint heartbeat keeps the visualizer alive without
-  // forcing it to react to dead silence.
-  //
-  // TODO(real-audio): when SettingsManager().visualizerAudioSource ==
-  // VisualizerAudioSource.real, swap this for a live tap of the audio
-  // output via AndroidVisualizer. Until that's wired, both modes share
-  // the same synthesized output (the dropdown still records the user's
-  // pick for when it's available).
+  // Broadband synthesized signal: three frequency sweeps that drift
+  // across bass / mid / treble, low-amplitude white-ish noise to
+  // populate every FFT bin, all gated by a 2 Hz beat envelope so the
+  // visualizer has a recognisable pulse. Amplitude scales by
+  // playback state — louder when something's playing, quiet (but
+  // not silent) when paused so the screen never goes dead.
+  final _rng = Random();
   Float32List _generate() {
-    final source = SettingsManager().visualizerAudioSource;
-    final isReal = source == VisualizerAudioSource.real;
-
-    final amp = _playing ? 0.6 : 0.1;
+    final amp = _playing ? 0.65 : 0.18;
     final out = Float32List(_samplesPerTick * 2);
-    const carrierHz = 220.0;
     const beatHz = 2.0;
-    const harmonicHz = 60.0;
 
     for (var i = 0; i < _samplesPerTick; i++) {
       final t = (_frame * _samplesPerTick + i) / _sampleRate;
-      final beat = (sin(2 * pi * beatHz * t) * 0.5 + 0.5); // [0,1]
-      final carrier = sin(2 * pi * carrierHz * t);
-      final harmonic = sin(2 * pi * harmonicHz * t) * 0.4;
-      final s = (carrier + harmonic) * beat * amp;
-      // Add a touch of stereo width by phase-shifting the right ear.
-      final r = (carrier + harmonic * sin(2 * pi * (harmonicHz + 1) * t))
-              * beat * amp;
-      out[2 * i] = s.clamp(-1.0, 1.0);
-      out[2 * i + 1] = (isReal ? r : s).clamp(-1.0, 1.0);
+
+      // Beat envelope — same shape as a low-frequency tremolo.
+      final beat = 0.5 + 0.5 * sin(2 * pi * beatHz * t);
+
+      // Three slow LFO-modulated sweeps spanning the spectrum:
+      //   bass:   60–180 Hz, sweeping at 0.31 Hz
+      //   mid:   440–1500 Hz, sweeping at 0.47 Hz
+      //   treble: 2 kHz–8 kHz, sweeping at 0.71 Hz
+      final bassF   =   60 +   60 * (0.5 + 0.5 * sin(2 * pi * 0.31 * t));
+      final midF    =  440 +  530 * (0.5 + 0.5 * sin(2 * pi * 0.47 * t));
+      final trebleF = 2000 + 3000 * (0.5 + 0.5 * sin(2 * pi * 0.71 * t));
+
+      final bass   = sin(2 * pi * bassF   * t) * 0.55;
+      final mid    = sin(2 * pi * midF    * t) * 0.30;
+      final treble = sin(2 * pi * trebleF * t) * 0.18;
+
+      // Light broadband noise so every FFT bin gets some energy —
+      // otherwise the spectrum-bar shader looks too quantised.
+      final noise = (_rng.nextDouble() * 2 - 1) * 0.08;
+
+      final sample = ((bass + mid + treble + noise) * beat * amp)
+          .clamp(-1.0, 1.0)
+          .toDouble();
+
+      // Slight stereo de-correlation on the highs so the waveform
+      // row of iChannel0 doesn't look identical on L/R.
+      final rJitter = (_rng.nextDouble() * 2 - 1) * 0.03;
+      final r = (sample + rJitter).clamp(-1.0, 1.0).toDouble();
+
+      out[2 * i] = sample;
+      out[2 * i + 1] = r;
     }
     _frame++;
     return out;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ flutter:
     - graphics/mstream-logo.png
     - graphics/default.png
     - assets/presets/
+    - assets/shaders/
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
## Summary
Adds a Shadertoy-style fragment-shader visualizer engine alongside the existing projectM/Milkdrop path, driven by a live FFT audio texture.

- Native `shader_engine.cpp` (GLES) compiles Shadertoy `mainImage` shaders asynchronously on a worker thread (shared EGL context), with cross-fade on cycle and multipass support.
- FFT audio texture built with bundled **kissfft**; real on-device audio capture via `RealAudioSource.kt` (AndroidVisualizer), plus the existing synthesized PCM source.
- Bundles **9 audio-reactive shaders** (`assets/shaders/01..09`), auto-discovered through the asset manifest (no code change to add more).
- Visualizer goes fullscreen + landscape-locked; settings/visualizer-screen wiring to pick engine + audio source and cycle presets.
- Fix: FFT band sampling corrected for the 512-bin audio texture.

## Shaders & attribution
Each shader file carries a header with author + license. Notably:
- **04 Cyber Fuji 2020** — CC BY 3.0 (attribution preserved in-file).
- **06–09** (4d-beats, neonwave-sunrise, neonwave-sunset, mountainbytes) — CC0, by mrange.

## Test plan
- [ ] Release build runs on Android 13+
- [ ] Visualizer opens fullscreen + landscape-locked
- [ ] Tap-to-cycle moves through all 9 shaders; cross-fade is smooth
- [ ] Shaders react to both synthesized and real (RECORD_AUDIO) audio
- [ ] FFT band sampling looks correct across the spectrum

🤖 Generated with [Claude Code](https://claude.com/claude-code)