### PR TITLE
Add per-server download storage location (App local / Permanent / SD card)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,12 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <!-- "All files access": lets the user store downloads in a folder they
+         choose in shared storage (Permanent / SD card modes) so the files
+         survive an app uninstall. Requested at runtime via permission_handler
+         (Permission.manageExternalStorage) only when one of those modes is
+         selected; App local mode needs no storage permission. -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <!-- Optional: only requested when the user opts into "real audio"
          mode for the visualizer. Android's AudioFx Visualizer API
          requires RECORD_AUDIO even to read the app's own audio output. -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+    <!-- Keeps the process alive while a background storage migration moves
+         downloaded files (MigrationService). -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
@@ -75,7 +78,14 @@
           <intent-filter>
             <action android:name="android.intent.action.MEDIA_BUTTON" />
           </intent-filter>
-        </receiver> 
+        </receiver>
+
+        <!-- Foreground service that keeps the process alive during a
+             background storage migration (file move). -->
+        <service
+            android:name=".MigrationService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
 
     </application>
 </manifest>

--- a/android/app/src/main/kotlin/com/example/mstream_music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.example.mstream_music
 
+import android.os.StatFs
 import com.ryanheise.audioservice.AudioServiceActivity
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
 // Extends AudioServiceActivity (from the audio_service pub package) so
 // the media session / foreground notification plumbing still works,
@@ -13,5 +15,23 @@ class MainActivity : AudioServiceActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         flutterEngine.plugins.add(VisualizerBridge())
+
+        // Free-space query for the storage-migration pre-check (no pure-Dart
+        // API for this). Returns available bytes on the volume holding `path`,
+        // or null if it can't be read.
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "mstream/storage")
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "freeBytes" -> {
+                        val p = call.argument<String>("path")
+                        try {
+                            result.success(StatFs(p).availableBytes)
+                        } catch (e: Exception) {
+                            result.success(null)
+                        }
+                    }
+                    else -> result.notImplemented()
+                }
+            }
     }
 }

--- a/android/app/src/main/kotlin/com/example/mstream_music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.example.mstream_music
 
+import android.content.Intent
+import android.os.Build
 import android.os.StatFs
 import com.ryanheise.audioservice.AudioServiceActivity
 import io.flutter.embedding.engine.FlutterEngine
@@ -16,18 +18,42 @@ class MainActivity : AudioServiceActivity() {
         super.configureFlutterEngine(flutterEngine)
         flutterEngine.plugins.add(VisualizerBridge())
 
-        // Free-space query for the storage-migration pre-check (no pure-Dart
-        // API for this). Returns available bytes on the volume holding `path`,
-        // or null if it can't be read.
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "mstream/storage")
             .setMethodCallHandler { call, result ->
                 when (call.method) {
+                    // Free bytes on the volume holding `path`, for the
+                    // storage-migration pre-check (no pure-Dart API).
                     "freeBytes" -> {
                         val p = call.argument<String>("path")
                         try {
                             result.success(StatFs(p).availableBytes)
                         } catch (e: Exception) {
                             result.success(null)
+                        }
+                    }
+                    // Start/stop a foreground service that keeps the process
+                    // alive while a background file move runs (so it survives
+                    // the app being backgrounded). Failures are non-fatal —
+                    // the move proceeds regardless.
+                    "startMove" -> {
+                        try {
+                            val i = Intent(this, MigrationService::class.java)
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                startForegroundService(i)
+                            } else {
+                                startService(i)
+                            }
+                            result.success(true)
+                        } catch (e: Exception) {
+                            result.success(false)
+                        }
+                    }
+                    "stopMove" -> {
+                        try {
+                            stopService(Intent(this, MigrationService::class.java))
+                            result.success(true)
+                        } catch (e: Exception) {
+                            result.success(false)
                         }
                     }
                     else -> result.notImplemented()

--- a/android/app/src/main/kotlin/com/example/mstream_music/MigrationService.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/MigrationService.kt
@@ -1,0 +1,61 @@
+package com.example.mstream_music
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+
+// Lightweight foreground service that keeps the app process alive (out of the
+// background-freeze that would otherwise stall a long file move) while a
+// storage migration runs in the Dart isolate. It does no work itself — the
+// move stays in Dart; this just holds an ongoing foreground notification so
+// Android won't suspend the process when the app is backgrounded.
+class MigrationService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val channelId = "mstream_migration"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val nm = getSystemService(NotificationManager::class.java)
+            nm?.createNotificationChannel(
+                NotificationChannel(
+                    channelId,
+                    "Moving downloads",
+                    NotificationManager.IMPORTANCE_LOW
+                )
+            )
+        }
+
+        val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, channelId)
+        } else {
+            @Suppress("DEPRECATION")
+            Notification.Builder(this)
+        }
+        val notification = builder
+            .setContentTitle("Moving downloads")
+            .setContentText("Keep mStream open until this finishes")
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setOngoing(true)
+            .build()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIF_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            startForeground(NOTIF_ID, notification)
+        }
+        return START_NOT_STICKY
+    }
+
+    companion object {
+        private const val NOTIF_ID = 4711
+    }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -105,11 +105,25 @@ class _MStreamAppState extends State<MStreamApp>
       builder: (context, snap) {
         final p = snap.data;
         if (p == null) return const SizedBox.shrink();
+        final pct = p.fraction;
         final label = p.failed
-            ? 'Move failed — will retry next time you open the app'
+            ? 'Move stopped — not enough space, or the location is unavailable.'
             : p.done
                 ? 'Move complete'
-                : 'Moving downloads… ${p.moved}/${p.total} — keep the app open';
+                : 'Moving downloads… '
+                    '${pct != null ? '${(pct * 100).round()}%' : '${p.moved}/${p.total}'}'
+                    ' — keep the app open';
+        Widget compactButton(String text, Color color, VoidCallback onTap) {
+          return TextButton(
+            onPressed: onTap,
+            style: TextButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                minimumSize: const Size(0, 32),
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap),
+            child: Text(text, style: TextStyle(color: color, fontSize: 12)),
+          );
+        }
+
         return Material(
           color: VelvetColors.surface,
           child: Padding(
@@ -134,16 +148,24 @@ class _MStreamAppState extends State<MStreamApp>
                           style: TextStyle(
                               color: VelvetColors.textSecondary, fontSize: 12),
                           overflow: TextOverflow.ellipsis)),
+                  if (p.failed)
+                    compactButton('Retry', VelvetColors.primary,
+                        () => MigrationManager().retry()),
+                  if (!p.done)
+                    compactButton('Cancel', VelvetColors.textSecondary,
+                        () => MigrationManager().cancel()),
                 ]),
-                const SizedBox(height: 6),
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(4),
-                  child: LinearProgressIndicator(
-                    value: p.failed ? 0 : p.fraction,
-                    minHeight: 4,
-                    backgroundColor: VelvetColors.border2,
+                if (!p.failed) ...[
+                  const SizedBox(height: 6),
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: LinearProgressIndicator(
+                      value: pct,
+                      minHeight: 4,
+                      backgroundColor: VelvetColors.border2,
+                    ),
                   ),
-                ),
+                ],
               ],
             ),
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'screens/auto_dj.dart';
 // import 'screens/downloads.dart'; // DownloadScreen — drawer entry hidden below
 import 'singletons/downloads.dart';
 import 'singletons/app_messenger.dart';
+import 'singletons/migration_manager.dart';
 import 'screens/add_server.dart';
 import 'screens/manage_server.dart';
 import 'screens/playlists_screen.dart';
@@ -80,6 +81,8 @@ class _MStreamAppState extends State<MStreamApp>
     _tabController = TabController(length: 2, vsync: this);
     ServerManager().loadServerList();
     DownloadManager().initDownloader();
+    // Resume a storage move that was interrupted by an app restart.
+    MigrationManager().resumeIfNeeded();
     // Android 13+ (targetSdk >= 33): OS no longer auto-prompts; audio_service
     // can't run its foreground media notification without this, so playback
     // silently fails. Fire-and-forget — first call shows the system dialog,
@@ -92,6 +95,61 @@ class _MStreamAppState extends State<MStreamApp>
   void dispose() {
     DownloadManager().dispose();
     super.dispose();
+  }
+
+  // Thin banner above the tabs showing a background storage move's progress
+  // (and resumed moves after an app restart). Hidden when none is running.
+  Widget _migrationBanner() {
+    return StreamBuilder<MigrationProgress?>(
+      stream: MigrationManager().progressStream,
+      builder: (context, snap) {
+        final p = snap.data;
+        if (p == null) return const SizedBox.shrink();
+        final label = p.failed
+            ? 'Move failed — will retry next time you open the app'
+            : p.done
+                ? 'Move complete'
+                : 'Moving downloads… ${p.moved}/${p.total} — keep the app open';
+        return Material(
+          color: VelvetColors.surface,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(children: [
+                  Icon(
+                      p.failed
+                          ? Icons.error_outline
+                          : p.done
+                              ? Icons.check_circle_outline
+                              : Icons.drive_file_move_outline,
+                      size: 16,
+                      color:
+                          p.failed ? VelvetColors.error : VelvetColors.primary),
+                  const SizedBox(width: 8),
+                  Expanded(
+                      child: Text(label,
+                          style: TextStyle(
+                              color: VelvetColors.textSecondary, fontSize: 12),
+                          overflow: TextOverflow.ellipsis)),
+                ]),
+                const SizedBox(height: 6),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: p.failed ? 0 : p.fraction,
+                    minHeight: 4,
+                    backgroundColor: VelvetColors.border2,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
   }
 
   @override
@@ -349,9 +407,13 @@ class _MStreamAppState extends State<MStreamApp>
                 },
               ),
             ])),
-            body: TabBarView(
-                children: [Browser(), NowPlaying()],
-                controller: _tabController),
+            body: Column(children: [
+              _migrationBanner(),
+              Expanded(
+                  child: TabBarView(
+                      children: [Browser(), NowPlaying()],
+                      controller: _tabController)),
+            ]),
             bottomNavigationBar: BottomBar()));
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,7 +109,10 @@ class _MStreamAppState extends State<MStreamApp>
         final label = p.failed
             ? 'Move stopped — not enough space, or the location is unavailable.'
             : p.done
-                ? 'Move complete'
+                ? (p.skipped > 0
+                    ? 'Move complete — ${p.skipped} skipped (unsupported '
+                        'name${p.skipped == 1 ? '' : 's'})'
+                    : 'Move complete')
                 : 'Moving downloads… '
                     '${pct != null ? '${(pct * 100).round()}%' : '${p.moved}/${p.total}'}'
                     ' — keep the app open';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -110,8 +110,9 @@ class _MStreamAppState extends State<MStreamApp>
             ? 'Move stopped — not enough space, or the location is unavailable.'
             : p.done
                 ? (p.skipped > 0
-                    ? 'Move complete — ${p.skipped} skipped (unsupported '
-                        'name${p.skipped == 1 ? '' : 's'})'
+                    ? 'Move complete — ${p.skipped} file'
+                        "${p.skipped == 1 ? '' : 's'} skipped "
+                        '(unsupported on the destination)'
                     : 'Move complete')
                 : 'Moving downloads… '
                     '${pct != null ? '${(pct * 100).round()}%' : '${p.moved}/${p.total}'}'

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'screens/metadata_screen.dart';
 import 'screens/auto_dj.dart';
 // import 'screens/downloads.dart'; // DownloadScreen — drawer entry hidden below
 import 'singletons/downloads.dart';
+import 'singletons/app_messenger.dart';
 import 'screens/add_server.dart';
 import 'screens/manage_server.dart';
 import 'screens/playlists_screen.dart';
@@ -55,6 +56,7 @@ Future<void> main() async {
       VelvetColors.setActive(palette);
       return MaterialApp(
         title: 'mStream Music',
+        scaffoldMessengerKey: rootMessengerKey,
         home: MStreamApp(),
         theme: buildAppTheme(palette),
         debugShowCheckedModeBanner: false,
@@ -440,8 +442,7 @@ class NowPlaying extends StatelessWidget {
                                           DownloadManager().downloadOneFile(
                                               queue[index].id,
                                               queue[index].extras!['server'],
-                                              queue[index].extras!['path'],
-                                              null);
+                                              queue[index].extras!['path']);
                                         }
                                       })
                                 ],
@@ -631,7 +632,7 @@ class NowPlaying extends StatelessWidget {
               Navigator.of(ctx).pop();
               for (final m in pending) {
                 DownloadManager().downloadOneFile(
-                    m.id, m.extras!['server'], m.extras!['path'], null);
+                    m.id, m.extras!['server'], m.extras!['path']);
               }
               ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                   content:

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show Platform;
+import 'dart:io' show Platform, File;
 
 import 'package:audio_service/audio_service.dart';
 import 'package:just_audio/just_audio.dart';
@@ -151,11 +151,15 @@ class AudioPlayerHandler extends BaseAudioHandler
   Future<void> addQueueItem(MediaItem item) async {
     queue.add(queue.value..add(item));
 
-    // Uri.file (not Uri.parse) so local paths with spaces / reserved chars —
-    // possible now that Permanent/SD folders are user-chosen (e.g. "My Music")
-    // — are encoded into a valid file:// URI instead of silently mis-parsing.
-    final uri = item.extras?['localPath'] != null
-        ? Uri.file(item.extras!['localPath'])
+    // Play the offline copy if it's actually on disk; otherwise stream
+    // (item.id is the server URL). Re-checking existence here means a file
+    // moved/deleted after the item was built (e.g. mid-migration, SD removed)
+    // falls back to streaming instead of a broken local URI. Uri.file (not
+    // Uri.parse) so paths with spaces — possible with user-chosen folders —
+    // encode correctly.
+    final String? localPath = item.extras?['localPath'];
+    final uri = (localPath != null && File(localPath).existsSync())
+        ? Uri.file(localPath)
         : Uri.parse(item.id);
     await _player.addAudioSource(AudioSource.uri(uri));
   }

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -151,8 +151,11 @@ class AudioPlayerHandler extends BaseAudioHandler
   Future<void> addQueueItem(MediaItem item) async {
     queue.add(queue.value..add(item));
 
+    // Uri.file (not Uri.parse) so local paths with spaces / reserved chars —
+    // possible now that Permanent/SD folders are user-chosen (e.g. "My Music")
+    // — are encoded into a valid file:// URI instead of silently mis-parsing.
     final uri = item.extras?['localPath'] != null
-        ? Uri.parse(item.extras!['localPath'])
+        ? Uri.file(item.extras!['localPath'])
         : Uri.parse(item.id);
     await _player.addAudioSource(AudioSource.uri(uri));
   }

