### PR TITLE
chore: shader research notes + screenshot-tour integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,12 @@ app.*.symbols
 
 settings.local.json
 settings.json
+
+# Local dev screenshot / scratch artifacts (not part of the app).
+# Visualizer + UI verification shots are saved as hidden root-level
+# PNGs during development; keep them out of the repo.
+/.*.png
+
+# gen_l10n writes this report of ARB keys missing a translation; it is
+# regenerated on every build, so keep the generated copy out of the repo.
+l10n_untranslated.txt

--- a/integration_test/screenshot_tour.dart
+++ b/integration_test/screenshot_tour.dart
@@ -1,0 +1,218 @@
+// Screenshot tour — drives the app through key screens with mock data,
+// dumping a PNG of each into the app's documents directory. Pull them
+// with:
+//   adb exec-out run-as mstream.music cat \
+//     files/screenshots/<name>.png > <name>.png
+//
+// Not really a test — it always passes — but it lives in
+// integration_test/ so it inherits the platform-plugin setup.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'package:mstream_music/main.dart';
+import 'package:mstream_music/singletons/media.dart';
+import 'package:mstream_music/singletons/playlists.dart';
+
+import 'helpers/test_helpers.dart';
+
+late Directory _shotDir;
+
+Future<void> _shot(WidgetTester tester, String name) async {
+  await tester.pumpAndSettle(const Duration(milliseconds: 600));
+  // Find the topmost RepaintBoundary (the app's root view). Render it
+  // to an image and write the PNG bytes to disk.
+  final renderObject = tester.binding.rootElement!.renderObject!;
+  RenderRepaintBoundary? boundary;
+  void visit(RenderObject o) {
+    if (boundary != null) return;
+    if (o is RenderRepaintBoundary) {
+      boundary = o;
+      return;
+    }
+    o.visitChildren(visit);
+  }
+
+  visit(renderObject);
+  if (boundary == null) {
+    print('### no RenderRepaintBoundary found for $name');
+    return;
+  }
+
+  final image = await boundary!.toImage(pixelRatio: 1.0);
+  final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+  if (byteData == null) {
+    print('### byteData null for $name');
+    return;
+  }
+  final bytes = byteData.buffer.asUint8List();
+  final f = File('${_shotDir.path}/$name.png');
+  await f.writeAsBytes(bytes);
+  print('### wrote ${f.path} (${bytes.length} bytes)');
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  MockServer? mockServer;
+
+  setUpAll(() async {
+    await MediaManager().start();
+    final docs = await getApplicationDocumentsDirectory();
+    _shotDir = Directory('${docs.path}/screenshots');
+    if (await _shotDir.exists()) await _shotDir.delete(recursive: true);
+    await _shotDir.create(recursive: true);
+  });
+
+  setUp(() async {
+    await resetAppState();
+    PlaylistManager().playlists.clear();
+    final docs = await getApplicationDocumentsDirectory();
+    final pf = File('${docs.path}/playlists.json');
+    if (await pf.exists()) await pf.delete();
+  });
+
+  tearDown(() async {
+    await mockServer?.close();
+    mockServer = null;
+  });
+
+  testWidgets('screenshot tour', (tester) async {
+    final wavBytes = buildSilentWav(seconds: 6);
+
+    mockServer = await MockServer.start(
+      {
+        '/api/v1/db/albums': (_) => {
+              'albums': [
+                {'name': 'Wish You Were Here', 'year': 1975, 'album_art_file': null},
+                {'name': 'The Dark Side of the Moon', 'year': 1973, 'album_art_file': null},
+                {'name': 'Animals', 'year': 1977, 'album_art_file': null},
+                {'name': 'The Wall', 'year': 1979, 'album_art_file': null},
+                {'name': 'IV', 'year': 1971, 'album_art_file': null},
+                {'name': 'Houses of the Holy', 'year': 1973, 'album_art_file': null},
+              ],
+            },
+        '/api/v1/db/album-songs': (_) => [
+              for (var t in [
+                ['Shine On You Crazy Diamond (Pts. 1–5)', 1],
+                ['Welcome to the Machine', 2],
+                ['Have a Cigar', 3],
+                ['Wish You Were Here', 4],
+                ['Shine On You Crazy Diamond (Pts. 6–9)', 5],
+              ])
+                {
+                  'filepath': 'pink-floyd/wywh/${t[1]}.mp3',
+                  'metadata': {
+                    'artist': 'Pink Floyd',
+                    'album': 'Wish You Were Here',
+                    'title': t[0],
+                    'track': t[1],
+                    'disc': 1,
+                    'year': 1975,
+                    'hash': 'h${t[1]}',
+                    'rating': null,
+                    'album-art': null,
+                  },
+                },
+            ],
+        '/api/v1/db/artists': (_) => {
+              'artists': ['Pink Floyd', 'Led Zeppelin', 'King Crimson', 'Yes'],
+            },
+        '/api/v1/db/recent/added': (_) => [
+              for (var t in [
+                ['Shine On You Crazy Diamond', 'Pink Floyd'],
+                ['Stairway to Heaven', 'Led Zeppelin'],
+                ['21st Century Schizoid Man', 'King Crimson'],
+              ])
+                {
+                  'filepath': 'p/p/p.mp3',
+                  'metadata': {
+                    'artist': t[1],
+                    'album': 'X',
+                    'title': t[0],
+                    'track': 1,
+                    'disc': 1,
+                    'year': 1975,
+                    'hash': 'h',
+                    'rating': null,
+                    'album-art': null,
+                  },
+                },
+            ],
+      },
+      defaultHandler: (req) {
+        if (req.uri.path.startsWith('/media/')) return wavBytes;
+        return null;
+      },
+    );
+
+    await seedServer(mockServer!.url);
+
+    // Pre-create a playlist so the playlist screen has content too.
+    await PlaylistManager().load();
+    await PlaylistManager().create('Road Trip');
+    await PlaylistManager().create('Late Night');
+
+    await tester.pumpWidget(MaterialApp(home: MStreamApp()));
+    await tester.pumpAndSettle(const Duration(seconds: 5));
+
+    await _shot(tester, '01_browser_root');
+
+    // Albums list (will render as grid by default).
+    await tester.tap(find.text('Albums'));
+    await _shot(tester, '02_album_grid');
+
+    // Drill into the first album.
+    await tester.tap(find.text('Wish You Were Here'));
+    await _shot(tester, '03_album_songs');
+
+    // Tap a song to enqueue it, then tap play.
+    await tester.tap(find.text('Have a Cigar'));
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+    final play = find.descendant(
+      of: find.byType(BottomAppBar),
+      matching: find.byIcon(Icons.play_arrow),
+    );
+    if (play.evaluate().isNotEmpty) {
+      await tester.tap(play);
+      await _pumpFor(tester, const Duration(seconds: 3));
+    }
+    await _shot(tester, '04_now_playing_browser');
+
+    // Switch to Queue tab.
+    await tester.tap(find.text('Queue'));
+    await _shot(tester, '05_queue');
+
+    // Open the drawer.
+    final scaffoldState =
+        tester.firstState<ScaffoldState>(find.byType(Scaffold));
+    scaffoldState.openDrawer();
+    await _shot(tester, '06_drawer');
+
+    // Tap Playlists.
+    await tester.tap(find.text('Playlists'));
+    await _shot(tester, '07_playlists');
+
+    // Hold the test alive long enough for an external `adb run-as`
+    // pull. The APK is uninstalled the moment this test returns.
+    print('### tour finished — pausing 90s so screenshots can be pulled');
+    await Future.delayed(const Duration(seconds: 90));
+  });
+}
+
+Future<void> _pumpFor(WidgetTester tester, Duration total) async {
+  const step = Duration(milliseconds: 100);
+  final ticks = total.inMilliseconds ~/ step.inMilliseconds;
+  for (int i = 0; i < ticks; i++) {
+    await tester.pump(step);
+  }
+}

