### PR TITLE
Visualizer: dB-mapped FFT audio pipeline + per-shader tuning panel

### DIFF
--- a/android/app/src/main/cpp/audio_texture.cpp
+++ b/android/app/src/main/cpp/audio_texture.cpp
@@ -9,10 +9,23 @@
 #define LOG_TAG "mstream/viz-bridge"
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
 
+// Response-curve note (see AudioTexture::upload and the minDb_/maxDb_/
+// smoothing_ fields): the spectrum bytes are produced by normalize FFT
+// magnitude to source amplitude → EMA-smooth (linear domain) → map a dB
+// window to [0,1]. This mirrors the Web Audio AnalyserNode / Shadertoy
+// convention the bundled shaders were authored against. The three knobs
+// are runtime-tunable via setParams() (the in-app tuning panel):
+//   minDb / maxDb : dB window mapped onto [0,1]. Lower minDb surfaces more
+//                   low-level detail; raise maxDb if loud passages clip to
+//                   white. (0 dB == a full-scale tone in a single bin.)
+//   smoothing     : temporal EMA. 0 = raw (flickery), 0.8 = Web Audio
+//                   default. Higher = smoother but laggier bars.
+
 AudioTexture::AudioTexture()
     : windowed_(FFT_SIZE, 0.0f),
       hannWindow_(FFT_SIZE, 0.0f),
-      texBytes_(BINS * 2, 0) {
+      texBytes_(BINS * 2, 0),
+      smoothedMag_(BINS, 0.0f) {
     // Precompute the Hann window. Used to taper the FFT input so we
     // don't get spectral leakage from the rectangular edges.
     for (int i = 0; i < FFT_SIZE; ++i) {
@@ -20,7 +33,11 @@ AudioTexture::AudioTexture()
             0.5f * (1.0f - std::cos(2.0f * 3.14159265358979f *
                                      static_cast<float>(i) /
                                      static_cast<float>(FFT_SIZE - 1)));
+        windowSum_ += hannWindow_[i];
     }
+    // Maps raw |X[k]| to the source amplitude A (see header). Guard the
+    // degenerate window so we never divide by zero.
+    normScale_ = (windowSum_ > 0.0f) ? (2.0f / windowSum_) : 1.0f;
 }
 
 AudioTexture::~AudioTexture() {
@@ -36,8 +53,11 @@ bool AudioTexture::init() {
 
     glGenTextures(1, &tex_);
     glBindTexture(GL_TEXTURE_2D, tex_);
+    // Seed with the zero-initialized byte buffer so the texture has
+    // defined (silent) contents before the first PCM arrives — upload()
+    // now skips frames with no new audio, so frame 0 may sample this.
     glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, BINS, 2, 0, GL_RED,
-                  GL_UNSIGNED_BYTE, nullptr);
+                  GL_UNSIGNED_BYTE, texBytes_.data());
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -65,10 +85,27 @@ void AudioTexture::addPcm(const float* samples, std::size_t frameCount) {
         ring_[ringHead_] = mono;
         ringHead_ = (ringHead_ + 1) % RING_SIZE;
     }
+    dirty_ = true;
+}
+
+void AudioTexture::setParams(float minDb, float maxDb, float smoothing) {
+    // Reject an inverted/zero window (would divide by zero or flip the
+    // mapping); leave the previous values in place if so.
+    if (maxDb > minDb) {
+        minDb_ = minDb;
+        maxDb_ = maxDb;
+    }
+    smoothing_ = smoothing < 0.0f ? 0.0f
+               : (smoothing > 0.99f ? 0.99f : smoothing);
 }
 
 GLuint AudioTexture::upload() {
     if (!tex_ || !fft_) return 0;
+
+    // No new PCM since the last upload? The texture already holds the
+    // current spectrum/waveform — skip the FFT and the re-upload.
+    if (!dirty_) return tex_;
+    dirty_ = false;
 
     // Pull the most recent FFT_SIZE samples from the ring (in order).
     // ringHead_ points at the next write slot, so the newest sample is
@@ -85,17 +122,24 @@ GLuint AudioTexture::upload() {
     kiss_fft_cpx out[BINS + 1];
     kiss_fftr(fft_, windowed_.data(), out);
 
-    // Magnitude → 0..255. Empirical scale to spread typical music
-    // amplitudes across the byte range without aggressive clipping;
-    // shaders can scale up further. log1p compresses dynamic range
-    // similar to what Shadertoy's audio channel does.
+    // Spectrum row → 0..255. Normalize the raw FFT magnitude to source
+    // amplitude (normScale_), EMA-smooth it in the linear domain so the
+    // bars don't strobe, then map a dB window onto [0,1]. dB compression
+    // spreads musical dynamics perceptually and — unlike the old
+    // log1p(mag*4)*0.4 — leaves headroom so loud low bins no longer peg
+    // to white. This matches the Web Audio / Shadertoy convention, so the
+    // bundled shaders see the response curve they were authored for.
+    const float dbRange = maxDb_ - minDb_;
     for (int i = 0; i < BINS; ++i) {
         const float re = out[i].r;
         const float im = out[i].i;
-        const float mag = std::sqrt(re * re + im * im);
-        const float compressed = std::log1p(mag * 4.0f) * 0.4f;
-        const float clamped = compressed > 1.0f ? 1.0f : compressed;
-        texBytes_[i] = static_cast<uint8_t>(clamped * 255.0f);
+        const float mag = std::sqrt(re * re + im * im) * normScale_;
+        smoothedMag_[i] =
+            smoothing_ * smoothedMag_[i] + (1.0f - smoothing_) * mag;
+        const float db = 20.0f * std::log10(std::fmax(smoothedMag_[i], 1e-7f));
+        float v = (db - minDb_) / dbRange;
+        v = v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v);
+        texBytes_[i] = static_cast<uint8_t>(v * 255.0f);
     }
 
     // Waveform row — most recent BINS samples mapped from [-1,1] to [0,255].

--- a/android/app/src/main/cpp/audio_texture.h
+++ b/android/app/src/main/cpp/audio_texture.h
@@ -9,6 +9,15 @@
 // PCM in is interleaved stereo. We mix L+R to mono and keep a 2048-
 // sample ring buffer; per upload, we take the most recent 1024 samples,
 // window them, FFT, and write 512 mag bins + 512 waveform samples.
+//
+// The spectrum row follows the Web Audio AnalyserNode / Shadertoy
+// convention the bundled shaders were authored against: the FFT
+// magnitude is normalized to source amplitude (so it's independent of
+// FFT size / window), EMA-smoothed in the linear domain to stop the
+// bars strobing, then mapped through a dB window to [0,1]. This
+// replaces the old uncalibrated log1p() curve that clipped the low
+// bins to white and forced every shader to pre-attenuate. Tuning
+// constants live at the top of audio_texture.cpp.
 
 #pragma once
 
@@ -42,6 +51,12 @@ public:
     // per frame. Returns the GL texture name.
     GLuint upload();
 
+    // Live-tune the spectrum response curve (see upload()). Safe to call
+    // from a thread other than upload()'s — these are plain float writes
+    // and a torn read just means one stale frame, which is fine for a
+    // visual control. Invalid windows (maxDb <= minDb) are ignored.
+    void setParams(float minDb, float maxDb, float smoothing);
+
     GLuint texture() const { return tex_; }
 
 private:
@@ -57,4 +72,23 @@ private:
     std::vector<float> windowed_;     // FFT_SIZE
     std::vector<float> hannWindow_;   // FFT_SIZE, precomputed
     std::vector<uint8_t> texBytes_;   // BINS * 2 (one row of FFT, one of waveform)
+    std::vector<float> smoothedMag_;  // BINS — EMA of normalized magnitude (linear)
+
+    // Amplitude normalization derived from the window (computed in ctor).
+    // |X[k]| for a tone of amplitude A is A/2 · Σw, so 2/Σw recovers A
+    // (0 dB == full-scale single-bin tone), independent of FFT_SIZE.
+    float windowSum_ = 0.0f;          // Σ hannWindow_
+    float normScale_ = 0.0f;          // 2 / windowSum_
+
+    // Set by addPcm(), cleared by upload(); lets upload() skip the FFT
+    // when no new PCM arrived (render ~60 Hz outpaces PCM ~30 Hz, so
+    // this elides about half the FFTs).
+    bool dirty_ = false;
+
+    // Response-curve params, tunable at runtime via setParams(). Defaults
+    // are the Web Audio / Shadertoy-style curve we calibrated; the in-app
+    // tuning panel overrides them. See upload() for how they're applied.
+    float minDb_ = -69.7f;
+    float maxDb_ = -20.7f;
+    float smoothing_ = 0.27f;
 };