--- a/lib/objects/display_item.dart
+++ b/lib/objects/display_item.dart
@@ -132,7 +132,9 @@ class DisplayItem {
     // Check if file is saved on device
     if (this.type == 'file') {
       String downloadDirectory = this.server!.localname + this.data!;
-      FileExplorer().getDownloadDir(this.server!.saveToSdCard).then((dir) {
+      FileExplorer()
+          .getDownloadDir(this.server!.storageMode, this.server!.storageBasePath)
+          .then((dir) {
         if (dir == null) {
           return;
         }

--- a/lib/objects/display_item.dart
+++ b/lib/objects/display_item.dart
@@ -150,6 +150,26 @@ class DisplayItem {
     }
   }
 
+  // Re-evaluates whether this file exists at the server's CURRENT storage
+  // location and updates [downloadProgress] (100 = present, 0 = not). Unlike
+  // the constructor's one-shot check (which only ever sets 100), this also
+  // CLEARS a stale badge — so after a server's download location changes, a row
+  // that no longer has a local copy stops claiming it's downloaded. A row
+  // that's mid-download (1–99%) is left alone. The caller refreshes the
+  // browser stream once after a batch.
+  Future<void> recheckDownloaded() async {
+    if (type != 'file' || server == null || data == null) return;
+    if (downloadProgress > 0 && downloadProgress < 100) return;
+    final dir = await FileExplorer()
+        .getDownloadDir(server!.storageMode, server!.storageBasePath);
+    bool present = false;
+    if (dir != null) {
+      present =
+          await File('${dir.path}/media/${server!.localname}${data!}').exists();
+    }
+    downloadProgress = present ? 100 : 0;
+  }
+
   // DisplayItem.fromJson(Map<String, dynamic> json)
   //     : name = json['name'],
   //       type = json['type'],

--- a/lib/objects/server.dart
+++ b/lib/objects/server.dart
@@ -43,9 +43,11 @@ class Server {
         // Migrate the old boolean: absent/false → appLocal; true → the
         // legacy external-app-private location (preserved losslessly so
         // existing SD-toggle downloads keep resolving).
-        storageMode = json['storageMode'] ??
-            ((json['saveToSdCard'] == true) ? 'legacyExternal' : 'appLocal'),
-        storageBasePath = json['storageBasePath'];
+        storageMode = json['storageMode'] is String
+            ? json['storageMode'] as String
+            : ((json['saveToSdCard'] == true) ? 'legacyExternal' : 'appLocal'),
+        storageBasePath =
+            json['storageBasePath'] is String ? json['storageBasePath'] : null;
 
   Map<String, dynamic> toJson() => {
         'url': url,

--- a/lib/objects/server.dart
+++ b/lib/objects/server.dart
@@ -1,7 +1,18 @@
 class Server {
   String url;
   String localname; // name we use when mappings files to the fs
-  bool saveToSdCard = false;
+
+  // Where downloaded files are stored. One of:
+  //   'appLocal'       — internal app-private storage (default; wiped on uninstall)
+  //   'permanent'      — a user-chosen folder in shared storage (survives uninstall)
+  //   'sdCard'         — a user-chosen folder on a removable SD card
+  //   'legacyExternal' — migration-only: the pre-existing saveToSdCard==true
+  //                      location (getExternalStorageDirectory). Not offered in
+  //                      the UI; a server keeps it until the user re-picks a mode.
+  // 'permanent'/'sdCard' keep their absolute base dir in [storageBasePath];
+  // 'appLocal'/'legacyExternal' resolve their base at runtime (basePath null).
+  String storageMode = 'appLocal';
+  String? storageBasePath;
 
   // Runtime-only flag (never persisted): set by a compatibility probe
   // when this client can't work with the server build at [url]. While
@@ -29,7 +40,12 @@ class Server {
         autoDJPaths = json['autoDJPaths']?.cast<String, bool>() ?? {},
         autoDJminRating = json['autoDJminRating'],
         playlists = List<String>.from(json['playlists'] ?? []),
-        saveToSdCard = json['saveToSdCard'] ?? false;
+        // Migrate the old boolean: absent/false → appLocal; true → the
+        // legacy external-app-private location (preserved losslessly so
+        // existing SD-toggle downloads keep resolving).
+        storageMode = json['storageMode'] ??
+            ((json['saveToSdCard'] == true) ? 'legacyExternal' : 'appLocal'),
+        storageBasePath = json['storageBasePath'];
 
   Map<String, dynamic> toJson() => {
         'url': url,
@@ -40,6 +56,7 @@ class Server {
         'autoDJPaths': autoDJPaths,
         'autoDJminRating': autoDJminRating,
         'playlists': playlists,
-        'saveToSdCard': saveToSdCard
+        'storageMode': storageMode,
+        'storageBasePath': storageBasePath
       };
 }

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -66,6 +66,10 @@ class MyCustomFormState extends State<MyCustomForm> {
   // Defaults to a generated id; making it editable lets a re-added
   // server reuse its old folder and recover its downloaded songs.
   final TextEditingController _downloadFolderCtrl = TextEditingController();
+  // True once the user types in / picks the download folder, so the URL
+  // auto-fill (subdomain-domain) stops overwriting their choice. Also set
+  // in edit mode, where the existing folder must be preserved.
+  bool _folderManuallyEdited = false;
 
   bool submitPending = false;
   // Download storage destination: 'appLocal' | 'permanent' | 'sdCard'
@@ -99,6 +103,7 @@ class MyCustomFormState extends State<MyCustomForm> {
   void initState() {
     super.initState();
 
+    bool isEdit = false;
     try {
       Server s = ServerManager().serverList[editThisServer ?? -1];
       _urlCtrl.text = s.url;
@@ -107,6 +112,7 @@ class MyCustomFormState extends State<MyCustomForm> {
       _storageMode = s.storageMode;
       _storageBasePath = s.storageBasePath;
       _downloadFolderCtrl.text = s.localname;
+      isEdit = true;
       // An existing server saved without credentials is a public
       // server — start in public mode so the toggle reflects reality.
       if ((s.username ?? '').isEmpty && (s.password ?? '').isEmpty) {
@@ -114,9 +120,12 @@ class MyCustomFormState extends State<MyCustomForm> {
       }
     } catch (err) {}
 
-    // New server: default to a generated folder id (overridable below).
-    if (_downloadFolderCtrl.text.isEmpty) {
-      _downloadFolderCtrl.text = Uuid().v4();
+    // Existing server: keep its folder as-is (it maps to already-downloaded
+    // files). New server: auto-derive the folder from the URL as the user
+    // types it, until they edit it themselves.
+    _folderManuallyEdited = isEdit;
+    if (!isEdit) {
+      _maybeAutofillFolder();
     }
 
     _detectSdCard();
@@ -124,6 +133,8 @@ class MyCustomFormState extends State<MyCustomForm> {
     // Stale-result-clearing: editing the URL invalidates whatever
     // banner the last test produced (it was for a different URL).
     _urlCtrl.addListener(_clearTestResult);
+    // Auto-name the download folder from the URL (new servers only).
+    _urlCtrl.addListener(_maybeAutofillFolder);
   }
 
   void _clearTestResult() {
@@ -133,6 +144,46 @@ class MyCustomFormState extends State<MyCustomForm> {
         _testSuccess = null;
       });
     }
+  }
+
+  // Auto-fills the download folder from the server URL as
+  // "${subdomain}-${domain}" (e.g. music.rum.st -> music-rum.st), unless
+  // the user has already typed or picked a folder. New servers only.
+  void _maybeAutofillFolder() {
+    if (_folderManuallyEdited) return;
+    final name = _defaultLocalName(_urlCtrl.text);
+    if (name != null && _downloadFolderCtrl.text != name) {
+      _downloadFolderCtrl.text = name;
+    }
+  }
+
+  // Derives a clean folder name from a server URL: the host's first label
+  // (subdomain), a dash, then the remaining labels (domain). IP / single-
+  // label / no-subdomain hosts use the bare host. Returns null if no host
+  // can be parsed yet. Sanitized for FAT/ext filesystems (SD cards).
+  String? _defaultLocalName(String url) {
+    final raw = url.trim();
+    if (raw.isEmpty) return null;
+    String host;
+    try {
+      host = Uri.parse(raw.contains('://') ? raw : 'https://$raw').host;
+    } catch (_) {
+      return null;
+    }
+    if (host.isEmpty) return null;
+    if (host.startsWith('www.')) host = host.substring(4);
+
+    final isIpv4 = RegExp(r'^\d{1,3}(\.\d{1,3}){3}$').hasMatch(host);
+    final labels = host.split('.');
+    final String name;
+    if (isIpv4 || host.contains(':') || labels.length < 3) {
+      name = host; // IP / single label / bare domain — use as-is
+    } else {
+      name = '${labels.first}-${labels.sublist(1).join('.')}';
+    }
+    // Keep only filesystem-safe characters.
+    final safe = name.replaceAll(RegExp(r'[^A-Za-z0-9._-]'), '-');
+    return safe.isEmpty ? null : safe;
   }
 
   // Verifies the connection the same way the Save button does: an
@@ -283,6 +334,7 @@ class MyCustomFormState extends State<MyCustomForm> {
   @override
   void dispose() {
     _urlCtrl.removeListener(_clearTestResult);
+    _urlCtrl.removeListener(_maybeAutofillFolder);
     _urlCtrl.dispose();
     _usernameCtrl.dispose();
     _passwordCtrl.dispose();
@@ -388,11 +440,12 @@ class MyCustomFormState extends State<MyCustomForm> {
     // residual text in the controllers.
     final username = _publicAccess ? '' : _usernameCtrl.text;
     final password = _publicAccess ? '' : _passwordCtrl.text;
-    // The user-chosen download folder (media/<this>); fall back to a
-    // generated id if they cleared the field.
-    final folder = _downloadFolderCtrl.text.trim().isEmpty
-        ? Uuid().v4()
-        : _downloadFolderCtrl.text.trim();
+    // The user-chosen download folder (media/<this>). If they cleared it,
+    // fall back to the URL-derived name, then a generated id.
+    String folder = _downloadFolderCtrl.text.trim();
+    if (folder.isEmpty) {
+      folder = _defaultLocalName(_urlCtrl.text) ?? Uuid().v4();
+    }
 
     // permanent/sdCard carry an absolute base path; the other modes
     // resolve their base at runtime, so null it out.
@@ -520,6 +573,7 @@ class MyCustomFormState extends State<MyCustomForm> {
       ),
     );
     if (chosen != null && mounted) {
+      _folderManuallyEdited = true;
       setState(() => _downloadFolderCtrl.text = chosen);
     }
   }
@@ -1029,6 +1083,7 @@ class MyCustomFormState extends State<MyCustomForm> {
                     child: TextFormField(
                       controller: _downloadFolderCtrl,
                       autocorrect: false,
+                      onChanged: (_) => _folderManuallyEdited = true,
                       decoration: InputDecoration(
                         isDense: true,
                         prefixIcon: Icon(Icons.folder_outlined),

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -678,6 +678,25 @@ class MyCustomFormState extends State<MyCustomForm> {
   }
 
   Future<void> saveServer(Uri lol, [String jwt = '']) async {
+    // Permanent / SD card need a folder the app can actually write to. If the
+    // mode was selected but no (writable) folder was picked, _storageBasePath
+    // is null — saving would store a null base path and route every download to
+    // "unavailable". Block it with a clear message instead of a silently broken
+    // server. (_storageBasePath is only set after the write-probe in
+    // _chooseStorageFolder passes, so a non-null value already means writable.)
+    if ((_storageMode == 'permanent' || _storageMode == 'sdCard') &&
+        _storageBasePath == null) {
+      if (mounted) {
+        setState(() => submitPending = false);
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+            content: Text(_storageMode == 'sdCard'
+                ? 'Choose a folder on the SD card first. If every folder is '
+                    "rejected, your device may not let apps write to the card — "
+                    'use Permanent or App local instead.'
+                : 'Choose a download folder first.')));
+      }
+      return;
+    }
     bool shouldUpdate = false;
     try {
       ServerManager().serverList[editThisServer ?? -1];
@@ -1098,7 +1117,9 @@ class MyCustomFormState extends State<MyCustomForm> {
       case 'sdCard':
         return Text(
           'Saved to a folder on the SD card you choose. May become '
-          'unavailable if the card is removed.',
+          'unavailable if the card is removed. Some devices don\'t let apps '
+          'write to SD cards — if folder selection keeps failing, use '
+          'Permanent or App local.',
           style: TextStyle(color: VelvetColors.textTertiary, fontSize: 11),
         );
       case 'appLocal':

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -575,8 +575,27 @@ class MyCustomFormState extends State<MyCustomForm> {
       return;
     }
     final chosen = await _browseForFolder(root);
-    if (chosen != null && mounted) {
-      setState(() => _storageBasePath = chosen);
+    if (chosen == null || !mounted) return;
+    // Confirm we can actually write there before committing — catches
+    // read-only roots / SD cards before downloads silently fail later.
+    if (!await _isWritable(chosen)) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+            content: Text("That folder isn't writable — pick another.")));
+      }
+      return;
+    }
+    setState(() => _storageBasePath = chosen);
+  }
+
+  Future<bool> _isWritable(String dirPath) async {
+    try {
+      final probe = File(path.join(dirPath, '.mstream_write_test'));
+      await probe.writeAsString('');
+      await probe.delete();
+      return true;
+    } catch (_) {
+      return false;
     }
   }
 
@@ -629,6 +648,13 @@ class MyCustomFormState extends State<MyCustomForm> {
                                   fontSize: 12),
                               overflow: TextOverflow.ellipsis),
                         ),
+                        IconButton(
+                          icon: Icon(Icons.create_new_folder_outlined,
+                              color: VelvetColors.primary),
+                          tooltip: 'New folder',
+                          onPressed: () => _createSubfolder(ctx, current,
+                              (p) => setSheet(() => current = p)),
+                        ),
                       ],
                     ),
                   ),
@@ -677,6 +703,52 @@ class MyCustomFormState extends State<MyCustomForm> {
         },
       ),
     );
+  }
+
+  // Prompts for a name and creates a subfolder under [parent], then calls
+  // [onCreated] with the new absolute path so the picker descends into it.
+  Future<void> _createSubfolder(BuildContext sheetCtx, String parent,
+      void Function(String) onCreated) async {
+    final ctrl = TextEditingController();
+    final name = await showDialog<String>(
+      context: sheetCtx,
+      builder: (dctx) => AlertDialog(
+        backgroundColor: VelvetColors.surface,
+        title: Text('New folder',
+            style: TextStyle(color: VelvetColors.textPrimary)),
+        content: TextField(
+          controller: ctrl,
+          autofocus: true,
+          autocorrect: false,
+          style: TextStyle(color: VelvetColors.textPrimary),
+          decoration: InputDecoration(hintText: 'Folder name'),
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.of(dctx).pop(),
+              child: Text('Cancel',
+                  style: TextStyle(color: VelvetColors.textSecondary))),
+          TextButton(
+              onPressed: () => Navigator.of(dctx).pop(ctrl.text.trim()),
+              child: Text('Create')),
+        ],
+      ),
+    );
+    ctrl.dispose();
+    if (name == null || name.isEmpty) return;
+    // Single path segment only — strip separators so a name can't escape
+    // the current directory.
+    final safe = name.replaceAll(RegExp(r'[\\/]+'), '_');
+    try {
+      final newDir = Directory(path.join(parent, safe));
+      newDir.createSync(recursive: true);
+      onCreated(newDir.path);
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Could not create folder')));
+      }
+    }
   }
 
   // Per-mode explanation under the dropdown. App local gets a prominent

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -13,6 +13,7 @@ import 'package:permission_handler/permission_handler.dart';
 import '../objects/server.dart';
 import '../singletons/file_explorer.dart';
 import '../singletons/server_list.dart';
+import '../singletons/migration_manager.dart';
 import '../theme/velvet_theme.dart';
 import '../util/server_compat.dart';
 
@@ -510,19 +511,23 @@ class MyCustomFormState extends State<MyCustomForm> {
       }
       return true;
     } catch (_) {
-      // Cross-volume: rename can't move across filesystems — offer a copy.
-      return await _copyAcrossVolumes(oldDir, newDir);
+      // Cross-volume: rename can't cross filesystems — ask what to do.
+      return await _promptCrossVolume(oldDir, newDir);
     }
   }
 
-  // Cross-volume relocation. Prompts (with file count + size): Copy moves the
-  // files (async copy -> verify -> delete originals); "Switch only" leaves
-  // them (re-download), optionally deleting the old copies; Cancel aborts.
-  // Fail-safe: a failed/canceled copy cleans up the partial, keeps the
-  // originals, and aborts the save. Returns true to proceed, false to abort.
-  Future<bool> _copyAcrossVolumes(Directory oldDir, Directory newDir) async {
+  // Cross-volume relocation. The files can't be instantly moved, so offer
+  // three clear choices: move them in the background (per-file copy+delete,
+  // resumable), leave them where they are, or delete the old copies. All
+  // three proceed with the storage change; only Cancel aborts it.
+  Future<bool> _promptCrossVolume(Directory oldDir, Directory newDir) async {
     if (!mounted) return false;
-    // Count + size from the source (App local is internal — fast to walk).
+    if (MigrationManager().isRunning) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text('A move is already running — let it finish first.')));
+      return false;
+    }
+    // Count + size for the prompt.
     int count = 0;
     int bytes = 0;
     try {
@@ -535,96 +540,91 @@ class MyCustomFormState extends State<MyCustomForm> {
     } catch (_) {}
 
     if (!mounted) return false;
-    bool deleteOld = false;
     final choice = await showDialog<String>(
       context: context,
-      builder: (ctx) => StatefulBuilder(
-        builder: (ctx, setInner) => AlertDialog(
-          backgroundColor: VelvetColors.surface,
-          title: Text('Move downloaded files?',
-              style: TextStyle(color: VelvetColors.textPrimary)),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                  "This server's $count downloaded file${count == 1 ? '' : 's'} "
-                  '(${_formatBytes(bytes)}) are on a different storage volume. '
-                  'Copy them to keep them offline at the new location, or '
-                  "switch without copying (they'll re-download).",
-                  style: TextStyle(color: VelvetColors.textSecondary)),
-              SizedBox(height: 4),
-              CheckboxListTile(
-                contentPadding: EdgeInsets.zero,
-                controlAffinity: ListTileControlAffinity.leading,
-                activeColor: VelvetColors.primary,
-                value: deleteOld,
-                onChanged: (v) => setInner(() => deleteOld = v ?? false),
-                title: Text('Delete the old files',
-                    style: TextStyle(color: VelvetColors.textPrimary)),
-                subtitle: Text('Only applies when switching without copying.',
-                    style: TextStyle(
-                        color: VelvetColors.textTertiary, fontSize: 12)),
-              ),
-            ],
+      builder: (ctx) => SimpleDialog(
+        backgroundColor: VelvetColors.surface,
+        title: Text('Different storage volume',
+            style: TextStyle(color: VelvetColors.textPrimary, fontSize: 18)),
+        children: [
+          Padding(
+            padding: EdgeInsets.fromLTRB(24, 0, 24, 12),
+            child: Text(
+                "This server's $count downloaded file${count == 1 ? '' : 's'} "
+                '(${_formatBytes(bytes)}) are on a different storage volume '
+                'from the new location. Choose what to do:',
+                style:
+                    TextStyle(color: VelvetColors.textSecondary, fontSize: 13)),
           ),
-          actions: [
-            TextButton(
+          _migrateOption(
+              ctx,
+              'move',
+              Icons.drive_file_move_outline,
+              'Move them',
+              'Copy to the new location in the background, deleting each old '
+                  'copy as it goes. Keep the app open until it finishes.'),
+          _migrateOption(
+              ctx,
+              'leave',
+              Icons.inventory_2_outlined,
+              'Leave them',
+              'Switch now; the old downloads stay where they are and '
+                  're-download at the new location.'),
+          _migrateOption(
+              ctx,
+              'delete',
+              Icons.delete_outline,
+              'Delete old downloads',
+              "Switch now and remove the old files; they'll re-download at "
+                  'the new location.'),
+          Padding(
+            padding: EdgeInsets.fromLTRB(24, 4, 12, 4),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
                 onPressed: () => Navigator.of(ctx).pop('cancel'),
                 child: Text('Cancel',
-                    style: TextStyle(color: VelvetColors.textSecondary))),
-            TextButton(
-                onPressed: () => Navigator.of(ctx).pop('switch'),
-                child: Text('Switch only')),
-            TextButton(
-                onPressed: () => Navigator.of(ctx).pop('copy'),
-                child: Text('Copy')),
-          ],
-        ),
+                    style: TextStyle(color: VelvetColors.textSecondary)),
+              ),
+            ),
+          ),
+        ],
       ),
     );
 
-    if (choice == null || choice == 'cancel') return false; // abort save
-    if (choice == 'switch') {
-      if (deleteOld) {
+    switch (choice) {
+      case 'move':
+        await MigrationManager().start(oldDir.path, newDir.path);
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+              content: Text('Moving your downloads in the background — keep '
+                  'the app open.')));
+        }
+        return true;
+      case 'leave':
+        return true; // switch; old files stay put
+      case 'delete':
         try {
           await oldDir.delete(recursive: true);
         } catch (_) {}
-      }
-      return true; // switch without copying
+        return true;
+      default: // cancel / dismissed
+        return false;
     }
+  }
 
-    // Copy: run the async copy behind a progress dialog.
-    if (!mounted) return false;
-    final ok = await showDialog<bool>(
-      context: context,
-      barrierDismissible: false,
-      builder: (ctx) => _CopyProgressDialog(src: oldDir, dst: newDir),
+  // One tappable option row in the cross-volume dialog.
+  Widget _migrateOption(BuildContext ctx, String value, IconData icon,
+      String title, String subtitle) {
+    return ListTile(
+      leading: Icon(icon, color: VelvetColors.primary),
+      title: Text(title,
+          style: TextStyle(
+              color: VelvetColors.textPrimary, fontWeight: FontWeight.w600)),
+      subtitle: Text(subtitle,
+          style: TextStyle(color: VelvetColors.textTertiary, fontSize: 12)),
+      onTap: () => Navigator.of(ctx).pop(value),
     );
-
-    if (ok != true) {
-      // Clean up a partial copy; the originals are untouched.
-      try {
-        if (newDir.existsSync()) await newDir.delete(recursive: true);
-      } catch (_) {}
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-            content: Text(
-                'Copy failed — files unchanged, storage location not changed.')));
-      }
-      return false;
-    }
-
-    // Success — remove the originals so the files live only at the new spot.
-    try {
-      await oldDir.delete(recursive: true);
-    } catch (_) {}
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text(
-              'Moved $count file${count == 1 ? '' : 's'} to the new location.')));
-    }
-    return true;
   }
 
   String _formatBytes(int bytes) {
@@ -634,6 +634,17 @@ class MyCustomFormState extends State<MyCustomForm> {
       return '${(bytes / 1024 / 1024).toStringAsFixed(1)} MB';
     }
     return '${(bytes / 1024 / 1024 / 1024).toStringAsFixed(2)} GB';
+  }
+
+  // Collapses a typed folder name to a single safe path segment: strips path
+  // separators and parent refs (no traversal out of media/), then trims
+  // leading/trailing separators and whitespace.
+  String _sanitizeFolderName(String name) {
+    return name
+        .replaceAll(RegExp(r'[\\/]+'), '_')
+        .replaceAll(RegExp(r'\.\.+'), '_')
+        .replaceAll(RegExp(r'^[\s._-]+'), '')
+        .replaceAll(RegExp(r'[\s._-]+$'), '');
   }
 
   Future<void> saveServer(Uri lol, [String jwt = '']) async {
@@ -651,7 +662,7 @@ class MyCustomFormState extends State<MyCustomForm> {
     final password = _publicAccess ? '' : _passwordCtrl.text;
     // The user-chosen download folder (media/<this>). If they cleared it,
     // fall back to the URL-derived name, then a generated id.
-    String folder = _downloadFolderCtrl.text.trim();
+    String folder = _sanitizeFolderName(_downloadFolderCtrl.text.trim());
     if (folder.isEmpty) {
       folder = _computeAutoFolder() ?? Uuid().v4();
     }
@@ -820,7 +831,14 @@ class MyCustomFormState extends State<MyCustomForm> {
       final granted = await _ensureAllFilesAccess();
       if (!granted) return;
     }
-    if (mounted) setState(() => _storageMode = v);
+    // Reset the chosen folder so each mode starts fresh — avoids carrying a
+    // Permanent path over to SD card (or vice versa) without re-picking.
+    if (mounted) {
+      setState(() {
+        _storageMode = v;
+        _storageBasePath = null;
+      });
+    }
   }
 
   // Requests MANAGE_EXTERNAL_STORAGE ("All files access"). On Android 11+
@@ -1014,9 +1032,9 @@ class MyCustomFormState extends State<MyCustomForm> {
     );
     ctrl.dispose();
     if (name == null || name.isEmpty) return;
-    // Single path segment only — strip separators so a name can't escape
-    // the current directory.
-    final safe = name.replaceAll(RegExp(r'[\\/]+'), '_');
+    // Single safe path segment so a name can't escape the current directory.
+    final safe = _sanitizeFolderName(name);
+    if (safe.isEmpty) return;
     try {
       final newDir = Directory(path.join(parent, safe));
       newDir.createSync(recursive: true);
@@ -1384,103 +1402,6 @@ class MyCustomFormState extends State<MyCustomForm> {
           ),
         ),
       ),
