### PR TITLE
Browser & queue UX: local search, API loading bar, download-all dialogs

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -388,6 +388,12 @@ class NowPlaying extends StatelessWidget {
                       },
                     ),
                     IconButton(
+                      icon: Icon(Icons.download_for_offline),
+                      color: VelvetColors.textSecondary,
+                      tooltip: 'Download all',
+                      onPressed: () => _downloadAll(context),
+                    ),
+                    IconButton(
                       icon: Icon(Icons.delete_sweep),
                       color: VelvetColors.error,
                       tooltip: 'Clear queue',
@@ -577,6 +583,60 @@ class NowPlaying extends StatelessWidget {
         child: Icon(Icons.music_note,
             color: VelvetColors.textSecondary, size: 22),
       );
+
+  // Queue "Download all": enqueue every track that isn't already on the
+  // device (no localPath) and is actually downloadable (has a server +
+  // path — local-only files are skipped). Confirms the count first and
+  // lets the user back out. downloadOneFile no-ops on files already on
+  // disk, so re-running is harmless.
+  void _downloadAll(BuildContext context) {
+    final queue = MediaManager().audioHandler.queue.value;
+    final pending = queue
+        .where((m) =>
+            m.extras?['localPath'] == null &&
+            m.extras?['server'] != null &&
+            m.extras?['path'] != null)
+        .toList();
+
+    if (pending.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(queue.isEmpty
+              ? 'Queue is empty — nothing to download'
+              : 'Nothing to download — tracks are already saved')));
+      return;
+    }
+
+    final n = pending.length;
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: VelvetColors.surface,
+        title: Text('Download all'),
+        content: Text(
+            '$n track${n == 1 ? '' : 's'} will be downloaded for offline playback.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text('Cancel',
+                style: TextStyle(color: VelvetColors.textSecondary)),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              for (final m in pending) {
+                DownloadManager().downloadOneFile(
+                    m.id, m.extras!['server'], m.extras!['path'], null);
+              }
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                  content:
+                      Text('$n download${n == 1 ? '' : 's'} started')));
+            },
+            child: Text('Download'),
+          ),
+        ],
+      ),
+    );
+  }
 
   void _showAddToPlaylistSheet(BuildContext context, MediaItem item) {
     showModalBottomSheet<void>(

--- a/lib/objects/display_item.dart
+++ b/lib/objects/display_item.dart
@@ -111,6 +111,22 @@ class DisplayItem {
     return null;
   }
 
+  // Case-insensitive substring match backing the browser's local
+  // search filter. Tests the same fields getText()/getSubText() can
+  // surface — title / filename / name plus artist / album / subtext —
+  // so a match always corresponds to text the user can actually see.
+  bool matchesQuery(String query) {
+    final q = query.trim().toLowerCase();
+    if (q.isEmpty) return true;
+    bool hit(String? s) => s != null && s.toLowerCase().contains(q);
+    return hit(name) ||
+        hit(metadata?.title) ||
+        hit(metadata?.artist) ||
+        hit(metadata?.album) ||
+        hit(subtext) ||
+        hit(data?.split('/').last);
+  }
+
   DisplayItem(
       this.server, this.name, this.type, this.data, this.icon, this.subtext) {
     // Check if file is saved on device

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -621,6 +621,52 @@ class _BrowserState extends State<Browser> {
                     ])))));
   }
 