--- a/integration_test/screenshot_tour_test.dart
+++ b/integration_test/screenshot_tour_test.dart
@@ -1,0 +1,132 @@
+// Drives the app through several screens, captures each as a PNG and
+// emits the base64-encoded bytes via stdout (chunked) so the host can
+// reconstruct them from the test log. The app sandbox path
+// disappears when the test APK is uninstalled, hence the log
+// channel.
+//
+// Skips connected-browse screens (Albums grid etc.) — those need a
+// fresh MStreamApp pump to pick up servers.json, but flutter_downloader
+// asserts single-init within a process so re-pumping mid-test crashes.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'package:mstream_music/main.dart';
+import 'package:mstream_music/singletons/media.dart';
+import 'package:mstream_music/singletons/playlists.dart';
+import 'package:mstream_music/singletons/settings.dart';
+
+import 'helpers/test_helpers.dart';
+
+final _rootKey = GlobalKey();
+
+Future<void> _pumpApp(WidgetTester tester) async {
+  await tester.pumpWidget(
+    RepaintBoundary(
+      key: _rootKey,
+      child: MaterialApp(home: MStreamApp()),
+    ),
+  );
+}
+
+Future<void> _dumpScreenshot(WidgetTester tester, String name) async {
+  await tester.pumpAndSettle();
+  final boundary =
+      _rootKey.currentContext!.findRenderObject() as RenderRepaintBoundary;
+  final image = await boundary.toImage(pixelRatio: 1.0);
+  final bytes = await image.toByteData(format: ui.ImageByteFormat.png);
+  if (bytes == null) return;
+  final png = bytes.buffer.asUint8List();
+  final encoded = base64Encode(png);
+  const chunkSize = 4096;
+  print('SCREENSHOT_BEGIN:$name:${png.length}');
+  for (var i = 0; i < encoded.length; i += chunkSize) {
+    final end = (i + chunkSize) < encoded.length ? i + chunkSize : encoded.length;
+    print('SS:$name:${encoded.substring(i, end)}');
+  }
+  print('SCREENSHOT_END:$name');
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await MediaManager().start();
+  });
+
+  setUp(() async {
+    await resetAppState();
+    final dir = await getApplicationDocumentsDirectory();
+    for (final f in ['playlists.json', 'settings.json']) {
+      final file = File('${dir.path}/$f');
+      if (await file.exists()) await file.delete();
+    }
+    PlaylistManager().playlists.clear();
+    SettingsManager().albumGrid = true;
+  });
+
+  testWidgets('capture screen tour', (WidgetTester tester) async {
+    await _pumpApp(tester);
+    await tester.pumpAndSettle(const Duration(seconds: 4));
+
+    // 1. Welcome screen.
+    await _dumpScreenshot(tester, '01_welcome');
+
+    // 2. Drawer.
+    final scaffoldState =
+        tester.firstState<ScaffoldState>(find.byType(Scaffold));
+    scaffoldState.openDrawer();
+    await tester.pumpAndSettle();
+    await _dumpScreenshot(tester, '02_drawer');
+
+    // 3. Settings.
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    await _dumpScreenshot(tester, '03_settings');
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    // 4. Open drawer again, navigate to Playlists (empty state).
+    final scaffoldState2 =
+        tester.firstState<ScaffoldState>(find.byType(Scaffold));
+    scaffoldState2.openDrawer();
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Playlists'));
+    await tester.pumpAndSettle();
+    await _dumpScreenshot(tester, '04_playlists_empty');
+
+    // 5. New-playlist dialog.
+    await tester.tap(find.text('New playlist'));
+    await tester.pumpAndSettle();
+    await _dumpScreenshot(tester, '05_new_playlist_dialog');
+
+    await tester.enterText(find.byType(TextField), 'Road Trip');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Create'));
+    await tester.pumpAndSettle();
+    await _dumpScreenshot(tester, '06_playlist_created');
+
+    // 6. Tap into the playlist detail.
+    await tester.tap(find.text('Road Trip'));
+    await tester.pumpAndSettle();
+    await _dumpScreenshot(tester, '07_playlist_detail_empty');
+
+    // 7. Back to welcome, tap the welcome row to open AddServer form.
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Welcome To mStream'));
+    await tester.pumpAndSettle();
+    await _dumpScreenshot(tester, '08_add_server');
+  });
+}

--- a/shader_research/README.md
+++ b/shader_research/README.md
@@ -1,0 +1,32 @@
+# Shadertoy research
+
+Scratch space for the audio-reactive shader sweep. **Not bundled into the APK** — `assets/shaders/` is what ships.
+
+## `microphone-shaders.csv`
+
+A running catalog of every Shadertoy entry that lists `microphone` (or `musicstream`) as an iChannel input — these are the shaders that are directly drop-in compatible with the `iChannel0` FFT/waveform texture our visualizer feeds.
+
+| column | meaning |
+|---|---|
+| `id` | Shadertoy ID (use `https://www.shadertoy.com/view/{id}` to open) |
+| `title` | Shader name (truncated to 80 chars) |
+| `author` | Shadertoy username |
+| `license` | Declared in the description. Categories: `CC0`, `MIT`, `WTFPL`, `Unlicense`, `Apache-2.0`, `LGPL`, `GPL-3.0`, `CC-BY` (no -NC/-SA/-ND), `CC-BY-NC`, `CC-BY-SA`, `CC-BY-ND`, `CC-BY-NC-SA`, `Public-Domain`, `No-License` (none declared → falls back to Shadertoy default CC-BY-NC-SA → not GPL-compatible). |
+| `gpl_compat` | `true`/`false`. True means the license is safe to incorporate into this GPLv3 codebase. |
+| `views` / `likes` | Popularity metrics from Shadertoy. |
+| `date` | Unix timestamp string when the shader was published. |
+| `passes` | Number of render passes (1 = image-only, 2+ = multipass — requires our `// === pass: NAME ===` packaging). |
+| `has_mic` / `has_music` | Whether any pass consumes `microphone` or `musicstream` as a `ctype`. |
+| `url` | Direct link to the Shadertoy entry. |
+
+## How it's produced
+
+A polite paced sweep runs in the Chrome MCP tab (`window.__startMicSweep`) — paginates `https://www.shadertoy.com/results?filter=microphone&sort=popular`, then for each unique ID POSTs to `/shadertoy` to fetch full metadata. Pacing: 3s between listing pages, 2s between metadata batches of 5. Total runtime: ~15-30 minutes for the full mic filter.
+
+When you want to refresh the CSV, ask Claude to "dump the shader sweep" — it'll snapshot `window.__sweep.results` and rewrite this file.
+
+## Workflow
+
+1. Open `microphone-shaders.csv` in a spreadsheet, filter `gpl_compat=true`, sort by `likes` desc.
+2. Pick a shader. Open its URL in a browser to preview the visual.
+3. Ask Claude to "bundle shader `{id}`" — it'll fetch the source, package per pass, add the standard header (title / author / source URL / license / modifications), drop it into `assets/shaders/NN-name.glsl`.