-    );
-  }
-}
-
-// Modal progress dialog that copies a directory tree (src -> dst) using async
-// I/O so the UI stays responsive on large libraries. Pops `true` once the
-// copy is verified (file count + total bytes), `false` on error or cancel.
-class _CopyProgressDialog extends StatefulWidget {
-  final Directory src;
-  final Directory dst;
-  const _CopyProgressDialog({required this.src, required this.dst});
-
-  @override
-  State<_CopyProgressDialog> createState() => _CopyProgressDialogState();
-}
-
-class _CopyProgressDialogState extends State<_CopyProgressDialog> {
-  int _copied = 0;
-  int _total = 0;
-  bool _canceled = false;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _run());
-  }
-
-  Future<void> _run() async {
-    try {
-      final files = <File>[];
-      await for (final e
-          in widget.src.list(recursive: true, followLinks: false)) {
-        if (e is File) files.add(e);
-      }
-      if (mounted) setState(() => _total = files.length);
-
-      int srcBytes = 0;
-      int lastPct = -1;
-      for (int i = 0; i < files.length; i++) {
-        if (_canceled) {
-          if (mounted) Navigator.of(context).pop(false);
-          return;
-        }
-        final f = files[i];
-        final rel = path.relative(f.path, from: widget.src.path);
-        final destPath = path.join(widget.dst.path, rel);
-        await Directory(path.dirname(destPath)).create(recursive: true);
-        await f.copy(destPath);
-        srcBytes += await f.length();
-        final done = i + 1;
-        final pct = (done * 100) ~/ files.length;
-        if (mounted && pct != lastPct) {
-          lastPct = pct;
-          setState(() => _copied = done);
-        }
-      }
-
-      // Verify: the destination has at least as many files + bytes.
-      int destCount = 0;
-      int destBytes = 0;
-      await for (final e
-          in widget.dst.list(recursive: true, followLinks: false)) {
-        if (e is File) {
-          destCount++;
-          destBytes += await e.length();
-        }
-      }
-      final ok = destCount >= files.length && destBytes >= srcBytes;
-      if (mounted) Navigator.of(context).pop(ok);
-    } catch (_) {
-      if (mounted) Navigator.of(context).pop(false);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final value = _total == 0 ? null : _copied / _total;
-    return AlertDialog(
-      backgroundColor: VelvetColors.surface,
-      title: Text(_canceled ? 'Canceling…' : 'Moving files…',
-          style: TextStyle(color: VelvetColors.textPrimary)),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          LinearProgressIndicator(value: value),
-          SizedBox(height: 12),
-          Text(_total == 0 ? 'Preparing…' : 'Copied $_copied of $_total files',
-              style: TextStyle(color: VelvetColors.textSecondary)),
-        ],
-      ),
-      actions: [
-        TextButton(
-          onPressed: _canceled ? null : () => setState(() => _canceled = true),
-          child: Text('Cancel',
-              style: TextStyle(color: VelvetColors.textSecondary)),
-        ),
-      ],
     );
   }
 }

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -14,6 +14,7 @@ import '../objects/server.dart';
 import '../singletons/file_explorer.dart';
 import '../singletons/server_list.dart';
 import '../singletons/migration_manager.dart';
+import '../singletons/downloads.dart';
 import '../theme/velvet_theme.dart';
 import '../util/server_compat.dart';
 
@@ -704,6 +705,13 @@ class MyCustomFormState extends State<MyCustomForm> {
 
     if (shouldUpdate) {
       final s = ServerManager().serverList[editThisServer!];
+      // If the storage target is changing, cancel in-flight downloads first so
+      // none land at the old location after the switch (they'd be stranded).
+      if (s.storageMode != _storageMode ||
+          s.storageBasePath != basePath ||
+          s.localname != folder) {
+        await DownloadManager().cancelAll();
+      }
       // Relocate already-downloaded files before flipping the server's
       // storage pointers. Same-volume = instant atomic move; cross-volume =
       // warn (files stay, user re-downloads). Cancel aborts the save.

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -7,6 +7,7 @@ import 'package:uuid/uuid.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
+import 'package:permission_handler/permission_handler.dart';
 // import 'package:flutter_barcode_scanner/flutter_barcode_scanner.dart';
 import '../objects/server.dart';
 import '../singletons/file_explorer.dart';
@@ -67,7 +68,14 @@ class MyCustomFormState extends State<MyCustomForm> {
   final TextEditingController _downloadFolderCtrl = TextEditingController();
 
   bool submitPending = false;
-  bool saveToSdCard = false;
+  // Download storage destination: 'appLocal' | 'permanent' | 'sdCard'
+  // (+ migration-only 'legacyExternal', shown as App local). 'permanent'
+  // and 'sdCard' also keep an absolute base dir in _storageBasePath.
+  String _storageMode = 'appLocal';
+  String? _storageBasePath;
+  // Browsable volume roots derived in _detectSdCard for the folder picker.
+  String? _sharedStorageRoot;
+  String? _sdCardRoot;
   // Public-access mode: server is reachable without authentication.
   // Disables the username/password fields and skips the login
   // fallback in checkServer. checkServer's existing /api/v1/ping
@@ -96,7 +104,8 @@ class MyCustomFormState extends State<MyCustomForm> {
       _urlCtrl.text = s.url;
       _usernameCtrl.text = s.username ?? '';
       _passwordCtrl.text = s.password ?? '';
-      saveToSdCard = s.saveToSdCard;
+      _storageMode = s.storageMode;
+      _storageBasePath = s.storageBasePath;
       _downloadFolderCtrl.text = s.localname;
       // An existing server saved without credentials is a public
       // server — start in public mode so the toggle reflects reality.
@@ -243,12 +252,32 @@ class MyCustomFormState extends State<MyCustomForm> {
     try {
       final dirs = await getExternalStorageDirectories();
       final hasSd = dirs != null && dirs.length > 1;
-      if (mounted && hasSd != _hasSdCard) {
-        setState(() => _hasSdCard = hasSd);
+      // Derive the browsable volume roots for the folder picker by
+      // stripping the "/Android/data/<pkg>/files" app-private suffix.
+      String? sharedRoot;
+      String? sdRoot;
+      if (dirs != null && dirs.isNotEmpty) {
+        sharedRoot = _volumeRoot(dirs[0].path);
+        if (dirs.length > 1) sdRoot = _volumeRoot(dirs[1].path);
+      }
+      if (mounted) {
+        setState(() {
+          _hasSdCard = hasSd;
+          _sharedStorageRoot = sharedRoot;
+          _sdCardRoot = sdRoot;
+        });
       }
     } catch (_) {
       // Platform doesn't support it — stay hidden.
     }
+  }
+
+  // ".../Android/data/<pkg>/files" -> the volume root the user can browse
+  // (e.g. /storage/emulated/0 or /storage/<uuid>). Falls back to the input
+  // when the app-private suffix isn't present.
+  String _volumeRoot(String appDirPath) {
+    final idx = appDirPath.indexOf('/Android/');
+    return idx > 0 ? appDirPath.substring(0, idx) : appDirPath;
   }
 
   @override
@@ -365,21 +394,28 @@ class MyCustomFormState extends State<MyCustomForm> {
         ? Uuid().v4()
         : _downloadFolderCtrl.text.trim();
 
+    // permanent/sdCard carry an absolute base path; the other modes
+    // resolve their base at runtime, so null it out.
+    final basePath = (_storageMode == 'permanent' || _storageMode == 'sdCard')
+        ? _storageBasePath
+        : null;
+
     if (shouldUpdate) {
-      // localname isn't part of editServer's signature — set it directly
-      // (callAfterEditServer below persists the change).
-      ServerManager().serverList[editThisServer!].localname = folder;
-      ServerManager().editServer(
-          editThisServer!, _urlCtrl.text, username, password, saveToSdCard);
-      await ServerManager()
-          .getServerPaths(ServerManager().serverList[editThisServer!]);
+      // localname + storage aren't part of editServer's signature — set
+      // them directly (callAfterEditServer below persists the change).
+      final s = ServerManager().serverList[editThisServer!];
+      s.localname = folder;
+      s.storageMode = _storageMode;
+      s.storageBasePath = basePath;
+      ServerManager()
+          .editServer(editThisServer!, _urlCtrl.text, username, password);
+      await ServerManager().getServerPaths(s);
       await ServerManager().callAfterEditServer();
     } else {
       Server newServer =
           new Server(lol.origin, username, password, jwt, folder);
-      if (saveToSdCard == true) {
-        newServer.saveToSdCard = true;
-      }
+      newServer.storageMode = _storageMode;
+      newServer.storageBasePath = basePath;
       await ServerManager().getServerPaths(newServer);
 
       await ServerManager().addServer(newServer);
@@ -416,7 +452,8 @@ class MyCustomFormState extends State<MyCustomForm> {
   // user can point this server at one — recovering a re-added server's
   // previously-downloaded songs.
   Future<void> _browseDownloadFolders() async {
-    final base = await FileExplorer().getDownloadDir(saveToSdCard);
+    final base =
+        await FileExplorer().getDownloadDir(_storageMode, _storageBasePath);
     if (!mounted) return;
     if (base == null) {
       ScaffoldMessenger.of(context)
@@ -484,6 +521,198 @@ class MyCustomFormState extends State<MyCustomForm> {
     );
     if (chosen != null && mounted) {
       setState(() => _downloadFolderCtrl.text = chosen);
+    }
+  }
+
+  // The dropdown offers only the three real modes; a migrated
+  // 'legacyExternal' server displays as App local but keeps its stored
+  // mode until the user actively changes it (so its old downloads aren't
+  // orphaned just by opening this screen).
+  String get _displayStorageMode =>
+      (_storageMode == 'permanent' || _storageMode == 'sdCard')
+          ? _storageMode
+          : 'appLocal';
+
+  Future<void> _onStorageModeChanged(String? v) async {
+    if (v == null || v == _storageMode) return;
+    // Permanent / SD card write outside the app sandbox -> need all-files
+    // access. If the user declines, keep the previous mode (the dropdown
+    // is value-controlled, so it snaps back).
+    if (v == 'permanent' || v == 'sdCard') {
+      final granted = await _ensureAllFilesAccess();
+      if (!granted) return;
+    }
+    if (mounted) setState(() => _storageMode = v);
+  }
+
+  // Requests MANAGE_EXTERNAL_STORAGE ("All files access"). On Android 11+
+  // request() bounces to a system settings screen, so the just-returned
+  // status can still be denied — the user grants there, then re-selects.
+  Future<bool> _ensureAllFilesAccess() async {
+    var status = await Permission.manageExternalStorage.status;
+    if (status.isGranted) return true;
+    status = await Permission.manageExternalStorage.request();
+    if (status.isGranted) return true;
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(
+            'Grant "All files access" to store downloads permanently, '
+            'then pick the mode again.'),
+        action: SnackBarAction(label: 'Settings', onPressed: openAppSettings),
+      ));
+    }
+    return false;
+  }
+
+  Future<void> _chooseStorageFolder() async {
+    if (!await _ensureAllFilesAccess()) return;
+    final root = _storageMode == 'sdCard' ? _sdCardRoot : _sharedStorageRoot;
+    if (root == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Could not locate a storage volume')));
+      }
+      return;
+    }
+    final chosen = await _browseForFolder(root);
+    if (chosen != null && mounted) {
+      setState(() => _storageBasePath = chosen);
+    }
+  }
+
+  // Minimal navigable folder browser (no plugin — pure dart:io). Starts at
+  // [rootPath], descends on tap; "Use this folder" returns the current
+  // absolute path. Cannot navigate above the root.
+  Future<String?> _browseForFolder(String rootPath) {
+    String current = rootPath;
+    return showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: VelvetColors.surface,
+      isScrollControlled: true,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setSheet) {
+          List<Directory> subs = [];
+          try {
+            subs = Directory(current)
+                .listSync()
+                .whereType<Directory>()
+                .toList()
+              ..sort((a, b) => path
+                  .basename(a.path)
+                  .toLowerCase()
+                  .compareTo(path.basename(b.path).toLowerCase()));
+          } catch (_) {}
+          final canGoUp = current != rootPath;
+          return SafeArea(
+            child: SizedBox(
+              height: MediaQuery.of(ctx).size.height * 0.6,
+              child: Column(
+                children: [
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(8, 8, 8, 0),
+                    child: Row(
+                      children: [
+                        IconButton(
+                          icon: Icon(Icons.arrow_upward,
+                              color: canGoUp
+                                  ? VelvetColors.textPrimary
+                                  : VelvetColors.textTertiary),
+                          onPressed: canGoUp
+                              ? () =>
+                                  setSheet(() => current = path.dirname(current))
+                              : null,
+                        ),
+                        Expanded(
+                          child: Text(current,
+                              style: TextStyle(
+                                  color: VelvetColors.textSecondary,
+                                  fontSize: 12),
+                              overflow: TextOverflow.ellipsis),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Divider(color: VelvetColors.border2, height: 1),
+                  Expanded(
+                    child: subs.isEmpty
+                        ? Center(
+                            child: Text('No subfolders here',
+                                style: TextStyle(
+                                    color: VelvetColors.textTertiary)))
+                        : ListView(
+                            children: subs
+                                .map((d) => ListTile(
+                                      leading: Icon(Icons.folder,
+                                          color: VelvetColors.primary),
+                                      title: Text(path.basename(d.path),
+                                          style: TextStyle(
+                                              color: VelvetColors.textPrimary),
+                                          overflow: TextOverflow.ellipsis),
+                                      onTap: () =>
+                                          setSheet(() => current = d.path),
+                                    ))
+                                .toList(),
+                          ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.all(12),
+                    child: SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton.icon(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: VelvetColors.primary,
+                          foregroundColor: Colors.white,
+                          padding: EdgeInsets.symmetric(vertical: 14),
+                        ),
+                        icon: Icon(Icons.check),
+                        label: Text('Use this folder'),
+                        onPressed: () => Navigator.of(ctx).pop(current),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  // Per-mode explanation under the dropdown. App local gets a prominent
+  // warning that its files vanish on uninstall (the whole reason this
+  // picker exists).
+  Widget _storageHelp() {
+    switch (_storageMode) {
+      case 'permanent':
+        return Text(
+          'Saved to a folder you choose. Survives uninstalling the app. '
+          'Requires "All files access".',
+          style: TextStyle(color: VelvetColors.textTertiary, fontSize: 11),
+        );
+      case 'sdCard':
+        return Text(
+          'Saved to a folder on the SD card you choose. May become '
+          'unavailable if the card is removed.',
+          style: TextStyle(color: VelvetColors.textTertiary, fontSize: 11),
+        );
+      case 'appLocal':
+      default:
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(Icons.warning_amber_rounded,
+                size: 14, color: VelvetColors.warning),
+            SizedBox(width: 6),
+            Expanded(
+              child: Text(
+                'Saved inside the app. Deleted when you uninstall or clear '
+                'the app.',
+                style: TextStyle(color: VelvetColors.warning, fontSize: 11),
+              ),
+            ),
+          ],
+        );
     }
   }
 
@@ -641,23 +870,77 @@ class MyCustomFormState extends State<MyCustomForm> {
                   ),
                 ),
               ],
-              // Switch only renders when an actual removable SD card
-              // is present (see _detectSdCard). Hidden on internal-
-              // storage-only phones — most modern devices.
-              if (_hasSdCard) ...[
-                SizedBox(height: 8),
-                SwitchListTile(
-                  contentPadding: EdgeInsets.zero,
-                  title: Text('Download to SD Card'),
-                  subtitle: Text(
-                    'Save downloaded music to the removable SD card '
-                    'instead of internal storage.',
-                    style: TextStyle(
-                        color: VelvetColors.textSecondary, fontSize: 12),
+              // Storage location: App local (default) / Permanent / SD card
+              // (the SD option only when a removable card is present, or when
+              // this server is already configured for it). Replaces the old
+              // SD-card toggle; see _storageHelp for the per-mode caveats.
+              SizedBox(height: 16),
+              Text('Storage location',
+                  style: TextStyle(
+                      color: VelvetColors.textSecondary,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600)),
+              SizedBox(height: 6),
+              InputDecorator(
+                decoration: InputDecoration(
+                  isDense: true,
+                  prefixIcon: Icon(Icons.sd_storage_outlined),
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<String>(
+                    value: _displayStorageMode,
+                    isExpanded: true,
+                    isDense: true,
+                    dropdownColor: VelvetColors.surface,
+                    style: TextStyle(color: VelvetColors.textPrimary),
+                    items: [
+                      DropdownMenuItem(
+                          value: 'appLocal', child: Text('App local')),
+                      DropdownMenuItem(
+                          value: 'permanent', child: Text('Permanent')),
+                      if (_hasSdCard || _storageMode == 'sdCard')
+                        DropdownMenuItem(
+                            value: 'sdCard', child: Text('SD card')),
+                    ],
+                    onChanged: submitPending ? null : _onStorageModeChanged,
                   ),
-                  value: saveToSdCard,
-                  onChanged: (v) => setState(() => saveToSdCard = v),
-                  activeThumbColor: VelvetColors.primary,
+                ),
+              ),
+              SizedBox(height: 8),
+              _storageHelp(),
+              if (_storageMode == 'permanent' ||
+                  _storageMode == 'sdCard') ...[
+                SizedBox(height: 10),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        _storageBasePath ?? 'No folder chosen yet',
+                        style: TextStyle(
+                            color: _storageBasePath == null
+                                ? VelvetColors.textTertiary
+                                : VelvetColors.textPrimary,
+                            fontSize: 12),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    SizedBox(width: 8),
+                    OutlinedButton.icon(
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: VelvetColors.textPrimary,
+                        side: BorderSide(color: VelvetColors.border2),
+                        padding:
+                            EdgeInsets.symmetric(vertical: 12, horizontal: 12),
+                        shape: RoundedRectangleBorder(
+                          borderRadius:
+                              BorderRadius.circular(VelvetColors.radiusSmall),
+                        ),
+                      ),
+                      icon: Icon(Icons.folder_open, size: 18),
+                      label: Text('Choose folder'),
+                      onPressed: submitPending ? null : _chooseStorageFolder,
+                    ),
+                  ],
                 ),
               ],
               SizedBox(height: 8),

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -13,6 +13,7 @@ import 'package:permission_handler/permission_handler.dart';
 import '../objects/server.dart';
 import '../singletons/file_explorer.dart';
 import '../singletons/server_list.dart';
+import '../singletons/browser_list.dart';
 import '../singletons/migration_manager.dart';
 import '../singletons/downloads.dart';
 import '../theme/velvet_theme.dart';
@@ -755,6 +756,10 @@ class MyCustomFormState extends State<MyCustomForm> {
           .editServer(editThisServer!, _urlCtrl.text, username, password);
       await ServerManager().getServerPaths(s);
       await ServerManager().callAfterEditServer();
+      // The browser may be showing this server's files with download badges
+      // computed against the OLD location — re-check them against the new one
+      // so stale "downloaded" marks correct themselves.
+      BrowserManager().refreshDownloadStatus(s);
     } else {
       Server newServer =
           new Server(lol.origin, username, password, jwt, folder);

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -466,6 +466,78 @@ class MyCustomFormState extends State<MyCustomForm> {
     }
   }
 
+  // Before an edited server's storage pointers change, relocate its
+  // already-downloaded files (the media/<localname> subtree). Within one
+  // volume this is an instant, atomic rename; across volumes (e.g. App local
+  // -> Permanent) files can't be moved, so we warn and let the user proceed
+  // — they re-download and delete the old copies manually. Returns false
+  // only when the user cancels that warning (so the save is aborted).
+  Future<bool> _migrateDownloads({
+    required String oldMode,
+    required String? oldBasePath,
+    required String oldLocalname,
+    required String newMode,
+    required String? newBasePath,
+    required String newLocalname,
+  }) async {
+    final oldBase = await FileExplorer().getDownloadDir(oldMode, oldBasePath);
+    if (oldBase == null) return true; // old location gone — nothing to move
+    final oldDir = Directory(path.join(oldBase.path, 'media', oldLocalname));
+    bool hasFiles = false;
+    try {
+      hasFiles = oldDir.existsSync() && oldDir.listSync().isNotEmpty;
+    } catch (_) {}
+    if (!hasFiles) return true; // nothing downloaded yet
+
+    final newBase = await FileExplorer().getDownloadDir(newMode, newBasePath);
+    if (newBase == null) return true; // new location unavailable right now
+    final newDir = Directory(path.join(newBase.path, 'media', newLocalname));
+    if (oldDir.path == newDir.path) return true; // same target, no-op
+    // Don't clobber a destination that already holds files — the user is
+    // pointing at an existing folder (recovery), not moving into a fresh one.
+    try {
+      if (newDir.existsSync() && newDir.listSync().isNotEmpty) return true;
+    } catch (_) {}
+
+    // Try an atomic move — succeeds only within the same volume.
+    try {
+      Directory(path.join(newBase.path, 'media')).createSync(recursive: true);
+      oldDir.renameSync(newDir.path);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+            content: Text('Moved downloaded files to the new folder.')));
+      }
+      return true;
+    } catch (_) {
+      // Cross-volume (or otherwise un-renamable): can't move. Warn the user.
+      if (!mounted) return false;
+      final proceed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          backgroundColor: VelvetColors.surface,
+          title: Text('Different storage volume',
+              style: TextStyle(color: VelvetColors.textPrimary)),
+          content: Text(
+              "Your downloaded files are on a different storage volume and "
+              "can't be moved automatically.\n\nIf you continue, those songs "
+              "will re-download to the new location. The old files stay where "
+              "they are — delete them manually if you want the space back.",
+              style: TextStyle(color: VelvetColors.textSecondary)),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                child: Text('Cancel',
+                    style: TextStyle(color: VelvetColors.textSecondary))),
+            TextButton(
+                onPressed: () => Navigator.of(ctx).pop(true),
+                child: Text('Continue')),
+          ],
+        ),
+      );
+      return proceed == true;
+    }
+  }
+
   Future<void> saveServer(Uri lol, [String jwt = '']) async {
     bool shouldUpdate = false;
     try {
@@ -493,9 +565,24 @@ class MyCustomFormState extends State<MyCustomForm> {
         : null;
 
     if (shouldUpdate) {
+      final s = ServerManager().serverList[editThisServer!];
+      // Relocate already-downloaded files before flipping the server's
+      // storage pointers. Same-volume = instant atomic move; cross-volume =
+      // warn (files stay, user re-downloads). Cancel aborts the save.
+      final migrationOk = await _migrateDownloads(
+        oldMode: s.storageMode,
+        oldBasePath: s.storageBasePath,
+        oldLocalname: s.localname,
+        newMode: _storageMode,
+        newBasePath: basePath,
+        newLocalname: folder,
+      );
+      if (!migrationOk) {
+        if (mounted) setState(() => submitPending = false);
+        return;
+      }
       // localname + storage aren't part of editServer's signature — set
       // them directly (callAfterEditServer below persists the change).
-      final s = ServerManager().serverList[editThisServer!];
       s.localname = folder;
       s.storageMode = _storageMode;
       s.storageBasePath = basePath;
@@ -514,7 +601,7 @@ class MyCustomFormState extends State<MyCustomForm> {
     }
 
     // Save Server List
-    Navigator.pop(context);
+    if (mounted) Navigator.pop(context);
   }
 
   Map<String, String> parseQrCode(String qrValue) {

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
@@ -151,10 +152,43 @@ class MyCustomFormState extends State<MyCustomForm> {
   // the user has already typed or picked a folder. New servers only.
   void _maybeAutofillFolder() {
     if (_folderManuallyEdited) return;
-    final name = _defaultLocalName(_urlCtrl.text);
+    final name = _computeAutoFolder();
     if (name != null && _downloadFolderCtrl.text != name) {
       _downloadFolderCtrl.text = name;
     }
+  }
+
+  // The auto folder name: "${subdomain}-${domain}", plus a stable short id
+  // when another configured server already uses that name — so two servers
+  // on the same domain don't share one download directory. (Checks the
+  // server list, not the filesystem, so re-adding a lost server can still
+  // reuse its orphaned folder for recovery.)
+  String? _computeAutoFolder() {
+    final base = _defaultLocalName(_urlCtrl.text);
+    if (base == null) return null;
+    return _localNameTaken(base) ? '$base-$_folderSuffix' : base;
+  }
+
+  // Does any *other* configured server already use this folder name?
+  bool _localNameTaken(String name) {
+    final list = ServerManager().serverList;
+    for (int i = 0; i < list.length; i++) {
+      if (i == editThisServer) continue; // ignore the server being edited
+      if (list[i].localname == name) return true;
+    }
+    return false;
+  }
+
+  // Stable per-screen short id, generated once and reused so the suffix
+  // doesn't churn while the user is still typing the URL.
+  String? _cachedFolderSuffix;
+  String get _folderSuffix => _cachedFolderSuffix ??= _nanoId();
+
+  String _nanoId([int length = 6]) {
+    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    final rnd = Random.secure();
+    return List.generate(length, (_) => chars[rnd.nextInt(chars.length)])
+        .join();
   }
 
   // Derives a clean folder name from a server URL: the host's first label
@@ -181,8 +215,13 @@ class MyCustomFormState extends State<MyCustomForm> {
     } else {
       name = '${labels.first}-${labels.sublist(1).join('.')}';
     }
-    // Keep only filesystem-safe characters.
-    final safe = name.replaceAll(RegExp(r'[^A-Za-z0-9._-]'), '-');
+    // Keep only filesystem-safe characters, then strip any leading or
+    // trailing separators so a no-subdomain or odd host can't yield a name
+    // starting with '-', '.', or '/'.
+    final safe = name
+        .replaceAll(RegExp(r'[^A-Za-z0-9._-]'), '-')
+        .replaceAll(RegExp(r'^[-._]+'), '')
+        .replaceAll(RegExp(r'[-._]+$'), '');
     return safe.isEmpty ? null : safe;
   }
 
@@ -444,7 +483,7 @@ class MyCustomFormState extends State<MyCustomForm> {
     // fall back to the URL-derived name, then a generated id.
     String folder = _downloadFolderCtrl.text.trim();
     if (folder.isEmpty) {
-      folder = _defaultLocalName(_urlCtrl.text) ?? Uuid().v4();
+      folder = _computeAutoFolder() ?? Uuid().v4();
     }
 
     // permanent/sdCard carry an absolute base path; the other modes

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -468,10 +468,11 @@ class MyCustomFormState extends State<MyCustomForm> {
 
   // Before an edited server's storage pointers change, relocate its
   // already-downloaded files (the media/<localname> subtree). Within one
-  // volume this is an instant, atomic rename; across volumes (e.g. App local
-  // -> Permanent) files can't be moved, so we warn and let the user proceed
-  // — they re-download and delete the old copies manually. Returns false
-  // only when the user cancels that warning (so the save is aborted).
+  // volume this is an instant, atomic rename; across volumes (App local on
+  // internal storage -> a Permanent/SD folder) rename can't cross
+  // filesystems, so we offer an async copy (copy -> verify -> delete
+  // originals) or a switch-without-copying. Returns false only when the user
+  // cancels (so the save is aborted).
   Future<bool> _migrateDownloads({
     required String oldMode,
     required String? oldBasePath,
@@ -509,33 +510,130 @@ class MyCustomFormState extends State<MyCustomForm> {
       }
       return true;
     } catch (_) {
-      // Cross-volume (or otherwise un-renamable): can't move. Warn the user.
-      if (!mounted) return false;
-      final proceed = await showDialog<bool>(
-        context: context,
-        builder: (ctx) => AlertDialog(
+      // Cross-volume: rename can't move across filesystems — offer a copy.
+      return await _copyAcrossVolumes(oldDir, newDir);
+    }
+  }
+
+  // Cross-volume relocation. Prompts (with file count + size): Copy moves the
+  // files (async copy -> verify -> delete originals); "Switch only" leaves
+  // them (re-download), optionally deleting the old copies; Cancel aborts.
+  // Fail-safe: a failed/canceled copy cleans up the partial, keeps the
+  // originals, and aborts the save. Returns true to proceed, false to abort.
+  Future<bool> _copyAcrossVolumes(Directory oldDir, Directory newDir) async {
+    if (!mounted) return false;
+    // Count + size from the source (App local is internal — fast to walk).
+    int count = 0;
+    int bytes = 0;
+    try {
+      await for (final e in oldDir.list(recursive: true, followLinks: false)) {
+        if (e is File) {
+          count++;
+          bytes += await e.length();
+        }
+      }
+    } catch (_) {}
+
+    if (!mounted) return false;
+    bool deleteOld = false;
+    final choice = await showDialog<String>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setInner) => AlertDialog(
           backgroundColor: VelvetColors.surface,
-          title: Text('Different storage volume',
+          title: Text('Move downloaded files?',
               style: TextStyle(color: VelvetColors.textPrimary)),
-          content: Text(
-              "Your downloaded files are on a different storage volume and "
-              "can't be moved automatically.\n\nIf you continue, those songs "
-              "will re-download to the new location. The old files stay where "
-              "they are — delete them manually if you want the space back.",
-              style: TextStyle(color: VelvetColors.textSecondary)),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                  "This server's $count downloaded file${count == 1 ? '' : 's'} "
+                  '(${_formatBytes(bytes)}) are on a different storage volume. '
+                  'Copy them to keep them offline at the new location, or '
+                  "switch without copying (they'll re-download).",
+                  style: TextStyle(color: VelvetColors.textSecondary)),
+              SizedBox(height: 4),
+              CheckboxListTile(
+                contentPadding: EdgeInsets.zero,
+                controlAffinity: ListTileControlAffinity.leading,
+                activeColor: VelvetColors.primary,
+                value: deleteOld,
+                onChanged: (v) => setInner(() => deleteOld = v ?? false),
+                title: Text('Delete the old files',
+                    style: TextStyle(color: VelvetColors.textPrimary)),
+                subtitle: Text('Only applies when switching without copying.',
+                    style: TextStyle(
+                        color: VelvetColors.textTertiary, fontSize: 12)),
+              ),
+            ],
+          ),
           actions: [
             TextButton(
-                onPressed: () => Navigator.of(ctx).pop(false),
+                onPressed: () => Navigator.of(ctx).pop('cancel'),
                 child: Text('Cancel',
                     style: TextStyle(color: VelvetColors.textSecondary))),
             TextButton(
-                onPressed: () => Navigator.of(ctx).pop(true),
-                child: Text('Continue')),
+                onPressed: () => Navigator.of(ctx).pop('switch'),
+                child: Text('Switch only')),
+            TextButton(
+                onPressed: () => Navigator.of(ctx).pop('copy'),
+                child: Text('Copy')),
           ],
         ),
-      );
-      return proceed == true;
+      ),
+    );
+
+    if (choice == null || choice == 'cancel') return false; // abort save
+    if (choice == 'switch') {
+      if (deleteOld) {
+        try {
+          await oldDir.delete(recursive: true);
+        } catch (_) {}
+      }
+      return true; // switch without copying
     }
+
+    // Copy: run the async copy behind a progress dialog.
+    if (!mounted) return false;
+    final ok = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => _CopyProgressDialog(src: oldDir, dst: newDir),
+    );
+
+    if (ok != true) {
+      // Clean up a partial copy; the originals are untouched.
+      try {
+        if (newDir.existsSync()) await newDir.delete(recursive: true);
+      } catch (_) {}
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+            content: Text(
+                'Copy failed — files unchanged, storage location not changed.')));
+      }
+      return false;
+    }
+
+    // Success — remove the originals so the files live only at the new spot.
+    try {
+      await oldDir.delete(recursive: true);
+    } catch (_) {}
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(
+              'Moved $count file${count == 1 ? '' : 's'} to the new location.')));
+    }
+    return true;
+  }
+
+  String _formatBytes(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    if (bytes < 1024 * 1024 * 1024) {
+      return '${(bytes / 1024 / 1024).toStringAsFixed(1)} MB';
+    }
+    return '${(bytes / 1024 / 1024 / 1024).toStringAsFixed(2)} GB';
   }
 
   Future<void> saveServer(Uri lol, [String jwt = '']) async {
@@ -1286,6 +1384,103 @@ class MyCustomFormState extends State<MyCustomForm> {
           ),
         ),
       ),