--- a/android/app/src/main/cpp/engine.h
+++ b/android/app/src/main/cpp/engine.h
@@ -34,4 +34,11 @@ public:
     //   ProjectM: .milk file contents
     //   Shader:   GLSL fragment shader (Shadertoy "mainImage" convention)
     virtual void loadPreset(const char* data, bool smoothTransition) = 0;
+
+    // Live-tune engine-specific parameters from a flat float array, pushed
+    // from the in-app tuning panel. The ShaderEngine maps [0..2] → the
+    // audio response curve (minDb, maxDb, smoothing) and [3..] → the
+    // iParams[] uniform exposed to shaders. Default no-op: engines that
+    // expose nothing tunable (e.g. ProjectM) ignore it.
+    virtual void setTuning(const float* /*values*/, std::size_t /*count*/) {}
 };

--- a/android/app/src/main/cpp/shader_engine.cpp
+++ b/android/app/src/main/cpp/shader_engine.cpp
@@ -42,6 +42,10 @@ uniform float iChannelTime[4];
 uniform vec3  iChannelResolution[4];
 uniform vec4  iDate;
 uniform float iSampleRate;
+// mstream tuning knobs, pushed from the in-app panel. Size must match
+// ShaderEngine::NUM_PARAMS. Shaders read iParams[i] where they'd otherwise
+// hardcode a constant; defaults are supplied by the UI on load.
+uniform float iParams[8];
 
 out vec4 outColor;
 
@@ -500,6 +504,7 @@ ShaderEngine::UniformLocs ShaderEngine::queryUniformLocations(GLuint program) {
     u.channelResolution = glGetUniformLocation(program, "iChannelResolution[0]");
     u.date              = glGetUniformLocation(program, "iDate");
     u.sampleRate        = glGetUniformLocation(program, "iSampleRate");
+    u.params            = glGetUniformLocation(program, "iParams[0]");
     return u;
 }
 