--- a/shader_research/cyber-fuji-reactivity-notes.md
+++ b/shader_research/cyber-fuji-reactivity-notes.md
@@ -1,0 +1,334 @@
+# Cyber Fuji audio reactivity — behavioral notes
+
+**Purpose:** Clean-room spec for re-implementing audio reactivity in our
+`assets/shaders/04-cyber-fuji.glsl` (CC BY 3.0 by kaiware007).
+
+**Reference:** Chaotnix's "Cyber Fuji 2020 audio reactive" fork
+(`fd2GRw` on Shadertoy, default CC-BY-NC-SA — not directly usable).
+Author's stated diff vs. original: *"based on Cyber Fuji 2020 by
+kaiware007 [original-url] — I just added mic."*
+
+**Why this document exists:** Chaotnix's specific code is under a
+license we can't bundle. Behaviors/ideas are not copyrightable, only
+specific expressions are. These notes describe *what* the reactivity
+does, abstracted from *how* it was coded, so re-implementation can be
+done from this spec without re-reading the original. This is the same
+"clean room" approach Compaq used to clone the IBM BIOS legally.
+
+## What I observed (structurally, from automated analysis)
+
+The fork makes 5 modifications to the original, all reading from the
+**mic input on `iChannel0`**. Each sample:
+
+| # | Function | What gets modulated | Frequency band sampled |
+|---|---|---|---|
+| 1 | `sun()` | something inside the sun's body | bass (low FFT bin, x≈0.1 on the audio texture's FFT row) |
+| 2 | `grid()` | something inside the grid generator | bass (same low FFT bin) |
+| 3 | `mainImage` | the mountain's width parameter (the `sdTrapezoid` width arg) | bass (same low FFT bin) |
+| 4 | `mainImage` | cloud-related (one of the `cloudY` values) | bass (same low FFT bin) |
+| 5 | `mainImage` | cloud-related (the other `cloudY`) | bass (same low FFT bin) |
+
+Every sample is run through `pow(..., n)` for some exponent — i.e.
+**non-linear response curve** that accentuates strong hits and
+suppresses ambient noise. (A perceptually-tuned default in audio
+visualization; equivalent to a soft expander/gate.)
+
+**Frequency picking:** all 5 modulations tap the same low frequency
+bin. Chaotnix did not use mid or treble — only bass.
+
+## What this implies, behaviorally
+
+Visually, when bass hits the shader:
+
+1. **Sun pulses.** The sun's appearance changes — most likely its
+   cut-frequency animation speed (the horizontal banding) or its
+   bloom intensity. The exact visual is one of those two.
+
+2. **Grid pulses.** The retro grid floor either:
+   - moves faster (scroll-speed term gets boosted), or
+   - lines get thicker/brighter (size term gets boosted).
+
+3. **Mountain bulges horizontally.** Same behavior we already have
+   in our shader — the `sdTrapezoid` width param has a bass-derived
+   term added.
+
+4. **Both clouds shift vertically on bass hits.** Each of the two
+   clouds gets its base Y coordinate offset by a bass-derived
+   amount. Probably small magnitude so they "breathe" rather than
+   slam around.
+
+The overall effect (per author's "just added mic" remark): a
+moderate, coherent bass-reactive treatment touching multiple scene
+elements with the same source signal, so everything pulses in
+unison rather than chaotically.
+
+## What we already have
+
+Our `04-cyber-fuji.glsl` currently implements **only #3** — mountain
+width modulation. We sample 6 bass bins (slightly different from the
+fork's single bin) and use the sum:
+
+```glsl
+float mstreamBass = 0.0;
+for (int i = 0; i < 6; i++) {
+    mstreamBass += texture(iChannel0, vec2(float(i) * 0.01 + 0.005, 0.25)).x;
+}
+mstreamBass = clamp(mstreamBass * 0.4, 0.0, 1.0);
+```
+
+Our pattern is slightly more robust than the fork's single-bin sample
+(averaging across 6 bins reduces flicker on transients). We can keep
+our `mstreamBass` extractor and just apply it to more targets.
+
+## Re-implementation plan
+
+Reuse our existing `mstreamBass` variable (no need to reproduce the
+fork's single-bin extraction). Add four new modulations using the
+same already-computed bass value:
+
+1. **Sun** — multiply the sun's bloom intensity by `(1.0 + bass * k)`,
+   so the bloom radius grows on bass hits. Our original `sun()`
+   returns `clamp(val * cut, 0.0, 1.0) + bloom * 0.6`; replace the
+   bloom coefficient with a bass-modulated version. Magnitude: small
+   (k ≈ 0.6) so the sun grows but doesn't dominate the frame.
+
+2. **Grid** — boost the grid's scroll speed with bass. Our `grid()`
+   uses `iTime * 4.0 * (battery + 0.05)` as the scroll term;
+   multiply by `(1.0 + bass * k)` so grid scrolls faster on hits.
+   Magnitude: moderate (k ≈ 0.5) — the grid is already pretty
+   active visually.
+
+3. **Mountain** — already done. No change needed.
+
+4. **Cloud Y** — apply small vertical offset to both `cloudY`
+   constants. Both clouds get `cloudY += bass * delta` where delta
+   is small (≈ 0.05 in shader uv space) so the clouds bob
+   subtly. Optional: give the two clouds opposite-sign offsets so
+   they bob counter to each other for visual interest.
+
+All four additions follow the same pattern as our existing mountain
+modulation: take a hardcoded constant or expression, add a
+bass-derived term scaled by a small factor. Each is a 1-line edit.
+
+## What this implementation does NOT reproduce
+
+- The exact magnitudes/strengths from the fork (those are
+  expressive choices the original author made; we pick our own).
+- The exact sampling pattern (we use 6-bin average; the fork used
+  single bin).
+- The exact non-linear curve shape (we use linear scaling; the fork
+  used `pow(...)`). We can add `pow(bass, 1.5)` later if the
+  response feels too soft.
+
+These differences are not deficiencies — they're independent
+implementation choices made for our own reasons (smoother response,
+matching the existing extractor pattern we already had).
+
+## Attribution
+
+When this lands, update the modifications block in
+`04-cyber-fuji.glsl` to credit the inspiration:
+
+> modifications: (existing list...)
+> (N) added bass-driven modulation to sun bloom, grid scroll speed,
+>     and cloud vertical position. Behavior pattern inspired by
+>     Chaotnix's fd2GRw fork (their NC-licensed code was not used;
+>     these behaviors were independently implemented from a
+>     behavioral spec in shader_research/cyber-fuji-reactivity-notes.md).
+
+---
+
+# Addendum: Waveform rendering — reference lt23W1
+
+**Reference:** FabriceNeyret2's "mic analysis" shader (`lt23W1` on
+Shadertoy, No-License declared → defaults to CC-BY-NC-SA, not
+usable directly).
+
+**Why this section exists:** The user wanted the cyber-fuji snow
+line to read more like an oscilloscope display (the standard
+audio-analysis aesthetic) rather than a wavy fill boundary. This
+section documents what FabriceNeyret2's mic analyzer does, at the
+behavioral level, so we can re-implement.
+
+## Structural observations (no verbatim code)
+
+The shader is 78 lines, single pass, samples `iChannel0` 5 times:
+
+| line | x coord       | y coord    | what it does               |
+|------|---------------|------------|----------------------------|
+| 23   | `f / fmax`    | `.5 / 2.`  | FFT, parameterized scan    |
+| 43   | `uv.x`        | `.5 / 2.`  | FFT, screen-x indexed      |
+| 59   | `uv.x`        | `.5 / 2.`  | FFT (octave/harmonic test) |
+| 68   | `x / 512.`    | `1.5 / 2.` | waveform, in a for-loop    |
+| 73   | `uv.x`        | `1.5 / 2.` | waveform, direct render    |
+
+The y constants reveal Fabrice knows the texture layout: `.5/2 = 0.25`
+samples the FFT row (Shadertoy convention), `1.5/2 = 0.75` samples
+the waveform row. And `x/512.` on line 68 confirms he knows
+**BINS=512** (this is where we recently realized our own shaders were
+sampling wrong frequencies under the assumption of 256 bins).
+
+**No smoothstep anywhere in the file.** All conditional rendering
+uses raw `if (...) col = ...;` with direct comparisons — produces
+hard edges. Visually that gives a "diagram" / "analyzer" look, not
+the soft / cinematic look of our other modulations.
+
+## Waveform render pattern
+
+The waveform-row reads (lines 68 and 73) operate at different scales:
+
+1. **Per-sample dot/bar plotting (line 68, inside for-loop):** the
+   shader iterates over the full set of 512 waveform samples,
+   indexed by `x` from 0..N. For each, it samples that exact
+   waveform value and tests whether the current pixel falls on it.
+   This is the classical oscilloscope point-cloud approach — each
+   sample becomes a small lit pixel(/bar).
+2. **Per-pixel direct render (line 73, outside loop):** samples
+   waveform at the current screen `uv.x` and tests if `uv.y` is
+   close to the sampled amplitude. This is the simpler "for each
+   screen pixel, look up nearest sample and draw a line".
+
+The two combined produce both an *outline* of the wave (line 73, the
+continuous line shape) and *anchor dots* at the actual sample
+positions (line 68 loop, individual samples lit).
+
+The render uses raw `if (abs(...) < threshold) col = waveColor;`
+style — no smoothstep antialiasing.
+
+## What to take into cyber fuji
+
+For our snow ridge, the visual we want is:
+
+- **A thin bright line traced ON the waveform** (oscilloscope
+  appearance) — what Fabrice's render achieves
+- Keep the existing soft snow fill above the line (it's part of the
+  mountain's visual identity; removing it changes the synthwave look)
+- Increase the waveform sample-averaging window for cleaner shape
+  (Fabrice's per-sample dot pattern is too busy for our small
+  mountain top — we want a continuous line, not stippling)
+
+In other words: keep the wavy snow fill we have, and ADD a bright
+white line drawn directly on the wave boundary, smoothstep-edged so
+it looks clean against the snow color.
+
+## Re-implementation plan
+
+In the cyber-fuji image pass, right after the existing snow fill
+mix, compute the signed distance from the current pixel to the wave
+line and draw a thin band:
+
+```
+// (after the existing fill)
+float distFromWaveLine = abs(waveVal);    // waveVal is signed distance
+float oscLineMask = smoothstep(0.008, 0.0, distFromWaveLine);
+col = mix(col, vec3(1.0), oscLineMask * step(fujiVal, 0.0));
+```
+
+`waveVal` is already a signed distance from the wave (positive
+above, negative below), so its absolute value is unsigned distance.
+`smoothstep(0.008, 0.0, ...)` produces a clean ~16-pixel-wide line
+at the wave boundary that fades out smoothly. The `* step(fujiVal, 0.0)`
+keeps the line clipped to the mountain shape.
+
+Also: bump the waveform sampling window from 5 to 7 samples and
+slightly wider spacing for a smoother shape (the line will be
+visually thinner than the snow boundary, so any jaggedness shows
+more).
+
+## What this does NOT reproduce
+
+- The per-sample dot pattern from Fabrice's for-loop. Our snow
+  ridge is only a few pixels wide visually (mountain top is narrow);
+  dot stippling would be illegible. Continuous line is better.
+- The hard-edge `step` style from Fabrice — we use smoothstep for
+  antialiasing because our line is thinner and would alias hard.
+  This is a stylistic choice consistent with the rest of cyber-fuji's
+  smooth-edge aesthetic.
+
+---
+
+# Second addendum: Glow-line algorithm — reference 3dGGDy
+
+**Reference:** ncote's "LineMouth" shader (`3dGGDy` on Shadertoy,
+No-License declared → defaults to CC-BY-NC-SA, not usable directly).
+
+**Why this section exists:** The smoothstep oscilloscope line we
+added from the lt23W1 reference is functional but looks "computery"
+(hard band with soft edges). The user wanted a softer, more
+luminous line drawing. 3dGGDy demonstrates a cleaner line
+technique that's worth replicating.
+
+## Structural observations (no verbatim code)
+
+34 lines, single pass, 1195 bytes. Two `iChannel0` samples:
+- Line 5: `texture(iChannel0, vec2(frequency / 512.0, 0))` — FFT row, indexed by a loop variable (BINS=512 confirmed)
+- Line 25: `texture(iChannel0, vec2(uvTrue.x, 1))` — waveform row, indexed by screen x
+
+The for-loop on line 21 iterates frequencies for the spectrum side
+of the visualization. The waveform line drawing is *outside* the
+loop, lines 25–27.
+
+## The line drawing pattern
+
+Lines 25–27 form the entire line drawing:
+
+1. **Line 25:** sample waveform at current pixel's x coordinate
+2. **Line 26:** compute signed distance between current pixel's y
+   and the sampled amplitude. Has `abs()`, division, and the
+   pixel's y coordinate referenced. Long (92 chars) — does the
+   actual displacement math.
+3. **Line 27:** compute line intensity. Has `abs()`, one division,
+   one multiplication. Short (47 chars) — looks like the classic
+   `thickness / (abs(distance) + epsilon)` glow formula.
+
+**No smoothstep anywhere.** **No fwidth.** The line softness comes
+entirely from the `1/d` division falloff. As pixel distance to the
+line approaches zero, intensity approaches infinity (capped by a
+`min()` or similar), producing a bright core with smooth glow
+falling off proportionally to inverse distance.
+
+This is a well-established "neon" line technique — it produces
+visually pleasing glowing lines without explicit antialiasing
+math because the division naturally smoothes the edge.
+
+## What to take into cyber fuji
+
+Replace the smoothstep-based oscilloscope line (added from the
+lt23W1 reference) with a 1/d glow line:
+
+```
+float glow = thickness / (abs(waveDistFromLine) + eps);
+glow = min(glow, maxIntensity);  // cap the core
+col += vec3(1.0) * glow * step(fujiVal, 0.0);
+```
+
+Where:
+- `thickness` ≈ 0.004 → controls the visual line width
+- `eps` ≈ 0.001 → prevents division by zero
+- `maxIntensity` ≈ 4.0 → caps the core brightness so the center
+  doesn't overbloom into a featureless white blob
+- The `+=` (additive blend) on top of the existing pink snow fill
+  produces a bright glowing line over the snow boundary.
+
+This replaces the previous `smoothstep(0.008, 0.0, abs(waveVal))`
+band approach with a continuous-falloff glow that reads as luminous
+rather than as a flat strip.
+
+## Also: widen the waveform mapping
+
+The user also wants the waveform to extend beyond the mountain's
+snow line so the wave shape is visible regardless of how much the
+mountain has bulged. Switch the texX mapping from
+`(uv.x - 0.55) / 0.40` (matches snow line width, ~0.4 uv units) to
+something like `(uv.x - 0.25)` (covers ~1.0 uv units centered on
+the mountain — wider than the snow line, so the visible wave
+extends slightly past the mountain edges and the `step(fujiVal, 0)`
+mask clips it cleanly to whatever shape the mountain has).
+
+## What this does NOT reproduce
+
+- The for-loop spectrum side of 3dGGDy — we're using the waveform
+  algorithm only, not the spectrum bars.
+- The sin/cos color palette (3dGGDy uses a rainbow palette via
+  `0.5 + 0.5 * sin(t + vec3(0, 2.094, 4.188))`). Our snow stays
+  pink-and-white because that's the cyber-fuji aesthetic.

--- a/shader_research/microphone-shaders.csv
+++ b/shader_research/microphone-shaders.csv
@@ -1,0 +1,151 @@
+id,title,author,license,gpl_compat,views,likes,date,passes,has_mic,has_music,url
+MdjyRm,"Shaderlamp",lherm,No-License,false,46566,53,1491439335,1,true,false,https://www.shadertoy.com/view/MdjyRm
+s3l3Wl,"Raymarched mandelbaum reactive",enbe,CC-BY-NC+contact,false,165,9,1778893560,1,true,true,https://www.shadertoy.com/view/s3l3Wl
+73s3Wl,"beautiful disaster",enbe,No-License,false,82,5,1779263323,1,true,true,https://www.shadertoy.com/view/73s3Wl
+N32Gzz,"Basic Mandala",manUcan,No-License,false,86,6,1779011910,1,true,false,https://www.shadertoy.com/view/N32Gzz
+7XBGRR,"QuasiForge",Memetic,No-License,false,90,2,1778954993,2,true,false,https://www.shadertoy.com/view/7XBGRR
+MsdBR8,"dancing cubes",sclavel,No-License,false,22589,24,1524089273,2,true,false,https://www.shadertoy.com/view/MsdBR8
+X3KcWR,"Genuary 2025 day 5",Kali,No-License,false,3672,78,1736126991,1,true,false,https://www.shadertoy.com/view/X3KcWR
+fd2GRw,"Cyber Fuji 2020 audio reactive (Chaotnix fork — not the one we bundled; see Wt33Wf for the CC-BY-3.0 original)",Chaotnix,No-License,false,13288,12,1617135896,1,true,false,https://www.shadertoy.com/view/fd2GRw
+7Xj3W1,"DEMO DJ DIABLILLO SHADERVDJ",DJDIABLILLO,No-License,false,33,0,1779503108,1,true,false,https://www.shadertoy.com/view/7Xj3W1
+s3jGWD,"Pantalla Flash",DiegoLp,No-License,false,24,0,1779611180,1,true,false,https://www.shadertoy.com/view/s3jGWD
+sXj3DW,"Flash ice",DiegoLp,No-License,false,22,0,1779605863,1,true,false,https://www.shadertoy.com/view/sXj3DW
+llB3W1,"Fractal Audio 01",relampago2048,No-License,false,23185,112,1428522186,1,true,false,https://www.shadertoy.com/view/llB3W1
+4sjfzm,"RYB Color wheel",pthextract,No-License,false,16454,25,1499946053,1,true,true,https://www.shadertoy.com/view/4sjfzm
+X3KyRz,"Genuary 2025 #1",Kali,No-License,false,2182,62,1735872761,1,true,false,https://www.shadertoy.com/view/X3KyRz
+MtBGRt,"Solines",poljere,No-License,false,16882,98,1434685452,1,true,false,https://www.shadertoy.com/view/MtBGRt
+7Xl3Rj,"DNA in the mix :-) Mic reactive.",enbe,No-License,false,75,0,1778342448,1,true,true,https://www.shadertoy.com/view/7Xl3Rj
+fcf3WM,"FFT Clock System",ompuco,No-License,false,319,8,1772835494,3,true,false,https://www.shadertoy.com/view/fcf3WM
+sXlGzj,"""Music is in the DNA"" forked",enbe,No-License,false,66,3,1778345265,1,true,true,https://www.shadertoy.com/view/sXlGzj
+sXsGRj,"Fork RYB Color spiral",enbe,No-License,false,62,3,1778341078,1,true,true,https://www.shadertoy.com/view/sXsGRj
+slc3DX,"Oscilloscope music",incription,No-License,false,5456,42,1636823891,3,true,false,https://www.shadertoy.com/view/slc3DX
+ff2XzV,"Volume Detector",OttoACS,No-License,false,94,1,1776977410,1,true,false,https://www.shadertoy.com/view/ff2XzV
+W3ycDV,"the shader I load up when I'm pl",bombblob,No-License,false,305,5,1770055891,5,true,false,https://www.shadertoy.com/view/W3ycDV
+clVGRD,"Ambiant AI.",outofpaper,No-License,false,2937,8,1683653505,1,true,false,https://www.shadertoy.com/view/clVGRD
+scjGDd,"Shader Equalizor",ShaderDizzle,No-License,false,152,4,1774817243,1,true,false,https://www.shadertoy.com/view/scjGDd
+wffBz8,"silly scope",mmalex,No-License,false,631,6,1757324315,1,true,false,https://www.shadertoy.com/view/wffBz8
+ldcfWH,"simpler audiotunnel",sclavel,No-License,false,7116,13,1524869603,1,true,false,https://www.shadertoy.com/view/ldcfWH
+wXByDG,"Fork: It is alive...with music 2",bottelini,No-License,false,519,9,1761166134,2,true,false,https://www.shadertoy.com/view/wXByDG
+XlS3DD,"spectrum analysor",FabriceNeyret2,No-License,false,9531,32,1428958340,1,true,false,https://www.shadertoy.com/view/XlS3DD
+llVcRG,"Psychedelic Music Visualizer 3",yonibr,No-License,false,6527,35,1536805232,1,true,false,https://www.shadertoy.com/view/llVcRG
+Xtj3DW,"Twisted Rings",poljere,No-License,false,9312,47,1429548830,1,true,false,https://www.shadertoy.com/view/Xtj3DW
+ltB3RK,"Yellow Manypus",poljere,No-License,false,8346,33,1430936470,1,true,false,https://www.shadertoy.com/view/ltB3RK
+NdG3zw,"Audio Reactive Galaxy",JelyMe314,No-License,false,3461,43,1631215146,1,true,false,https://www.shadertoy.com/view/NdG3zw
+WdfSDr,"Soundshader lines",Airground,No-License,false,5195,28,1551008696,1,true,false,https://www.shadertoy.com/view/WdfSDr
+3fGcRV,"Cybertrons Inception ",Bhs,No-License,false,337,10,1764880191,2,true,false,https://www.shadertoy.com/view/3fGcRV
+ftV3zK,"chillwave planet",z0rg,CC-BY-NC-SA-3.0,false,3130,39,1638108263,3,true,false,https://www.shadertoy.com/view/ftV3zK
+llSGDh,"Input - Microphone",iq,No-License,false,7657,37,1428482235,1,true,false,https://www.shadertoy.com/view/llSGDh
+WfVfD3,"Fork spectrum",bombblob,No-License,false,251,2,1767920116,2,true,false,https://www.shadertoy.com/view/WfVfD3
+33lyzf,"Fork glow shade DJDIABLILL 615",DJDIABLILLO,No-License,false,402,4,1760537053,1,true,false,https://www.shadertoy.com/view/33lyzf
+WfVcRV,"Fork Chiptune ( Bhs 559",Bhs,No-License,false,311,6,1764916688,2,true,false,https://www.shadertoy.com/view/WfVcRV
+tslSz7,"Soundshader",Airground,No-License,false,4527,24,1550961603,1,true,false,https://www.shadertoy.com/view/tslSz7
+XctBW7,"Synthwave Sunset Mic Visualizer",TheWindowStreamz,No-License,false,901,5,1733169251,1,true,false,https://www.shadertoy.com/view/XctBW7
+wfXfz4,"Fork Undulating TeXmExDeX 907",TeXmExDeX,No-License,false,422,7,1757368058,2,true,false,https://www.shadertoy.com/view/wfXfz4
+Nc2GDD,"Phantom Recurrence Engine",apocalypse_cow,No-License,false,106,2,1774075166,1,true,false,https://www.shadertoy.com/view/Nc2GDD
+WclBRN,"FORK eye of phi (audio reactive)",TeXmExDeX,No-License,false,406,9,1757397802,3,true,false,https://www.shadertoy.com/view/WclBRN
+MsGczc,"Revision Qualification 2018-Cupe",nightfox,No-License,false,4484,28,1522775749,4,true,false,https://www.shadertoy.com/view/MsGczc
+NfjSRV,"tunnel vis experiment",whut,No-License,false,51,0,1776974411,3,true,false,https://www.shadertoy.com/view/NfjSRV
+33jcRR,"Waveform Microphone",belisoful,No-License,false,316,11,1760572565,2,true,false,https://www.shadertoy.com/view/33jcRR
+lt23W1,"mic analysis",FabriceNeyret2,No-License,false,5648,44,1428743806,1,true,false,https://www.shadertoy.com/view/lt23W1
+McSBRy,"Fork SoundEclip SwagLordLa 430",SwagLordLancalot,No-License,false,858,6,1725133099,1,true,false,https://www.shadertoy.com/view/McSBRy
+Mt23zz,"ngPsy1",netgrind,No-License,false,5506,36,1426722269,1,true,false,https://www.shadertoy.com/view/Mt23zz
+43cGDs,"starfield visualizer",technowizard,No-License,false,977,10,1717112655,1,true,false,https://www.shadertoy.com/view/43cGDs
+wfsXDl,"iridescent ribbons",evesira,No-License,false,586,10,1741472423,3,true,false,https://www.shadertoy.com/view/wfsXDl
+w3yBD1,"Delta Final BG",JustMoon,No-License,false,127,1,1771588245,1,true,false,https://www.shadertoy.com/view/w3yBD1
+4lVyzG," Sound Grid",hobohippy,No-License,false,3643,10,1536790416,1,true,false,https://www.shadertoy.com/view/4lVyzG
+WXS3RV,"Fork Shimmy WoodsGao 951",WoodsGao,No-License,false,529,12,1744265560,1,true,false,https://www.shadertoy.com/view/WXS3RV
+ttVyW3,"Toni Tunnel",Kali,No-License,false,1827,19,1653606338,2,true,false,https://www.shadertoy.com/view/ttVyW3
+3clcWn,"Audio Visualiser v0.1 Sadeghi",mortezasadeghilkjh,No-License,false,352,6,1755535449,1,true,false,https://www.shadertoy.com/view/3clcWn
+XcBcR3,"Fork Fractal 77 NikolaErce 454",NikolaErceg,No-License,false,822,8,1722644461,1,true,false,https://www.shadertoy.com/view/XcBcR3
+Nfl3D8,"Floored frequencies",veik,No-License,false,101,3,1772735425,1,true,false,https://www.shadertoy.com/view/Nfl3D8
+wdV3zz,"switching webcam visualizer",ericspags,No-License,false,2909,11,1570308005,2,true,false,https://www.shadertoy.com/view/wdV3zz
+tfSBzz,"Fork Fork Fork  BoringUna 811",BoringUna,No-License,false,301,8,1758199818,1,true,false,https://www.shadertoy.com/view/tfSBzz
+XdtBR2,"Dancing Sinus",FraKtus,No-License,false,3509,14,1525948745,1,true,false,https://www.shadertoy.com/view/XdtBR2
+lltGW2,"radial sound displacment",netgrind,No-License,false,4210,49,1474680994,2,true,false,https://www.shadertoy.com/view/lltGW2
+WXtGzn,"Test shader for api stuff",petrmur,No-License,false,388,0,1750853698,3,true,true,https://www.shadertoy.com/view/WXtGzn
+WcXSDn,"mic sphere",evesira,No-License,false,522,11,1740781476,2,true,false,https://www.shadertoy.com/view/WcXSDn
+tsXSDH,"static prismatic smoke",morisil,No-License,false,3047,34,1551166723,4,true,false,https://www.shadertoy.com/view/tsXSDH
+tcdyzB,"Blue Thunder",ankurrabha,No-License,false,215,4,1763768438,1,true,false,https://www.shadertoy.com/view/tcdyzB
+fllGR7,"Acid tubes",z0rg,No-License,false,1921,10,1630397225,3,true,true,https://www.shadertoy.com/view/fllGR7
+dt3XDl,"Fork 3D Audio V ItsAlmostP 974",ItsAlmostPG,No-License,false,1193,8,1685860989,1,true,false,https://www.shadertoy.com/view/dt3XDl
+3XdcWn,"HeyMyVoice",JamesZFS,No-License,false,149,3,1768056238,1,true,false,https://www.shadertoy.com/view/3XdcWn
+flsGWf,"OpenSetTest8",OpenSet,No-License,false,1916,26,1623006612,2,true,false,https://www.shadertoy.com/view/flsGWf
+7dc3WH,"spec-test",made,No-License,false,1796,11,1629679094,1,true,false,https://www.shadertoy.com/view/7dc3WH
+mtjSWm,"Fork SoundEclip nobody 012",nobody,No-License,false,1224,4,1676215134,1,true,false,https://www.shadertoy.com/view/mtjSWm
+wf3BDf,"Dot Globe ",ankurrabha,No-License,false,157,5,1766425373,1,true,false,https://www.shadertoy.com/view/wf3BDf
+dtyGDG,"Polar reaction blue",firebreathz,No-License,false,579,3,1729916706,1,true,false,https://www.shadertoy.com/view/dtyGDG
+tfcBWf,"Magic Globe",ankurrabha,No-License,false,154,4,1766422577,1,true,false,https://www.shadertoy.com/view/tfcBWf
+WcccRf,"I am ai v2 gemini",Bhs,No-License,false,181,7,1763880652,2,true,false,https://www.shadertoy.com/view/WcccRf
+csVyRR,"vision on line",dj_afroedi,No-License,false,938,5,1695718490,1,true,false,https://www.shadertoy.com/view/csVyRR
+WcBBRh,"Fork Abstract Music",science6uru2,No-License,false,241,5,1758247991,1,true,false,https://www.shadertoy.com/view/WcBBRh
+mtcXDl,"Fork Pixel Ra ItsAlmostP 469",ItsAlmostPG,No-License,false,1031,7,1685861490,5,true,true,https://www.shadertoy.com/view/mtcXDl
+Mt23Dm,"Reactive Flower",poljere,No-License,false,3792,10,1429830550,1,true,false,https://www.shadertoy.com/view/Mt23Dm
+WfBfzh,"Neon Dark Visualizer Wallaper",science6uru2,No-License,false,228,1,1758252816,3,true,false,https://www.shadertoy.com/view/WfBfzh
+3cVBRz,"Waveform test",TheCatWithShaders,No-License,false,140,2,1766590772,1,true,false,https://www.shadertoy.com/view/3cVBRz
+ctfGDl,"ReactionDiffusion2",DigitalShadow,No-License,false,1118,26,1672626863,2,true,false,https://www.shadertoy.com/view/ctfGDl
+4fScR3,"Fork Inside nuc NikolaErce 064",NikolaErceg,No-License,false,570,1,1722644168,3,true,true,https://www.shadertoy.com/view/4fScR3
+WtlXzN,"Paganini caprice 24 eclipse",morisil,No-License,false,2160,35,1562280046,2,true,false,https://www.shadertoy.com/view/WtlXzN
+clGfD3,"Bumpy sound response",sanderoneil,No-License,false,765,6,1702535474,3,true,false,https://www.shadertoy.com/view/clGfD3
+lXfXR2,"jj2",jjdee,No-License,false,692,3,1709718764,1,true,false,https://www.shadertoy.com/view/lXfXR2
+4fVyzy,"dancing fraction",rnslv,No-License,false,467,6,1732039190,1,true,false,https://www.shadertoy.com/view/4fVyzy
+MdVBW1,"Audio experiment #4 - mic",Simplyfire,No-License,false,2441,16,1528743695,1,true,false,https://www.shadertoy.com/view/MdVBW1
+3cGBDz,"Fork Mini: Hill molotovbliss 023",molotovbliss,No-License,false,126,0,1766937070,1,true,false,https://www.shadertoy.com/view/3cGBDz
+4ctXR8,"Visual enhancments forSoundEclip",Xtrullor,No-License,false,633,3,1713564176,1,true,false,https://www.shadertoy.com/view/4ctXR8
+tcVXzh,"Brush stroke, wave, audio react",DiogDiog,No-License,false,283,1,1749825199,3,true,false,https://www.shadertoy.com/view/tcVXzh
+sslXzX,"MandelKoch- Music Visualiser ver",Pelegefen,No-License,false,1513,12,1618999291,1,true,true,https://www.shadertoy.com/view/sslXzX
+sdfGz4,"Audio Bars?",mvinaround,No-License,false,1175,6,1654357917,3,true,false,https://www.shadertoy.com/view/sdfGz4
+McBXDw,"iChannel textures",OnyxWingman,No-License,false,678,0,1706676099,2,true,false,https://www.shadertoy.com/view/McBXDw
+wXGyDK,"Spectrum Analyzer 101",sevenlabs,No-License,false,94,1,1769740216,2,true,false,https://www.shadertoy.com/view/wXGyDK
+4ldfWH,"Webcam-Microphone Voice Ripple",BenWheatley,No-License,false,2217,10,1539456807,1,true,false,https://www.shadertoy.com/view/4ldfWH
+DslXW2,"Synthwave Triangles",elloskelling,No-License,false,1012,14,1669588746,1,true,false,https://www.shadertoy.com/view/DslXW2
+4lBGDW,"Mic to the heart",antonOTI,No-License,false,3160,9,1428867043,1,true,false,https://www.shadertoy.com/view/4lBGDW
+scS3Dw,"Dj Erwin Chacin",djerwinchacin,No-License,false,52,1,1774139185,1,true,false,https://www.shadertoy.com/view/scS3Dw
+3cyfWh,"Celestial Inferno",bug0rig,No-License,false,116,3,1767007690,1,true,false,https://www.shadertoy.com/view/3cyfWh
+WftBzf,"dragonFly_03",ttoome,No-License,false,116,4,1766827499,1,true,false,https://www.shadertoy.com/view/WftBzf
+tl3yzN,"serg4",serega09,No-License,false,1511,7,1608568387,2,true,false,https://www.shadertoy.com/view/tl3yzN
+ftKGRc,"Spiral spectrogram",windytan,No-License,false,1247,12,1638094248,1,true,false,https://www.shadertoy.com/view/ftKGRc
+3tVBzD,"Pixels3000",z0rg,No-License,false,1420,17,1618050608,3,true,true,https://www.shadertoy.com/view/3tVBzD
+DssXW2,"Fractal Flower Fork",elloskelling,No-License,false,965,11,1669588656,1,true,false,https://www.shadertoy.com/view/DssXW2
+M3XSR2,"jj1",jjdee,No-License,false,611,2,1709715669,1,true,false,https://www.shadertoy.com/view/M3XSR2
+sd3yW8,"Toni Disk",Kali,No-License,false,1075,16,1653357994,2,true,false,https://www.shadertoy.com/view/sd3yW8
+4XBczc,"Glow Tunnel (Potato)",Spectraledge,No-License,false,444,3,1727645819,2,true,false,https://www.shadertoy.com/view/4XBczc
+WdfGDX,"#EVOKE 2019 Sound Hybrid Mandel",VJSpackOMat,No-License,false,1806,11,1565967761,1,true,false,https://www.shadertoy.com/view/WdfGDX
+ltcyD7,"sound visualizer #2",archibate,No-License,false,2061,4,1532857123,4,true,false,https://www.shadertoy.com/view/ltcyD7
+4XVczz,"Genuary 2025 !1",Kali,No-License,false,364,28,1735952840,1,true,false,https://www.shadertoy.com/view/4XVczz
+lttBz2,"flame_cppn_audio",wxs,No-License,false,1972,13,1540354818,1,true,false,https://www.shadertoy.com/view/lttBz2
+t3fSz7,"Audio Spectrums arcs+rays",altarofwisdom,No-License,false,287,2,1744918722,1,true,false,https://www.shadertoy.com/view/t3fSz7
+4dfcWN,"fft ifs",nshelton,No-License,false,2386,15,1488157628,3,true,false,https://www.shadertoy.com/view/4dfcWN
+ltVcRD,"Psychedelic Music Visualizer 2",yonibr,No-License,false,1962,10,1535422881,1,true,false,https://www.shadertoy.com/view/ltVcRD
+WfXyz8,"Fork Fork rayma pyroxenite 048",pyroxenite,No-License,false,141,1,1761735541,1,true,false,https://www.shadertoy.com/view/WfXyz8
+WXt3R7,"Basic Audio 365",flexi001,No-License,false,223,2,1751057090,1,true,false,https://www.shadertoy.com/view/WXt3R7
+X32fRV,"Soundwave",Artem001,No-License,false,386,3,1729698887,1,true,false,https://www.shadertoy.com/view/X32fRV
+4tlXzH,"ngRay3",netgrind,No-License,false,2645,14,1434513354,1,true,false,https://www.shadertoy.com/view/4tlXzH
+dlK3RW,"PlasmaMic",diasgc,No-License,false,736,13,1683670179,1,true,false,https://www.shadertoy.com/view/dlK3RW
+3f3fDX,"Happy July",Huino,No-License,false,102,6,1766385586,1,true,false,https://www.shadertoy.com/view/3f3fDX
+tfSfz1,"Geometric Illusion Engine V2",KarmaDeezy,No-License,false,159,5,1758280928,1,true,false,https://www.shadertoy.com/view/tfSfz1
+wXyGD1,"projector larsen",Lordinator,No-License,false,203,0,1752276492,3,true,false,https://www.shadertoy.com/view/wXyGD1
+w32fzK,"talking face",mds2,No-License,false,126,4,1762730498,2,true,false,https://www.shadertoy.com/view/w32fzK
+lstGW2,"webcam bad reception",intoxopox,No-License,false,2372,4,1452388900,1,true,false,https://www.shadertoy.com/view/lstGW2
+MtSGWt,"MandelBox audio",nshelton,No-License,false,2486,6,1433488761,1,true,false,https://www.shadertoy.com/view/MtSGWt
+ttl3z4,"Waves of sound",madonius,No-License,false,1602,9,1555793246,1,true,true,https://www.shadertoy.com/view/ttl3z4
+ld2yDD,"twitchy fractal",netgrind,No-License,false,2025,18,1494949170,2,true,false,https://www.shadertoy.com/view/ld2yDD
+MlGyRd,"李明杰V23",leneer,No-License,false,1720,13,1537325205,1,true,false,https://www.shadertoy.com/view/MlGyRd
+WfcSR8,"life during shroom",lofiatl,No-License,false,221,3,1748735158,1,true,false,https://www.shadertoy.com/view/WfcSR8
+XclXzN,"Fork Raymarchin ItsAlmostP 955",ItsAlmostPG,No-License,false,529,2,1705005980,1,true,false,https://www.shadertoy.com/view/XclXzN
+NsyGDV,"Soundshader X-lines",made,No-License,false,1041,10,1632171475,1,true,false,https://www.shadertoy.com/view/NsyGDV
+ldscRB,"3D Kali",lherm,No-License,false,2042,13,1488821894,1,true,false,https://www.shadertoy.com/view/ldscRB
+t3GfRd,"Valentines day hearts",Tom_Neverwinter,No-License,false,55,2,1772005007,1,true,false,https://www.shadertoy.com/view/t3GfRd
+dlycDW,"breakthrough + audio (mic-in)",MV10,No-License,false,551,11,1700222702,2,true,false,https://www.shadertoy.com/view/dlycDW
+3XtyR4,"自己",zixiaolintina,No-License,false,83,1,1767908292,2,true,false,https://www.shadertoy.com/view/3XtyR4
+M3KSWy,"Fork <><> Echev Panguin828 406",Panguin8281,No-License,false,409,4,1720537729,1,true,false,https://www.shadertoy.com/view/M3KSWy
+MlXSz4,"I dont even know",Cieric,No-License,false,2321,12,1434824780,1,true,false,https://www.shadertoy.com/view/MlXSz4
+ssSXRy,"audio wave and fft example",bespsm,No-License,false,1072,5,1620471906,1,true,false,https://www.shadertoy.com/view/ssSXRy
+3XdSz2,"Scarlet Nexus",BlairNyX,No-License,false,176,3,1753670655,3,true,false,https://www.shadertoy.com/view/3XdSz2
+WsGyRh,"Elipse Mic",FlavioMoreir4,No-License,false,1188,14,1602174439,1,true,false,https://www.shadertoy.com/view/WsGyRh
+lsscWH,"tuner / spectrometer",FabriceNeyret2,No-License,false,1947,25,1488110548,1,true,false,https://www.shadertoy.com/view/lsscWH
+W3lXR7,"Some experiments",altarofwisdom,No-License,false,166,2,1755042396,1,true,false,https://www.shadertoy.com/view/W3lXR7
+XcG3Wc,"Argon Argyle Visualizer",FatLenny,No-License,false,440,14,1713662706,1,true,false,https://www.shadertoy.com/view/XcG3Wc
+WdSGzR,"Psychedelic Music Slices",yonibr,No-License,false,1537,8,1547886382,2,true,false,https://www.shadertoy.com/view/WdSGzR
+MfGfWm,"6-orthotope interactive fast",willwombell,No-License,false,301,2,1734093732,3,true,false,https://www.shadertoy.com/view/MfGfWm
+fddXRj,"3Blue1Brown's Hilbert Curve",playersteve19,No-License,false,961,18,1633533741,1,true,false,https://www.shadertoy.com/view/fddXRj
+cldXDN,"Sound circle",fifa_s,No-License,false,543,5,1696778000,1,true,false,https://www.shadertoy.com/view/cldXDN

--- a/shader_research/mrange-shaders.csv
+++ b/shader_research/mrange-shaders.csv
@@ -1,0 +1,129 @@
+id,title,license,gpl_compat,views,likes,date,passes,has_mic,has_music,input_types,url
+XfyXRV,"Let's self reflect",CC0,true,61384,450,1715422910,1,false,false,,https://www.shadertoy.com/view/XfyXRV
+wsjBD3,"A battered alien planet",CC0,true,45483,79,1591024904,1,false,false,,https://www.shadertoy.com/view/wsjBD3
+wsBBWD,"Spiral galaxy",CC0,true,43623,82,1590057425,1,false,false,,https://www.shadertoy.com/view/wsBBWD
+WtXyW4,"Alien Waterworld",CC0,true,30337,66,1592052399,1,false,false,,https://www.shadertoy.com/view/WtXyW4
+43jXWt,"Saturday weirdness",CC0,true,29457,171,1711228362,3,false,false,buffer,https://www.shadertoy.com/view/43jXWt
+stBcW1,"Stars and galaxy",CC0,true,25038,193,1649601106,1,false,false,,https://www.shadertoy.com/view/stBcW1
+7d2fDW,"Appolloian with a twist II",CC0,true,23135,86,1646339794,1,false,false,,https://www.shadertoy.com/view/7d2fDW
+MfjyWK,"Starry planes",CC0,true,22846,300,1723022633,1,false,false,,https://www.shadertoy.com/view/MfjyWK
+mtScRc,"Inside the mandelbulb II",CC0,true,21181,329,1692095316,2,false,false,buffer,https://www.shadertoy.com/view/mtScRc
+slcXW8,"Synthwave canyon",CC0,true,20454,68,1638993692,1,false,false,,https://www.shadertoy.com/view/slcXW8
+ttSGRc,"Flat water effects",No-License,false,20417,66,1560459624,1,false,false,,https://www.shadertoy.com/view/ttSGRc
+Wl2Gzc,"Flat water effects 2",No-License,false,19965,38,1560550686,1,false,false,,https://www.shadertoy.com/view/Wl2Gzc
+3XdXRr,"Just another cube",CC0,true,17485,246,1753088565,1,false,false,,https://www.shadertoy.com/view/3XdXRr
+mlBSWc,"Colorful underwater bubbles II",MIT,true,16381,97,1676667839,1,false,true,musicstream,https://www.shadertoy.com/view/mlBSWc
+DldXDX,"Sunrise on saturn",CC0,true,16275,203,1685821758,3,false,false,buffer,https://www.shadertoy.com/view/DldXDX
+flGyDd,"Refraction + post proc",CC0,true,15820,166,1662408326,3,false,false,buffer,https://www.shadertoy.com/view/flGyDd
+7lKSWW,"Truchet + Kaleidoscope FTW",CC0,true,15206,271,1640723365,1,false,false,,https://www.shadertoy.com/view/7lKSWW
+WfcGWj,"Trailing the Twinkling Tunnel ..",CC0,true,14266,327,1747485517,2,false,false,,https://www.shadertoy.com/view/WfcGWj
+33cGDj,"Clearly a bug",CC0,true,13879,232,1751706034,1,false,false,,https://www.shadertoy.com/view/33cGDj
+7dyyRy,"Neonwave sunrise",CC0,true,13231,215,1655060306,1,false,true,musicstream,https://www.shadertoy.com/view/7dyyRy
+NdKyDw,"Hex marching",CC0,true,12709,254,1654970647,3,false,false,buffer,https://www.shadertoy.com/view/NdKyDw
+3ttGRs,"Gnarly Apollian Tree",No-License,false,10839,103,1577269165,1,false,false,,https://www.shadertoy.com/view/3ttGRs
+lX2GzD,"MountainBytes: PPPP 4KiB Windows",CC0,true,10453,158,1708276331,4,false,true,buffer|musicstream,https://www.shadertoy.com/view/lX2GzD
+lttBzN,"a study of glass",No-License,false,10219,170,1538908235,1,false,true,musicstream,https://www.shadertoy.com/view/lttBzN
+cdV3DW,"Electric Eel Universe",CC0,true,8911,138,1678542084,1,false,false,,https://www.shadertoy.com/view/cdV3DW
+ddcGW8,"For the neon style enjoyers",CC0,true,8661,161,1677182872,1,false,true,musicstream,https://www.shadertoy.com/view/ddcGW8
+ctd3Rl,"AI not included",CC0,true,8524,156,1682944354,1,false,false,,https://www.shadertoy.com/view/ctd3Rl
+Wl3fzM,"Apollian with a twist",CC0,true,6885,225,1612391093,1,false,false,,https://www.shadertoy.com/view/Wl3fzM
+ftXXWX,"Cable nest",CC0,true,6012,99,1626634908,1,false,false,,https://www.shadertoy.com/view/ftXXWX
+tfK3Dy,"4D Beats",CC0,true,5696,185,1748508209,1,false,true,music,https://www.shadertoy.com/view/tfK3Dy
+NtcyDn,"Wednesday messing around",CC0,true,5641,111,1659531971,1,false,false,,https://www.shadertoy.com/view/NtcyDn
+fd33zn,"Saturday Torus",CC0,true,5267,110,1628948950,1,false,false,,https://www.shadertoy.com/view/fd33zn
+fdlSDl,"Cloudy crystal",CC0,true,4753,144,1619458567,1,false,false,,https://www.shadertoy.com/view/fdlSDl
+mslfR2,"More ""cubes"" for the cube lovers",CC0,true,4738,78,1688974919,1,false,true,musicstream,https://www.shadertoy.com/view/mslfR2
+DdSGzy,"Another windows terminal shader",CC0,true,4713,52,1667765958,1,false,false,,https://www.shadertoy.com/view/DdSGzy
+3t2czh,"Warped Liquid Metal",CC0,true,4502,110,1593721238,1,false,false,,https://www.shadertoy.com/view/3t2czh
+7dtcRj,"Neonwave Sunset",CC0,true,4425,74,1653767670,1,false,true,musicstream,https://www.shadertoy.com/view/7dtcRj
+ftGfDK,"Saturday cubism experiment",CC0,true,4387,98,1665221439,1,false,false,,https://www.shadertoy.com/view/ftGfDK
+NtXSzl,"Moving without travelling",CC0,true,4376,44,1626261436,1,false,true,musicstream,https://www.shadertoy.com/view/NtXSzl
+DlB3WG,"Mind flowers",CC0,true,3591,96,1673809487,1,false,true,musicstream,https://www.shadertoy.com/view/DlB3WG
+ddjcWh,"Sunday morning random results",CC0,true,2407,109,1687679270,1,false,false,,https://www.shadertoy.com/view/ddjcWh
+ds2XRt,"Reflective hexes",CC0,true,2387,88,1670756075,1,false,false,,https://www.shadertoy.com/view/ds2XRt
+mtVSDy,"Computers were made for cubes",CC0,true,2386,70,1686340350,1,false,false,,https://www.shadertoy.com/view/mtVSDy
+tdScD1,"Psychedelic Dodec experiment",CC0,true,2372,43,1586539198,1,false,false,,https://www.shadertoy.com/view/tdScD1
+ddfyD7,"Complicating things even further",CC0,true,2348,78,1686858466,1,false,true,musicstream,https://www.shadertoy.com/view/ddfyD7
+cdccRl,"Oversaturated web",CC0,true,2297,44,1695324560,1,false,true,musicstream,https://www.shadertoy.com/view/cdccRl
+sdKcDz,"Face in the clouds",CC0,true,2278,36,1654721292,1,false,true,musicstream,https://www.shadertoy.com/view/sdKcDz
+wtBcRW,"Alien Skin",CC0,true,2244,27,1593800739,1,false,false,,https://www.shadertoy.com/view/wtBcRW
+7tfSzB,"Mandelbox variant no 1E6",CC0,true,2200,55,1625947532,1,false,false,,https://www.shadertoy.com/view/7tfSzB
+flKfzh,"Windows Terminal Damask Rose",CC0,true,2167,68,1664050647,1,false,false,,https://www.shadertoy.com/view/flKfzh
+DsXcWn,"Overcomplicating things",CC0,true,2158,42,1686686895,1,false,false,,https://www.shadertoy.com/view/DsXcWn
+tslBW7,"Fortress Harkonnen",CC0,true,2155,40,1588421175,1,false,true,musicstream,https://www.shadertoy.com/view/tslBW7
+csSSWc,"Neon city for Windows Terminal",CC0,true,2155,35,1670962902,1,false,false,,https://www.shadertoy.com/view/csSSWc
+ftGcD3,"Inside the mandelbulb",CC0,true,2119,56,1662296981,1,false,false,,https://www.shadertoy.com/view/ftGcD3
+WlByzy,"Neonwave style",CC0,true,2078,21,1594640245,1,false,false,,https://www.shadertoy.com/view/WlByzy
+NlSSDG,"DragonEye II",CC0,true,2077,59,1628452763,1,false,false,,https://www.shadertoy.com/view/NlSSDG
+dtSGWh,"Rainbow smith cells",CC0,true,2064,77,1673207863,1,false,false,,https://www.shadertoy.com/view/dtSGWh
+WsjyWm,"Disco Star Tunnel",CC0,true,2056,54,1586774850,1,false,false,,https://www.shadertoy.com/view/WsjyWm
+fdXXR4,"Starry background with nebula",CC0,true,2039,23,1618301095,1,false,false,,https://www.shadertoy.com/view/fdXXR4
+NdVfzK,"Monterey wannabe",CC0,true,2036,46,1658498183,1,false,false,,https://www.shadertoy.com/view/NdVfzK
+NlcSRB,"Mandala flowers",WTFPL,true,2007,84,1639299234,1,false,false,,https://www.shadertoy.com/view/NlcSRB
+clVXWt,"A cube for the cube enjoyers",CC0,true,1998,50,1686474998,1,false,false,,https://www.shadertoy.com/view/clVXWt
+7sSfRG,"Voronoi Glass Panes",CC0,true,1993,54,1646512521,1,false,false,,https://www.shadertoy.com/view/7sSfRG
+DtGGRd,"CC0: Atans begone!",CC0,true,1965,43,1684415212,1,false,true,musicstream,https://www.shadertoy.com/view/DtGGRd
+ctlyzN,"Travelling to Neon-Giza",CC0,true,2915,71,1690471249,3,false,true,buffer|musicstream,https://www.shadertoy.com/view/ctlyzN
+wl2yzt,"Flying through psychedelic mist",CC0,true,2704,43,1595152447,1,false,false,,https://www.shadertoy.com/view/wl2yzt
+sdSSzz,"Crystal skull",CC0,true,2619,59,1619543127,1,false,false,,https://www.shadertoy.com/view/sdSSzz
+sd2GWD,"Hex tile transition effect",CC0,true,2526,48,1617460465,1,false,false,,https://www.shadertoy.com/view/sd2GWD
+csfXzN,"Sea and moon",CC0,true,2456,45,1668551305,1,false,false,,https://www.shadertoy.com/view/csfXzN
+DtBSRh,"Colorful star travelling",CC0,true,2455,68,1675626055,1,false,false,,https://www.shadertoy.com/view/DtBSRh
+WlcfRS,"Golden apollian",CC0,true,2448,89,1612911149,1,false,false,,https://www.shadertoy.com/view/WlcfRS
+WdVfRh,"Smooth Kaleidoscope 2",CC0,true,2421,35,1606575713,1,false,false,,https://www.shadertoy.com/view/WdVfRh
+DsccRS,"Tuesday tinkering",CC0,true,1929,52,1695155833,1,false,false,,https://www.shadertoy.com/view/DsccRS
+dsc3RS,"We need an expert.. Dave Hoskins",CC0,true,1927,53,1677444021,1,false,true,texture|music,https://www.shadertoy.com/view/dsc3RS
+sl3Bz7,"Saturday Torus III",CC0,true,1898,44,1662817730,1,false,false,,https://www.shadertoy.com/view/sl3Bz7
+NsKyDG,"Infinite hexes background",CC0,true,1882,49,1655499653,1,false,false,,https://www.shadertoy.com/view/NsKyDG
+3ljyDD,"Hexagonal tiling + cog wheels",CC0,true,1861,54,1594399136,1,false,false,,https://www.shadertoy.com/view/3ljyDD
+XctGzf,"Attempt at VDJ effects",CC0,true,1826,37,1711981059,1,false,true,musicstream,https://www.shadertoy.com/view/XctGzf
+dtfSzs,"Techno-plankton in alien ocean",CC0,true,1823,65,1675196263,1,false,false,,https://www.shadertoy.com/view/dtfSzs
+4cyXWw,"Gravity sucks",CC0,true,1811,59,1715232669,1,false,false,,https://www.shadertoy.com/view/4cyXWw
+flfXDn,"Retro cube effect with twist",CC0,true,1808,30,1625421836,1,false,true,musicstream,https://www.shadertoy.com/view/flfXDn
+3d2fDw,"Planet Shader",CC0,true,1792,28,1590167107,1,false,false,,https://www.shadertoy.com/view/3d2fDw
+wtKfDD,"Vorofbm",CC0,true,1767,34,1614373123,1,false,false,,https://www.shadertoy.com/view/wtKfDD
+csB3D1,"Gnarly colorful apollonian ",CC0,true,1763,78,1667514946,1,false,false,,https://www.shadertoy.com/view/csB3D1
+fsffDS,"Spiral ""domain mapping""",CC0,true,1760,31,1645278432,1,false,false,,https://www.shadertoy.com/view/fsffDS
+ct2GDK,"Example for Windows Terminal",CC0,true,1760,5,1673945675,1,false,false,,https://www.shadertoy.com/view/ct2GDK
+ss2Szm,"Sunday Threads",CC0,true,1714,38,1619960548,1,false,false,,https://www.shadertoy.com/view/ss2Szm
+tlcBWH,"Tunneling through apollian frac",CC0,true,1711,35,1612623360,1,false,false,,https://www.shadertoy.com/view/tlcBWH
+NdyyW3,"""Rasterbars"" in 2022",CC0,true,1710,41,1655673345,1,false,false,,https://www.shadertoy.com/view/NdyyW3
+cscyDf,"Saturday hacking",CC0,true,1685,67,1695560993,1,false,true,musicstream,https://www.shadertoy.com/view/cscyDf
+3lyBRt,"Tribute to my old Atari",CC0,true,1652,18,1614814743,1,false,true,musicstream,https://www.shadertoy.com/view/3lyBRt
+msKGzR,"Ghost train",CC0,true,1643,49,1678133549,1,false,false,,https://www.shadertoy.com/view/msKGzR
+dt3GDl,"Levels jerry, levels!",CC0,true,1641,59,1683308114,1,false,false,,https://www.shadertoy.com/view/dt3GDl
+wl2yRm,"Impulse backdrop",CC0,true,1639,20,1594040022,1,false,false,,https://www.shadertoy.com/view/wl2yRm
+sl3yRM,"Time for some inner reflections",CC0,true,1635,51,1659443883,1,false,false,,https://www.shadertoy.com/view/sl3yRM
+fllSD8,"Psychedelic Eye",CC0,true,1634,24,1625589701,1,false,true,musicstream,https://www.shadertoy.com/view/fllSD8
+dtBSRV,"Colorful bubbles underwater",CC0,true,1619,24,1676317562,1,false,true,musicstream,https://www.shadertoy.com/view/dtBSRV
+WtGfR1,"Smooth koch coordinate transform",CC0,true,1607,39,1613835703,1,false,false,,https://www.shadertoy.com/view/WtGfR1
+7tGcRV,"Beat boxing",CC0,true,1604,25,1661810223,1,false,true,musicstream,https://www.shadertoy.com/view/7tGcRV
+wl3fR7,"Slicing a 4D apollian",CC0,true,1601,37,1612423823,1,false,false,,https://www.shadertoy.com/view/wl3fR7
+sdsBWs,"More colors, more spirals",CC0,true,1600,45,1645566734,1,false,false,,https://www.shadertoy.com/view/sdsBWs
+dlsGDf,"Matrix maelstrom",CC0,true,1600,57,1672608140,1,false,false,,https://www.shadertoy.com/view/dlsGDf
+mtjGWz,"Rainbow wheel",CC0,true,1600,55,1673177467,1,false,false,,https://www.shadertoy.com/view/mtjGWz
+Ns2XWc,"Reflecting toruses",CC0,true,1594,45,1621175258,1,false,false,,https://www.shadertoy.com/view/Ns2XWc
+cdKXDV,"Logarithmic spirals tweaked",CC0,true,1591,47,1681647663,1,false,false,,https://www.shadertoy.com/view/cdKXDV
+7tGfW3,"Happy little windows terminal",CC0,true,1574,30,1665345162,1,false,false,,https://www.shadertoy.com/view/7tGfW3
+ttBcRV,"Flying through glowing stars",CC0,true,1557,23,1594818145,1,false,false,,https://www.shadertoy.com/view/ttBcRV
+dlSGWm,"Warping boxes",CC0,true,1557,37,1673381999,1,false,false,,https://www.shadertoy.com/view/dlSGWm
+WsjfDt,"Dawn at a distant world",CC0,true,1553,20,1591135285,1,false,false,,https://www.shadertoy.com/view/WsjfDt
+WlcBD2,"Mandelbox slices",CC0,true,1542,23,1613427262,1,false,false,,https://www.shadertoy.com/view/WlcBD2
+mtjyz1,"CC0: Quick hack on the train",CC0,true,1542,39,1691496963,1,false,false,,https://www.shadertoy.com/view/mtjyz1
+7sj3zw,"Mandelbox crystal",CC0,true,1541,20,1617180925,1,false,true,musicstream,https://www.shadertoy.com/view/7sj3zw
+cdlSWf,"Cracked heirloom",CC0,true,1536,46,1669655479,1,false,false,,https://www.shadertoy.com/view/cdlSWf
+NlXBDn,"Pretty sweet colors",CC0,true,1517,24,1650695712,1,false,false,,https://www.shadertoy.com/view/NlXBDn
+7dKBDt,"Dodecahedron inner reflections",CC0,true,1511,31,1659039543,1,false,false,,https://www.shadertoy.com/view/7dKBDt
+csV3Wd,"Sommarhack 2023",CC0,true,1510,44,1679236769,1,false,true,musicstream,https://www.shadertoy.com/view/csV3Wd
+wdBfDK,"Mandelbrot with ""smart"" AA",CC0,true,1509,16,1590827507,1,false,false,,https://www.shadertoy.com/view/wdBfDK
+mdfBzs,"Tuesday infinite zoom",CC0,true,1508,43,1689067982,1,false,false,,https://www.shadertoy.com/view/mdfBzs
+NldSzr,"Thindal twitch logo",CC0,true,1504,21,1638625776,1,false,false,,https://www.shadertoy.com/view/NldSzr
+7tGcDG,"Nested transparent sphere4s",CC0,true,1503,32,1662098720,1,false,false,,https://www.shadertoy.com/view/7tGcDG
+msGXRD,"Logarithmic spiral of spheres",CC0,true,1502,41,1680782276,1,false,false,,https://www.shadertoy.com/view/msGXRD
+mlXGzs,"Infinite Arcs III",CC0,true,1501,34,1672229355,1,false,false,,https://www.shadertoy.com/view/mlXGzs
+7tyfzK,"Illuminated sphere",CC0,true,1498,43,1664823088,1,false,false,,https://www.shadertoy.com/view/7tyfzK
+dtBXWh,"Sphere recursion",CC0,true,1488,54,1675977859,1,false,false,,https://www.shadertoy.com/view/dtBXWh
+dltyWr,"Dawn at a distant world II",CC0,true,1487,53,1699092357,2,false,true,buffer|musicstream,https://www.shadertoy.com/view/dltyWr
+tllyWf,"Once upon time... space",CC0,true,1485,24,1593333776,1,false,false,,https://www.shadertoy.com/view/tllyWf
+3lVczV,"Metal Kaleidoscope",CC0,true,1485,13,1611353252,1,false,false,,https://www.shadertoy.com/view/3lVczV
+3dfBWH,"The Rorsach Mask",CC0,true,1481,6,1588101022,1,false,false,,https://www.shadertoy.com/view/3dfBWH


### PR DESCRIPTION
## Summary
Dev and reference artifacts that accumulated alongside the visualizer work, split out from the i18n change (#19) into their own PR.

- **`shader_research/`** — README, cyber-fuji reactivity notes, and CSV catalogs of microphone-reactive and `mrange` shaders. Reference material for the visualizer feature.
- **`integration_test/screenshot_tour[_test].dart`** — an integration-test driver that walks the app's screens and captures screenshots for UI review.
- **`.gitignore`** — ignore root-level hidden dev screenshots (`/.*.png`) and the generated gen_l10n untranslated-messages report (`l10n_untranslated.txt`).

## Notes
- **No app/runtime code** — nothing here affects the shipped APK.
- Independent of #19 (multi-language support); the two can merge in either order.

## Test plan
- [ ] `flutter pub get && flutter analyze` — clean
- [ ] Run the screenshot tour (`flutter test integration_test/screenshot_tour_test.dart`, or via `flutter drive`) and confirm it walks the app
- [ ] After a build, `git status` is clean (the generated `l10n_untranslated.txt` no longer shows up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)