+    );
+  }
+}
+
+// Modal progress dialog that copies a directory tree (src -> dst) using async
+// I/O so the UI stays responsive on large libraries. Pops `true` once the
+// copy is verified (file count + total bytes), `false` on error or cancel.
+class _CopyProgressDialog extends StatefulWidget {
+  final Directory src;
+  final Directory dst;
+  const _CopyProgressDialog({required this.src, required this.dst});
+
+  @override
+  State<_CopyProgressDialog> createState() => _CopyProgressDialogState();
+}
+
+class _CopyProgressDialogState extends State<_CopyProgressDialog> {
+  int _copied = 0;
+  int _total = 0;
+  bool _canceled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _run());
+  }
+
+  Future<void> _run() async {
+    try {
+      final files = <File>[];
+      await for (final e
+          in widget.src.list(recursive: true, followLinks: false)) {
+        if (e is File) files.add(e);
+      }
+      if (mounted) setState(() => _total = files.length);
+
+      int srcBytes = 0;
+      int lastPct = -1;
+      for (int i = 0; i < files.length; i++) {
+        if (_canceled) {
+          if (mounted) Navigator.of(context).pop(false);
+          return;
+        }
+        final f = files[i];
+        final rel = path.relative(f.path, from: widget.src.path);
+        final destPath = path.join(widget.dst.path, rel);
+        await Directory(path.dirname(destPath)).create(recursive: true);
+        await f.copy(destPath);
+        srcBytes += await f.length();
+        final done = i + 1;
+        final pct = (done * 100) ~/ files.length;
+        if (mounted && pct != lastPct) {
+          lastPct = pct;
+          setState(() => _copied = done);
+        }
+      }
+
+      // Verify: the destination has at least as many files + bytes.
+      int destCount = 0;
+      int destBytes = 0;
+      await for (final e
+          in widget.dst.list(recursive: true, followLinks: false)) {
+        if (e is File) {
+          destCount++;
+          destBytes += await e.length();
+        }
+      }
+      final ok = destCount >= files.length && destBytes >= srcBytes;
+      if (mounted) Navigator.of(context).pop(ok);
+    } catch (_) {
+      if (mounted) Navigator.of(context).pop(false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final value = _total == 0 ? null : _copied / _total;
+    return AlertDialog(
+      backgroundColor: VelvetColors.surface,
+      title: Text(_canceled ? 'Canceling…' : 'Moving files…',
+          style: TextStyle(color: VelvetColors.textPrimary)),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          LinearProgressIndicator(value: value),
+          SizedBox(height: 12),
+          Text(_total == 0 ? 'Preparing…' : 'Copied $_copied of $_total files',
+              style: TextStyle(color: VelvetColors.textSecondary)),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _canceled ? null : () => setState(() => _canceled = true),
+          child: Text('Cancel',
+              style: TextStyle(color: VelvetColors.textSecondary)),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -539,6 +539,15 @@ class MyCustomFormState extends State<MyCustomForm> {
       }
     } catch (_) {}
 
+    // Free space on the destination volume (nearest existing ancestor of the
+    // target). If the library won't fit, warn — a "Move" may fail partway.
+    Directory probe = newDir;
+    while (!probe.existsSync() && probe.parent.path != probe.path) {
+      probe = probe.parent;
+    }
+    final free = await MigrationManager().freeBytes(probe.path);
+    final tight = free != null && bytes > free;
+
     if (!mounted) return false;
     final choice = await showDialog<String>(
       context: context,
@@ -556,6 +565,26 @@ class MyCustomFormState extends State<MyCustomForm> {
                 style:
                     TextStyle(color: VelvetColors.textSecondary, fontSize: 13)),
           ),
+          if (tight)
+            Padding(
+              padding: EdgeInsets.fromLTRB(24, 0, 24, 12),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(Icons.warning_amber_rounded,
+                      size: 16, color: VelvetColors.warning),
+                  SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                        'Not enough free space at the destination '
+                        '(${_formatBytes(free)} free). A move may fail '
+                        'partway — free up space first.',
+                        style: TextStyle(
+                            color: VelvetColors.warning, fontSize: 12)),
+                  ),
+                ],
+              ),
+            ),
           _migrateOption(
               ctx,
               'move',
@@ -594,7 +623,7 @@ class MyCustomFormState extends State<MyCustomForm> {
 
     switch (choice) {
       case 'move':
-        await MigrationManager().start(oldDir.path, newDir.path);
+        await MigrationManager().start(oldDir.path, newDir.path, count, bytes);
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(SnackBar(
               content: Text('Moving your downloads in the background — keep '

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -1,12 +1,15 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
 import 'package:flutter/material.dart';
+import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 // import 'package:flutter_barcode_scanner/flutter_barcode_scanner.dart';
 import '../objects/server.dart';
+import '../singletons/file_explorer.dart';
 import '../singletons/server_list.dart';
 import '../theme/velvet_theme.dart';
 import '../util/server_compat.dart';
@@ -58,6 +61,10 @@ class MyCustomFormState extends State<MyCustomForm> {
   TextEditingController _urlCtrl = TextEditingController();
   TextEditingController _usernameCtrl = TextEditingController();
   TextEditingController _passwordCtrl = TextEditingController();
+  // Per-server download subfolder (downloads live in media/<this>).
+  // Defaults to a generated id; making it editable lets a re-added
+  // server reuse its old folder and recover its downloaded songs.
+  final TextEditingController _downloadFolderCtrl = TextEditingController();
 
   bool submitPending = false;
   bool saveToSdCard = false;
@@ -90,12 +97,18 @@ class MyCustomFormState extends State<MyCustomForm> {
       _usernameCtrl.text = s.username ?? '';
       _passwordCtrl.text = s.password ?? '';
       saveToSdCard = s.saveToSdCard;
+      _downloadFolderCtrl.text = s.localname;
       // An existing server saved without credentials is a public
       // server — start in public mode so the toggle reflects reality.
       if ((s.username ?? '').isEmpty && (s.password ?? '').isEmpty) {
         _publicAccess = true;
       }
     } catch (err) {}
+
+    // New server: default to a generated folder id (overridable below).
+    if (_downloadFolderCtrl.text.isEmpty) {
+      _downloadFolderCtrl.text = Uuid().v4();
+    }
 
     _detectSdCard();
 
@@ -244,6 +257,7 @@ class MyCustomFormState extends State<MyCustomForm> {
     _urlCtrl.dispose();
     _usernameCtrl.dispose();
     _passwordCtrl.dispose();
+    _downloadFolderCtrl.dispose();
 
     super.dispose();
   }
@@ -345,8 +359,16 @@ class MyCustomFormState extends State<MyCustomForm> {
     // residual text in the controllers.
     final username = _publicAccess ? '' : _usernameCtrl.text;
     final password = _publicAccess ? '' : _passwordCtrl.text;
+    // The user-chosen download folder (media/<this>); fall back to a
+    // generated id if they cleared the field.
+    final folder = _downloadFolderCtrl.text.trim().isEmpty
+        ? Uuid().v4()
+        : _downloadFolderCtrl.text.trim();
 
     if (shouldUpdate) {
+      // localname isn't part of editServer's signature — set it directly
+      // (callAfterEditServer below persists the change).
+      ServerManager().serverList[editThisServer!].localname = folder;
       ServerManager().editServer(
           editThisServer!, _urlCtrl.text, username, password, saveToSdCard);
       await ServerManager()
@@ -354,7 +376,7 @@ class MyCustomFormState extends State<MyCustomForm> {
       await ServerManager().callAfterEditServer();
     } else {
       Server newServer =
-          new Server(lol.origin, username, password, jwt, Uuid().v4());
+          new Server(lol.origin, username, password, jwt, folder);
       if (saveToSdCard == true) {
         newServer.saveToSdCard = true;
       }
@@ -388,6 +410,81 @@ class MyCustomFormState extends State<MyCustomForm> {
     if (!_formKey.currentState!.validate()) return;
     _formKey.currentState!.save();
     checkServer();
+  }
+
+  // Lists the existing per-server download folders (media/<id>) so the
+  // user can point this server at one — recovering a re-added server's
+  // previously-downloaded songs.
+  Future<void> _browseDownloadFolders() async {
+    final base = await FileExplorer().getDownloadDir(saveToSdCard);
+    if (!mounted) return;
+    if (base == null) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('No storage available')));
+      return;
+    }
+    final mediaDir = Directory(path.join(base.path, 'media'));
+    final folders = mediaDir.existsSync()
+        ? mediaDir.listSync().whereType<Directory>().toList()
+        : <Directory>[];
+    if (!mounted) return;
+    if (folders.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('No existing download folders found')));
+      return;
+    }
+    final chosen = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: VelvetColors.surface,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: EdgeInsets.fromLTRB(20, 16, 20, 8),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text('Existing download folders',
+                    style: TextStyle(
+                        color: VelvetColors.textPrimary,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700)),
+              ),
+            ),
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: folders.map((d) {
+                  final name = path.basename(d.path);
+                  int count = 0;
+                  DateTime? modified;
+                  try {
+                    count = d.listSync().length;
+                    modified = d.statSync().modified;
+                  } catch (_) {}
+                  return ListTile(
+                    leading: Icon(Icons.folder, color: VelvetColors.primary),
+                    title: Text(name,
+                        style: TextStyle(color: VelvetColors.textPrimary),
+                        overflow: TextOverflow.ellipsis),
+                    subtitle: Text(
+                        '$count item${count == 1 ? '' : 's'}'
+                        '${modified != null ? ' · ${modified.toString().split('.').first}' : ''}',
+                        style: TextStyle(
+                            color: VelvetColors.textSecondary, fontSize: 12)),
+                    onTap: () => Navigator.of(ctx).pop(name),
+                  );
+                }).toList(),
+              ),
+            ),
+            SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+    if (chosen != null && mounted) {
+      setState(() => _downloadFolderCtrl.text = chosen);
+    }
   }
 
   @override
@@ -563,6 +660,53 @@ class MyCustomFormState extends State<MyCustomForm> {
                   activeThumbColor: VelvetColors.primary,
                 ),
               ],