+  // Browser "Download all": same confirm + empty-state UX as the queue's
+  // button. Counts the file rows in the *current* list (folders / headers
+  // are ignored); alerts if there are none, otherwise confirms the count
+  // before enqueueing. downloadOneFile no-ops on files already on disk.
+  void _downloadAll(BuildContext context) {
+    final files =
+        BrowserManager().browserList.where((e) => e.type == 'file').toList();
+    if (files.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text('Nothing to download in this list')));
+      return;
+    }
+    final n = files.length;
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: VelvetColors.surface,
+        title: Text('Download all'),
+        content: Text('$n file${n == 1 ? '' : 's'} will be downloaded.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text('Cancel',
+                style: TextStyle(color: VelvetColors.textSecondary)),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              for (final e in files) {
+                String downloadUrl = e.server!.url +
+                    '/media' +
+                    e.data! +
+                    (e.server!.jwt == null ? '' : '?token=' + e.server!.jwt!);
+                DownloadManager().downloadOneFile(downloadUrl,
+                    e.server!.localname, e.data!, e.server!.saveToSdCard);
+              }
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                  content: Text('$n download${n == 1 ? '' : 's'} started')));
+            },
+            child: Text('Download'),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
       Material(
@@ -675,32 +721,7 @@ class _BrowserState extends State<Browser> {
                               color: VelvetColors.textSecondary,
                             ),
                             tooltip: 'Download',
-                            onPressed: () {
-                              int count = 0;
-
-                              BrowserManager().browserList.forEach((e) {
-                                if (e.type == 'file') {
-                                  String downloadUrl = e.server!.url +
-                                      '/media' +
-                                      e.data! +
-                                      (e.server!.jwt == null
-                                          ? ''
-                                          : '?token=' + e.server!.jwt!);
-
-                                  DownloadManager().downloadOneFile(
-                                      downloadUrl,
-                                      e.server!.localname,
-                                      e.data!,
-                                      e.server!.saveToSdCard);
-                                  count++;
-                                }
-                              });
-
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                      content:
-                                          Text('$count downloads started')));
-                            }),
+                            onPressed: () => _downloadAll(context)),
                         IconButton(
                             icon: Icon(
                               Icons.library_add,

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -764,6 +764,26 @@ class _BrowserState extends State<Browser> {
                   ]);
             }),
       ),