@@ -667,6 +672,7 @@ void ShaderEngine::renderPass(int idx, const Pass& p, GLuint targetFbo,
     if (p.locs.mouse      >= 0) glUniform4f(p.locs.mouse, 0,0,0,0);
     if (p.locs.date       >= 0) glUniform4f(p.locs.date, 0,0,0,0);
     if (p.locs.sampleRate >= 0) glUniform1f(p.locs.sampleRate, 44100.0f);
+    if (p.locs.params     >= 0) glUniform1fv(p.locs.params, NUM_PARAMS, params_);
     if (p.locs.channelTime >= 0) {
         const float t[4] = {elapsed,elapsed,elapsed,elapsed};
         glUniform1fv(p.locs.channelTime, 4, t);
@@ -772,6 +778,18 @@ void ShaderEngine::renderFrame() {
 
 void ShaderEngine::addPcm(const float* samples, std::size_t frameCount) {
     audio_.addPcm(samples, frameCount);
+}
+
+void ShaderEngine::setTuning(const float* values, std::size_t count) {
+    if (!values) return;
+    // Layout: [0]=minDb, [1]=maxDb, [2]=smoothing, [3..]=iParams[0..].
+    // Runs on the render thread (the bridge applies the latest value
+    // before renderFrame), so params_ writes don't race renderPass reads.
+    if (count >= 3) audio_.setParams(values[0], values[1], values[2]);
+    for (int i = 0; i < NUM_PARAMS; ++i) {
+        const std::size_t idx = static_cast<std::size_t>(i) + 3;
+        params_[i] = (idx < count) ? values[idx] : 0.0f;
+    }
 }
 
 void ShaderEngine::loadPreset(const char* data, bool /*smoothTransition*/) {

--- a/android/app/src/main/cpp/shader_engine.h
+++ b/android/app/src/main/cpp/shader_engine.h
@@ -64,6 +64,12 @@ public:
     void renderFrame() override;
     void addPcm(const float* samples, std::size_t frameCount) override;
     void loadPreset(const char* data, bool smoothTransition) override;
+    void setTuning(const float* values, std::size_t count) override;
+
+    // Number of user tuning floats exposed to shaders as `uniform float
+    // iParams[NUM_PARAMS]`. The first 3 setTuning() values drive the
+    // audio response curve; the remainder fill iParams.
+    static constexpr int NUM_PARAMS = 8;
 
     // Pass slot indices: 0..3 = bufferA..D, 4 = image. Used by the
     // anonymous-namespace parser in the .cpp; exposed here so it can
@@ -98,6 +104,7 @@ private:
         GLint channelResolution = -1;
         GLint date = -1;
         GLint sampleRate = -1;
+        GLint params = -1;   // iParams[NUM_PARAMS] — user tuning knobs
     };
 
     struct Pass {
@@ -184,6 +191,12 @@ private:
     static constexpr float kTransitionDuration = 0.6f;
 
     AudioTexture audio_;
+
+    // User tuning knobs pushed via setTuning(), bound to the iParams[]
+    // uniform each frame. Defaults to 0; the UI pushes each shader's
+    // declared defaults on load, so shaders that read iParams[i] always
+    // see a sensible value.
+    float params_[NUM_PARAMS] = {0.0f};
 
     // --- Worker thread state ---
     std::thread worker_;

--- a/android/app/src/main/cpp/visualizer_bridge.cpp
+++ b/android/app/src/main/cpp/visualizer_bridge.cpp
@@ -196,6 +196,23 @@ Java_com_example_mstream_1music_VisualizerBridge_nativeAddPcm(
 }
 
 JNIEXPORT void JNICALL
+Java_com_example_mstream_1music_VisualizerBridge_nativeSetTuning(
+        JNIEnv* env, jobject /*thiz*/, jlong ctxPtr,
+        jfloatArray valuesArray) {
+    auto* ctx = reinterpret_cast<BridgeContext*>(ctxPtr);
+    if (!ctx || !ctx->engine || !valuesArray) return;
+    jsize len = env->GetArrayLength(valuesArray);
+    if (len <= 0) return;
+    jfloat* data = env->GetFloatArrayElements(valuesArray, nullptr);
+    if (!data) return;
+    // setTuning touches no GL state, so no eglMakeCurrent needed; it runs
+    // on the render thread (Kotlin enqueues) so params don't race the
+    // renderFrame reads.
+    ctx->engine->setTuning(data, static_cast<std::size_t>(len));
+    env->ReleaseFloatArrayElements(valuesArray, data, JNI_ABORT);
+}
+
+JNIEXPORT void JNICALL
 Java_com_example_mstream_1music_VisualizerBridge_nativeLoadPresetData(
         JNIEnv* env, jobject /*thiz*/, jlong ctxPtr,
         jstring presetData, jboolean smoothTransition) {

--- a/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
@@ -39,6 +39,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
         surface: Surface, width: Int, height: Int, engineKind: Int): Long
     private external fun nativeRenderFrame(ctxPtr: Long)
     private external fun nativeAddPcm(ctxPtr: Long, samples: FloatArray)
+    private external fun nativeSetTuning(ctxPtr: Long, values: FloatArray)
     private external fun nativeLoadPresetData(
         ctxPtr: Long, presetData: String, smoothTransition: Boolean)
     private external fun nativeDispose(ctxPtr: Long)
@@ -70,6 +71,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
         when (call.method) {
             "create" -> handleCreate(call, result)
             "addPcm" -> handleAddPcm(call, result)
+            "setTuning" -> handleSetTuning(call, result)
             "loadPreset" -> handleLoadPreset(call, result)
             "pause" -> {
                 renderThread?.pauseRendering()
@@ -152,6 +154,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
             initFn = ::nativeInit,
             renderFn = ::nativeRenderFrame,
             addPcmFn = ::nativeAddPcm,
+            setTuningFn = ::nativeSetTuning,
             disposeFn = ::nativeDispose,
         ).also { it.start() }
 
@@ -173,6 +176,23 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
             }
         }
         renderThread?.enqueuePcm(samples)
+        result.success(null)
+    }
+
+    private fun handleSetTuning(call: MethodCall, result: MethodChannel.Result) {
+        val raw = call.argument<Any>("values")
+        val values = when (raw) {
+            is FloatArray -> raw
+            is DoubleArray -> FloatArray(raw.size) { raw[it].toFloat() }
+            is List<*> -> FloatArray(raw.size) { (raw[it] as Number).toFloat() }
+            else -> {
+                result.success(null)
+                return
+            }
+        }
+        // Applied on the render thread before the next frame, so it can't
+        // race the native renderFrame's uniform reads.
+        renderThread?.enqueueTuning(values)
         result.success(null)
     }
 
@@ -199,6 +219,7 @@ private class RenderThread(
     private val initFn: (Surface, Int, Int, Int) -> Long,
     private val renderFn: (Long) -> Unit,
     private val addPcmFn: (Long, FloatArray) -> Unit,
+    private val setTuningFn: (Long, FloatArray) -> Unit,
     private val disposeFn: (Long) -> Unit,
 ) : Thread("mstream-visualizer-render") {
 
@@ -207,12 +228,19 @@ private class RenderThread(
     private val pauseLock = Object()
     private val pcmQueue = ConcurrentLinkedQueue<FloatArray>()
     private val presetQueue = ConcurrentLinkedQueue<Triple<String, Boolean, (Long, String, Boolean) -> Unit>>()
+    // Only the most recent tuning snapshot matters, so a single volatile
+    // slot (not a queue) — a fast slider drag just coalesces.
+    @Volatile private var pendingTuning: FloatArray? = null
     private val frameNanos = 1_000_000_000L / 60L // ~16.67 ms
 
     fun enqueuePcm(samples: FloatArray) {
         pcmQueue.offer(samples)
         // Cap backlog so a paused render thread doesn't OOM.
         while (pcmQueue.size > 8) pcmQueue.poll()
+    }
+
+    fun enqueueTuning(values: FloatArray) {
+        pendingTuning = values
     }
 
     fun enqueuePreset(data: String, smooth: Boolean,
@@ -278,6 +306,7 @@ private class RenderThread(
                 }
                 drainPresets(ctx)
                 drainPcm(ctx)
+                drainTuning(ctx)
                 renderFn(ctx)
                 lastFrame += frameNanos
                 val sleep = lastFrame - System.nanoTime()
@@ -305,6 +334,12 @@ private class RenderThread(
             addPcmFn(ctx, batch)
             batch = pcmQueue.poll()
         }
+    }
+
+    private fun drainTuning(ctx: Long) {
+        val t = pendingTuning ?: return
+        pendingTuning = null
+        setTuningFn(ctx, t)
     }
 
     private fun drainPresets(ctx: Long) {

--- a/assets/shaders/01-spectrum-bars.glsl
+++ b/assets/shaders/01-spectrum-bars.glsl
@@ -5,12 +5,18 @@
 //
 // Demonstrates the simplest audio reaction — sample the FFT row of
 // iChannel0 (y near 0.25) at one frequency per bar.
+//
+// params (iParams[]):
+//   0 = contrast (FFT bar contrast / pow exponent)
+//   1 = bars (number of bars across the screen)
+// param: contrast 0.5 3.0 1.51
+// param: bars 12 96 76
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 uv = fragCoord / iResolution.xy;
 
-    // 48 bars across the screen.
-    float numBars = 48.0;
+    // Bar count (iParams[1]); floor keeps whole bars while dragging.
+    float numBars = floor(iParams[1]);
     float bar = floor(uv.x * numBars);
     float barCenter = (bar + 0.5) / numBars;
 
@@ -24,9 +30,9 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // frequencies instead of dead air at 15–22 kHz.
     float freq = pow(bar / numBars, 1.6) * 0.30;
     float amp = texture(iChannel0, vec2(freq, 0.25)).x;
-    // pow expands contrast; no extra gain (real audio is hot enough
-    // that the old *1.4 pegged the bass bars at full height).
-    amp = pow(amp, 1.5);
+    // pow expands contrast (iParams[0]); no extra gain (real audio is
+    // hot enough that the old *1.4 pegged the bass bars at full height).
+    amp = pow(amp, iParams[0]);
 
     // Gap between bars.
     float barWidth = 0.7 / numBars;

--- a/assets/shaders/02-audio-tunnel.glsl
+++ b/assets/shaders/02-audio-tunnel.glsl
@@ -6,6 +6,12 @@
 //
 // Demonstrates the "sample 3 bands" pattern — useful for picking out
 // rhythm sections without doing a full equalizer.
+//
+// params (iParams[]):
+//   0 = bassSpeed (how much bass accelerates the tunnel)
+//   1 = trebleGlow (treble spoke brightness)
+// param: bassSpeed 0.0 2.5 0.19
+// param: trebleGlow 0.0 4.0 2.53
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
@@ -27,7 +33,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
     // Tunnel rings. log(r) gives even spacing in screen space as
     // they recede; scroll outward over time, faster with bass.
-    float speed = 0.4 + bass * 0.8;
+    float speed = 0.4 + bass * iParams[0];
     float ring = fract(log(max(r, 0.001)) * 3.0 - iTime * speed);
     float ringEdge = smoothstep(0.5, 0.42, abs(ring - 0.5));
 
@@ -37,7 +43,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec3 col = mix(cold, warm, clamp(mids, 0.0, 1.0));
 
     float spoke = 0.5 + 0.5 * sin(a * 12.0 + iTime * 0.6);
-    col += pow(spoke, 12.0) * treble * vec3(1.0, 0.8, 0.4) * 1.5;
+    col += pow(spoke, 12.0) * treble * vec3(1.0, 0.8, 0.4) * iParams[1];
 
     // Vignette by 1/r so the center stays bright and the edges fall off.
     col *= ringEdge / max(r * 1.4, 0.18);

--- a/assets/shaders/03-plasma-pulse.glsl
+++ b/assets/shaders/03-plasma-pulse.glsl
@@ -7,6 +7,10 @@
 //
 // Demonstrates the "average FFT into a loudness signal" pattern, useful
 // when you want music-reactive intensity without picking specific bands.
+//
+// params (iParams[]):
+//   0 = reactivity (loudness → brightness gain)
+// param: reactivity 0.0 5.0 2.37
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 uv = fragCoord / iResolution.xy;
@@ -39,7 +43,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     col.g = 0.5 + 0.5 * sin(v * 3.14159 + 2.094);
     col.b = 0.5 + 0.5 * sin(v * 3.14159 + 4.188);
 
-    col *= 0.35 + loudness * 2.0;
+    col *= 0.35 + loudness * iParams[0];
 
     fragColor = vec4(col, 1.0);
 }

--- a/assets/shaders/04-cyber-fuji.glsl
+++ b/assets/shaders/04-cyber-fuji.glsl
@@ -51,6 +51,14 @@
 //
 // Synthwave / Outrun-style sun + mountains + grid sunset.
 //
+// params (iParams[]):
+//   0 = bassGain (sun bloom throb)     1 = lowMidGain (mountain width)
+//   2 = midGain (grid sway)            3 = trebleGain (cloud bounce)
+// param: bassGain 0.0 0.40 0.11
+// param: lowMidGain 0.0 0.40 0.10
+// param: midGain 0.0 0.60 0.26
+// param: trebleGain 0.0 0.60 0.17
+//
 // === channel image.0 = music
 // === channel image.1 = buffera
 // === channel buffera.0 = music
@@ -298,19 +306,19 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     for (int i = 0; i < 6; i++) {
         rawBass += texture(iChannel0, vec2(0.004 + float(i) * 0.004, 0.25)).x;
     }
-    rawBass = clamp(rawBass * 0.13, 0.0, 1.0);
+    rawBass = clamp(rawBass * iParams[0], 0.0, 1.0);
 
     float rawLowMid = 0.0;
     for (int i = 0; i < 6; i++) {
         rawLowMid += texture(iChannel0, vec2(0.028 + float(i) * 0.006, 0.25)).x;
     }
-    rawLowMid = clamp(rawLowMid * 0.14, 0.0, 1.0);
+    rawLowMid = clamp(rawLowMid * iParams[1], 0.0, 1.0);
 
     float rawMid = 0.0;
     for (int i = 0; i < 6; i++) {
         rawMid += texture(iChannel0, vec2(0.070 + float(i) * 0.020, 0.25)).x;
     }
-    rawMid = clamp(rawMid * 0.24, 0.0, 1.0);
+    rawMid = clamp(rawMid * iParams[2], 0.0, 1.0);
 
     float rawTreble = 0.0;
     for (int i = 0; i < 6; i++) {
@@ -319,16 +327,17 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Real music has far less 8-11 kHz "air" than the old synth signal,
     // so sample the lower "presence" range (~3-7 kHz: cymbals, hi-hats,
     // sibilance) and boost the gain so clouds react to real audio.
-    rawTreble = clamp(rawTreble * 0.22, 0.0, 1.0);
+    rawTreble = clamp(rawTreble * iParams[3], 0.0, 1.0);
 
     vec4 raw  = vec4(rawBass, rawLowMid, rawMid, rawTreble);
-    // Square all bands (mrange's "fft *= fft" technique from neonwave
-    // sunset): expands dynamic range so every element sits calm on
-    // quiet passages and pops on transients, instead of riding the
-    // log1p compression's always-hot floor. Prescales above are set so
-    // typical-loud music lands near ~0.9 pre-square (not pre-clamped),
-    // and the visual amplitudes below are sized for the squared output.
-    raw *= raw;
+    // NOTE: an `raw *= raw` square (mrange's "fft *= fft" trick) used to
+    // sit here to claw dynamic range back out of the engine's old log1p
+    // FFT curve, which clamped the low bins to an always-hot floor. The
+    // audio texture now ships a normalized, dB-mapped, EMA-smoothed
+    // spectrum (Web Audio / Shadertoy convention), so that square would
+    // be redundant double-compression — removed. The prescales above act
+    // as per-band sum→[0,1] normalizers; the visual amplitudes below are
+    // sized for these (un-squared) band levels.
     vec4 prev = texture(iChannel1, vec2(0.5, 0.5));
 
     // Asymmetric smoothing vec4-wise: 0.15 attack (raw > prev), 0.5 release.

--- a/assets/shaders/05-hex-marching.glsl
+++ b/assets/shaders/05-hex-marching.glsl
@@ -2,18 +2,35 @@
 // author: mrange (Shadertoy)
 // source: https://www.shadertoy.com/view/NdKyDw
 // license: CC0 (Public Domain dedication)
-// modifications: (1) repackaged into our multipass format.
-//                (2) image pass gains an iChannel1 = music route and
-//                samples the bass FFT to add a brightness pulse on
-//                beats. Original buffer pass sources untouched.
+// modifications: (1) repackaged into our multipass format; the upstream
+//                buffer/image passes are otherwise unchanged.
+//                (2) bufferC is an added bass ONSET detector: it tracks a
+//                baseline of the low-frequency energy and emits only how
+//                far the current bass rises ABOVE it, so the image pass
+//                flashes on kicks and stays neutral between them. Replaces
+//                an earlier bass→brightness multiplier that rode the
+//                absolute bass *level* and read as permanently pegged.
 //
 // Multipass: bufferA computes hex marching geometry, bufferB does a feedback
-// pass sampling itself + bufferA, image samples bufferB for the final frame.
+// pass sampling itself + bufferA, bufferC tracks the bass-onset envelope,
+// image samples bufferB (scene) + bufferC (pulse) for the final frame.
+//
+// params (iParams[]):
+//   0 = flash (kick flash strength)        1 = sensitivity (onset gain)
+//   2 = baseline (bass baseline inertia)   3 = release (flash decay)
+//   4 = deadzone (onset noise floor)
+// param: flash 0.0 2.25 1.76
+// param: sensitivity 1.0 18.0 9.4
+// param: baseline 0.80 0.99 0.89
+// param: release 0.70 0.98 0.86
+// param: deadzone 0.0 0.15 0.023
 //
 // === channel image.0 = bufferb
-// === channel image.1 = music
+// === channel image.1 = bufferc
 // === channel bufferb.0 = buffera
 // === channel bufferb.1 = bufferb
+// === channel bufferc.0 = music
+// === channel bufferc.1 = bufferc
 //
 // === pass: image ===
 // License CC0: Hex Marching
@@ -27,24 +44,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   col = clamp(col, 0.0, 1.0);
   col *= smoothstep(0.0, 2.0, TIME);
 
-  // mstream addition: brightness pulses on bass hits. Sample a few
-  // low FFT bins from the music channel (iChannel1) and use them as
-  // a multiplier on the otherwise time-only output.
-  // AudioTexture has 512 bins (~43 Hz/bin @ 44.1 kHz); these 4 samples
-  // cover bins ~2–7 ≈ 85–300 Hz, the kick/sub-bass range.
-  float bass = 0.0;
-  for (int i = 0; i < 4; i++) {
-    bass += texture(iChannel1, vec2(float(i) * 0.004 + 0.004, 0.25)).x;
-  }
-  // Lower prescale so loud bass doesn't pre-clamp before the square,
-  // and square for dynamic range (mrange's "fft *= fft" technique).
-  bass = clamp(bass * 0.20, 0.0, 1.0);
-  bass *= bass;
-  // Gentle brightness coefficient: this multiply lands right before the
-  // sqrt() gamma below, so a big boost pushes bright pixels past 1.0 and
-  // clips them to white (the "saturated" look). 0.45 keeps the pulse
-  // visible without blowing out highlights.
-  col *= 1.0 + bass * 0.45;
+  // mstream: flash on bass onsets. bufferC (iChannel1) outputs a pulse in
+  // .r that spikes when bass rises above its recent baseline and decays to
+  // ~0 between hits — a transient flash, NOT a constant brightness boost
+  // (the constant boost is what made the old level-based mod peg).
+  float pulse = texture(iChannel1, vec2(0.5, 0.5)).x;
+  col *= 1.0 + pulse * iParams[0];   // iParams[0] = flash strength
 
   col = sqrt(col);
   fragColor = vec4(col, 1.0);
@@ -313,6 +318,38 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   
   vec3 col = pcol.xyz;
   col += vec3(0.9, .8, 1.2)*mix(0.5, 0.66, length(p))*(0.05+bcol);
-  
+
   fragColor = vec4(col, 1.0);
+}
+// === pass: bufferc ===
+// Bass onset detector (mstream addition). Writes one value to every pixel;
+// the image pass samples a single texel.
+//   iChannel0 = music   (FFT spectrum row, y=0.25)
+//   iChannel1 = bufferc  (self-feedback: previous frame's {pulse, baseline})
+// Output: .r = pulse (0..1, flares on kicks, ~0 between), .g = bass baseline.
+//
+// Buffers are RGBA8, so the feedback EMA only resolves ~1/255 per step. We
+// keep the baseline time-constant moderate and add a small dead-zone on the
+// onset so 8-bit quantization noise can't leak through as a constant glow.
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  // Current bass = mean of the lowest 4 bins (kick / sub-bass,
+  // ~85-345 Hz at the 512-bin, 44.1 kHz layout).
+  float bass = 0.0;
+  for (int i = 0; i < 4; i++) {
+    bass += texture(iChannel0, vec2(float(i) * 0.004 + 0.004, 0.25)).x;
+  }
+  bass *= 0.25;
+
+  vec4 prev = texture(iChannel1, vec2(0.5, 0.5));
+  // Baseline inertia (iParams[2]): follows sustained bass, lags transients.
+  float baseline = mix(bass, prev.y, iParams[2]);
+
+  // Onset = bass above baseline, past a dead-zone (iParams[4]) that eats
+  // the ~1/255 quantization band. ~0 in steady state; spikes on a kick.
+  // iParams[1] = sensitivity (onset gain).
+  float onset = clamp((bass - baseline - iParams[4]) * iParams[1], 0.0, 1.0);
+  // Instant attack; iParams[3] = release (flash decay per frame).
+  float pulse = max(onset, prev.x * iParams[3]);
+
+  fragColor = vec4(pulse, baseline, 0.0, 1.0);
 }

--- a/assets/shaders/06-4d-beats.glsl
+++ b/assets/shaders/06-4d-beats.glsl
@@ -6,6 +6,10 @@
 //                wires iChannel0 to our audio texture by default.
 //
 // Beat-driven 4D grid visualization by mrange, animated by audio FFT.
+//
+// params (iParams[]):
+//   0 = tempo (beat-clock multiplier)
+// param: tempo 0.5 4.0 1.9
 
 // CC0: 4D Beats
 // Continuing experiments with yesterday's grid structure
@@ -32,7 +36,7 @@ void mainImage(out vec4 O, vec2 C) {
   // Musical timing: beat-synced animation
   //  floor(T)+sqrt(F) gives the beat synchronized speed-up
   //  floor(T)+F*F also works
-  float i,z,d,k,T=iChannelTime[0]*1.9,F=fract(T),t=floor(T)+sqrt(F);
+  float i,z,d,k,T=iChannelTime[0]*iParams[0],F=fract(T),t=floor(T)+sqrt(F);
   
   // 2D rotation matrix that spins based on musical beats
   mat2 R=mat2(cos(t*.1+11.*U.wxzw));

--- a/assets/shaders/07-neonwave-sunrise.glsl
+++ b/assets/shaders/07-neonwave-sunrise.glsl
@@ -6,6 +6,10 @@
 //                wires iChannel0 to our audio texture by default.
 //
 // Synthwave sunrise — neon sun + reflective water, music-reactive.
+//
+// params (iParams[]):
+//   0 = fftBars (moon FFT bar height)
+// param: fftBars 0.0 0.2 0.074
 
 // CC0 - Neonwave sunrise
 //  Inspired by a tweet by I wanted to create something that looked
@@ -255,7 +259,7 @@ vec4 moon(vec3 ro, vec3 rd) {
     float d0    = abs(pp.y);
     vec2 cp     = vec2(0.055*abs(msny-float(i)), 0.25);
     float fft   = texture(iChannel0, cp).x;
-    float d1    = length(pp)-0.05*fft;
+    float d1    = length(pp)-iParams[0]*fft;
     float h     =mix(0.66, 0.99, fft);
     vec3 mcol1  = hsv2rgb(vec3(h, 0.55, 1.0));
     vec3 mcol2  = hsv2rgb(vec3(h, 0.85, 1.0));

--- a/assets/shaders/08-neonwave-sunset.glsl
+++ b/assets/shaders/08-neonwave-sunset.glsl
@@ -6,6 +6,10 @@
 //                wires iChannel0 to our audio texture by default.
 //
 // Synthwave sunset companion to Neonwave sunrise, music-reactive.
+//
+// params (iParams[]):
+//   0 = synthGain (roadside oscilloscope height)
+// param: synthGain 0.0 3.0 1.0
 
 // License CC0: Neon Sunset
 //  Code is hackish but I thought it looked good enough to share
@@ -146,7 +150,7 @@ float synth(vec2 p, float aa, out float h, out float db) {
   const int around = 0;
   for (int i = -around; i <=around ;++i) {
     float fft = texture(iChannel0, vec2((n+float(i))*st, 0.25)).x; 
-    fft *= fft;
+    fft *= fft * iParams[0];
     if (i == 0) h = fft;
     float dibb = segmentx((p-vec2(st*float(i), 0.0)).yx, fft+0.05)-st*0.4;
     dib = min(dib, dibb);

--- a/lib/native/shader_params.dart
+++ b/lib/native/shader_params.dart
@@ -1,0 +1,62 @@
+// Parses the per-shader tuning knobs a `.glsl` declares in its header.
+//
+// A shader exposes a knob with a comment line of the form:
+//
+//   // param: <name> <min> <max> <default>
+//
+// e.g.  // param: flash 0.0 1.5 0.6
+//
+// The i-th `// param:` line (in source order) maps to `iParams[i]` in the
+// shader — the engine binds the pushed values to a `uniform float
+// iParams[NUM_PARAMS]`. The in-app tuning panel builds one slider per
+// declared param, and pushes the values through VisualizerBridge.setTuning
+// prefixed by the three global response-curve knobs.
+
+/// One tunable knob declared by a shader. [index] is its `iParams[]` slot.
+class ShaderParam {
+  final int index;
+  final String name;
+  final double min;
+  final double max;
+  final double def;
+
+  const ShaderParam({
+    required this.index,
+    required this.name,
+    required this.min,
+    required this.max,
+    required this.def,
+  });
+
+  /// Clamp a value to this param's declared range.
+  double clamp(double v) => v < min ? min : (v > max ? max : v);
+}
+
+final RegExp _paramLine = RegExp(
+  r'^\s*//\s*param:\s*([A-Za-z0-9_]+)\s+(-?[0-9]*\.?[0-9]+)\s+'
+  r'(-?[0-9]*\.?[0-9]+)\s+(-?[0-9]*\.?[0-9]+)\s*$',
+  multiLine: true,
+);
+
+/// Extracts `// param:` declarations from [source], in declaration order
+/// (so each param's list position == its `iParams[]` index). Malformed or
+/// degenerate (max <= min) lines are skipped. Capped at [maxParams] to
+/// match the engine's `iParams[]` size.
+List<ShaderParam> parseShaderParams(String source, {int maxParams = 8}) {
+  final out = <ShaderParam>[];
+  for (final m in _paramLine.allMatches(source)) {
+    if (out.length >= maxParams) break;
+    final min = double.tryParse(m.group(2)!);
+    final max = double.tryParse(m.group(3)!);
+    final def = double.tryParse(m.group(4)!);
+    if (min == null || max == null || def == null || max <= min) continue;
+    out.add(ShaderParam(
+      index: out.length,
+      name: m.group(1)!,
+      min: min,
+      max: max,
+      def: def,
+    ));
+  }
+  return out;
+}

--- a/lib/native/visualizer_bridge.dart
+++ b/lib/native/visualizer_bridge.dart
@@ -49,6 +49,20 @@ class VisualizerBridge {
     }
   }
 
+  /// Pushes live tuning values to the engine. Layout is
+  /// `[minDb, maxDb, smoothing, p0, p1, …]`: the first three drive the
+  /// native audio response curve, the rest fill the shaders' `iParams[]`
+  /// uniform. Applied on the render thread before the next frame.
+  /// No-op on the Milkdrop engine. Best-effort (purely cosmetic).
+  static Future<void> setTuning(List<double> values) async {
+    try {
+      await _channel.invokeMethod(
+          'setTuning', {'values': Float32List.fromList(values)});
+    } on PlatformException {
+      // best-effort: tuning is cosmetic
+    }
+  }
+
   /// Loads a Milkdrop preset from in-memory `.milk` text. Faster than
   /// the file-path variant since native code doesn't have to read from
   /// the filesystem (or be granted permission to). [smooth] enables

--- a/lib/native/visualizer_presets.dart
+++ b/lib/native/visualizer_presets.dart
@@ -31,6 +31,18 @@ class VisualizerPresets {
   final Map<VisualizerPresetKind, int> _cursors = {};
   final Random _rng = Random();
 
+  // The most recently loaded preset's asset path and raw source. The
+  // visualizer screen reads [currentShaderSource] to parse `// param:`
+  // tuning knobs, and uses [currentShaderPath] as the persistence key.
+  String? _currentPath;
+  String? _currentSource;
+
+  /// Asset path of the most recently loaded preset (null until one loads).
+  String? get currentShaderPath => _currentPath;
+
+  /// Raw source of the most recently loaded preset (null until one loads).
+  String? get currentShaderSource => _currentSource;
+
   String _directoryFor(VisualizerPresetKind kind) {
     switch (kind) {
       case VisualizerPresetKind.milkdrop:
@@ -75,31 +87,36 @@ class VisualizerPresets {
   }
 
   /// Load a random preset of the given kind into the running engine.
-  /// No-op if nothing is bundled.
-  Future<void> loadRandom(
+  /// Returns the loaded asset path (or null if nothing is bundled).
+  Future<String?> loadRandom(
     VisualizerPresetKind kind, {
     bool smooth = true,
   }) async {
     final paths = await _list(kind);
-    if (paths.isEmpty) return;
+    if (paths.isEmpty) return null;
     final pick = paths[_rng.nextInt(paths.length)];
     await _loadByPath(pick, smooth: smooth);
+    return pick;
   }
 
   /// Advance to the next preset in the sorted list, wrapping around.
-  Future<void> loadNext(
+  /// Returns the loaded asset path (or null if nothing is bundled).
+  Future<String?> loadNext(
     VisualizerPresetKind kind, {
     bool smooth = true,
   }) async {
     final paths = await _list(kind);
-    if (paths.isEmpty) return;
+    if (paths.isEmpty) return null;
     final next = ((_cursors[kind] ?? -1) + 1) % paths.length;
     _cursors[kind] = next;
     await _loadByPath(paths[next], smooth: smooth);
+    return paths[next];
   }
 
   Future<void> _loadByPath(String assetPath, {required bool smooth}) async {
     final data = await rootBundle.loadString(assetPath);
+    _currentPath = assetPath;
+    _currentSource = data;
     await VisualizerBridge.loadPreset(data, smooth: smooth);
   }
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -153,6 +153,22 @@ class _SettingsScreenState extends State<SettingsScreen> {
               onChanged: (v) => _onVisualizerSourceChanged(v),
             ),
           ),
+          SwitchListTile(
+            title: Text('Visualizer tuning knobs'),
+            subtitle: Text(
+              'Show live sliders over the visualizer to tweak each '
+              'shader\'s audio reactivity. Shader engine only.',
+              style: TextStyle(
+                  color: VelvetColors.textSecondary, fontSize: 12),
+            ),
+            value: SettingsManager().showVisualizerKnobs,
+            onChanged: (v) async {
+              setState(() {});
+              await SettingsManager().setShowVisualizerKnobs(v);
+              setState(() {});
+            },
+            activeThumbColor: VelvetColors.primary,
+          ),
           Divider(color: VelvetColors.border, height: 1),
           _sectionHeader('Browse'),
           SwitchListTile(

--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../native/projectm_controller.dart';
+import '../native/shader_params.dart';
 import '../native/visualizer_bridge.dart';
 import '../native/visualizer_presets.dart';
 import '../singletons/settings.dart';
@@ -36,6 +37,31 @@ class _VisualizerScreenState extends State<VisualizerScreen>
   VisualizerPresetKind get _presetKind => _engine == VisualizerEngine.shader
       ? VisualizerPresetKind.shader
       : VisualizerPresetKind.milkdrop;
+
+  // --- Tuning panel (Shader engine + showVisualizerKnobs only) ---------
+  // Whether to surface the live tuning sliders at all. Snapshotted at
+  // bringup like _engine (the setting can't change while we're open).
+  late final bool _knobsEnabled = _engine == VisualizerEngine.shader &&
+      SettingsManager().showVisualizerKnobs;
+  bool _panelOpen = false;
+  String? _shaderKey; // current shader asset path (persistence key)
+  List<ShaderParam> _shaderParams = const [];
+  List<double> _paramValues = []; // per-shader iParams values
+  List<double> _globalValues =
+      List<double>.from(SettingsManager.defaultGlobalParams);
+
+  // Slider [min, max] and labels for the global response-curve knobs, in
+  // the same order as SettingsManager.defaultGlobalParams.
+  static const List<List<double>> _globalRanges = [
+    [-120.0, -50.0], // dB floor (minDb)
+    [-60.0, -5.0], // dB ceiling (maxDb)
+    [0.0, 0.95], // smoothing
+  ];
+  static const List<String> _globalLabels = [
+    'dB floor',
+    'dB ceiling',
+    'Smoothing',
+  ];
 
   @override
   void initState() {
@@ -82,11 +108,15 @@ class _VisualizerScreenState extends State<VisualizerScreen>
   // before _bringUpBridge has succeeded).
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (_textureId == null) return;
+    if (!mounted || _textureId == null) return;
     switch (state) {
-      case AppLifecycleState.paused:
       case AppLifecycleState.inactive:
       case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+        // Backgrounded but the activity is still alive — home, app switch,
+        // notification shade, etc. Park the render loop to save power and
+        // STAY on the screen, so returning resumes the visualizer right
+        // where it left off.
         if (!_backgroundPaused) {
           _backgroundPaused = true;
           VisualizerAudio().stop();
@@ -101,7 +131,15 @@ class _VisualizerScreenState extends State<VisualizerScreen>
         }
         break;
       case AppLifecycleState.detached:
-        // App is shutting down — dispose() will run shortly.
+        // The activity was destroyed while the Flutter engine/isolate lives
+        // on — which is exactly what swiping the app away from recents does
+        // while audio_service keeps the process alive for playback. (A plain
+        // home-press only stops the activity → 'paused', not 'detached', so
+        // the visualizer survives and resumes.) Pop the visualizer so the
+        // retained navigation stack drops back to the main screen and the
+        // next open lands there. When nothing keeps the process alive,
+        // swipe-away just kills it and a relaunch is a fresh start anyway.
+        Navigator.of(context).maybePop();
         break;
     }
   }
@@ -139,31 +177,141 @@ class _VisualizerScreenState extends State<VisualizerScreen>
       // falls back to its idle preset if we don't load one (still
       // looks fine); ShaderEngine clears to black so loading is
       // essential.
-      await VisualizerPresets().loadRandom(_presetKind, smooth: false);
+      final path = await VisualizerPresets().loadRandom(_presetKind, smooth: false);
+      _onShaderLoaded(path);
     }
+  }
+
+  // Cycle to the next preset, then refresh the tuning panel for it.
+  Future<void> _nextPreset() async {
+    final path = await VisualizerPresets().loadNext(_presetKind);
+    _onShaderLoaded(path);
+  }
+
+  // Called after every shader load. Parses the shader's `// param:`
+  // knobs, loads persisted-or-default values, and pushes them to the
+  // engine. Runs for the Shader engine regardless of whether the panel
+  // is visible — shaders read iParams[i] and would otherwise see 0, so
+  // their declared defaults must always be pushed.
+  void _onShaderLoaded(String? path) {
+    if (!mounted || _engine != VisualizerEngine.shader || path == null) return;
+    final source = VisualizerPresets().currentShaderSource ?? '';
+    final params = parseShaderParams(source);
+    final saved = SettingsManager().visualizerShaderParams[path];
+    final values = <double>[
+      for (var i = 0; i < params.length; i++)
+        params[i].clamp((saved != null && i < saved.length)
+            ? saved[i]
+            : params[i].def),
+    ];
+    final g = SettingsManager().visualizerGlobalParams;
+    final globals = g.length == _globalLabels.length
+        ? List<double>.from(g)
+        : List<double>.from(SettingsManager.defaultGlobalParams);
+    setState(() {
+      _shaderKey = path;
+      _shaderParams = params;
+      _paramValues = values;
+      _globalValues = globals;
+    });
+    _pushTuning();
+  }
+
+  // Push [global response curve..., per-shader params...] to the engine.
+  void _pushTuning() {
+    VisualizerBridge.setTuning([..._globalValues, ..._paramValues]);
+  }
+
+  void _persistGlobal() =>
+      SettingsManager().setVisualizerGlobalParams(_globalValues);
+
+  void _persistShader() {
+    final key = _shaderKey;
+    if (key != null) {
+      SettingsManager().setVisualizerShaderParams(key, _paramValues);
+    }
+  }
+
+  // Reset the current shader's knobs + the global curve to their
+  // defaults and drop the saved overrides.
+  void _resetTuning() {
+    setState(() {
+      _paramValues = _shaderParams.map((p) => p.def).toList();
+      _globalValues = List<double>.from(SettingsManager.defaultGlobalParams);
+    });
+    _pushTuning();
+    final key = _shaderKey;
+    if (key != null) SettingsManager().clearVisualizerShaderParams(key);
+    SettingsManager().setVisualizerGlobalParams(const []);
   }
 
   @override
   Widget build(BuildContext context) {
     final supported = Platform.isAndroid;
-    // No AppBar — the visualizer is fullscreen + immersive. Long-press
-    // exits (the bottom overlay still tells the user how).
+    // No AppBar — the visualizer is fullscreen + immersive. The top-left
+    // back button is the reliable exit; tap-to-cycle and long-press are
+    // secondary.
     return Scaffold(
       backgroundColor: Colors.black,
-      body: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        // Tap when rendering = next preset (so the user can cycle).
-        // Tap when stuck on the placeholder = close (no preset to
-        // switch). Long-press always closes — escape hatch.
-        onTap: () {
-          if (_textureId != null) {
-            VisualizerPresets().loadNext(_presetKind);
-          } else {
-            Navigator.of(context).maybePop();
-          }
-        },
-        onLongPress: () => Navigator.of(context).maybePop(),
-        child: supported ? _androidBody() : _unsupported(),
+      body: Stack(
+        children: [
+          GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            // Tap when rendering = next preset (so the user can cycle).
+            // Tap on the placeholder = exit. Long-press always exits.
+            onTap: () {
+              if (_textureId != null) {
+                _nextPreset();
+              } else {
+                _exit();
+              }
+            },
+            onLongPress: _exit,
+            child: supported ? _androidBody() : _unsupported(),
+          ),
+          // Always-visible escape hatch, on top of everything. Guarantees a
+          // way out even if the OS resumes the app straight into the
+          // visualizer after a swipe-away — immersive mode hides the system
+          // back affordance and long-press isn't discoverable.
+          SafeArea(
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: _closeButton(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Reliable exit: pop back into the app if possible; if the visualizer is
+  // somehow the only route, drop to the OS rather than trap the user.
+  void _exit() {
+    final nav = Navigator.of(context);
+    if (nav.canPop()) {
+      nav.pop();
+    } else {
+      SystemNavigator.pop();
+    }
+  }
+
+  Widget _closeButton() {
+    return GestureDetector(
+      onTap: _exit,
+      child: Container(
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: Colors.black.withAlpha(120),
+          shape: BoxShape.circle,
+        ),
+        child: Icon(
+          Icons.arrow_back,
+          color: Colors.white.withAlpha(230),
+          size: 22,
+        ),
       ),
     );
   }
@@ -184,7 +332,7 @@ class _VisualizerScreenState extends State<VisualizerScreen>
             left: 0,
             right: 0,
             child: Text(
-              'Tap = next preset · long-press to close',
+              'Tap = next preset · back arrow (top-left) or long-press to exit',
               textAlign: TextAlign.center,
               style: TextStyle(
                 color: Colors.white.withAlpha(160),
@@ -193,10 +341,215 @@ class _VisualizerScreenState extends State<VisualizerScreen>
               ),
             ),
           ),
+          if (_knobsEnabled) ..._tuningOverlay(),
         ],
       );
     }
     return Center(child: _statusPlaceholder());
+  }
+
+  // Live tuning overlay: a gear handle that toggles a right-side slider
+  // panel. Both absorb their own taps so they don't trigger next-preset.
+  List<Widget> _tuningOverlay() {
+    return [
+      // Gear handle, only while the panel is closed (the open panel sits
+      // on top and carries its own close button).
+      if (!_panelOpen)
+        Positioned(
+          top: 12,
+          right: 12,
+          child: GestureDetector(
+            onTap: () => setState(() => _panelOpen = true),
+            child: Container(
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: Colors.black.withAlpha(120),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.tune,
+                color: Colors.white.withAlpha(220),
+                size: 22,
+              ),
+            ),
+          ),
+        ),
+      if (_panelOpen)
+        Positioned(
+          top: 0,
+          bottom: 0,
+          right: 0,
+          width: 340,
+          child: GestureDetector(
+            // Absorb taps so the parent's next-preset handler doesn't fire.
+            onTap: () {},
+            child: Container(
+              color: Colors.black.withAlpha(190),
+              child: SafeArea(child: _tuningPanelContent()),
+            ),
+          ),
+        ),
+    ];
+  }
+
+  Widget _tuningPanelContent() {
+    final shaderName = _shaderKey != null ? _prettyShaderName(_shaderKey!) : '';
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Tuning',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              TextButton(
+                onPressed: _resetTuning,
+                child: Text('Reset',
+                    style: TextStyle(color: VelvetColors.primary)),
+              ),
+              IconButton(
+                onPressed: () => setState(() => _panelOpen = false),
+                icon: Icon(Icons.close, color: Colors.white70, size: 20),
+                tooltip: 'Close',
+              ),
+            ],
+          ),
+          Expanded(
+            child: ListView(
+              children: [
+                _panelSectionLabel('Response curve · all shaders'),
+                for (var i = 0;
+                    i < _globalValues.length && i < _globalLabels.length;
+                    i++)
+                  _globalSlider(i),
+                const SizedBox(height: 10),
+                _panelSectionLabel(shaderName.isEmpty ? 'Shader' : shaderName),
+                if (_shaderParams.isEmpty)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    child: Text(
+                      'This shader exposes no knobs.',
+                      style: TextStyle(color: Colors.white60, fontSize: 12),
+                    ),
+                  ),
+                for (var i = 0; i < _shaderParams.length; i++)
+                  _shaderSlider(i),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _panelSectionLabel(String text) => Padding(
+        padding: const EdgeInsets.only(top: 6, bottom: 2),
+        child: Text(
+          text.toUpperCase(),
+          style: TextStyle(
+            color: VelvetColors.primary,
+            fontSize: 11,
+            letterSpacing: 1.0,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      );
+
+  Widget _globalSlider(int i) {
+    final range = _globalRanges[i];
+    final v = _globalValues[i].clamp(range[0], range[1]).toDouble();
+    return _sliderRow(
+      label: _globalLabels[i],
+      value: v,
+      min: range[0],
+      max: range[1],
+      onChanged: (nv) {
+        setState(() => _globalValues[i] = nv);
+        _pushTuning();
+      },
+      onChangeEnd: (_) => _persistGlobal(),
+    );
+  }
+
+  Widget _shaderSlider(int i) {
+    final p = _shaderParams[i];
+    final v = _paramValues[i].clamp(p.min, p.max).toDouble();
+    return _sliderRow(
+      label: p.name,
+      value: v,
+      min: p.min,
+      max: p.max,
+      onChanged: (nv) {
+        setState(() => _paramValues[i] = nv);
+        _pushTuning();
+      },
+      onChangeEnd: (_) => _persistShader(),
+    );
+  }
+
+  Widget _sliderRow({
+    required String label,
+    required double value,
+    required double min,
+    required double max,
+    required ValueChanged<double> onChanged,
+    required ValueChanged<double> onChangeEnd,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(label,
+                  style: TextStyle(color: Colors.white, fontSize: 13)),
+            ),
+            Text(
+              value.toStringAsFixed(2),
+              style: TextStyle(
+                color: Colors.white70,
+                fontSize: 12,
+                fontFamily: 'monospace',
+              ),
+            ),
+          ],
+        ),
+        SliderTheme(
+          data: SliderTheme.of(context).copyWith(
+            trackHeight: 2,
+            activeTrackColor: VelvetColors.primary,
+            inactiveTrackColor: Colors.white24,
+            thumbColor: VelvetColors.primary,
+            overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
+          ),
+          child: Slider(
+            value: value,
+            min: min,
+            max: max,
+            onChanged: onChanged,
+            onChangeEnd: onChangeEnd,
+          ),
+        ),
+      ],
+    );
+  }
+
+  // assets/shaders/05-hex-marching.glsl -> "hex marching"
+  String _prettyShaderName(String path) {
+    var n = path.split('/').last;
+    n = n.replaceAll('.glsl', '');
+    n = n.replaceFirst(RegExp(r'^\d+-'), '');
+    n = n.replaceAll('-', ' ');
+    return n;
   }
 
   Widget _statusPlaceholder() {

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -128,6 +128,20 @@ class SettingsManager {
   // lighter alternative driven by the bundled .glsl catalog.
   VisualizerEngine visualizerEngine = VisualizerEngine.milkdrop;
 
+  // Visualizer tuning knobs (Shader engine only). Hidden by default —
+  // flipping [showVisualizerKnobs] reveals an in-visualizer slider panel
+  // for curious users. Tuned values persist: [visualizerGlobalParams] is
+  // the global response-curve override [minDb, maxDb, smoothing] (empty =
+  // native defaults), and [visualizerShaderParams] holds per-shader
+  // iParams overrides keyed by the shader's asset path.
+  bool showVisualizerKnobs = false;
+  List<double> visualizerGlobalParams = const [];
+  Map<String, List<double>> visualizerShaderParams = {};
+
+  /// Native AudioTexture response-curve defaults — keep in sync with
+  /// audio_texture.cpp (minDb_ / maxDb_ / smoothing_).
+  static const List<double> defaultGlobalParams = [-69.7, -20.7, 0.27];
+
   late final BehaviorSubject<bool> _albumGridStream =
       BehaviorSubject<bool>.seeded(albumGrid);
   late final BehaviorSubject<int> _letterStripStream =
@@ -161,6 +175,21 @@ class SettingsManager {
           : const [];
       visualizerAudioSource = _readVisualizerAudioSource(m);
       visualizerEngine = _readVisualizerEngine(m);
+      showVisualizerKnobs = m['showVisualizerKnobs'] ?? false;
+      final rawGlobal = m['visualizerGlobalParams'];
+      visualizerGlobalParams = rawGlobal is List
+          ? rawGlobal.whereType<num>().map((n) => n.toDouble()).toList()
+          : const [];
+      visualizerShaderParams = {};
+      final rawShaderParams = m['visualizerShaderParams'];
+      if (rawShaderParams is Map) {
+        rawShaderParams.forEach((k, v) {
+          if (k is String && v is List) {
+            visualizerShaderParams[k] =
+                v.whereType<num>().map((n) => n.toDouble()).toList();
+          }
+        });
+      }
       _albumGridStream.add(albumGrid);
       _letterStripStream.add(letterStripThreshold);
       _themeStream.add(appTheme);
@@ -227,6 +256,9 @@ class SettingsManager {
       'eqBandGains': eqBandGains,
       'visualizerAudioSource': visualizerAudioSource.name,
       'visualizerEngine': visualizerEngine.name,
+      'showVisualizerKnobs': showVisualizerKnobs,
+      'visualizerGlobalParams': visualizerGlobalParams,
+      'visualizerShaderParams': visualizerShaderParams,
     }));
   }
 
@@ -283,6 +315,30 @@ class SettingsManager {
     await _save();
   }
 
+  Future<void> setShowVisualizerKnobs(bool v) async {
+    showVisualizerKnobs = v;
+    await _save();
+  }
+
+  Future<void> setVisualizerGlobalParams(List<double> v) async {
+    visualizerGlobalParams = v;
+    await _save();
+  }
+
+  /// Persist per-shader iParams overrides for [key] (the shader asset
+  /// path). Call on slider release, not every drag tick.
+  Future<void> setVisualizerShaderParams(String key, List<double> v) async {
+    visualizerShaderParams = {...visualizerShaderParams, key: v};
+    await _save();
+  }
+
+  /// Drop any saved overrides for [key], reverting it to shader defaults.
+  Future<void> clearVisualizerShaderParams(String key) async {
+    if (!visualizerShaderParams.containsKey(key)) return;
+    visualizerShaderParams = {...visualizerShaderParams}..remove(key);
+    await _save();
+  }
+
   Future<void> resetAll() async {
     TranscodeManager().transcodeOn = false;
     albumGrid = true;
@@ -294,6 +350,9 @@ class SettingsManager {
     eqBandGains = const [];
     visualizerAudioSource = VisualizerAudioSource.synthesized;
     visualizerEngine = VisualizerEngine.milkdrop;
+    showVisualizerKnobs = false;
+    visualizerGlobalParams = const [];
+    visualizerShaderParams = {};
     _albumGridStream.add(albumGrid);
     _letterStripStream.add(letterStripThreshold);
     _themeStream.add(appTheme);


### PR DESCRIPTION
## Summary

Reworks the Shadertoy shader engine's audio reactivity and adds an optional, default-hidden in-app tuning panel. Branched off `master` (kept separate from the in-flight `upgrade/flutter-3.44` work).

## Audio pipeline (`cpp/audio_texture`)

The spectrum row of the `iChannel0` audio texture now follows the Web Audio / Shadertoy convention the bundled shaders were authored against:

- **Normalize** raw FFT magnitude to source amplitude (window-sum based, FFT-size independent).
- **EMA-smooth** in the linear domain so bars don't strobe.
- **Map a dB window** `[minDb, maxDb] → [0,1]`, replacing the old uncalibrated `log1p(mag*4)*0.4` curve that clipped the low bins to white and forced every shader to pre-attenuate.
- Skip the FFT on frames with no new PCM (render ~60 Hz outpaces PCM ~30 Hz).

## Per-shader tuning panel

- Shaders declare knobs in their header: `// param: <name> <min> <max> <default>`. The *i*-th declaration maps to `uniform float iParams[8]` (parser: `lib/native/shader_params.dart`).
- Values flow Dart → `setTuning` MethodChannel → JNI → `ShaderEngine` (`[0..2]` = global dB curve via `AudioTexture::setParams`, `[3..]` = `iParams`). Pushed on every shader load so defaults always apply.
- In-visualizer slider overlay, **gated behind `Settings → Visualizer tuning knobs` (default off)** — a feature for curious users. Tuned values persist per-shader and globally (`settings.json`), with a Reset button.
- Knobs wired into shaders `01`–`08`; defaults baked from an on-device tuning pass. `09` (mountainbytes) has no audio path and is unchanged.

## Navigation / lifecycle fixes

- Always-visible **back button** (top-left) with a trap-proof exit.
- Exit the visualizer on `detached` (task swiped away from recents, while `audio_service` keeps the process alive) so a relaunch lands on the main screen — a plain home-press still resumes the visualizer where it left off.

## Testing

- C++ TUs syntax-checked (both ABIs); `nativeSetTuning` confirmed exported in the shipped `.so`; `flutter analyze` clean; debug APK built + installed on a Galaxy S25 (arm64).
- Verified on-device end-to-end: the panel renders, sliders drive `iParams` live, shaders compile/react, and tuned values persist (defaults here were baked from that pass).

## Notes for reviewers

- Touches the **Shader engine only** — the Milkdrop/projectM path is unaffected.
- `assets/shaders/09-mountainbytes.glsl` intentionally exposes no knobs (no audio reactivity in the port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