+              SizedBox(height: 8),
+              Text('Download folder',
+                  style: TextStyle(
+                      color: VelvetColors.textSecondary,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600)),
+              SizedBox(height: 6),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: TextFormField(
+                      controller: _downloadFolderCtrl,
+                      autocorrect: false,
+                      decoration: InputDecoration(
+                        isDense: true,
+                        prefixIcon: Icon(Icons.folder_outlined),
+                        hintText: 'folder name',
+                      ),
+                    ),
+                  ),
+                  SizedBox(width: 8),
+                  OutlinedButton.icon(
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: VelvetColors.textPrimary,
+                      side: BorderSide(color: VelvetColors.border2),
+                      padding:
+                          EdgeInsets.symmetric(vertical: 14, horizontal: 12),
+                      shape: RoundedRectangleBorder(
+                        borderRadius:
+                            BorderRadius.circular(VelvetColors.radiusSmall),
+                      ),
+                    ),
+                    icon: Icon(Icons.folder_open, size: 18),
+                    label: Text('Browse'),
+                    onPressed: submitPending ? null : _browseDownloadFolders,
+                  ),
+                ],
+              ),
+              SizedBox(height: 6),
+              Text(
+                "Files download to a 'media/<folder>' directory on this "
+                "device. Re-using a previous server's folder keeps its "
+                "downloaded songs when you re-add a lost server.",
+                style:
+                    TextStyle(color: VelvetColors.textTertiary, fontSize: 11),
+              ),
               SizedBox(height: 24),
               // QR Code button hidden — flutter_barcode_scanner is
               // commented out in pubspec.yaml (hasn't kept up with

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -189,59 +189,31 @@ class _BrowserState extends State<Browser> {
     final dir = await FileExplorer()
         .getDownloadDir(i.server!.storageMode, i.server!.storageBasePath);
     // A null dir means the configured location is unavailable (SD card
-    // removed / folder deleted). Treat it exactly like "not downloaded"
-    // and fall through to streaming, rather than returning a null item
-    // (which would make the track unplayable instead of just online-only).
+    // removed / folder deleted) — treat as "not downloaded".
     final String? finalString =
         dir == null ? null : '${dir.path}/media/$downloadDirectory';
+    final bool isLocal =
+        finalString != null && new File(finalString).existsSync() == true;
 
-    if (finalString != null && new File(finalString).existsSync() == true) {
-      String? artUrl = i.metadata?.albumArt != null
-          ? Uri.parse(i.server!.url.toString())
-              .resolve('/album-art/' +
-                  i.metadata!.albumArt! +
-                  '?compress=l&token=' +
-                  (i.server!.jwt ?? ''))
-              .toString()
-          : null;
-
-      return new MediaItem(
-          id: Uuid().v4(),
-          title: i.metadata?.title ?? i.name,
-          album: i.metadata?.album,
-          artist: i.metadata?.artist,
-          extras: {
-            'path': i.data,
-            'localPath': finalString,
-            'year': i.metadata?.year,
-            'artUrl': artUrl,
-            // bpm + musicalKey power AutoDJ's BPM-continuity /
-            // harmonic-mixing modes — read off the currently
-            // playing item when computing the next pick's payload.
-            'bpm': i.metadata?.bpm,
-            'musicalKey': i.metadata?.musicalKey,
-          });
-    }
-
-    String prefix =
-        TranscodeManager().transcodeOn == true ? '/transcode' : '/media';
-
+    // Streaming URL — used as the MediaItem id for BOTH local and online
+    // items, so playback can fall back to streaming if the local file goes
+    // missing (moved mid-migration, SD removed, deleted externally). The
+    // local path lives in extras and is re-checked for existence at play time.
     String p = '';
     i.data!.split("/").forEach((element) {
-      if (element.length == 0) {
-        return;
-      }
+      if (element.length == 0) return;
       p += "/" + Uri.encodeComponent(element);
     });
-
-    String lolUrl = i.server!.url +
+    final String prefix =
+        TranscodeManager().transcodeOn == true ? '/transcode' : '/media';
+    final String streamUrl = i.server!.url +
         prefix +
         p +
         '?app_uuid=' +
         Uuid().v4() +
         (i.server!.jwt == null ? '' : '&token=' + i.server!.jwt!);
 
-    String? artUrl = i.metadata?.albumArt != null
+    final String? artUrl = i.metadata?.albumArt != null
         ? Uri.parse(i.server!.url.toString())
             .resolve('/album-art/' +
                 i.metadata!.albumArt! +
@@ -251,15 +223,18 @@ class _BrowserState extends State<Browser> {
         : null;
 
     return new MediaItem(
-        id: lolUrl,
+        id: streamUrl,
         title: i.metadata?.title ?? i.name,
         album: i.metadata?.album,
         artist: i.metadata?.artist,
         extras: {
           'server': i.server!.localname,
           'path': i.data,
+          if (isLocal) 'localPath': finalString,
           'year': i.metadata?.year,
           'artUrl': artUrl,
+          // bpm + musicalKey power AutoDJ's BPM-continuity / harmonic-mixing
+          // modes — read off the currently playing item.
           'bpm': i.metadata?.bpm,
           'musicalKey': i.metadata?.musicalKey,
         });

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -186,11 +186,16 @@ class _BrowserState extends State<Browser> {
   // isn't available.
   Future<MediaItem?> _buildFileItem(DisplayItem i) async {
     String downloadDirectory = i.server!.localname + i.data!;
-    final dir = await FileExplorer().getDownloadDir(i.server!.saveToSdCard);
-    if (dir == null) return null;
-    String finalString = '${dir.path}/media/$downloadDirectory';
+    final dir = await FileExplorer()
+        .getDownloadDir(i.server!.storageMode, i.server!.storageBasePath);
+    // A null dir means the configured location is unavailable (SD card
+    // removed / folder deleted). Treat it exactly like "not downloaded"
+    // and fall through to streaming, rather than returning a null item
+    // (which would make the track unplayable instead of just online-only).
+    final String? finalString =
+        dir == null ? null : '${dir.path}/media/$downloadDirectory';
 
-    if (new File(finalString).existsSync() == true) {
+    if (finalString != null && new File(finalString).existsSync() == true) {
       String? artUrl = i.metadata?.albumArt != null
           ? Uri.parse(i.server!.url.toString())
               .resolve('/album-art/' +
@@ -654,8 +659,8 @@ class _BrowserState extends State<Browser> {
                     '/media' +
                     e.data! +
                     (e.server!.jwt == null ? '' : '?token=' + e.server!.jwt!);
-                DownloadManager().downloadOneFile(downloadUrl,
-                    e.server!.localname, e.data!, e.server!.saveToSdCard,
+                DownloadManager().downloadOneFile(
+                    downloadUrl, e.server!.localname, e.data!,
                     referenceItem: e);
               }
               ScaffoldMessenger.of(context).showSnackBar(SnackBar(

--- a/lib/singletons/app_messenger.dart
+++ b/lib/singletons/app_messenger.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+// Global ScaffoldMessenger key so context-less singletons (e.g.
+// DownloadManager) can surface SnackBars. Wired into
+// MaterialApp.scaffoldMessengerKey in main.dart.
+final GlobalKey<ScaffoldMessengerState> rootMessengerKey =
+    GlobalKey<ScaffoldMessengerState>();
+
+// Best-effort SnackBar from anywhere. No-ops if the messenger isn't
+// mounted yet (e.g. very early startup).
+void showGlobalSnack(String message) {
+  rootMessengerKey.currentState?.showSnackBar(SnackBar(content: Text(message)));
+}

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -5,6 +5,7 @@ import 'package:rxdart/rxdart.dart';
 
 import '../singletons/server_list.dart';
 import '../singletons/settings.dart';
+import '../singletons/migration_manager.dart';
 import '../objects/display_item.dart';
 import '../objects/server.dart';
 import '../theme/velvet_theme.dart';
@@ -51,6 +52,7 @@ class BrowserManager {
       BehaviorSubject<String>.seeded(listName);
 
   StreamSubscription<int>? _letterStripSub;
+  StreamSubscription<MigrationProgress?>? _migrationSub;
 
   BrowserManager._privateConstructor() {
     // When the letter-strip threshold changes, re-emit the current
@@ -60,6 +62,12 @@ class BrowserManager {
     // requiring the user to navigate away and back.
     _letterStripSub =
         SettingsManager().letterStripStream.listen((_) => updateStream());
+    // When a storage move finishes, re-check on-device download badges so a
+    // background "Move them" re-marks files now present at the new location
+    // (the edit-time refresh ran before the move had finished).
+    _migrationSub = MigrationManager().progressStream.listen((p) {
+      if (p?.done == true) refreshAllDownloadStatus();
+    });
   }
   static final BrowserManager _instance = BrowserManager._privateConstructor();
 
@@ -217,6 +225,32 @@ class BrowserManager {
     _browserStream.sink.add(browserList);
   }
 
+  // Re-check the on-device download badge for cached file rows against their
+  // server's CURRENT storage location, then refresh the browser once. Used
+  // after a server's download location changes (and when a storage move
+  // finishes) so a badge computed against the old path corrects itself —
+  // including clearing a "downloaded" mark for a file that's no longer there.
+  Future<void> refreshDownloadStatus(Server server) =>
+      _refreshDownloadStatus((i) => i.server == server);
+
+  Future<void> refreshAllDownloadStatus() =>
+      _refreshDownloadStatus((_) => true);
+
+  Future<void> _refreshDownloadStatus(bool Function(DisplayItem) match) async {
+    final items = <DisplayItem>{};
+    for (final frame in browserCache) {
+      for (final item in frame) {
+        if (item.type == 'file' && match(item)) items.add(item);
+      }
+    }
+    for (final item in browserList) {
+      if (item.type == 'file' && match(item)) items.add(item);
+    }
+    if (items.isEmpty) return;
+    await Future.wait(items.map((i) => i.recheckDownloaded()));
+    updateStream();
+  }
+
   void popBrowser() {
     if (BrowserManager().browserCache.length < 2) {
       return;
@@ -267,6 +301,7 @@ class BrowserManager {
   }
 
   void dispose() {
+    _migrationSub?.cancel();
     _browserStream.close();
     _browserLabel.close();
     _loading.close();

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -75,11 +75,13 @@ class DownloadManager {
     }
 
     // Drive the originating browser row's inline progress bar, if any.
-    // Only repaint the browser when the rounded percentage actually
-    // changes, so a burst of sub-percent ticks doesn't thrash the list.
+    // Quantize to 5% buckets so a full-list repaint fires at most ~20
+    // times per download instead of up to 100× — this matters when
+    // "Download all" runs many downloads concurrently. Completion still
+    // lands on 100 (a multiple of 5).
     final DisplayItem? row = dt.referenceDisplayItem;
     if (row != null) {
-      final int pct = (dt.progress.clamp(0.0, 1.0) * 100).round();
+      final int pct = ((dt.progress.clamp(0.0, 1.0) * 100).round() ~/ 5) * 5;
       if (row.downloadProgress != pct) {
         row.downloadProgress = pct;
         BrowserManager().updateStream();

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as path;
 
 import '../objects/download_tracker.dart';
 import '../objects/display_item.dart';
+import '../objects/server.dart';
 
 class DownloadManager {
   DownloadManager._privateConstructor();
@@ -25,6 +26,10 @@ class DownloadManager {
       BehaviorSubject<Map<String, DownloadTracker>>.seeded(downloadMap);
 
   Map<String, DownloadTracker> downloadMap = {};
+  // Destination keys (serverName+filepath) of downloads currently in
+  // flight, so a duplicate tap / second "Download all" can't enqueue the
+  // same file twice and interleave writes to the same path.
+  final Set<String> _inFlight = {};
   StreamSubscription<TaskUpdate>? _updatesSub;
 
   Future<void> initDownloader() async {
@@ -38,14 +43,34 @@ class DownloadManager {
     final DownloadTracker? dt = downloadMap[update.task.taskId];
     if (dt == null) return;
 
+    bool terminal = false;
     if (update is TaskProgressUpdate) {
       // progress is 0.0–1.0; negative values signal error/special states,
       // so ignore those and keep the last good value.
       if (update.progress >= 0) dt.progress = update.progress;
     } else if (update is TaskStatusUpdate) {
-      if (update.status == TaskStatus.complete) {
-        dt.progress = 1.0;
-        // TODO: update queue items
+      switch (update.status) {
+        case TaskStatus.complete:
+          dt.progress = 1.0;
+          terminal = true;
+          // TODO: patch matching queue MediaItems' localPath so an
+          // already-queued track switches from streaming to the fresh
+          // local copy without a queue rebuild.
+          break;
+        case TaskStatus.failed:
+        case TaskStatus.notFound:
+          // Reset the row so a stuck partial bar doesn't imply a cached
+          // file that isn't there, and tell the user it didn't work.
+          dt.progress = 0;
+          terminal = true;
+          showGlobalSnack('A download failed — check your connection.');
+          break;
+        case TaskStatus.canceled:
+          dt.progress = 0;
+          terminal = true;
+          break;
+        default:
+          break; // enqueued / running / paused / waitingToRetry
       }
     }
 
@@ -59,6 +84,14 @@ class DownloadManager {
         row.downloadProgress = pct;
         BrowserManager().updateStream();
       }
+    }
+
+    // On a terminal status, release the tracker (and the DisplayItem it
+    // retains) and clear the in-flight guard so the file can be retried.
+    if (terminal) {
+      _inFlight.remove(dt.filePath);
+      dt.referenceDisplayItem = null;
+      downloadMap.remove(update.task.taskId);
     }
 
     // Re-emit so the Downloads screen's StreamBuilder rebuilds.
@@ -77,7 +110,16 @@ class DownloadManager {
       {DisplayItem? referenceItem}) async {
     String downloadDirectory = serverName + filepath;
 
-    final server = ServerManager().lookupServer(serverName);
+    // The originating server may have been removed while this track lingered
+    // in the queue — lookupServer is a bare firstWhere that would throw.
+    final Server server;
+    try {
+      server = ServerManager().lookupServer(serverName);
+    } catch (_) {
+      showGlobalSnack('That server is no longer configured.');
+      return;
+    }
+
     final dir = await FileExplorer()
         .getDownloadDir(server.storageMode, server.storageBasePath);
     if (dir == null) {
@@ -92,8 +134,10 @@ class DownloadManager {
     String downloadTo = '${dir.path}/media/$downloadDirectory';
 
     if (new File(downloadTo).existsSync() == true) {
-      print('exists!');
-      return;
+      return; // already cached on disk
+    }
+    if (_inFlight.contains(downloadDirectory)) {
+      return; // a download for this exact file is already running
     }
 
     String targetDir = path.dirname(downloadTo);
@@ -113,6 +157,7 @@ class DownloadManager {
         updates: Updates.statusAndProgress,
       );
 
+      _inFlight.add(downloadDirectory);
       downloadMap[task.taskId] =
           new DownloadTracker(downloadUrl, downloadDirectory)
             ..referenceDisplayItem = referenceItem;
@@ -121,6 +166,7 @@ class DownloadManager {
       await FileDownloader().enqueue(task);
     } catch (e) {
       // The volume could vanish between the null-check and the write.
+      _inFlight.remove(downloadDirectory);
       showGlobalSnack('Could not start download — storage unavailable.');
     }
   }

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -154,14 +154,6 @@ class DownloadManager {
       return;
     }
 
-    // FAT/exFAT cards can't store certain characters; on an SD-card server,
-    // skip such files (they'd fail to write anyway) and warn once.
-    if (server.storageMode == 'sdCard' &&
-        hasFatIllegalChars(downloadDirectory)) {
-      _warnFatSkip();
-      return;
-    }
-
     final dir = await FileExplorer()
         .getDownloadDir(server.storageMode, server.storageBasePath);
     if (dir == null) {
@@ -170,6 +162,20 @@ class DownloadManager {
       showGlobalSnack(
           'Storage location unavailable — reconnect the SD card or change '
           "this server's storage location in Edit Server.");
+      return;
+    }
+
+    // A user-chosen folder (Permanent / SD card) may sit on a FAT/exFAT
+    // filesystem that can't store certain names. When the name is illegal,
+    // probe the actual destination (cached) — the same source of truth
+    // migration uses, rather than trusting the mode label — and skip it
+    // (it would fail to write anyway), warning once.
+    final isUserFolder =
+        server.storageMode == 'permanent' || server.storageMode == 'sdCard';
+    if (isUserFolder &&
+        hasFatIllegalChars(downloadDirectory) &&
+        await isFatLikeDir(dir.path)) {
+      _warnFatSkip();
       return;
     }
 

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -111,6 +111,21 @@ class DownloadManager {
     _downloadStream.close();
   }
 
+  // Cancel every in-flight download. Used before a storage-location change so
+  // nothing lands at the old location after the switch (it would be stranded).
+  // The canceled-task updates flow through _onUpdate, which resets each row and
+  // removes its tracker.
+  Future<void> cancelAll() async {
+    try {
+      final tasks = await FileDownloader().allTasks();
+      if (tasks.isNotEmpty) {
+        await FileDownloader()
+            .cancelTasksWithIds(tasks.map((t) => t.taskId).toList());
+      }
+    } catch (_) {}
+    _inFlight.clear(); // allow immediate re-download of the same files
+  }
+
   // Show the "name not supported" warning, at most once every few seconds so
   // a batch download doesn't queue a snackbar per skipped file.
   void _warnFatSkip() {

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:mstream_music/singletons/file_explorer.dart';
 import 'package:mstream_music/singletons/server_list.dart';
 import 'package:mstream_music/singletons/browser_list.dart';
+import 'package:mstream_music/singletons/app_messenger.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:background_downloader/background_downloader.dart';
 import 'package:path/path.dart' as path;
@@ -72,14 +73,19 @@ class DownloadManager {
   }
 
   Future<void> downloadOneFile(String downloadUrl, String serverName,
-      String filepath, bool? saveToSdCard,
+      String filepath,
       {DisplayItem? referenceItem}) async {
     String downloadDirectory = serverName + filepath;
 
-    bool sd =
-        saveToSdCard ?? ServerManager().lookupServer(serverName).saveToSdCard;
-    final dir = await FileExplorer().getDownloadDir(sd);
+    final server = ServerManager().lookupServer(serverName);
+    final dir = await FileExplorer()
+        .getDownloadDir(server.storageMode, server.storageBasePath);
     if (dir == null) {
+      // Storage location unavailable (e.g. SD card removed / chosen folder
+      // deleted). Tell the user instead of silently doing nothing.
+      showGlobalSnack(
+          'Storage location unavailable — reconnect the SD card or change '
+          "this server's storage location in Edit Server.");
       return;
     }
 
@@ -93,25 +99,30 @@ class DownloadManager {
     String targetDir = path.dirname(downloadTo);
     String filename = path.basename(downloadTo);
 
-    new Directory(targetDir).createSync(recursive: true);
+    try {
+      new Directory(targetDir).createSync(recursive: true);
 
-    // The destination is an absolute path (app external storage or SD card),
-    // expressed to background_downloader via BaseDirectory.root + the
-    // absolute directory.
-    final DownloadTask task = DownloadTask(
-      url: downloadUrl,
-      filename: filename,
-      baseDirectory: BaseDirectory.root,
-      directory: targetDir,
-      updates: Updates.statusAndProgress,
-    );
+      // The destination is an absolute path (app docs, a permanent shared
+      // folder, or the SD card), expressed to background_downloader via
+      // BaseDirectory.root + the absolute directory.
+      final DownloadTask task = DownloadTask(
+        url: downloadUrl,
+        filename: filename,
+        baseDirectory: BaseDirectory.root,
+        directory: targetDir,
+        updates: Updates.statusAndProgress,
+      );
 
-    downloadMap[task.taskId] =
-        new DownloadTracker(downloadUrl, downloadDirectory)
-          ..referenceDisplayItem = referenceItem;
-    _downloadStream.add(downloadMap);
+      downloadMap[task.taskId] =
+          new DownloadTracker(downloadUrl, downloadDirectory)
+            ..referenceDisplayItem = referenceItem;
+      _downloadStream.add(downloadMap);
 
-    await FileDownloader().enqueue(task);
+      await FileDownloader().enqueue(task);
+    } catch (e) {
+      // The volume could vanish between the null-check and the write.
+      showGlobalSnack('Could not start download — storage unavailable.');
+    }
   }
 
   Stream<Map<String, DownloadTracker>> get downloadSream =>

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -5,6 +5,7 @@ import 'package:mstream_music/singletons/file_explorer.dart';
 import 'package:mstream_music/singletons/server_list.dart';
 import 'package:mstream_music/singletons/browser_list.dart';
 import 'package:mstream_music/singletons/app_messenger.dart';
+import 'package:mstream_music/singletons/migration_manager.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:background_downloader/background_downloader.dart';
 import 'package:path/path.dart' as path;
@@ -30,6 +31,9 @@ class DownloadManager {
   // flight, so a duplicate tap / second "Download all" can't enqueue the
   // same file twice and interleave writes to the same path.
   final Set<String> _inFlight = {};
+  // Throttle the "unsupported name" warning so a "Download all" to an SD card
+  // doesn't queue one snackbar per skipped file.
+  DateTime? _lastFatWarn;
   StreamSubscription<TaskUpdate>? _updatesSub;
 
   Future<void> initDownloader() async {
@@ -107,6 +111,19 @@ class DownloadManager {
     _downloadStream.close();
   }
 
+  // Show the "name not supported" warning, at most once every few seconds so
+  // a batch download doesn't queue a snackbar per skipped file.
+  void _warnFatSkip() {
+    final now = DateTime.now();
+    if (_lastFatWarn == null ||
+        now.difference(_lastFatWarn!) > const Duration(seconds: 3)) {
+      _lastFatWarn = now;
+      showGlobalSnack(
+          "Some tracks can't be saved on this card — their names aren't "
+          'supported. They stream instead.');
+    }
+  }
+
   Future<void> downloadOneFile(String downloadUrl, String serverName,
       String filepath,
       {DisplayItem? referenceItem}) async {
@@ -119,6 +136,14 @@ class DownloadManager {
       server = ServerManager().lookupServer(serverName);
     } catch (_) {
       showGlobalSnack('That server is no longer configured.');
+      return;
+    }
+
+    // FAT/exFAT cards can't store certain characters; on an SD-card server,
+    // skip such files (they'd fail to write anyway) and warn once.
+    if (server.storageMode == 'sdCard' &&
+        hasFatIllegalChars(downloadDirectory)) {
+      _warnFatSkip();
       return;
     }
 

--- a/lib/singletons/file_explorer.dart
+++ b/lib/singletons/file_explorer.dart
@@ -21,7 +21,7 @@ class FileExplorer {
   Future<String> getServerDir(Server s) async {
     Directory? woo = await getDownloadDir(s.storageMode, s.storageBasePath);
     if (woo == null) {
-      return 'NO SD CARD DETECTED';
+      return 'Download location unavailable';
     }
 
     return new Directory(path.join(woo.path.toString(), 'media/${s.localname}'))

--- a/lib/singletons/file_explorer.dart
+++ b/lib/singletons/file_explorer.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
+import './app_messenger.dart';
 import './browser_list.dart';
 import '../objects/display_item.dart';
 import '../objects/server.dart';
@@ -18,7 +19,7 @@ class FileExplorer {
   }
 
   Future<String> getServerDir(Server s) async {
-    Directory? woo = await getDownloadDir(s.saveToSdCard);
+    Directory? woo = await getDownloadDir(s.storageMode, s.storageBasePath);
     if (woo == null) {
       return 'NO SD CARD DETECTED';
     }
@@ -35,8 +36,11 @@ class FileExplorer {
     Directory file;
     if (directory == null) {
       BrowserManager().clear();
-      Directory? woo = await getDownloadDir(s.saveToSdCard);
+      Directory? woo = await getDownloadDir(s.storageMode, s.storageBasePath);
       if (woo == null) {
+        // permanent/sdCard location is gone (card removed / folder deleted).
+        showGlobalSnack('Download location unavailable for this server.');
+        BrowserManager().addListToStack(newList); // show an empty list
         return;
       }
       file = new Directory(path.join(woo.path.toString(), 'media'));
@@ -71,7 +75,7 @@ class FileExplorer {
   }
 
   Future<void> getPathForServer(Server s) async {
-    Directory? woo = await getDownloadDir(s.saveToSdCard);
+    Directory? woo = await getDownloadDir(s.storageMode, s.storageBasePath);
     if (woo != null) {
       Directory file =
           new Directory(path.join(woo.path.toString(), 'media/${s.localname}'));
@@ -97,11 +101,29 @@ class FileExplorer {
     BrowserManager().removeAll(path, server, 'localDirectory');
   }
 
-  Future<Directory?> getDownloadDir(bool sd) {
-    if (sd == false) {
-      return getApplicationDocumentsDirectory();
+  // Resolves the base directory under which a server's downloads live
+  // (final paths are <base>/media/<localname>/...). Driven by the
+  // server's storage mode rather than a bool so callers can choose
+  // app-local, a user-picked permanent folder, or an SD-card folder.
+  //
+  // Returns null when the configured location is currently unavailable
+  // (permanent/sdCard base path missing — e.g. SD card removed or the
+  // folder was deleted). Every caller already null-guards getDownloadDir,
+  // so a null cleanly means "no local copy here" (playback streams,
+  // listings empty) instead of throwing on an unmounted volume.
+  Future<Directory?> getDownloadDir(
+      String storageMode, String? storageBasePath) async {
+    switch (storageMode) {
+      case 'permanent':
+      case 'sdCard':
+        if (storageBasePath == null) return null;
+        final dir = Directory(storageBasePath);
+        return dir.existsSync() ? dir : null;
+      case 'legacyExternal':
+        return getExternalStorageDirectory();
+      case 'appLocal':
+      default:
+        return getApplicationDocumentsDirectory();
     }
-
-    return getExternalStorageDirectory();
   }
 }

--- a/lib/singletons/migration_manager.dart
+++ b/lib/singletons/migration_manager.dart
@@ -123,6 +123,47 @@ class MigrationManager {
     return '/'; // internal storage is always mounted
   }
 
+  // Stream-copies [src] to [destPath], calling [onBytes] with the running byte
+  // count for intra-file progress. Returns false if canceled mid-copy (the
+  // partial destination is removed); throws on I/O error (e.g. ENOSPC) after
+  // cleaning up the partial, leaving the source intact.
+  Future<bool> _copyFileStreamed(
+      File src, String destPath, void Function(int written) onBytes) async {
+    final sink = File(destPath).openWrite();
+    int written = 0;
+    bool canceled = false;
+    try {
+      await for (final chunk in src.openRead()) {
+        if (_cancelRequested) {
+          canceled = true;
+          break;
+        }
+        sink.add(chunk);
+        written += chunk.length;
+        onBytes(written);
+      }
+      await sink.flush();
+      await sink.close();
+    } catch (e) {
+      try {
+        await sink.close();
+      } catch (_) {}
+      try {
+        final p = File(destPath);
+        if (p.existsSync()) await p.delete();
+      } catch (_) {}
+      rethrow;
+    }
+    if (canceled) {
+      try {
+        final p = File(destPath);
+        if (p.existsSync()) await p.delete();
+      } catch (_) {}
+      return false;
+    }
+    return true;
+  }
+
   // Begin moving [sourcePath] -> [destPath]. [totalFiles]/[totalBytes] are the
   // already-computed source size (from the dialog) so we don't re-walk.
   Future<void> start(String sourcePath, String destPath, int totalFiles,
@@ -291,19 +332,23 @@ class MigrationManager {
         final destPath = path.join(dest.path, rel);
         await Directory(path.dirname(destPath)).create(recursive: true);
         try {
-          await f.rename(destPath); // same-volume fast path
+          await f.rename(destPath); // same-volume fast path (instant)
         } catch (_) {
-          try {
-            await f.copy(destPath);
-          } catch (e) {
-            // Out of space / write error: clean up the partial destination
-            // file and keep the original. Propagate so the run records a
-            // failure (no blanket delete of un-copied files).
-            try {
-              final p = File(destPath);
-              if (p.existsSync()) await p.delete();
-            } catch (_) {}
-            rethrow;
+          // Cross-volume: stream-copy so the bar advances within a large file
+          // (and Cancel is responsive mid-file). Throws on error after
+          // cleaning up the partial; returns false if canceled mid-copy.
+          final ok = await _copyFileStreamed(f, destPath, (written) {
+            final mb = movedBytes + written;
+            final pct = totalBytes > 0 ? (mb * 100) ~/ totalBytes : -1;
+            if (pct != lastPct) {
+              lastPct = pct;
+              _progress.add(MigrationProgress(moved, total,
+                  movedBytes: mb, totalBytes: totalBytes));
+            }
+          });
+          if (!ok) {
+            canceled = true; // canceled mid-copy; partial already removed
+            break;
           }
           await f.delete();
         }

--- a/lib/singletons/migration_manager.dart
+++ b/lib/singletons/migration_manager.dart
@@ -7,14 +7,63 @@ import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:rxdart/rxdart.dart';
 
-// FAT/exFAT (typical removable SD cards) reject these characters in file and
-// directory names; '/' is the legal path separator between segments.
+// FAT/exFAT (typical removable SD cards) can't store certain names. '/' is the
+// legal segment separator and is never itself illegal.
 final RegExp _fatIllegalChars = RegExp(r'[<>:"|?*\\\x00-\x1f]');
+// Reserved DOS device names (any segment, with or without an extension).
+final RegExp _fatReservedNames =
+    RegExp(r'^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)', caseSensitive: false);
 
-// True if [relativePath] holds a character FAT/exFAT can't store — such files
-// can't be saved to a typical SD card.
-bool hasFatIllegalChars(String relativePath) =>
-    _fatIllegalChars.hasMatch(relativePath);
+// True if [relativePath] has any segment a FAT/exFAT volume can't store: an
+// illegal character, a reserved device name, or a trailing dot/space (FAT
+// strips those, so the saved name wouldn't match what we later look up).
+// Evaluated per '/'-separated segment (the runtime path separator on Android).
+bool hasFatIllegalChars(String relativePath) {
+  if (_fatIllegalChars.hasMatch(relativePath)) return true;
+  for (final seg in relativePath.split('/')) {
+    if (seg.isEmpty) continue;
+    if (seg.endsWith('.') || seg.endsWith(' ')) return true;
+    if (_fatReservedNames.hasMatch(seg)) return true;
+  }
+  return false;
+}
+
+// Cache FAT-probe results per directory so a "Download all" batch or a
+// migration walk doesn't re-probe the same volume repeatedly.
+final Map<String, bool> _fatProbeCache = {};
+
+// Whether [dirPath]'s filesystem rejects FAT-illegal characters (typical of an
+// SD card). Probes by writing a normal file (must succeed) then one containing
+// '?' (fails on FAT/exFAT). This is the single source of truth both downloads
+// and migration use to decide whether to skip un-storable names. Cached.
+// Defaults to false (don't skip) when it can't tell — and a failed cleanup of
+// the probe file never flips the verdict (it only affects the throwaway probe).
+Future<bool> isFatLikeDir(String dirPath) async {
+  final cached = _fatProbeCache[dirPath];
+  if (cached != null) return cached;
+  bool result;
+  try {
+    final ok = File(path.join(dirPath, '.mstream_probe'));
+    await ok.writeAsString('');
+    try {
+      await ok.delete();
+    } catch (_) {}
+    try {
+      final bad = File(path.join(dirPath, '.mstream_probe_q?'));
+      await bad.writeAsString('');
+      try {
+        await bad.delete();
+      } catch (_) {}
+      result = false; // '?' accepted → not FAT
+    } catch (_) {
+      result = true; // normal name OK but '?' rejected → FAT-like
+    }
+  } catch (_) {
+    result = false; // can't write here at all — not a charset limit
+  }
+  _fatProbeCache[dirPath] = result;
+  return result;
+}
 
 // Progress of a background storage migration (moving a server's downloaded
 // files from one storage volume to another, one file at a time).
@@ -87,27 +136,6 @@ class MigrationManager {
     try {
       await _channel.invokeMethod(active ? 'startMove' : 'stopMove');
     } catch (_) {}
-  }
-
-  // Whether [dirPath]'s filesystem rejects FAT-illegal characters (typical of
-  // an SD card). Probes by writing a normal file (must succeed) then one with
-  // a '?' (fails on FAT). Defaults to false (don't skip) if it can't tell.
-  Future<bool> _isFatLike(String dirPath) async {
-    try {
-      final ok = File(path.join(dirPath, '.mstream_probe'));
-      await ok.writeAsString('');
-      await ok.delete();
-    } catch (_) {
-      return false; // can't write here at all — not a charset limit
-    }
-    try {
-      final bad = File(path.join(dirPath, '.mstream_probe_q?'));
-      await bad.writeAsString('');
-      await bad.delete();
-      return false; // illegal char accepted → not FAT
-    } catch (_) {
-      return true; // normal name OK but '?' rejected → FAT-like
-    }
   }
 
   // The mount root of a path, so resume can tell "source folder deleted" (root
@@ -308,7 +336,7 @@ class MigrationManager {
         try {
           await dest.create(recursive: true);
         } catch (_) {}
-        fatLike = await _isFatLike(dest.path);
+        fatLike = await isFatLikeDir(dest.path);
         await _setService(true);
       }
 
@@ -334,23 +362,44 @@ class MigrationManager {
         try {
           await f.rename(destPath); // same-volume fast path (instant)
         } catch (_) {
-          // Cross-volume: stream-copy so the bar advances within a large file
-          // (and Cancel is responsive mid-file). Throws on error after
-          // cleaning up the partial; returns false if canceled mid-copy.
-          final ok = await _copyFileStreamed(f, destPath, (written) {
-            final mb = movedBytes + written;
-            final pct = totalBytes > 0 ? (mb * 100) ~/ totalBytes : -1;
-            if (pct != lastPct) {
-              lastPct = pct;
-              _progress.add(MigrationProgress(moved, total,
-                  movedBytes: mb, totalBytes: totalBytes));
+          // Cross-volume copy. A failure here is either a whole-volume problem
+          // (out of space — stop so the user can Retry/Cancel) or this one file
+          // being un-storable on the destination (e.g. a >4 GB file on FAT32,
+          // or a name the pre-check missed). In the latter case skip just this
+          // file so one bad file can't strand the entire library.
+          bool copied = false;
+          try {
+            // stream-copy so the bar advances within a large file (and Cancel
+            // is responsive mid-file). Throws on I/O error after cleaning up
+            // the partial; returns false if canceled mid-copy.
+            final ok = await _copyFileStreamed(f, destPath, (written) {
+              final mb = movedBytes + written;
+              final pct = totalBytes > 0 ? (mb * 100) ~/ totalBytes : -1;
+              if (pct != lastPct) {
+                lastPct = pct;
+                _progress.add(MigrationProgress(moved, total,
+                    movedBytes: mb, totalBytes: totalBytes));
+              }
+            });
+            if (!ok) {
+              canceled = true; // canceled mid-copy; partial already removed
+              break;
             }
-          });
-          if (!ok) {
-            canceled = true; // canceled mid-copy; partial already removed
-            break;
+            copied = true;
+          } catch (_) {
+            if (_cancelRequested) {
+              canceled = true;
+              break;
+            }
+            // Out of room on the destination volume → stop the move. Otherwise
+            // (or if free space can't be read) treat it as a per-file problem
+            // and skip it, leaving the source copy intact.
+            final free = await freeBytes(dest.path) ?? -1;
+            if (free >= 0 && free < sizes[i]) rethrow;
+            skipped++;
+            continue;
           }
-          await f.delete();
+          if (copied) await f.delete();
         }
         moved++;
         movedBytes += sizes[i];

--- a/lib/singletons/migration_manager.dart
+++ b/lib/singletons/migration_manager.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+import 'package:rxdart/rxdart.dart';
+
+// Progress of a background storage migration (moving a server's downloaded
+// files from one storage volume to another, one file at a time).
+class MigrationProgress {
+  final int moved;
+  final int total;
+  final bool done;
+  final bool failed;
+  const MigrationProgress(this.moved, this.total,
+      {this.done = false, this.failed = false});
+
+  // null = indeterminate (total unknown yet).
+  double? get fraction =>
+      total <= 0 ? null : (moved / total).clamp(0.0, 1.0).toDouble();
+}
+
+// Moves a server's downloaded files across storage volumes in the background,
+// one file at a time (rename when possible, otherwise copy then delete the
+// original). Because it deletes each original only after that file is at the
+// destination, an interruption can never blanket-wipe un-copied files. The
+// move is recorded in a sentinel file so it resumes when the app is reopened.
+class MigrationManager {
+  MigrationManager._();
+  static final MigrationManager _instance = MigrationManager._();
+  factory MigrationManager() => _instance;
+
+  final BehaviorSubject<MigrationProgress?> _progress =
+      BehaviorSubject<MigrationProgress?>.seeded(null);
+  Stream<MigrationProgress?> get progressStream => _progress.stream;
+
+  bool _running = false;
+  bool get isRunning => _running;
+
+  Future<File> get _sentinel async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File(path.join(dir.path, 'migration.json'));
+  }
+
+  // Begin moving [sourcePath] -> [destPath] in the background. Writes the
+  // sentinel first so the move can resume if the app is killed mid-way.
+  Future<void> start(String sourcePath, String destPath) async {
+    if (_running) return;
+    final total = await _countFiles(Directory(sourcePath));
+    try {
+      final s = await _sentinel;
+      await s.writeAsString(jsonEncode(
+          {'source': sourcePath, 'dest': destPath, 'total': total}));
+    } catch (_) {}
+    unawaited(_run(Directory(sourcePath), Directory(destPath), total));
+  }
+
+  // Resume an interrupted move on app startup, if a sentinel is present.
+  Future<void> resumeIfNeeded() async {
+    try {
+      final s = await _sentinel;
+      if (!s.existsSync()) return;
+      final data = jsonDecode(await s.readAsString()) as Map<String, dynamic>;
+      final source = Directory(data['source'] as String);
+      final dest = Directory(data['dest'] as String);
+      final total = (data['total'] as int?) ?? 0;
+      if (!source.existsSync()) {
+        await s.delete(); // nothing left to move
+        return;
+      }
+      unawaited(_run(source, dest, total));
+    } catch (_) {
+      // Corrupt/unreadable sentinel — drop it so we don't loop on it.
+      try {
+        final s = await _sentinel;
+        if (s.existsSync()) await s.delete();
+      } catch (_) {}
+    }
+  }
+
+  Future<int> _countFiles(Directory d) async {
+    int n = 0;
+    try {
+      if (!d.existsSync()) return 0;
+      await for (final e in d.list(recursive: true, followLinks: false)) {
+        if (e is File) n++;
+      }
+    } catch (_) {}
+    return n;
+  }
+
+  Future<void> _run(Directory source, Directory dest, int total) async {
+    if (_running) return;
+    _running = true;
+    try {
+      // moved = already-moved count, so a resumed run shows true progress.
+      final remaining = await _countFiles(source);
+      int moved = (total - remaining).clamp(0, total);
+      _progress.add(MigrationProgress(moved, total));
+
+      final files = <File>[];
+      try {
+        await for (final e
+            in source.list(recursive: true, followLinks: false)) {
+          if (e is File) files.add(e);
+        }
+      } catch (_) {}
+
+      for (final f in files) {
+        if (!f.existsSync()) continue; // already moved on a prior pass
+        final rel = path.relative(f.path, from: source.path);
+        final destPath = path.join(dest.path, rel);
+        await Directory(path.dirname(destPath)).create(recursive: true);
+        try {
+          await f.rename(destPath); // same-volume fast path
+        } catch (_) {
+          await f.copy(destPath); // cross-volume: copy then drop the original
+          await f.delete();
+        }
+        moved++;
+        _progress.add(MigrationProgress(moved.clamp(0, total), total));
+      }
+
+      // Remove the source tree only if it's now empty — a file that arrived
+      // after our scan (e.g. an in-flight download) is preserved, not wiped.
+      if (await _countFiles(source) == 0) {
+        try {
+          if (source.existsSync()) await source.delete(recursive: true);
+        } catch (_) {}
+      }
+      try {
+        final s = await _sentinel;
+        if (s.existsSync()) await s.delete();
+      } catch (_) {}
+
+      _progress.add(MigrationProgress(total, total, done: true));
+      await Future.delayed(const Duration(seconds: 3));
+      _progress.add(null); // clear the banner
+    } catch (_) {
+      // Leave the sentinel in place so it retries next launch.
+      _progress.add(MigrationProgress(0, total, failed: true));
+    } finally {
+      _running = false;
+    }
+  }
+}

--- a/lib/singletons/migration_manager.dart
+++ b/lib/singletons/migration_manager.dart
@@ -7,6 +7,15 @@ import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:rxdart/rxdart.dart';
 
+// FAT/exFAT (typical removable SD cards) reject these characters in file and
+// directory names; '/' is the legal path separator between segments.
+final RegExp _fatIllegalChars = RegExp(r'[<>:"|?*\\\x00-\x1f]');
+
+// True if [relativePath] holds a character FAT/exFAT can't store — such files
+// can't be saved to a typical SD card.
+bool hasFatIllegalChars(String relativePath) =>
+    _fatIllegalChars.hasMatch(relativePath);
+
 // Progress of a background storage migration (moving a server's downloaded
 // files from one storage volume to another, one file at a time).
 class MigrationProgress {
@@ -14,11 +23,13 @@ class MigrationProgress {
   final int total; // total files
   final int movedBytes;
   final int totalBytes;
+  final int skipped; // files skipped (names unsupported on the destination)
   final bool done;
   final bool failed; // stopped on an error; awaiting Retry/Cancel
   const MigrationProgress(this.moved, this.total,
       {this.movedBytes = 0,
       this.totalBytes = 0,
+      this.skipped = 0,
       this.done = false,
       this.failed = false});
 
@@ -76,6 +87,27 @@ class MigrationManager {
     try {
       await _channel.invokeMethod(active ? 'startMove' : 'stopMove');
     } catch (_) {}
+  }
+
+  // Whether [dirPath]'s filesystem rejects FAT-illegal characters (typical of
+  // an SD card). Probes by writing a normal file (must succeed) then one with
+  // a '?' (fails on FAT). Defaults to false (don't skip) if it can't tell.
+  Future<bool> _isFatLike(String dirPath) async {
+    try {
+      final ok = File(path.join(dirPath, '.mstream_probe'));
+      await ok.writeAsString('');
+      await ok.delete();
+    } catch (_) {
+      return false; // can't write here at all — not a charset limit
+    }
+    try {
+      final bad = File(path.join(dirPath, '.mstream_probe_q?'));
+      await bad.writeAsString('');
+      await bad.delete();
+      return false; // illegal char accepted → not FAT
+    } catch (_) {
+      return true; // normal name OK but '?' rejected → FAT-like
+    }
   }
 
   // Begin moving [sourcePath] -> [destPath]. [totalFiles]/[totalBytes] are the
@@ -193,10 +225,19 @@ class MigrationManager {
           movedBytes: movedBytes, totalBytes: totalBytes));
 
       // Hold a foreground service for the duration so backgrounding the app
-      // doesn't freeze the move.
-      if (files.isNotEmpty) await _setService(true);
+      // doesn't freeze the move; detect a FAT/exFAT destination (SD card) so
+      // files with unsupported names are skipped, not fatal.
+      bool fatLike = false;
+      if (files.isNotEmpty) {
+        try {
+          await dest.create(recursive: true);
+        } catch (_) {}
+        fatLike = await _isFatLike(dest.path);
+        await _setService(true);
+      }
 
       int lastPct = -1;
+      int skipped = 0;
       bool canceled = false;
       for (int i = 0; i < files.length; i++) {
         if (_cancelRequested) {
@@ -206,6 +247,12 @@ class MigrationManager {
         final f = files[i];
         if (!f.existsSync()) continue;
         final rel = path.relative(f.path, from: source.path);
+        // Can't store this name on a FAT/exFAT card — leave it at the source
+        // rather than failing the whole move.
+        if (fatLike && hasFatIllegalChars(rel)) {
+          skipped++;
+          continue;
+        }
         final destPath = path.join(dest.path, rel);
         await Directory(path.dirname(destPath)).create(recursive: true);
         try {
@@ -258,7 +305,10 @@ class MigrationManager {
       } catch (_) {}
 
       _progress.add(MigrationProgress(total, total,
-          movedBytes: totalBytes, totalBytes: totalBytes, done: true));
+          movedBytes: totalBytes,
+          totalBytes: totalBytes,
+          skipped: skipped,
+          done: true));
       succeeded = true;
     } catch (_) {
       await _recordFailure();

--- a/lib/singletons/migration_manager.dart
+++ b/lib/singletons/migration_manager.dart
@@ -70,6 +70,14 @@ class MigrationManager {
     }
   }
 
+  // Start/stop the foreground service that keeps the process alive during a
+  // move (so it survives backgrounding). Non-fatal — the move runs regardless.
+  Future<void> _setService(bool active) async {
+    try {
+      await _channel.invokeMethod(active ? 'startMove' : 'stopMove');
+    } catch (_) {}
+  }
+
   // Begin moving [sourcePath] -> [destPath]. [totalFiles]/[totalBytes] are the
   // already-computed source size (from the dialog) so we don't re-walk.
   Future<void> start(String sourcePath, String destPath, int totalFiles,
@@ -184,6 +192,10 @@ class MigrationManager {
       _progress.add(MigrationProgress(moved, total,
           movedBytes: movedBytes, totalBytes: totalBytes));
 
+      // Hold a foreground service for the duration so backgrounding the app
+      // doesn't freeze the move.
+      if (files.isNotEmpty) await _setService(true);
+
       int lastPct = -1;
       bool canceled = false;
       for (int i = 0; i < files.length; i++) {
@@ -254,6 +266,7 @@ class MigrationManager {
           MigrationProgress(0, total, totalBytes: totalBytes, failed: true));
     } finally {
       _running = false;
+      unawaited(_setService(false));
     }
     // Cosmetic: clear the "done" banner after a moment — outside the busy
     // window, so a new move can start immediately.

--- a/lib/singletons/migration_manager.dart
+++ b/lib/singletons/migration_manager.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/services.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:rxdart/rxdart.dart';
@@ -9,27 +10,42 @@ import 'package:rxdart/rxdart.dart';
 // Progress of a background storage migration (moving a server's downloaded
 // files from one storage volume to another, one file at a time).
 class MigrationProgress {
-  final int moved;
-  final int total;
+  final int moved; // files moved so far
+  final int total; // total files
+  final int movedBytes;
+  final int totalBytes;
   final bool done;
-  final bool failed;
+  final bool failed; // stopped on an error; awaiting Retry/Cancel
   const MigrationProgress(this.moved, this.total,
-      {this.done = false, this.failed = false});
+      {this.movedBytes = 0,
+      this.totalBytes = 0,
+      this.done = false,
+      this.failed = false});
 
-  // null = indeterminate (total unknown yet).
-  double? get fraction =>
-      total <= 0 ? null : (moved / total).clamp(0.0, 1.0).toDouble();
+  // Byte-based when known (smoother on big files), else file-count, else
+  // indeterminate (null).
+  double? get fraction {
+    if (totalBytes > 0) {
+      return (movedBytes / totalBytes).clamp(0.0, 1.0).toDouble();
+    }
+    if (total > 0) return (moved / total).clamp(0.0, 1.0).toDouble();
+    return null;
+  }
 }
 
 // Moves a server's downloaded files across storage volumes in the background,
 // one file at a time (rename when possible, otherwise copy then delete the
-// original). Because it deletes each original only after that file is at the
-// destination, an interruption can never blanket-wipe un-copied files. The
-// move is recorded in a sentinel file so it resumes when the app is reopened.
+// original). Deleting each original only after its copy lands means an
+// interruption can never blanket-wipe un-copied files. A sentinel file records
+// the move so it resumes when the app is reopened — but a move that *errored*
+// (e.g. out of space) is not auto-retried; it waits for the user to Retry or
+// Cancel from the banner.
 class MigrationManager {
   MigrationManager._();
   static final MigrationManager _instance = MigrationManager._();
   factory MigrationManager() => _instance;
+
+  static const MethodChannel _channel = MethodChannel('mstream/storage');
 
   final BehaviorSubject<MigrationProgress?> _progress =
       BehaviorSubject<MigrationProgress?>.seeded(null);
@@ -37,41 +53,66 @@ class MigrationManager {
 
   bool _running = false;
   bool get isRunning => _running;
+  bool _cancelRequested = false;
 
   Future<File> get _sentinel async {
     final dir = await getApplicationDocumentsDirectory();
     return File(path.join(dir.path, 'migration.json'));
   }
 
-  // Begin moving [sourcePath] -> [destPath] in the background. Writes the
-  // sentinel first so the move can resume if the app is killed mid-way.
-  Future<void> start(String sourcePath, String destPath) async {
-    if (_running) return;
-    final total = await _countFiles(Directory(sourcePath));
+  // Free bytes on the volume holding [dirPath] (native StatFs), or null if it
+  // can't be determined.
+  Future<int?> freeBytes(String dirPath) async {
     try {
-      final s = await _sentinel;
-      await s.writeAsString(jsonEncode(
-          {'source': sourcePath, 'dest': destPath, 'total': total}));
-    } catch (_) {}
-    unawaited(_run(Directory(sourcePath), Directory(destPath), total));
+      return await _channel.invokeMethod<int>('freeBytes', {'path': dirPath});
+    } catch (_) {
+      return null;
+    }
   }
 
-  // Resume an interrupted move on app startup, if a sentinel is present.
+  // Begin moving [sourcePath] -> [destPath]. [totalFiles]/[totalBytes] are the
+  // already-computed source size (from the dialog) so we don't re-walk.
+  Future<void> start(String sourcePath, String destPath, int totalFiles,
+      int totalBytes) async {
+    if (_running) return;
+    try {
+      final s = await _sentinel;
+      await s.writeAsString(jsonEncode({
+        'source': sourcePath,
+        'dest': destPath,
+        'total': totalFiles,
+        'totalBytes': totalBytes,
+        'failures': 0,
+      }));
+    } catch (_) {}
+    unawaited(
+        _run(Directory(sourcePath), Directory(destPath), totalFiles, totalBytes));
+  }
+
+  // On app startup: auto-resume an interrupted move — UNLESS it previously
+  // errored (failures > 0), in which case surface an actionable banner and
+  // wait for Retry/Cancel rather than looping forever.
   Future<void> resumeIfNeeded() async {
     try {
       final s = await _sentinel;
       if (!s.existsSync()) return;
       final data = jsonDecode(await s.readAsString()) as Map<String, dynamic>;
       final source = Directory(data['source'] as String);
-      final dest = Directory(data['dest'] as String);
       final total = (data['total'] as int?) ?? 0;
+      final totalBytes = (data['totalBytes'] as int?) ?? 0;
+      final failures = (data['failures'] as int?) ?? 0;
       if (!source.existsSync()) {
         await s.delete(); // nothing left to move
         return;
       }
-      unawaited(_run(source, dest, total));
+      if (failures > 0) {
+        _progress.add(
+            MigrationProgress(0, total, totalBytes: totalBytes, failed: true));
+        return;
+      }
+      unawaited(
+          _run(source, Directory(data['dest'] as String), total, totalBytes));
     } catch (_) {
-      // Corrupt/unreadable sentinel — drop it so we don't loop on it.
       try {
         final s = await _sentinel;
         if (s.existsSync()) await s.delete();
@@ -79,52 +120,122 @@ class MigrationManager {
     }
   }
 
-  Future<int> _countFiles(Directory d) async {
-    int n = 0;
+  // User tapped Retry on the failed banner — clear the failure count and run.
+  Future<void> retry() async {
+    if (_running) return;
     try {
-      if (!d.existsSync()) return 0;
-      await for (final e in d.list(recursive: true, followLinks: false)) {
-        if (e is File) n++;
-      }
+      final s = await _sentinel;
+      if (!s.existsSync()) return;
+      final data = jsonDecode(await s.readAsString()) as Map<String, dynamic>;
+      data['failures'] = 0;
+      await s.writeAsString(jsonEncode(data));
+      unawaited(_run(Directory(data['source'] as String),
+          Directory(data['dest'] as String), (data['total'] as int?) ?? 0,
+          (data['totalBytes'] as int?) ?? 0));
     } catch (_) {}
-    return n;
   }
 
-  Future<void> _run(Directory source, Directory dest, int total) async {
+  // User tapped Cancel — stop, drop the sentinel, clear the banner. Files
+  // already moved stay at the destination; the rest stay at the source.
+  Future<void> cancel() async {
+    _cancelRequested = true;
+    try {
+      final s = await _sentinel;
+      if (s.existsSync()) await s.delete();
+    } catch (_) {}
+    _progress.add(null);
+  }
+
+  Future<void> _recordFailure() async {
+    try {
+      final s = await _sentinel;
+      if (!s.existsSync()) return;
+      final data = jsonDecode(await s.readAsString()) as Map<String, dynamic>;
+      data['failures'] = ((data['failures'] as int?) ?? 0) + 1;
+      await s.writeAsString(jsonEncode(data));
+    } catch (_) {}
+  }
+
+  Future<void> _run(
+      Directory source, Directory dest, int total, int totalBytes) async {
     if (_running) return;
     _running = true;
+    _cancelRequested = false;
+    bool succeeded = false;
     try {
-      // moved = already-moved count, so a resumed run shows true progress.
-      final remaining = await _countFiles(source);
-      int moved = (total - remaining).clamp(0, total);
-      _progress.add(MigrationProgress(moved, total));
-
+      // One walk: gather the remaining files + their sizes.
       final files = <File>[];
+      final sizes = <int>[];
+      int remainingBytes = 0;
       try {
         await for (final e
             in source.list(recursive: true, followLinks: false)) {
-          if (e is File) files.add(e);
+          if (e is File) {
+            final sz = await e.length();
+            files.add(e);
+            sizes.add(sz);
+            remainingBytes += sz;
+          }
         }
       } catch (_) {}
 
-      for (final f in files) {
-        if (!f.existsSync()) continue; // already moved on a prior pass
+      int moved = (total - files.length).clamp(0, total);
+      int movedBytes = (totalBytes - remainingBytes).clamp(0, totalBytes);
+      _progress.add(MigrationProgress(moved, total,
+          movedBytes: movedBytes, totalBytes: totalBytes));
+
+      int lastPct = -1;
+      bool canceled = false;
+      for (int i = 0; i < files.length; i++) {
+        if (_cancelRequested) {
+          canceled = true;
+          break;
+        }
+        final f = files[i];
+        if (!f.existsSync()) continue;
         final rel = path.relative(f.path, from: source.path);
         final destPath = path.join(dest.path, rel);
         await Directory(path.dirname(destPath)).create(recursive: true);
         try {
           await f.rename(destPath); // same-volume fast path
         } catch (_) {
-          await f.copy(destPath); // cross-volume: copy then drop the original
+          try {
+            await f.copy(destPath);
+          } catch (e) {
+            // Out of space / write error: clean up the partial destination
+            // file and keep the original. Propagate so the run records a
+            // failure (no blanket delete of un-copied files).
+            try {
+              final p = File(destPath);
+              if (p.existsSync()) await p.delete();
+            } catch (_) {}
+            rethrow;
+          }
           await f.delete();
         }
         moved++;
-        _progress.add(MigrationProgress(moved.clamp(0, total), total));
+        movedBytes += sizes[i];
+        final pct = totalBytes > 0
+            ? (movedBytes * 100) ~/ totalBytes
+            : (total > 0 ? (moved * 100) ~/ total : 100);
+        if (pct != lastPct) {
+          lastPct = pct;
+          _progress.add(MigrationProgress(moved, total,
+              movedBytes: movedBytes, totalBytes: totalBytes));
+        }
+      }
+
+      if (canceled) {
+        _progress.add(null); // sentinel already removed by cancel()
+        return;
       }
 
       // Remove the source tree only if it's now empty — a file that arrived
-      // after our scan (e.g. an in-flight download) is preserved, not wiped.
-      if (await _countFiles(source) == 0) {
+      // mid-move (e.g. an in-flight download) is preserved, not wiped.
+      final hasLeftovers = await source
+          .list(recursive: true, followLinks: false)
+          .any((e) => e is File);
+      if (!hasLeftovers) {
         try {
           if (source.existsSync()) await source.delete(recursive: true);
         } catch (_) {}
@@ -134,14 +245,21 @@ class MigrationManager {
         if (s.existsSync()) await s.delete();
       } catch (_) {}
 
-      _progress.add(MigrationProgress(total, total, done: true));
-      await Future.delayed(const Duration(seconds: 3));
-      _progress.add(null); // clear the banner
+      _progress.add(MigrationProgress(total, total,
+          movedBytes: totalBytes, totalBytes: totalBytes, done: true));
+      succeeded = true;
     } catch (_) {
-      // Leave the sentinel in place so it retries next launch.
-      _progress.add(MigrationProgress(0, total, failed: true));
+      await _recordFailure();
+      _progress.add(
+          MigrationProgress(0, total, totalBytes: totalBytes, failed: true));
     } finally {
       _running = false;
+    }
+    // Cosmetic: clear the "done" banner after a moment — outside the busy
+    // window, so a new move can start immediately.
+    if (succeeded) {
+      await Future.delayed(const Duration(seconds: 3));
+      if (!_running) _progress.add(null);
     }
   }
 }

--- a/lib/singletons/migration_manager.dart
+++ b/lib/singletons/migration_manager.dart
@@ -110,6 +110,19 @@ class MigrationManager {
     }
   }
 
+  // The mount root of a path, so resume can tell "source folder deleted" (root
+  // still mounted) from "source volume not mounted" (e.g. SD card removed).
+  String _volumeRoot(String p) {
+    if (p.startsWith('/storage/emulated/')) return '/storage/emulated/0';
+    if (p.startsWith('/storage/')) {
+      final parts = p.split('/'); // ['', 'storage', '<vol>', ...]
+      if (parts.length >= 3 && parts[2].isNotEmpty) {
+        return '/storage/${parts[2]}';
+      }
+    }
+    return '/'; // internal storage is always mounted
+  }
+
   // Begin moving [sourcePath] -> [destPath]. [totalFiles]/[totalBytes] are the
   // already-computed source size (from the dialog) so we don't re-walk.
   Future<void> start(String sourcePath, String destPath, int totalFiles,
@@ -142,8 +155,30 @@ class MigrationManager {
       final totalBytes = (data['totalBytes'] as int?) ?? 0;
       final failures = (data['failures'] as int?) ?? 0;
       if (!source.existsSync()) {
-        await s.delete(); // nothing left to move
-        return;
+        // Distinguish "source folder gone" (move finished / folder deleted —
+        // its volume is still mounted) from "source volume not mounted yet"
+        // (an SD-card source that isn't ready at launch, or was removed).
+        if (Directory(_volumeRoot(source.path)).existsSync()) {
+          await s.delete(); // genuinely gone — nothing to resume
+          return;
+        }
+        // Volume isn't mounted. Give it a moment to appear (cards mount a few
+        // seconds after launch), then resume; if it stays away, pause — keep
+        // the sentinel so the move isn't abandoned. The user can reconnect the
+        // card and Retry, or Cancel.
+        bool back = false;
+        for (int i = 0; i < 10; i++) {
+          await Future.delayed(const Duration(seconds: 1));
+          if (source.existsSync()) {
+            back = true;
+            break;
+          }
+        }
+        if (!back) {
+          _progress.add(MigrationProgress(0, total,
+              totalBytes: totalBytes, failed: true));
+          return; // keep the sentinel for a later attempt
+        }
       }
       if (failures > 0) {
         _progress.add(

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -117,8 +117,8 @@ class ServerManager {
     }
 
     // Create server directory (for downloads)
-    Directory? file =
-        await FileExplorer().getDownloadDir(newServer.saveToSdCard);
+    Directory? file = await FileExplorer()
+        .getDownloadDir(newServer.storageMode, newServer.storageBasePath);
     if (file != null) {
       String dir = path.join(file.path, "media/${newServer.localname}");
       await new Directory(dir).create(recursive: true);
@@ -129,12 +129,14 @@ class ServerManager {
     _serverListStream.sink.add(serverList);
   }
 
+  // Storage mode + base path are set directly on the Server in the
+  // add-server form (like localname is), so they aren't part of this
+  // signature — callAfterEditServer() persists whatever was set.
   Future<void> editServer(int serverIndex, String url, String? username,
-      String? password, bool saveToSd) async {
+      String? password) async {
     serverList[serverIndex].url = url;
     ServerManager().serverList[serverIndex].password = password;
     ServerManager().serverList[serverIndex].username = username;
-    ServerManager().serverList[serverIndex].saveToSdCard = saveToSd;
 
     await callAfterEditServer();
   }
@@ -233,8 +235,8 @@ class ServerManager {
   }
 
   Future<void> _deleteServeDirectory(Server removedServer) async {
-    Directory? directory =
-        await FileExplorer().getDownloadDir(removedServer.saveToSdCard);
+    Directory? directory = await FileExplorer().getDownloadDir(
+        removedServer.storageMode, removedServer.storageBasePath);
     if (directory != null) {
       Directory dir = new Directory(path.join(
           directory.path.toString(), "media/${removedServer.localname}"));

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -5,6 +5,7 @@ import 'package:mstream_music/singletons/file_explorer.dart';
 
 import '../objects/server.dart';
 import '../util/server_compat.dart';
+import './app_messenger.dart';
 import './browser_list.dart';
 
 import 'package:path_provider/path_provider.dart';
@@ -59,8 +60,12 @@ class ServerManager {
     List serversJson = await readServerManager();
 
     serversJson.forEach((s) {
-      Server newServer = Server.fromJson(s);
-      serverList.add(newServer);
+      try {
+        serverList.add(Server.fromJson(s));
+      } catch (e) {
+        // Skip a corrupt entry instead of failing to load every server
+        // that comes after it in the file.
+      }
     });
 
     _serverListStream.sink.add(serverList);
@@ -120,8 +125,16 @@ class ServerManager {
     Directory? file = await FileExplorer()
         .getDownloadDir(newServer.storageMode, newServer.storageBasePath);
     if (file != null) {
-      String dir = path.join(file.path, "media/${newServer.localname}");
-      await new Directory(dir).create(recursive: true);
+      try {
+        String dir = path.join(file.path, "media/${newServer.localname}");
+        await new Directory(dir).create(recursive: true);
+      } catch (e) {
+        // A permanent/SD path can fail to create (unmounted, read-only).
+        // Don't let that abort the save below and lose the server entirely.
+        showGlobalSnack(
+            'Saved, but the download folder could not be created — storage '
+            'may be unavailable.');
+      }
     }
 
     await writeServerFile();

--- a/test/objects/server_test.dart
+++ b/test/objects/server_test.dart
@@ -19,7 +19,9 @@ void main() {
       expect(s.autoDJPaths, isEmpty);
       expect(s.autoDJminRating, isNull);
       expect(s.playlists, isEmpty);
-      expect(s.saveToSdCard, isFalse);
+      // No storage fields and no legacy flag -> default app-local.
+      expect(s.storageMode, 'appLocal');
+      expect(s.storageBasePath, isNull);
     });
 
     test('parses full payload with auto DJ + playlists', () {
@@ -32,7 +34,8 @@ void main() {
         'autoDJPaths': {'rock': true, 'jazz': false},
         'autoDJminRating': 6,
         'playlists': ['favs', 'roadtrip'],
-        'saveToSdCard': true,
+        'storageMode': 'permanent',
+        'storageBasePath': '/storage/emulated/0/Music',
       });
       expect(s.username, 'alice');
       expect(s.password, 'secret');
@@ -40,10 +43,11 @@ void main() {
       expect(s.autoDJPaths, {'rock': true, 'jazz': false});
       expect(s.autoDJminRating, 6);
       expect(s.playlists, ['favs', 'roadtrip']);
-      expect(s.saveToSdCard, isTrue);
+      expect(s.storageMode, 'permanent');
+      expect(s.storageBasePath, '/storage/emulated/0/Music');
     });
 
-    test('treats missing autoDJPaths/playlists/saveToSdCard as defaults', () {
+    test('treats missing autoDJPaths/playlists/storage as defaults', () {
       final s = Server.fromJson({
         'url': 'u',
         'username': null,
@@ -53,7 +57,50 @@ void main() {
       });
       expect(s.autoDJPaths, isEmpty);
       expect(s.playlists, isEmpty);
-      expect(s.saveToSdCard, isFalse);
+      expect(s.storageMode, 'appLocal');
+      expect(s.storageBasePath, isNull);
+    });
+  });
+
+  group('Server.fromJson storage migration', () {
+    test('legacy saveToSdCard:true migrates to legacyExternal', () {
+      final s = Server.fromJson({
+        'url': 'u',
+        'username': null,
+        'password': null,
+        'jwt': null,
+        'localname': 'l',
+        'saveToSdCard': true,
+      });
+      // Preserved losslessly: the resolver maps legacyExternal to the old
+      // getExternalStorageDirectory() so existing downloads still resolve.
+      expect(s.storageMode, 'legacyExternal');
+      expect(s.storageBasePath, isNull);
+    });
+
+    test('legacy saveToSdCard:false migrates to appLocal', () {
+      final s = Server.fromJson({
+        'url': 'u',
+        'username': null,
+        'password': null,
+        'jwt': null,
+        'localname': 'l',
+        'saveToSdCard': false,
+      });
+      expect(s.storageMode, 'appLocal');
+    });
+
+    test('explicit storageMode wins over a legacy flag', () {
+      final s = Server.fromJson({
+        'url': 'u',
+        'username': null,
+        'password': null,
+        'jwt': null,
+        'localname': 'l',
+        'saveToSdCard': true,
+        'storageMode': 'appLocal',
+      });
+      expect(s.storageMode, 'appLocal');
     });
   });
 
@@ -69,7 +116,8 @@ void main() {
       original.autoDJPaths = {'rock': true, 'jazz': false};
       original.autoDJminRating = 7;
       original.playlists = ['p1'];
-      original.saveToSdCard = true;
+      original.storageMode = 'permanent';
+      original.storageBasePath = '/storage/emulated/0/Music';
 
       final reparsed = Server.fromJson(original.toJson());
 
@@ -81,7 +129,14 @@ void main() {
       expect(reparsed.autoDJPaths, original.autoDJPaths);
       expect(reparsed.autoDJminRating, original.autoDJminRating);
       expect(reparsed.playlists, original.playlists);
-      expect(reparsed.saveToSdCard, original.saveToSdCard);
+      expect(reparsed.storageMode, original.storageMode);
+      expect(reparsed.storageBasePath, original.storageBasePath);
+    });
+
+    test('does not emit the obsolete saveToSdCard key', () {
+      final json = Server('u', null, null, null, 'l').toJson();
+      expect(json.containsKey('saveToSdCard'), isFalse);
+      expect(json['storageMode'], 'appLocal');
     });
   });
 }


### PR DESCRIPTION
## Summary

Replaces the single per-server "Download to SD Card" toggle with an explicit **Storage location** choice on the add/edit-server screen, and hardens the surrounding download code along the way.

Motivation: downloads defaulted to a generated (UUID) folder in app-private storage, which Android wipes on uninstall — so a re-added server couldn't find its old songs, and there was no way to keep downloads permanently.

## What's new

**Storage location** dropdown (per server):
- **App local** (default) — the app's own internal storage; deleted on uninstall, no permission.
- **Permanent** — a folder you choose in shared storage that survives uninstall (`MANAGE_EXTERNAL_STORAGE`, requested at runtime).
- **SD card** — a folder on a removable card; only shown when one is present.

Supporting pieces:
- Editable **Download folder** name, auto-derived from the URL as `${subdomain}-${domain}` (e.g. `music.rum.st` → `music-rum.st`) instead of a UUID, with duplicate-name disambiguation (`...-<nanoid>`), input sanitizing (no separators / `..`), and a **Browse** / **New folder** picker (pure `dart:io`, no new plugin — keeps the AGP9 build clean). Save is blocked until a Permanent/SD-card folder has been picked **and** passed a write-probe, so a server can't be saved into a silently-unavailable state.
- **Moving downloads when the storage location changes.** Within one volume it's an instant atomic rename. Across volumes (App-local internal ↔ shared storage are different mounts on Android 11+), a clear dialog offers three choices — **Move them**, **Leave them** (re-download), **Delete old downloads** — and **warns up front** (native `StatFs` free-space check) if the library won't fit. In-flight downloads are canceled before the switch so none strand at the old location. "Move them" runs in the **background**, held alive by a **foreground service** so it keeps going if you leave the app, with a **streamed, byte-level progress banner** + **Cancel** (responsive even mid-file). It's a **per-file copy-then-delete** (an interruption can't blanket-delete an un-copied file), **resumes after an app restart** via a sentinel (and waits for an SD-card source to remount rather than abandoning the move). **Any single file the destination can't store** — an unsupported name (FAT/exFAT illegal chars, reserved DOS names, trailing dot/space) or a >4 GB file on FAT32 — is **skipped with a count, not fatal**; only a genuine out-of-space stops the move, which is then **not** auto-retried (the banner offers **Retry / Cancel** and a failed copy cleans up its partial file).
- **Resilience**: an unavailable location (SD removed / folder deleted) degrades playback to streaming instead of going silent. Playback re-checks the local file and **falls back to streaming if it's gone** (moved mid-migration, SD removed, deleted externally), and uses `Uri.file` so folders with spaces play offline. The browser's "downloaded" badges also **re-check themselves** when a server's storage location changes (and when a background move finishes), so they never keep showing a stale mark against the old path.

## Download-code hardening (audit follow-up)

A review surfaced several latent issues, mostly pre-existing, now fixed:
- Guard a `lookupServer` crash when syncing a queued track whose server was removed.
- Handle failed/canceled downloads (reset the stuck progress bar + notify) instead of silent failure.
- Clean up the download-tracker map on terminal status (was an unbounded leak).
- Dedup in-flight downloads so a double-tap can't enqueue/corrupt the same file.
- Guard `addServer`'s directory create so a bad path can't drop the server from `servers.json`.
- Throttle browser repaints to 5% buckets during "Download all".
- Skip downloads whose names the **actual destination filesystem** can't store — determined by a cached write-probe shared with the migration path, not by the mode label — instead of a misleading error.

## Model / migration

`Server.saveToSdCard` (bool) → `storageMode` + `storageBasePath`, with lossless migration of existing servers (old `false` → App local; old `true` → a legacy mode that keeps resolving to the previous location). Unit tests updated + migration cases added.

## Testing

- `flutter analyze` clean (only pre-existing warnings); `flutter test` green (incl. `Server` migration cases).
- Earlier revisions deployed + exercised on a physical device (Galaxy S25 / Android 15). The SD-card-specific paths can't be verified here (no device with a card), so they're built + analyze-clean and **shipping for user feedback** — see below.

## Known limitations (deliberately out of scope)

- **SD-card writes to a user-chosen folder may be restricted on Android 11+.** `MANAGE_EXTERNAL_STORAGE` reliably grants File-API writes to *primary* shared storage but not always to a *removable* card (`/storage/<uuid>`), and behavior varies by OEM/version. The flow **fails safe**: the folder picker write-probes the chosen folder and rejects it with a clear message rather than failing silently, and Save won't persist a server without a verified folder. Confirming which devices allow it needs real-card feedback; the proper fix (Storage Access Framework) is a larger change that would replace the path-based download/play pipeline.
- A reformatted/swapped SD card (new volume UUID) makes a parked migration unrecoverable except via Cancel (the old path is gone); no data is lost from the destination.
- The free-space check is a **warning**, not a hard block; out-of-space mid-move stops safely with Retry/Cancel.
- A track downloaded while already queued keeps streaming until re-queued (pre-existing TODO).
- Permanent / SD require Android 11+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