+      // Thin indeterminate bar while any browser server call is in
+      // flight (all go through ApiManager.makeServerCall). Fixed 3px
+      // slot — empty when idle — so the list never jumps.
+      StreamBuilder<bool>(
+        stream: BrowserManager().loadingStream,
+        initialData: BrowserManager().isLoading,
+        builder: (context, snap) {
+          final loading = snap.data ?? false;
+          return SizedBox(
+            height: 3,
+            child: loading
+                ? LinearProgressIndicator(
+                    minHeight: 3,
+                    color: VelvetColors.primary,
+                    backgroundColor: Colors.transparent,
+                  )
+                : null,
+          );
+        },
+      ),
       Expanded(
           child: SizedBox(
               child: StreamBuilder<List<DisplayItem>>(

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -10,6 +10,7 @@ import '../objects/display_item.dart';
 import '../theme/velvet_theme.dart';
 import '../widgets/album_grid.dart';
 import '../widgets/letter_strip.dart';
+import '../widgets/local_search_bar.dart';
 import 'package:uuid/uuid.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 
@@ -19,9 +20,48 @@ import '../singletons/media.dart';
 
 import 'add_server.dart';
 
-class Browser extends StatelessWidget {
+class Browser extends StatefulWidget {
+  @override
+  State<Browser> createState() => _BrowserState();
+}
+
+class _BrowserState extends State<Browser> {
+  // Local-search state. _searchOpen toggles the header search field;
+  // _searchQuery filters the *displayed* list only — BrowserManager's
+  // browserList and back-stack are never mutated, so navigation, the
+  // letter-strip math and scroll restore all stay intact. Any
+  // navigation (folder/album/etc. tap, or Back) clears both via
+  // _closeSearch() so a filter never carries over into a new view.
+  String _searchQuery = '';
+  bool _searchOpen = false;
+
+  // Item types whose tap loads a new list (vs. file/localFile, which
+  // just enqueue and leave the current list in place). Tapping any of
+  // these closes local search.
+  static const Set<String> _navTypes = {
+    'addServer',
+    'directory',
+    'playlist',
+    'execAction',
+    'artist',
+    'album',
+    'localDirectory',
+  };
+
+  void _closeSearch() {
+    if (!_searchOpen && _searchQuery.isEmpty) return;
+    setState(() {
+      _searchOpen = false;
+      _searchQuery = '';
+    });
+  }
+
   void handleTap(
       List<DisplayItem> browserList, int index, BuildContext context) {
+    if (_navTypes.contains(browserList[index].type)) {
+      _closeSearch();
+    }
+
     if (browserList[index].type == 'addServer') {
       Navigator.push(
         context,
@@ -559,10 +599,11 @@ class Browser extends StatelessWidget {
                           quarterTurns: 3,
                           child: LinearProgressIndicator(
                             // value: displayList[index].downloadProgress/100,
-                            value: BrowserManager()
-                                    .browserList[i]
-                                    .downloadProgress /
-                                100,
+                            // Index against the passed list `b` (the
+                            // possibly search-filtered view), not the
+                            // manager's unfiltered browserList — otherwise
+                            // the bar reads the wrong row while searching.
+                            value: b[i].downloadProgress / 100,
                             valueColor: AlwaysStoppedAnimation(
                                 VelvetColors.success),
                             backgroundColor: Colors.transparent,
@@ -597,14 +638,37 @@ class Browser extends StatelessWidget {
                   children: <Widget>[
                     if (browserList.length == 0 ||
                         browserList[0].type != 'execAction') ...[
+                      if (_searchOpen) ...[
+                        // Search mode: a close button + the live-filtering
+                        // field fill the header. Download / Add All are
+                        // hidden here so they always act on the full list,
+                        // never the filtered subset.
+                        IconButton(
+                            icon: Icon(Icons.close,
+                                color: VelvetColors.textSecondary),
+                            tooltip: 'Close search',
+                            onPressed: _closeSearch),
+                        Expanded(
+                            child: LocalSearchBar(
+                                hintText: 'Search this list',
+                                onChanged: (q) =>
+                                    setState(() => _searchQuery = q))),
+                      ] else ...[
                       IconButton(
                           icon: Icon(Icons.keyboard_arrow_left,
                               color: VelvetColors.textSecondary),
                           tooltip: 'Go Back',
                           onPressed: () {
+                            _closeSearch();
                             BrowserManager().popBrowser();
                           }),
                       Row(children: <Widget>[
+                        IconButton(
+                            icon: Icon(Icons.search,
+                                color: VelvetColors.textSecondary),
+                            tooltip: 'Search list',
+                            onPressed: () =>
+                                setState(() => _searchOpen = true)),
                         IconButton(
                             icon: Icon(
                               Icons.download_sharp,
@@ -674,6 +738,7 @@ class Browser extends StatelessWidget {
                               }
                             })
                       ])
+                      ],
                     ] else ...[
                       Expanded(
                           child: TextField(
@@ -704,7 +769,36 @@ class Browser extends StatelessWidget {
               child: StreamBuilder<List<DisplayItem>>(
                   stream: BrowserManager().browserListStream,
                   builder: (context, snapshot) {
-                    final List<DisplayItem> browserList = snapshot.data ?? [];
+                    final List<DisplayItem> rawList = snapshot.data ?? [];
+
+                    // Local search filters only the *displayed* list; the
+                    // manager's browserList (hence navigation / back-stack
+                    // / scroll restore) is untouched. The execAction home
+                    // menu is fixed section shortcuts, not content, so it
+                    // is never filtered.
+                    final bool isHome = rawList.isNotEmpty &&
+                        rawList[0].type == 'execAction';
+                    final String q = _searchQuery.trim();
+                    final bool filtering =
+                        _searchOpen && q.isNotEmpty && !isHome;
+                    final List<DisplayItem> browserList = filtering
+                        ? rawList.where((it) => it.matchesQuery(q)).toList()
+                        : rawList;
+
+                    if (filtering && browserList.isEmpty) {
+                      return Center(
+                        child: Padding(
+                          padding: const EdgeInsets.all(24),
+                          child: Text(
+                            'No matches for "$q"',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                                color: VelvetColors.textSecondary,
+                                fontSize: 14),
+                          ),
+                        ),
+                      );
+                    }
 
                     // If the whole list is albums and the user has the
                     // album-grid setting on, show a grid of album cards
@@ -777,7 +871,8 @@ class Browser extends StatelessWidget {
                         // Artists, File Explorer) — see BrowserManager
                         // .alphabeticalCache.
                         if (!BrowserManager().isAlphabetical ||
-                            browserList.isEmpty) {
+                            browserList.isEmpty ||
+                            filtering) {
                           return content;
                         }
                         return Stack(

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -82,33 +82,41 @@ class ApiManager {
 
   Future makeServerCall(Server? currentServer, String location, Map payload,
       String getOrPost) async {
-    Server server = ServerManager().currentServer ??
-        (throw Exception('No Server Selected'));
+    // Bracket every browse fetch so the browser can show one global
+    // loading bar. The finally guarantees the in-flight counter is
+    // balanced even on the early throws / HTTP-error / network paths.
+    BrowserManager().beginLoading();
+    try {
+      Server server = ServerManager().currentServer ??
+          (throw Exception('No Server Selected'));
 
-    if (server.unsupported) {
-      throw Exception('Server Call Failed');
+      if (server.unsupported) {
+        throw Exception('Server Call Failed');
+      }
+
+      Uri currentUri = Uri.parse(server.url).resolve(location);
+
+      var response;
+      if (getOrPost == 'GET') {
+        response = await http
+            .get(currentUri, headers: {'x-access-token': server.jwt ?? ''});
+      } else {
+        response = await http.post(currentUri,
+            body: json.encode(payload),
+            headers: {
+              'Content-Type': 'application/json',
+              'x-access-token': server.jwt ?? ''
+            });
+      }
+
+      if (response.statusCode > 299) {
+        throw Exception('Server Call Failed');
+      }
+
+      return jsonDecode(response.body);
+    } finally {
+      BrowserManager().endLoading();
     }
-
-    Uri currentUri = Uri.parse(server.url).resolve(location);
-
-    var response;
-    if (getOrPost == 'GET') {
-      response = await http
-          .get(currentUri, headers: {'x-access-token': server.jwt ?? ''});
-    } else {
-      response = await http.post(currentUri,
-          body: json.encode(payload),
-          headers: {
-            'Content-Type': 'application/json',
-            'x-access-token': server.jwt ?? ''
-          });
-    }
-
-    if (response.statusCode > 299) {
-      throw Exception('Server Call Failed');
-    }
-
-    return jsonDecode(response.body);
   }
 
   Future<void> getRecursiveFiles(String directory,

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -23,7 +23,27 @@ class BrowserManager {
       alphabeticalCache.isNotEmpty ? alphabeticalCache.last : false;
 
   String listName = 'Welcome';
-  bool loading = false;
+
+  // In-flight server-call tracking for the browser's global loading bar.
+  // makeServerCall (the chokepoint every browse fetch passes through)
+  // brackets each request with beginLoading()/endLoading(); the counter
+  // keeps the bar up across overlapping calls and flips the stream only
+  // on the 0<->1 transition, so there are no redundant rebuilds.
+  int _inFlightCalls = 0;
+  late final BehaviorSubject<bool> _loading =
+      BehaviorSubject<bool>.seeded(false);
+  Stream<bool> get loadingStream => _loading.stream;
+  bool get isLoading => _loading.value;
+
+  void beginLoading() {
+    _inFlightCalls++;
+    if (_inFlightCalls == 1) _loading.add(true);
+  }
+
+  void endLoading() {
+    if (_inFlightCalls > 0) _inFlightCalls--;
+    if (_inFlightCalls == 0) _loading.add(false);
+  }
 
   late final BehaviorSubject<List<DisplayItem>> _browserStream =
       BehaviorSubject<List<DisplayItem>>.seeded(browserList);
@@ -249,6 +269,7 @@ class BrowserManager {
   void dispose() {
     _browserStream.close();
     _browserLabel.close();
+    _loading.close();
   }
 
   Stream<List<DisplayItem>> get browserListStream => _browserStream.stream;

--- a/lib/widgets/local_search_bar.dart
+++ b/lib/widgets/local_search_bar.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../theme/velvet_theme.dart';
+
+/// A small, reusable local-search input: a search-icon-prefixed field
+/// with an inline clear button. Purely client-side — it owns its text
+/// controller and just reports changes via [onChanged]; the host screen
+/// decides how to filter its own list (e.g. DisplayItem.matchesQuery).
+///
+/// Designed to drop into any list screen's header. Pair it with a search
+/// toggle and a close affordance owned by the host (see browser.dart).
+class LocalSearchBar extends StatefulWidget {
+  final ValueChanged<String> onChanged;
+  final String hintText;
+  final bool autofocus;
+
+  const LocalSearchBar({
+    Key? key,
+    required this.onChanged,
+    this.hintText = 'Search this list',
+    this.autofocus = true,
+  }) : super(key: key);
+
+  @override
+  State<LocalSearchBar> createState() => _LocalSearchBarState();
+}
+
+class _LocalSearchBarState extends State<LocalSearchBar> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _clear() {
+    if (_controller.text.isEmpty) return;
+    _controller.clear();
+    widget.onChanged('');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: _controller,
+      autofocus: widget.autofocus,
+      textInputAction: TextInputAction.search,
+      style: TextStyle(color: VelvetColors.textPrimary, fontSize: 15),
+      cursorColor: VelvetColors.primary,
+      onChanged: widget.onChanged,
+      decoration: InputDecoration(
+        isDense: true,
+        filled: true,
+        fillColor: VelvetColors.raised,
+        contentPadding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+        hintText: widget.hintText,
+        hintStyle: TextStyle(color: VelvetColors.textSecondary),
+        prefixIcon: Icon(Icons.search, color: VelvetColors.textSecondary),
+        // Rebuild only the clear button as text comes and goes, rather
+        // than the whole field, by listening to the controller directly.
+        suffixIcon: ValueListenableBuilder<TextEditingValue>(
+          valueListenable: _controller,
+          builder: (context, value, _) {
+            if (value.text.isEmpty) return const SizedBox.shrink();
+            return IconButton(
+              icon: Icon(Icons.clear, color: VelvetColors.textSecondary),
+              tooltip: 'Clear',
+              onPressed: _clear,
+            );
+          },
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(VelvetColors.radiusSmall),
+          borderSide: BorderSide.none,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Four small, self-contained browser/queue UX improvements — one commit each, all on top of `master` (e72ca17):

- **Local list search** (`4efcbde`) — a search toggle in the Browser header reveals a live, client-side filter over the current list (case-insensitive match on the visible title / filename / name plus artist / album / subtext). It filters only what's *rendered* — `BrowserManager`'s list, back-stack, scroll position and the A–Z letter strip are untouched, and any navigation or Back clears it. Adds a reusable `LocalSearchBar` widget and `DisplayItem.matchesQuery`.
- **API loading indicator** (`5323390`) — every browse fetch is bracketed in the single `makeServerCall` chokepoint (in-flight counter + `BehaviorSubject<bool>` on `BrowserManager`, balanced in a `try/finally`), driving a thin indeterminate bar under the Browser header. Folder/album/artist/search navigation previously gave no feedback. (Revives the previously-dead `loading` field.)
- **Queue "Download all"** (`7b93b15`) — new header button that enqueues every queue track not already on the device. Alerts when there's nothing to download, otherwise shows a "N tracks will be downloaded" confirm dialog with a Cancel.
- **Browser "Download all" guard** (`03a76c5`) — the existing Browser Download button gets the same confirm + empty-state dialog.

## Notes
- New user-facing strings are plain literals (this branch is off pre-i18n `master`); they'd need translating if merged alongside the i18n work.
- Also fixes a latent bug where a file row's progress bar indexed the unfiltered list while a search filter was active.

## Test plan
- **Search:** open Albums / Artists / a folder → filter is live; clearing, closing, or navigating resets it; no match shows an empty state.
- **Loading bar:** navigate between views → thin bar shows for the duration of each fetch.
- **Queue download-all:** empty queue or all-saved → alert; otherwise confirm dialog with count + Cancel; Download enqueues (already-saved tracks skipped by `downloadOneFile`).
- **Browser download-all:** a list with no files (Artists/Albums/empty folder) → alert; a list with files → confirm dialog with count + Cancel.
- `flutter analyze` clean (only pre-existing warnings); debug APK builds and runs on a physical device (Galaxy S25, Android).

🤖 Generated with [Claude Code](https://claude.com/claude-code)