### PR TITLE
Shadertoy fragment-shader visualizer engine + real-audio capture

### DIFF
--- a/android/app/src/main/kotlin/com/example/mstream_music/RealAudioSource.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/RealAudioSource.kt
@@ -21,6 +21,11 @@ import android.util.Log
 private const val TAG = "mstream/viz-realaudio"
 
 class RealAudioSource(
+    // Audio session to attach the Visualizer to. Pass the app's own
+    // player session — session 0 (global output mix) is blocked for
+    // normal apps on modern Android (it needs the privileged
+    // CAPTURE_AUDIO_OUTPUT permission).
+    private val sessionId: Int,
     // Called whenever a fresh waveform chunk arrives. The Float array
     // is interleaved stereo (L,R,L,R,…) in [-1, 1]; size = 2 *
     // captureSize. Same shape as what the synthesized source emits.
@@ -36,7 +41,7 @@ class RealAudioSource(
      */
     fun start(): Boolean {
         try {
-            val v = Visualizer(0)
+            val v = Visualizer(sessionId)
             // Largest capture size the device supports (typically 1024).
             val sizeRange = Visualizer.getCaptureSizeRange()
             v.captureSize = sizeRange[1]

--- a/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
@@ -79,7 +79,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
                 renderThread?.resumeRendering()
                 result.success(null)
             }
-            "startRealAudio" -> handleStartRealAudio(result)
+            "startRealAudio" -> handleStartRealAudio(call, result)
             "stopRealAudio" -> {
                 stopRealAudio()
                 result.success(null)
@@ -92,12 +92,15 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
         }
     }
 
-    private fun handleStartRealAudio(result: MethodChannel.Result) {
+    private fun handleStartRealAudio(call: MethodCall, result: MethodChannel.Result) {
         // Already running? No-op success.
         if (realAudio != null) { result.success(true); return }
         val rt = renderThread
         if (rt == null) { result.success(false); return }
-        val src = RealAudioSource { samples -> rt.enqueuePcm(samples) }
+        // Attach to the app's own player session (passed from Dart).
+        // Session 0 = global output mix is blocked on modern Android.
+        val sessionId = call.argument<Int>("sessionId") ?: 0
+        val src = RealAudioSource(sessionId) { samples -> rt.enqueuePcm(samples) }
         val ok = src.start()
         if (ok) {
             realAudio = src

--- a/assets/shaders/01-spectrum-bars.glsl
+++ b/assets/shaders/01-spectrum-bars.glsl
@@ -24,7 +24,9 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // frequencies instead of dead air at 15–22 kHz.
     float freq = pow(bar / numBars, 1.6) * 0.30;
     float amp = texture(iChannel0, vec2(freq, 0.25)).x;
-    amp = pow(amp, 1.4) * 1.4;
+    // pow expands contrast; no extra gain (real audio is hot enough
+    // that the old *1.4 pegged the bass bars at full height).
+    amp = pow(amp, 1.5);
 
     // Gap between bars.
     float barWidth = 0.7 / numBars;

--- a/assets/shaders/02-audio-tunnel.glsl
+++ b/assets/shaders/02-audio-tunnel.glsl
@@ -27,17 +27,17 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
     // Tunnel rings. log(r) gives even spacing in screen space as
     // they recede; scroll outward over time, faster with bass.
-    float speed = 0.4 + bass * 1.2;
+    float speed = 0.4 + bass * 0.8;
     float ring = fract(log(max(r, 0.001)) * 3.0 - iTime * speed);
     float ringEdge = smoothstep(0.5, 0.42, abs(ring - 0.5));
 
     // Color mix shifts with the mids; spokes pop on treble hits.
     vec3 cold = vec3(0.25, 0.55, 1.0);
     vec3 warm = vec3(1.0, 0.35, 0.55);
-    vec3 col = mix(cold, warm, clamp(mids * 1.5, 0.0, 1.0));
+    vec3 col = mix(cold, warm, clamp(mids, 0.0, 1.0));
 
     float spoke = 0.5 + 0.5 * sin(a * 12.0 + iTime * 0.6);
-    col += pow(spoke, 12.0) * treble * vec3(1.0, 0.8, 0.4) * 3.0;
+    col += pow(spoke, 12.0) * treble * vec3(1.0, 0.8, 0.4) * 1.5;
 
     // Vignette by 1/r so the center stays bright and the edges fall off.
     col *= ringEdge / max(r * 1.4, 0.18);

--- a/assets/shaders/03-plasma-pulse.glsl
+++ b/assets/shaders/03-plasma-pulse.glsl
@@ -39,7 +39,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     col.g = 0.5 + 0.5 * sin(v * 3.14159 + 2.094);
     col.b = 0.5 + 0.5 * sin(v * 3.14159 + 4.188);
 
-    col *= 0.35 + loudness * 3.5;
+    col *= 0.35 + loudness * 2.0;
 
     fragColor = vec4(col, 1.0);
 }

--- a/assets/shaders/04-cyber-fuji.glsl
+++ b/assets/shaders/04-cyber-fuji.glsl
@@ -66,7 +66,7 @@ float sun(vec2 uv, float battery, float bass)
 				+ clamp(uv.y * 14.0 + 1.0, -6.0, 6.0);
     cut = clamp(cut, 0.0, 1.0);
     // mstream: bloom coefficient scaled by bass for throbbing glow
-    return clamp(val * cut, 0.0, 1.0) + bloom * (0.6 * (1.0 + bass * 1.0));
+    return clamp(val * cut, 0.0, 1.0) + bloom * (0.6 * (1.0 + bass * 0.8));
 }
 
 float grid(vec2 uv, float battery, float bass)
@@ -74,7 +74,7 @@ float grid(vec2 uv, float battery, float bass)
     vec2 size = vec2(uv.y, uv.y * uv.y * 0.2) * 0.01;
     // mstream: lateral sway proportional to bass — grid rocks left/right.
     // Slow sin so cycles read as a sway (~2s period), not vibration.
-    float sway = sin(iTime * 3.0) * bass * 1.2;
+    float sway = sin(iTime * 3.0) * bass * 0.8;
     uv += vec2(sway, iTime * 4.0 * (battery + 0.05));
     uv = abs(fract(uv) - 0.5);
  	vec2 lines = smoothstep(size, vec2(0.0), uv);
@@ -230,14 +230,14 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
             cloudUV.x = mod(cloudUV.x + iTime * 0.1, 4.0) - 2.0;
             float cloudTime = iTime * 0.5;
             // mstream: cloud Y bounces with treble (positive offset on this layer)
-            float cloudY = -0.5 + mstreamTreble * 0.3;
+            float cloudY = -0.5 + mstreamTreble * 0.40;
             float cloudVal1 = sdCloud(cloudUV,
                                      vec2(0.1 + sin(cloudTime + 140.5)*0.1,cloudY),
                                      vec2(1.05 + cos(cloudTime * 0.9 - 36.56) * 0.1, cloudY),
                                      vec2(0.2 + cos(cloudTime * 0.867 + 387.165) * 0.1,0.25+cloudY),
                                      vec2(0.5 + cos(cloudTime * 0.9675 - 15.162) * 0.09, 0.25+cloudY), 0.075);
             // mstream: second cloud layer bounces counter-direction (treble)
-            cloudY = -0.6 - mstreamTreble * 0.3;
+            cloudY = -0.6 - mstreamTreble * 0.40;
             float cloudVal2 = sdCloud(cloudUV,
                                      vec2(-0.9 + cos(cloudTime * 1.02 + 541.75) * 0.1,cloudY),
                                      vec2(-0.5 + sin(cloudTime * 0.9 - 316.56) * 0.1, cloudY),
@@ -298,27 +298,37 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     for (int i = 0; i < 6; i++) {
         rawBass += texture(iChannel0, vec2(0.004 + float(i) * 0.004, 0.25)).x;
     }
-    rawBass = clamp(rawBass * 0.25, 0.0, 1.0);
+    rawBass = clamp(rawBass * 0.13, 0.0, 1.0);
 
     float rawLowMid = 0.0;
     for (int i = 0; i < 6; i++) {
         rawLowMid += texture(iChannel0, vec2(0.028 + float(i) * 0.006, 0.25)).x;
     }
-    rawLowMid = clamp(rawLowMid * 0.35, 0.0, 1.0);
+    rawLowMid = clamp(rawLowMid * 0.14, 0.0, 1.0);
 
     float rawMid = 0.0;
     for (int i = 0; i < 6; i++) {
         rawMid += texture(iChannel0, vec2(0.070 + float(i) * 0.020, 0.25)).x;
     }
-    rawMid = clamp(rawMid * 0.5, 0.0, 1.0);
+    rawMid = clamp(rawMid * 0.24, 0.0, 1.0);
 
     float rawTreble = 0.0;
     for (int i = 0; i < 6; i++) {
-        rawTreble += texture(iChannel0, vec2(0.20 + float(i) * 0.060, 0.25)).x;
+        rawTreble += texture(iChannel0, vec2(0.13 + float(i) * 0.035, 0.25)).x;
     }
-    rawTreble = clamp(rawTreble * 0.6, 0.0, 1.0);
+    // Real music has far less 8-11 kHz "air" than the old synth signal,
+    // so sample the lower "presence" range (~3-7 kHz: cymbals, hi-hats,
+    // sibilance) and boost the gain so clouds react to real audio.
+    rawTreble = clamp(rawTreble * 0.22, 0.0, 1.0);
 
     vec4 raw  = vec4(rawBass, rawLowMid, rawMid, rawTreble);
+    // Square all bands (mrange's "fft *= fft" technique from neonwave
+    // sunset): expands dynamic range so every element sits calm on
+    // quiet passages and pops on transients, instead of riding the
+    // log1p compression's always-hot floor. Prescales above are set so
+    // typical-loud music lands near ~0.9 pre-square (not pre-clamped),
+    // and the visual amplitudes below are sized for the squared output.
+    raw *= raw;
     vec4 prev = texture(iChannel1, vec2(0.5, 0.5));
 
     // Asymmetric smoothing vec4-wise: 0.15 attack (raw > prev), 0.5 release.

--- a/assets/shaders/05-hex-marching.glsl
+++ b/assets/shaders/05-hex-marching.glsl
@@ -36,8 +36,15 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   for (int i = 0; i < 4; i++) {
     bass += texture(iChannel1, vec2(float(i) * 0.004 + 0.004, 0.25)).x;
   }
-  bass = clamp(bass * 0.7, 0.0, 1.0);
-  col *= 1.0 + bass * 0.8;
+  // Lower prescale so loud bass doesn't pre-clamp before the square,
+  // and square for dynamic range (mrange's "fft *= fft" technique).
+  bass = clamp(bass * 0.20, 0.0, 1.0);
+  bass *= bass;
+  // Gentle brightness coefficient: this multiply lands right before the
+  // sqrt() gamma below, so a big boost pushes bright pixels past 1.0 and
+  // clips them to white (the "saturated" look). 0.45 keeps the pulse
+  // visible without blowing out highlights.
+  col *= 1.0 + bass * 0.45;
 
   col = sqrt(col);
   fragColor = vec4(col, 1.0);

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -36,6 +36,12 @@ class AudioPlayerHandler extends BaseAudioHandler
 
   Stream<Duration> get positionStream => _player.positionStream;
 
+  // Android audio session id of the underlying player. The visualizer's
+  // real-audio capture attaches a Visualizer to THIS session — the
+  // global output mix (session 0) is blocked for normal apps on modern
+  // Android. Null until a source has loaded.
+  int? get androidAudioSessionId => _player.androidAudioSessionId;
+
   Server? autoDJServer;
 
   var jsonAutoDJIgnoreList;

--- a/lib/native/visualizer_bridge.dart
+++ b/lib/native/visualizer_bridge.dart
@@ -87,15 +87,17 @@ class VisualizerBridge {
     }
   }
 
-  /// Asks Kotlin to attach an `AndroidVisualizer` to audio session 0
-  /// and start streaming waveform samples into the render thread's
-  /// PCM queue. Returns true on success, false if Visualizer creation
-  /// failed (commonly because RECORD_AUDIO was revoked or the OS
-  /// doesn't allow session-0 capture). Callers should fall back to
-  /// synthesized PCM on false.
-  static Future<bool> startRealAudio() async {
+  /// Asks Kotlin to attach an `AndroidVisualizer` to the given audio
+  /// session and stream waveform samples into the render thread's PCM
+  /// queue. [sessionId] should be the app's own player session — the
+  /// global mix (session 0) is blocked for normal apps on modern
+  /// Android. Returns true on success, false if Visualizer creation
+  /// failed (RECORD_AUDIO revoked, OS restriction, etc.); callers
+  /// should fall back to synthesized PCM on false.
+  static Future<bool> startRealAudio(int sessionId) async {
     try {
-      final ok = await _channel.invokeMethod<bool>('startRealAudio');
+      final ok = await _channel.invokeMethod<bool>(
+          'startRealAudio', {'sessionId': sessionId});
       return ok == true;
     } on PlatformException catch (e) {
       // ignore: avoid_print

--- a/lib/singletons/visualizer_audio.dart
+++ b/lib/singletons/visualizer_audio.dart
@@ -55,13 +55,21 @@ class VisualizerAudio {
     // revoked or OS quirk), silently fall back to synthesized so
     // the user still sees something.
     if (SettingsManager().visualizerAudioSource == VisualizerAudioSource.real) {
-      final ok = await VisualizerBridge.startRealAudio();
-      if (ok) {
-        _realAttached = true;
-        return;
+      // Attach the Visualizer to THIS app's own audio session, not the
+      // global mix (session 0), which modern Android blocks. The session
+      // id is null until the player has loaded a source, so real audio
+      // only attaches once something has been played.
+      final sessionId = MediaManager().audioHandler.androidAudioSessionId;
+      if (sessionId != null) {
+        final ok = await VisualizerBridge.startRealAudio(sessionId);
+        if (ok) {
+          _realAttached = true;
+          return;
+        }
       }
       // ignore: avoid_print
-      print('VisualizerAudio: real-audio attach failed; using synthesized');
+      print('VisualizerAudio: real-audio attach failed '
+          '(sessionId=$sessionId); using synthesized');
     }
 
     _timer = Timer.periodic(


### PR DESCRIPTION
## Summary
Adds a second visualizer engine alongside projectM/Milkdrop: a Shadertoy-style GLSL fragment-shader renderer driven by an FFT audio texture. Selectable in **Settings → Visualizer engine**.

**Engine**
- Vendored KissFFT for PCM → frequency texture (512-bin FFT row + waveform row, Shadertoy convention).
- Async shader compile on a shared-EGL worker thread; cross-fade transition on cycle.
- Multipass support: `// === pass: common/buffera..d/image ===` + `// === channel ... ===` routing (ping-pong buffers, self-feedback).
- Shaders are drop-in assets (`assets/shaders/*.glsl`), auto-discovered via AssetManifest.

**Bundled shaders (9)** — all GPL-compatible:
- MIT originals: Spectrum Bars, Audio Tunnel, Plasma Pulse
- Cyber Fuji 2020 — CC-BY-3.0 (kaiware007/Jan Mróz), audio reactivity added clean-room
- CC0 by mrange: Hex marching, 4D Beats, Neonwave sunrise, Neonwave Sunset, MountainBytes

**Real-audio capture**
- Taps the app's **own** just_audio session via `android.media.audiofx.Visualizer` — global-mix capture (`session 0`) is blocked on modern Android (Android 16 returns `NO_INIT`). Falls back to a synthesized broadband signal if no session is active.

**Audio reactivity**
- Per-band FFT (bass / low-mid / mid / treble) with mrange's `fft *= fft` squaring for dynamic range against the compressed texture; calibrated against real music so elements breathe rather than peg.

**UX**: visualizer goes fullscreen + locks landscape.

## Note for reviewer
Cyber Fuji is CC-BY-3.0 (attribution required). The user-facing credits/attributions screen + the project `LICENSE` (GPLv3) are staged separately on `master` and cover these bundled shaders.

## Test plan
- [x] All 9 shaders compile on-device (verified via `PassSet compiled` logcat)
- [x] Real audio attaches to the app session on Android 16 (was silently falling back before)
- [x] Cyber Fuji + Hex marching reactivity calibrated against real music
- [ ] Regression-check the Milkdrop/projectM engine still works
- [ ] Sanity-check on a second device / older Android version

🤖 Generated with [Claude Code](https://claude.com/claude-code)