### PR TITLE
Client-side casting: DLNA + Chromecast

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -47,7 +47,10 @@ android {
 
     defaultConfig {
         applicationId "mstream.music"
-        minSdk = flutter.minSdkVersion
+        // Raised from flutter.minSdkVersion to 26 (Android 8.0): the
+        // media_cast_dlna plugin (DLNA casting) requires API 26+. This drops
+        // support for Android 7.x and below.
+        minSdk = 26
         targetSdk = 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.mstream_music">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <!-- DLNA/UPnP casting (media_cast_dlna): SSDP discovery needs Wi-Fi
+         multicast; ACCESS_WIFI_STATE/ACCESS_NETWORK_STATE help the UPnP stack
+         choose the right network interface. -->
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -76,7 +76,17 @@
 
         <!-- Chromecast / Google Cast (flutter_chrome_cast): points at the
              plugin's built-in options provider, which uses the Default Media
-             Receiver. Required by the Cast framework. -->
+             Receiver. Required by the Cast framework.
+
+             Theme note: Cast init (GoogleCastContext.getSharedInstance) works
+             fine under Flutter's default LaunchTheme / NormalTheme above. We
+             only call the SDK's discovery + session APIs and render our own
+             picker UI; the Cast *Material widgets* (MediaRouteButton, expanded
+             controller) are the part that needs a Theme.AppCompat host, and we
+             don't use them. So casting works today by virtue of what we use,
+             not an explicit AppCompat dependency. If you ever add one of those
+             widgets, or change MainActivity's theme, re-test that casting still
+             initializes. -->
         <meta-data
             android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
             android:value="com.felnanuke.google_cast.GoogleCastOptionsProvider" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -73,6 +73,13 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <!-- Chromecast / Google Cast (flutter_chrome_cast): points at the
+             plugin's built-in options provider, which uses the Default Media
+             Receiver. Required by the Cast framework. -->
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="com.felnanuke.google_cast.GoogleCastOptionsProvider" />
             
         <service android:name="com.ryanheise.audioservice.AudioService" android:exported="true" android:foregroundServiceType="mediaPlayback">
           <intent-filter>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,18 +24,15 @@ import 'screens/manage_server.dart';
 import 'screens/playlists_screen.dart';
 import 'screens/settings_screen.dart';
 import 'screens/share_playlist_dialog.dart';
-import 'screens/visualizer_screen.dart';
-
 import 'singletons/auto_dj_manager.dart';
 import 'singletons/media.dart';
 import 'singletons/playlists.dart';
 import 'singletons/settings.dart';
-import 'singletons/sleep_timer.dart';
 import 'theme/velvet_theme.dart';
-import 'widgets/sleep_timer_sheet.dart';
 import 'media/cast_target.dart';
 import 'singletons/cast_manager.dart';
 import 'widgets/cast_picker_sheet.dart';
+import 'widgets/more_actions_sheet.dart';
 import 'widgets/waveform_progress.dart';
 
 Future<void> main() async {
@@ -234,6 +231,26 @@ class _MStreamAppState extends State<MStreamApp>
                 ],
               ),
               actions: <Widget>[
+                StreamBuilder<CastTarget>(
+                    stream: CastManager().activeTargetStream,
+                    initialData: CastManager().activeTarget,
+                    builder: (context, snapshot) {
+                      final casting =
+                          !(snapshot.data ?? CastTarget.local).isLocal;
+                      return IconButton(
+                        icon:
+                            Icon(casting ? Icons.cast_connected : Icons.cast),
+                        tooltip: 'Play on…',
+                        color: casting ? VelvetColors.primary : null,
+                        onPressed: () {
+                          showModalBottomSheet(
+                            context: context,
+                            backgroundColor: VelvetColors.surface,
+                            builder: (_) => CastPickerSheet(),
+                          );
+                        },
+                      );
+                    }),
                 StreamBuilder<List<Server>>(
                     stream: ServerManager().serverListStream,
                     builder: (context, snapshot) {
@@ -475,30 +492,15 @@ class NowPlaying extends StatelessWidget {
                           ),
                         );
                       }),
+                  // Visualizer + Clear queue moved to the "More" sheet; the
+                  // Download-all bulk action (from the server-download-folder
+                  // PR) stays here as a queue-specific action.
                   Row(mainAxisSize: MainAxisSize.min, children: [
-                    IconButton(
-                      icon: Icon(Icons.auto_awesome),
-                      color: VelvetColors.textSecondary,
-                      tooltip: 'Visualizer',
-                      onPressed: () {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(builder: (_) => VisualizerScreen()),
-                        );
-                      },
-                    ),
                     IconButton(
                       icon: Icon(Icons.download_for_offline),
                       color: VelvetColors.textSecondary,
                       tooltip: 'Download all',
                       onPressed: () => _downloadAll(context),
-                    ),
-                    IconButton(
-                      icon: Icon(Icons.delete_sweep),
-                      color: VelvetColors.error,
-                      tooltip: 'Clear queue',
-                      onPressed: () {
-                        MediaManager().audioHandler.customAction('clearPlaylist');
-                      },
                     ),
                   ]),
                 ]),
@@ -1025,107 +1027,19 @@ class BottomBar extends StatelessWidget {
                                 : VelvetColors.appBarTextSecondary,
                             onPressed: toggleRepeat);
                       }),
-                  StreamBuilder<dynamic>(
-                      // stream: MediaManager().audioHandler.playbackState,
-                      stream: MediaManager().audioHandler.customState,
-                      builder: (context, snapshot) {
-                        final Server? autoDJState =
-                            (snapshot.data?.autoDJState as Server?);
-                        return IconButton(
-                            icon: Icon(Icons.album),
-                            color: (autoDJState == null)
-                                ? VelvetColors.appBarText
-                                : Colors.blue,
-                            onPressed: () {
-                              if (ServerManager().currentServer == null) {
-                                return;
-                              }
-
-                              if (autoDJState == null) {
-                                MediaManager().audioHandler.customAction(
-                                    'setAutoDJ', {
-                                  'autoDJServer': ServerManager().currentServer
-                                });
-
-                                if (ServerManager().serverList.length == 1) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                      SnackBar(
-                                          content: Text("Auto DJ Enabled")));
-                                } else {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                      SnackBar(
-                                          content: Text(
-                                              "Auto DJ Enabled For ${ServerManager().currentServer!.url.toString()}")));
-                                }
-                              } else if (ServerManager().currentServer! ==
-                                  autoDJState) {
-                                MediaManager().audioHandler.customAction(
-                                    'setAutoDJ', {'autoDJServer': null});
-
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                        content: Text("Auto DJ Disabled")));
-                              } else {
-                                MediaManager().audioHandler.customAction(
-                                    'setAutoDJ', {
-                                  'autoDJServer': ServerManager().currentServer
-                                });
-                                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                                    content: Text(
-                                        "Auto DJ Enabled For ${ServerManager().currentServer!.url.toString()}")));
-                              }
-                            });
-                      }),
-                  StreamBuilder<CastTarget>(
-                      stream: CastManager().activeTargetStream,
-                      initialData: CastManager().activeTarget,
-                      builder: (context, snapshot) {
-                        final casting =
-                            !(snapshot.data ?? CastTarget.local).isLocal;
-                        return IconButton(
-                          icon: Icon(
-                              casting ? Icons.cast_connected : Icons.cast),
-                          tooltip: 'Play on…',
-                          color: casting
-                              ? VelvetColors.primary
-                              : VelvetColors.appBarTextSecondary,
-                          onPressed: () {
-                            showModalBottomSheet(
-                              context: context,
-                              backgroundColor: VelvetColors.surface,
-                              builder: (_) => CastPickerSheet(),
-                            );
-                          },
-                        );
-                      }),
-                  StreamBuilder<Duration?>(
-                      stream: SleepTimerManager().remainingStream,
-                      initialData: SleepTimerManager().remaining,
-                      builder: (context, snapshot) {
-                        final active = snapshot.data != null;
-                        return IconButton(
-                          icon: Icon(active
-                              ? Icons.bedtime
-                              : Icons.bedtime_outlined),
-                          color: active
-                              ? VelvetColors.primary
-                              : VelvetColors.appBarTextSecondary,
-                          onPressed: () {
-                            showModalBottomSheet(
-                              context: context,
-                              backgroundColor: VelvetColors.surface,
-                              // isScrollControlled lets the sheet
-                              // exceed the default half-screen cap
-                              // — needed because the custom-time
-                              // TextField triggers the soft keyboard
-                              // and the sheet has to grow + resize
-                              // to stay above it.
-                              isScrollControlled: true,
-                              builder: (_) => SleepTimerSheet(),
-                            );
-                          },
-                        );
-                      }),
+                  IconButton(
+                    icon: Icon(Icons.more_vert),
+                    color: VelvetColors.appBarTextSecondary,
+                    tooltip: 'More',
+                    onPressed: () {
+                      showModalBottomSheet(
+                        context: context,
+                        backgroundColor: VelvetColors.surface,
+                        builder: (_) =>
+                            MoreActionsSheet(parentContext: context),
+                      );
+                    },
+                  ),
                 ])
               ])
         ])));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,9 @@ import 'singletons/settings.dart';
 import 'singletons/sleep_timer.dart';
 import 'theme/velvet_theme.dart';
 import 'widgets/sleep_timer_sheet.dart';
+import 'media/cast_target.dart';
+import 'singletons/cast_manager.dart';
+import 'widgets/cast_picker_sheet.dart';
 import 'widgets/waveform_progress.dart';
 
 Future<void> main() async {
@@ -1072,6 +1075,28 @@ class BottomBar extends StatelessWidget {
                                         "Auto DJ Enabled For ${ServerManager().currentServer!.url.toString()}")));
                               }
                             });
+                      }),
+                  StreamBuilder<CastTarget>(
+                      stream: CastManager().activeTargetStream,
+                      initialData: CastManager().activeTarget,
+                      builder: (context, snapshot) {
+                        final casting =
+                            !(snapshot.data ?? CastTarget.local).isLocal;
+                        return IconButton(
+                          icon: Icon(
+                              casting ? Icons.cast_connected : Icons.cast),
+                          tooltip: 'Play on…',
+                          color: casting
+                              ? VelvetColors.primary
+                              : VelvetColors.appBarTextSecondary,
+                          onPressed: () {
+                            showModalBottomSheet(
+                              context: context,
+                              backgroundColor: VelvetColors.surface,
+                              builder: (_) => CastPickerSheet(),
+                            );
+                          },
+                        );
                       }),
                   StreamBuilder<Duration?>(
                       stream: SleepTimerManager().remainingStream,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -74,6 +74,7 @@ class MStreamApp extends StatefulWidget {
 class _MStreamAppState extends State<MStreamApp>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
+  StreamSubscription<String>? _castErrorSub;
 
   @override
   void initState() {
@@ -89,10 +90,16 @@ class _MStreamAppState extends State<MStreamApp>
     // subsequent calls are no-ops once granted. Must run after runApp so the
     // permission_handler plugin has an Activity to attach the dialog to.
     Permission.notification.request();
+    // Surface cast failures (renderer unreachable / session won't connect) as a
+    // toast; the handler has already fallen back to local playback.
+    _castErrorSub = CastManager().castErrorStream.listen((msg) {
+      rootMessengerKey.currentState?.showSnackBar(SnackBar(content: Text(msg)));
+    });
   }
 
   @override
   void dispose() {
+    _castErrorSub?.cancel();
     DownloadManager().dispose();
     super.dispose();
   }

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -11,6 +11,7 @@ import 'playback_backend.dart';
 import 'local_playback_backend.dart';
 import 'dlna_playback_backend.dart';
 import 'chromecast_playback_backend.dart';
+import 'cast_log.dart';
 import 'cast_target.dart';
 import '../objects/server.dart';
 import '../singletons/auto_dj_manager.dart';
@@ -117,7 +118,7 @@ class AudioPlayerHandler extends BaseAudioHandler
       // (typically empty on cold start).
       await _backend.setSources(queue.value);
     } catch (e) {
-      print("Error seeding playback backend: $e");
+      castLog('Error seeding playback backend', error: e);
     }
     await _applySavedEqualizer();
   }
@@ -158,7 +159,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     _switchChain = _switchChain
         .then((_) => _doSwitchToTarget(target))
         .catchError((Object e) {
-      print('Cast backend switch failed: $e');
+      castLog('Cast backend switch failed', error: e);
     });
     return _switchChain;
   }

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -202,9 +202,62 @@ class AudioPlayerHandler extends BaseAudioHandler
     }
     _broadcastState();
 
+    // The remote backends swallow load/connection errors internally (so they
+    // never throw here); detect a failed cast by whether playback actually
+    // starts. If the renderer is unreachable / a Cast session won't connect /
+    // the media is unplayable, fall back to local so playback isn't left
+    // silently dead, and surface a toast.
+    final isRemote = !identical(next, _localBackend);
+    if (isRemote && wasPlaying && queue.value.isNotEmpty) {
+      final started = await _awaitRemoteStart(next);
+      if (!started) {
+        await _fallBackToLocal(prev, next, pos, idx);
+        return;
+      }
+    }
+
     if (!identical(prev, _localBackend)) {
       await prev.dispose();
     }
+  }
+
+  // True once a freshly-activated remote backend actually starts (reaches
+  // ready/playing) within a timeout; false if it stays stuck loading (renderer
+  // unreachable / session won't connect / unplayable media).
+  Future<bool> _awaitRemoteStart(PlaybackBackend backend) async {
+    bool started(BackendProcessingState s) =>
+        s == BackendProcessingState.ready ||
+        s == BackendProcessingState.completed;
+    if (started(backend.processingState)) return true;
+    try {
+      await backend.processingStateStream
+          .firstWhere(started)
+          .timeout(const Duration(seconds: 12));
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  // A cast failed to start — resume on the phone at the same spot, tear down
+  // the failed (and abandoned previous) remote backend, and tell CastManager
+  // so the UI reverts to "This device" and shows a message.
+  Future<void> _fallBackToLocal(PlaybackBackend prev, PlaybackBackend failed,
+      Duration pos, int idx) async {
+    await failed.pause();
+    await _localBackend.setSources(queue.value);
+    _backendSubject.add(_localBackend);
+    if (queue.value.isNotEmpty) {
+      await _localBackend.seek(pos, index: idx);
+      await _localBackend.play();
+    }
+    _broadcastState();
+    if (!identical(failed, _localBackend)) await failed.dispose();
+    if (!identical(prev, _localBackend) && !identical(prev, failed)) {
+      await prev.dispose();
+    }
+    CastManager().reportCastFailed(
+        "Couldn't play on the cast device — back on this phone");
   }
 
   @override

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show File;
 
 import 'package:audio_service/audio_service.dart';
 import 'package:just_audio/just_audio.dart';
@@ -10,8 +9,11 @@ import 'package:uuid/uuid.dart';
 import 'package:http/http.dart' as http;
 import 'playback_backend.dart';
 import 'local_playback_backend.dart';
+import 'dlna_playback_backend.dart';
+import 'cast_target.dart';
 import '../objects/server.dart';
 import '../singletons/auto_dj_manager.dart';
+import '../singletons/cast_manager.dart';
 import '../singletons/settings.dart';
 import '../util/camelot.dart';
 
@@ -21,15 +23,17 @@ class AudioPlayerHandler extends BaseAudioHandler
   // ignore: close_sinks
   final BehaviorSubject<List<MediaItem>> _recentSubject =
       BehaviorSubject<List<MediaItem>>();
-  // Playback is delegated to a swappable backend. Today the only
-  // implementation is the local just_audio backend; casting backends
-  // (DLNA / Chromecast) will implement the same PlaybackBackend surface so
-  // the queue / Auto-DJ / shuffle / repeat logic in this handler stays
-  // backend-agnostic. Kept non-final so a future cast session can swap it —
-  // when that lands, the position/state stream getters below will need a
-  // switching subject; today there's a single backend so direct delegation
-  // is correct.
-  PlaybackBackend _backend = LocalPlaybackBackend();
+  // Playback is delegated to a swappable backend so casting can move audio
+  // off-device without changing the queue / Auto-DJ / shuffle / repeat logic
+  // here. The active backend lives in a BehaviorSubject; the handler's derived
+  // streams switchMap over it so existing listeners auto-resubscribe when the
+  // backend swaps (see positionStream and _init). The local just_audio backend
+  // is persistent (reused when switching back from a cast device); remote
+  // backends are built per-session and disposed on switch-away.
+  final LocalPlaybackBackend _localBackend = LocalPlaybackBackend();
+  late final BehaviorSubject<PlaybackBackend> _backendSubject =
+      BehaviorSubject<PlaybackBackend>.seeded(_localBackend);
+  PlaybackBackend get _backend => _backendSubject.value;
 
   // Android-only native equalizer, exposed for the EQ screen. Lives on the
   // local backend (null on non-Android / remote backends). eq_screen.dart
@@ -38,7 +42,8 @@ class AudioPlayerHandler extends BaseAudioHandler
 
   int? get index => _backend.currentIndex;
 
-  Stream<Duration> get positionStream => _backend.positionStream;
+  Stream<Duration> get positionStream =>
+      _backendSubject.switchMap((b) => b.positionStream);
 
   // Android audio session id of the active backend. The visualizer's
   // real-audio capture attaches a Visualizer to THIS session — the
@@ -77,7 +82,10 @@ class AudioPlayerHandler extends BaseAudioHandler
         .whereType<MediaItem>()
         .listen((item) => _recentSubject.add([item]));
     // Broadcast media item changes (with duration if it's known yet).
-    _backend.currentIndexStream.listen((index) {
+    // These derived streams switchMap over the active backend so they keep
+    // working across a cast backend swap — the new backend's streams are
+    // subscribed automatically and the old ones cancelled.
+    _backendSubject.switchMap((b) => b.currentIndexStream).listen((index) {
       if (index == queue.value.length - 1) {
         autoDJ();
       }
@@ -86,19 +94,23 @@ class AudioPlayerHandler extends BaseAudioHandler
     // duration usually arrives via durationStream after the source
     // loads. Re-emit the current MediaItem with the duration filled in
     // so the BottomBar progress formula stops dividing by 1.
-    _backend.durationStream.listen((_) => _emitCurrentMediaItem());
+    _backendSubject
+        .switchMap((b) => b.durationStream)
+        .listen((_) => _emitCurrentMediaItem());
     // Propagate backend state changes to AudioService clients.
-    _backend.changeStream.listen((_) => _broadcastState());
+    _backendSubject
+        .switchMap((b) => b.changeStream)
+        .listen((_) => _broadcastState());
     // Stop the service when playback reaches the end of the queue.
-    _backend.processingStateStream.listen((state) {
+    _backendSubject.switchMap((b) => b.processingStateStream).listen((state) {
       if (state == BackendProcessingState.completed) stop();
     });
+    // Route cast-target selection (from the picker) to a backend swap.
+    CastManager().onTargetSelected = _switchToTarget;
     try {
       // Seed the backend with whatever is already in the queue
       // (typically empty on cold start).
-      await _backend.setSources(
-        queue.value.map((item) => Uri.parse(item.id)).toList(),
-      );
+      await _backend.setSources(queue.value);
     } catch (e) {
       print("Error seeding playback backend: $e");
     }
@@ -133,6 +145,52 @@ class AudioPlayerHandler extends BaseAudioHandler
     mediaItem.add(dur != null ? item.copyWith(duration: dur) : item);
   }
 
+  /// Switch playback to a [CastTarget] chosen in the cast picker. Builds the
+  /// matching backend (the persistent local just_audio backend, or a fresh
+  /// DLNA session) and hands it the current queue + position so playback
+  /// continues on the new device. Wired to CastManager.onTargetSelected.
+  Future<void> _switchToTarget(CastTarget target) async {
+    final PlaybackBackend next;
+    if (target.isLocal) {
+      next = _localBackend;
+    } else if (target.kind == CastTargetKind.dlna) {
+      next = DlnaPlaybackBackend(udn: target.id);
+    } else {
+      return; // Chromecast: Phase 4.
+    }
+    if (identical(next, _backend)) return;
+    await _switchBackend(next);
+  }
+
+  // Carry the current position / index / playing state + shuffle/repeat to the
+  // new backend, make it active (switchMap re-subscribes the derived streams),
+  // resume, then tear down the previous backend if it was a per-session remote
+  // one (the local backend is persistent and reused).
+  Future<void> _switchBackend(PlaybackBackend next) async {
+    final prev = _backend;
+    final pos = prev.position;
+    final idx = prev.currentIndex ?? 0;
+    final wasPlaying = prev.playing;
+
+    await prev.pause();
+
+    await next.setShuffleEnabled(prev.shuffleEnabled);
+    await next.setRepeatAll(prev.repeatAll);
+    await next.setSources(queue.value);
+    _backendSubject.add(next);
+    if (queue.value.isNotEmpty) {
+      await next.seek(pos, index: idx);
+    }
+    if (wasPlaying) {
+      await next.play();
+    }
+    _broadcastState();
+
+    if (!identical(prev, _localBackend)) {
+      await prev.dispose();
+    }
+  }
+
   @override
   BehaviorSubject<dynamic> customState =
       BehaviorSubject<dynamic>.seeded(CustomEvent(null));
@@ -149,18 +207,11 @@ class AudioPlayerHandler extends BaseAudioHandler
   @override
   Future<void> addQueueItem(MediaItem item) async {
     queue.add(queue.value..add(item));
-
-    // Play the offline copy if it's actually on disk; otherwise stream
-    // (item.id is the server URL). Re-checking existence here means a file
-    // moved/deleted after the item was built (e.g. mid-migration, SD removed)
-    // falls back to streaming instead of a broken local URI. Uri.file (not
-    // Uri.parse) so paths with spaces — possible with user-chosen folders —
-    // encode correctly.
-    final String? localPath = item.extras?['localPath'];
-    final uri = (localPath != null && File(localPath).existsSync())
-        ? Uri.file(localPath)
-        : Uri.parse(item.id);
-    await _backend.addSource(uri);
+    // The backend extracts the playable URI (local backend) or builds renderer
+    // metadata (cast backend) from the item itself. The offline-file detection
+    // (File.existsSync + Uri.file) from the server-download-folder PR now lives
+    // in LocalPlaybackBackend._uriFor.
+    await _backend.addSource(item);
   }
 
   @override

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -36,6 +36,10 @@ class AudioPlayerHandler extends BaseAudioHandler
       BehaviorSubject<PlaybackBackend>.seeded(_localBackend);
   PlaybackBackend get _backend => _backendSubject.value;
 
+  // Serializes cast-target switches so rapid re-selection can't interleave two
+  // _switchBackend calls (racing on _backend / dispose).
+  Future<void> _switchChain = Future<void>.value();
+
   // Android-only native equalizer, exposed for the EQ screen. Lives on the
   // local backend (null on non-Android / remote backends). eq_screen.dart
   // reads this via MediaManager().audioHandler.equalizer.
@@ -150,7 +154,16 @@ class AudioPlayerHandler extends BaseAudioHandler
   /// matching backend (the persistent local just_audio backend, or a fresh
   /// DLNA session) and hands it the current queue + position so playback
   /// continues on the new device. Wired to CastManager.onTargetSelected.
-  Future<void> _switchToTarget(CastTarget target) async {
+  Future<void> _switchToTarget(CastTarget target) {
+    _switchChain = _switchChain
+        .then((_) => _doSwitchToTarget(target))
+        .catchError((Object e) {
+      print('Cast backend switch failed: $e');
+    });
+    return _switchChain;
+  }
+
+  Future<void> _doSwitchToTarget(CastTarget target) async {
     final PlaybackBackend next;
     if (target.isLocal) {
       next = _localBackend;

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -511,6 +511,8 @@ class AudioPlayerHandler extends BaseAudioHandler
         'server': autoDJServer!.localname,
         'path': filepath,
         'year': metadata['year'],
+        'track': metadata['track'],
+        'disc': metadata['disc'],
         'artUrl': artUrl,
         // bpm + musicalKey power the next AutoDJ pick's continuity
         // payload (see autoDJ() above). 'musical-key' is the wire

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -10,6 +10,7 @@ import 'package:http/http.dart' as http;
 import 'playback_backend.dart';
 import 'local_playback_backend.dart';
 import 'dlna_playback_backend.dart';
+import 'chromecast_playback_backend.dart';
 import 'cast_target.dart';
 import '../objects/server.dart';
 import '../singletons/auto_dj_manager.dart';
@@ -155,8 +156,10 @@ class AudioPlayerHandler extends BaseAudioHandler
       next = _localBackend;
     } else if (target.kind == CastTargetKind.dlna) {
       next = DlnaPlaybackBackend(udn: target.id);
+    } else if (target.kind == CastTargetKind.chromecast) {
+      next = ChromecastPlaybackBackend(deviceId: target.id);
     } else {
-      return; // Chromecast: Phase 4.
+      return;
     }
     if (identical(next, _backend)) return;
     await _switchBackend(next);

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show Platform, File;
+import 'dart:io' show File;
 
 import 'package:audio_service/audio_service.dart';
 import 'package:just_audio/just_audio.dart';
@@ -8,6 +8,8 @@ import 'package:mstream_music/main.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:uuid/uuid.dart';
 import 'package:http/http.dart' as http;
+import 'playback_backend.dart';
+import 'local_playback_backend.dart';
 import '../objects/server.dart';
 import '../singletons/auto_dj_manager.dart';
 import '../singletons/settings.dart';
@@ -19,28 +21,30 @@ class AudioPlayerHandler extends BaseAudioHandler
   // ignore: close_sinks
   final BehaviorSubject<List<MediaItem>> _recentSubject =
       BehaviorSubject<List<MediaItem>>();
-  // Android-only: a native equalizer attached to the player's audio
-  // pipeline. just_audio has no iOS/macOS/Linux equivalent, so this
-  // stays null on those platforms and the EQ screen renders an
-  // "Android only" empty state instead.
-  final AndroidEqualizer? equalizer =
-      Platform.isAndroid ? AndroidEqualizer() : null;
-  late final AudioPlayer _player = equalizer != null
-      ? AudioPlayer(
-          audioPipeline:
-              AudioPipeline(androidAudioEffects: [equalizer!]),
-        )
-      : AudioPlayer();
+  // Playback is delegated to a swappable backend. Today the only
+  // implementation is the local just_audio backend; casting backends
+  // (DLNA / Chromecast) will implement the same PlaybackBackend surface so
+  // the queue / Auto-DJ / shuffle / repeat logic in this handler stays
+  // backend-agnostic. Kept non-final so a future cast session can swap it —
+  // when that lands, the position/state stream getters below will need a
+  // switching subject; today there's a single backend so direct delegation
+  // is correct.
+  PlaybackBackend _backend = LocalPlaybackBackend();
 
-  int? get index => _player.currentIndex;
+  // Android-only native equalizer, exposed for the EQ screen. Lives on the
+  // local backend (null on non-Android / remote backends). eq_screen.dart
+  // reads this via MediaManager().audioHandler.equalizer.
+  AndroidEqualizer? get equalizer => _backend.equalizer;
 
-  Stream<Duration> get positionStream => _player.positionStream;
+  int? get index => _backend.currentIndex;
 
-  // Android audio session id of the underlying player. The visualizer's
+  Stream<Duration> get positionStream => _backend.positionStream;
+
+  // Android audio session id of the active backend. The visualizer's
   // real-audio capture attaches a Visualizer to THIS session — the
   // global output mix (session 0) is blocked for normal apps on modern
-  // Android. Null until a source has loaded.
-  int? get androidAudioSessionId => _player.androidAudioSessionId;
+  // Android. Null until a source has loaded (or while casting).
+  int? get androidAudioSessionId => _backend.androidAudioSessionId;
 
   Server? autoDJServer;
 
@@ -73,7 +77,7 @@ class AudioPlayerHandler extends BaseAudioHandler
         .whereType<MediaItem>()
         .listen((item) => _recentSubject.add([item]));
     // Broadcast media item changes (with duration if it's known yet).
-    _player.currentIndexStream.listen((index) {
+    _backend.currentIndexStream.listen((index) {
       if (index == queue.value.length - 1) {
         autoDJ();
       }
@@ -82,26 +86,21 @@ class AudioPlayerHandler extends BaseAudioHandler
     // duration usually arrives via durationStream after the source
     // loads. Re-emit the current MediaItem with the duration filled in
     // so the BottomBar progress formula stops dividing by 1.
-    _player.durationStream.listen((_) => _emitCurrentMediaItem());
-    // Propagate all events from the audio player to AudioService clients.
-    _player.playbackEventStream.listen(_broadcastState);
-    // In this example, the service stops when reaching the end.
-    _player.processingStateStream.listen((state) {
-      if (state == ProcessingState.completed) stop();
+    _backend.durationStream.listen((_) => _emitCurrentMediaItem());
+    // Propagate backend state changes to AudioService clients.
+    _backend.changeStream.listen((_) => _broadcastState());
+    // Stop the service when playback reaches the end of the queue.
+    _backend.processingStateStream.listen((state) {
+      if (state == BackendProcessingState.completed) stop();
     });
     try {
-      print("### _player.setAudioSources (init)");
-      // just_audio 0.10 deprecated ConcatenatingAudioSource; the playlist
-      // API now lives on AudioPlayer directly. Seed with whatever is
-      // already in the queue (typically empty on cold start).
-      await _player.setAudioSources(
-        queue.value
-            .map((item) => AudioSource.uri(Uri.parse(item.id)))
-            .toList(),
+      // Seed the backend with whatever is already in the queue
+      // (typically empty on cold start).
+      await _backend.setSources(
+        queue.value.map((item) => Uri.parse(item.id)).toList(),
       );
-      print("### loaded");
     } catch (e) {
-      print("Error: $e");
+      print("Error seeding playback backend: $e");
     }
     await _applySavedEqualizer();
   }
@@ -130,7 +129,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     if (queue.value.isEmpty) return;
     final i = (index ?? 0).clamp(0, queue.value.length - 1);
     final item = queue.value[i];
-    final dur = _player.duration;
+    final dur = _backend.duration;
     mediaItem.add(dur != null ? item.copyWith(duration: dur) : item);
   }
 
@@ -144,7 +143,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     // the [QueueHandler] mixin will delegate to this method.
     if (index < 0 || index > queue.value.length) return;
     // This jumps to the beginning of the queue item at newIndex.
-    _player.seek(Duration.zero, index: index);
+    _backend.seek(Duration.zero, index: index);
   }
 
   @override
@@ -161,58 +160,58 @@ class AudioPlayerHandler extends BaseAudioHandler
     final uri = (localPath != null && File(localPath).existsSync())
         ? Uri.file(localPath)
         : Uri.parse(item.id);
-    await _player.addAudioSource(AudioSource.uri(uri));
+    await _backend.addSource(uri);
   }
 
   @override
-  Future<void> play() => _player.play();
+  Future<void> play() => _backend.play();
 
   @override
-  Future<void> pause() => _player.pause();
+  Future<void> pause() => _backend.pause();
 
   @override
   Future<void> skipToNext() async {
-    _player.seekToNext();
+    _backend.seekToNext();
   }
 
   @override
   Future<void> skipToPrevious() async {
-    _player.seekToPrevious();
+    _backend.seekToPrevious();
   }
 
   @override
-  Future<void> seek(Duration position) => _player.seek(position);
+  Future<void> seek(Duration position) => _backend.seek(position);
 
   @override
   Future<void> stop() async {
-    await _player.stop();
+    await _backend.stop();
     await super.stop();
   }
 
   @override
   Future<void> setShuffleMode(AudioServiceShuffleMode doesntMatter) async {
-    if (_player.shuffleModeEnabled == true) {
-      _player.setShuffleModeEnabled(false);
+    if (_backend.shuffleEnabled == true) {
+      await _backend.setShuffleEnabled(false);
       await super.setShuffleMode(AudioServiceShuffleMode.none);
     } else {
-      _player.setShuffleModeEnabled(true);
+      await _backend.setShuffleEnabled(true);
       await super.setShuffleMode(AudioServiceShuffleMode.all);
     }
 
-    _broadcastState(new PlaybackEvent());
+    _broadcastState();
   }
 
   @override
   Future<void> setRepeatMode(AudioServiceRepeatMode doesntMatter) async {
-    if (_player.loopMode == LoopMode.all) {
-      _player.setLoopMode(LoopMode.off);
+    if (_backend.repeatAll == true) {
+      await _backend.setRepeatAll(false);
       await super.setRepeatMode(AudioServiceRepeatMode.none);
     } else {
-      _player.setLoopMode(LoopMode.all);
+      await _backend.setRepeatAll(true);
       await super.setRepeatMode(AudioServiceRepeatMode.all);
     }
 
-    _broadcastState(new PlaybackEvent());
+    _broadcastState();
   }
 
   @override
@@ -224,18 +223,18 @@ class AudioPlayerHandler extends BaseAudioHandler
   @override
   Future<void> removeQueueItemAt(int i) async {
     await super.removeQueueItemAt(i);
-    await _player.removeAudioSourceAt(i);
+    await _backend.removeSourceAt(i);
     queue.add(queue.value..removeAt(i));
   }
 
   customAction(String name, [Map<String, dynamic>? extras]) async {
     switch (name) {
       case 'clearPlaylist':
-        await _player.stop();
+        await _backend.stop();
         await super.stop();
-        await _player.clearAudioSources();
+        await _backend.clearSources();
         queue.add(queue.value..clear());
-        _broadcastState(new PlaybackEvent());
+        _broadcastState();
         break;
       case 'forceAutoDJRefresh':
         customState.add(CustomEvent(autoDJServer));
@@ -256,7 +255,7 @@ class AudioPlayerHandler extends BaseAudioHandler
             await autoDJ(autoPlay: true);
             autoDJ();
           } else if (index == queue.value.length - 1 &&
-              _player.processingState == ProcessingState.idle) {
+              _backend.processingState == BackendProcessingState.idle) {
             autoDJ(autoPlay: true, incrementIndex: true);
           } else {
             autoDJ();
@@ -268,13 +267,13 @@ class AudioPlayerHandler extends BaseAudioHandler
   }
 
   /// Broadcasts the current state to all clients.
-  void _broadcastState(PlaybackEvent event) {
-    final playing = _player.playing;
-    final AudioServiceShuffleMode shuffle = _player.shuffleModeEnabled == true
+  void _broadcastState() {
+    final playing = _backend.playing;
+    final AudioServiceShuffleMode shuffle = _backend.shuffleEnabled == true
         ? AudioServiceShuffleMode.all
         : AudioServiceShuffleMode.none;
 
-    final AudioServiceRepeatMode repeat = _player.loopMode == LoopMode.all
+    final AudioServiceRepeatMode repeat = _backend.repeatAll == true
         ? AudioServiceRepeatMode.all
         : AudioServiceRepeatMode.none;
 
@@ -293,18 +292,18 @@ class AudioPlayerHandler extends BaseAudioHandler
       shuffleMode: shuffle,
       repeatMode: repeat,
       androidCompactActionIndices: [0, 1, 3],
-      processingState: {
-        ProcessingState.idle: AudioProcessingState.idle,
-        ProcessingState.loading: AudioProcessingState.loading,
-        ProcessingState.buffering: AudioProcessingState.buffering,
-        ProcessingState.ready: AudioProcessingState.ready,
-        ProcessingState.completed: AudioProcessingState.completed,
-      }[_player.processingState]!,
+      processingState: const {
+        BackendProcessingState.idle: AudioProcessingState.idle,
+        BackendProcessingState.loading: AudioProcessingState.loading,
+        BackendProcessingState.buffering: AudioProcessingState.buffering,
+        BackendProcessingState.ready: AudioProcessingState.ready,
+        BackendProcessingState.completed: AudioProcessingState.completed,
+      }[_backend.processingState]!,
       playing: playing,
-      updatePosition: _player.position,
-      bufferedPosition: _player.bufferedPosition,
-      speed: _player.speed,
-      queueIndex: event.currentIndex,
+      updatePosition: _backend.position,
+      bufferedPosition: _backend.bufferedPosition,
+      speed: _backend.speed,
+      queueIndex: _backend.currentIndex,
     ));
   }
 
@@ -480,7 +479,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     addQueueItem(item);
 
     if (incrementIndex == true && index != null) {
-      _player.seek(Duration.zero, index: index! + 1);
+      _backend.seek(Duration.zero, index: index! + 1);
     }
     if (autoPlay == true) {
       play();

--- a/lib/media/cast_art.dart
+++ b/lib/media/cast_art.dart
@@ -1,0 +1,21 @@
+import 'package:audio_service/audio_service.dart' show MediaItem;
+
+/// Full-resolution album-art URL for casting to a TV / big screen.
+///
+/// A queued item's art URL points at the server's `/album-art/` endpoint with
+/// a `compress=<size>` param (l/m/s) — a downscaled image that looks fine on
+/// the phone but blurry on a TV. This drops the `compress` param so the
+/// renderer fetches the original full-resolution art, while preserving the
+/// auth `token` (and anything else) in the URL. Returns null if the item has
+/// no art, and the URL unchanged if it has no `compress` param.
+String? castArtUrl(MediaItem item) {
+  final raw = item.artUri?.toString() ?? item.extras?['artUrl'] as String?;
+  if (raw == null) return null;
+  final uri = Uri.tryParse(raw);
+  if (uri == null || !uri.queryParameters.containsKey('compress')) return raw;
+  final params = Map<String, String>.from(uri.queryParameters)
+    ..remove('compress');
+  return uri
+      .replace(queryParameters: params.isEmpty ? null : params)
+      .toString();
+}

--- a/lib/media/cast_art.dart
+++ b/lib/media/cast_art.dart
@@ -1,5 +1,8 @@
 import 'package:audio_service/audio_service.dart' show MediaItem;
 
+/// Helpers for the metadata the cast backends (DLNA / Chromecast) send to a
+/// renderer, derived from a queued [MediaItem].
+
 /// Full-resolution album-art URL for casting to a TV / big screen.
 ///
 /// A queued item's art URL points at the server's `/album-art/` endpoint with
@@ -18,4 +21,20 @@ String? castArtUrl(MediaItem item) {
   return uri
       .replace(queryParameters: params.isEmpty ? null : params)
       .toString();
+}
+
+/// Reads an integer from a queued item's extras (e.g. track / disc / year),
+/// tolerating int or num storage. Returns null if absent or non-numeric.
+int? intExtra(MediaItem item, String key) {
+  final v = item.extras?[key];
+  if (v is int) return v;
+  if (v is num) return v.toInt();
+  return null;
+}
+
+/// Release date (year only) from a queued item's extras, for cast metadata.
+/// Null when the year is missing or non-positive.
+DateTime? releaseDateFor(MediaItem item) {
+  final y = intExtra(item, 'year');
+  return (y != null && y > 0) ? DateTime(y) : null;
 }

--- a/lib/media/cast_log.dart
+++ b/lib/media/cast_log.dart
@@ -1,0 +1,21 @@
+import 'dart:developer' as developer;
+
+/// Structured logging for the casting subsystem (the DLNA + Chromecast
+/// backends and their discoverers).
+///
+/// Routes through `dart:developer` so messages carry a `cast` source tag and
+/// an attached error/stack object instead of bare `print()` calls — they stay
+/// filterable in `adb logcat` / DevTools (filter on the `cast` name) and are
+/// lint-clean (no `avoid_print` ignores needed).
+///
+/// These are diagnostic logs for *caught, non-fatal* failures: a renderer that
+/// won't load a track, a discovery backend that won't start. Failures the user
+/// actually needs to know about are surfaced separately, via
+/// [CastManager.reportCastFailed] → an on-screen toast, not from here.
+///
+/// (Crash reporting — Sentry/Crashlytics — is a separate, app-wide decision;
+/// when one is added, this is the single place to forward cast diagnostics to
+/// it.)
+void castLog(String message, {Object? error, StackTrace? stackTrace}) {
+  developer.log(message, name: 'cast', error: error, stackTrace: stackTrace);
+}

--- a/lib/media/cast_target.dart
+++ b/lib/media/cast_target.dart
@@ -1,0 +1,42 @@
+/// What kind of device a [CastTarget] is. Drives the icon shown in the picker
+/// and (later) which backend is built when the target is selected.
+enum CastTargetKind { local, dlna, chromecast }
+
+/// A selectable playback destination shown in the cast picker: either the
+/// local device (on-device just_audio playback) or a remote renderer
+/// discovered on the network.
+class CastTarget {
+  /// Stable identity. The local device uses [localId]; remote devices use
+  /// their protocol id (UDN for DLNA, the Cast device id for Chromecast).
+  final String id;
+  final String name;
+  final CastTargetKind kind;
+
+  const CastTarget({
+    required this.id,
+    required this.name,
+    required this.kind,
+  });
+
+  /// Sentinel id for "this device" (local just_audio playback).
+  static const String localId = '__local__';
+
+  /// The always-present local target.
+  static const CastTarget local = CastTarget(
+    id: localId,
+    name: 'This device',
+    kind: CastTargetKind.local,
+  );
+
+  bool get isLocal => kind == CastTargetKind.local;
+
+  @override
+  bool operator ==(Object other) =>
+      other is CastTarget && other.id == id && other.kind == kind;
+
+  @override
+  int get hashCode => Object.hash(id, kind);
+
+  @override
+  String toString() => 'CastTarget($kind, $name, $id)';
+}

--- a/lib/media/chromecast_discoverer.dart
+++ b/lib/media/chromecast_discoverer.dart
@@ -32,8 +32,15 @@ class ChromecastDeviceDiscoverer implements DeviceDiscoverer {
     _running = true;
     try {
       if (!_initialized) {
-        await GoogleCastContext.instance
-            .setSharedInstanceWithOptions(GoogleCastOptions());
+        // The app ID is REQUIRED: the native side does `map["appId"] as
+        // String`, so a bare GoogleCastOptions() (no appId) throws and the
+        // Cast context never initializes — meaning no devices are ever
+        // discovered. Must use the Android-specific options with an appId.
+        // CC1AD845 is Google's Default Media Receiver, supported by every Cast
+        // device, so plain audio URLs play without a custom receiver app.
+        await GoogleCastContext.instance.setSharedInstanceWithOptions(
+          GoogleCastOptionsAndroid(appId: 'CC1AD845'),
+        );
         _sub = GoogleCastDiscoveryManager.instance.devicesStream
             .listen(_onDevices);
         _initialized = true;

--- a/lib/media/chromecast_discoverer.dart
+++ b/lib/media/chromecast_discoverer.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+
+import 'package:flutter_chrome_cast/flutter_chrome_cast.dart';
+import 'package:rxdart/rxdart.dart';
+
+import 'cast_target.dart';
+import 'device_discoverer.dart';
+
+/// Discovers Chromecast / Google Cast devices via the native Google Cast SDK
+/// (flutter_chrome_cast) and surfaces them as [CastTarget]s for [CastManager].
+///
+/// Android-only here (registered only on Android in MediaManager.start). The
+/// shared Cast context is initialized lazily on first [start]; the backend
+/// ([ChromecastPlaybackBackend]) reuses the same native context to control the
+/// device addressed by its id.
+class ChromecastDeviceDiscoverer implements DeviceDiscoverer {
+  final BehaviorSubject<List<CastTarget>> _subject =
+      BehaviorSubject<List<CastTarget>>.seeded(const []);
+  StreamSubscription<List<GoogleCastDevice>>? _sub;
+  bool _initialized = false;
+  bool _running = false;
+
+  @override
+  Stream<List<CastTarget>> get devicesStream => _subject.stream;
+
+  @override
+  List<CastTarget> get devices => _subject.value;
+
+  @override
+  Future<void> start() async {
+    if (_running) return;
+    _running = true;
+    try {
+      if (!_initialized) {
+        await GoogleCastContext.instance
+            .setSharedInstanceWithOptions(GoogleCastOptions());
+        _sub = GoogleCastDiscoveryManager.instance.devicesStream
+            .listen(_onDevices);
+        _initialized = true;
+      }
+      await GoogleCastDiscoveryManager.instance.startDiscovery();
+    } catch (e) {
+      _running = false;
+      // ignore: avoid_print
+      print('Chromecast discovery start failed: $e');
+    }
+  }
+
+  @override
+  Future<void> stop() async {
+    if (!_running) return;
+    _running = false;
+    try {
+      await GoogleCastDiscoveryManager.instance.stopDiscovery();
+    } catch (_) {/* best-effort */}
+  }
+
+  void _onDevices(List<GoogleCastDevice> devices) {
+    _subject.add(devices
+        .map((d) => CastTarget(
+              id: d.deviceID,
+              name: d.friendlyName,
+              kind: CastTargetKind.chromecast,
+            ))
+        .toList());
+  }
+
+  Future<void> dispose() async {
+    await _sub?.cancel();
+    await _subject.close();
+  }
+}

--- a/lib/media/chromecast_discoverer.dart
+++ b/lib/media/chromecast_discoverer.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_chrome_cast/flutter_chrome_cast.dart';
 import 'package:rxdart/rxdart.dart';
 
+import 'cast_log.dart';
 import 'cast_target.dart';
 import 'device_discoverer.dart';
 
@@ -48,8 +49,7 @@ class ChromecastDeviceDiscoverer implements DeviceDiscoverer {
       await GoogleCastDiscoveryManager.instance.startDiscovery();
     } catch (e) {
       _running = false;
-      // ignore: avoid_print
-      print('Chromecast discovery start failed: $e');
+      castLog('Chromecast discovery start failed', error: e);
     }
   }
 

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -1,0 +1,419 @@
+import 'dart:async';
+import 'dart:math' show Random;
+
+import 'package:audio_service/audio_service.dart' show MediaItem;
+import 'package:flutter_chrome_cast/flutter_chrome_cast.dart';
+import 'package:just_audio/just_audio.dart' show AndroidEqualizer;
+import 'package:rxdart/rxdart.dart';
+
+import 'playback_backend.dart';
+
+/// [PlaybackBackend] that plays through a Chromecast / Google Cast device via
+/// the native Cast SDK (flutter_chrome_cast).
+///
+/// Like the DLNA backend it emulates just_audio's playlist (the receiver plays
+/// one track at a time): it owns the source list + index, loads the current
+/// track with the Remote Media Client, and advances when the receiver reports
+/// IDLE with idleReason FINISHED. Unlike DLNA, the Cast SDK pushes position +
+/// media-status via streams (no polling), and loadMedia takes autoPlay +
+/// playPosition so resume-at-position is native.
+class ChromecastPlaybackBackend implements PlaybackBackend {
+  ChromecastPlaybackBackend({required String deviceId}) : _deviceId = deviceId;
+
+  final String _deviceId;
+  final Random _rng = Random();
+
+  final _client = GoogleCastRemoteMediaClient.instance;
+  final _sessions = GoogleCastSessionManager.instance;
+
+  List<MediaItem> _items = <MediaItem>[];
+  int _index = -1;
+  int _loadedIndex = -1;
+  bool _shuffle = false;
+  bool _repeatAll = false;
+  bool _playing = false;
+  bool _advancing = false;
+  bool _sessionStarted = false;
+  Duration _position = Duration.zero;
+  Duration? _duration;
+  BackendProcessingState _state = BackendProcessingState.idle;
+
+  StreamSubscription<GoggleCastMediaStatus?>? _statusSub;
+  StreamSubscription<Duration>? _positionSub;
+
+  final BehaviorSubject<int?> _indexSubject = BehaviorSubject<int?>.seeded(null);
+  final BehaviorSubject<Duration> _positionSubject =
+      BehaviorSubject<Duration>.seeded(Duration.zero);
+  final BehaviorSubject<Duration?> _durationSubject =
+      BehaviorSubject<Duration?>.seeded(null);
+  final BehaviorSubject<BackendProcessingState> _stateSubject =
+      BehaviorSubject<BackendProcessingState>.seeded(
+          BackendProcessingState.idle);
+  final StreamController<void> _changeController =
+      StreamController<void>.broadcast();
+
+  // isClosed-guarded emitters so a late async callback after dispose() can't
+  // add to a closed subject.
+  void _emitIndex(int? v) {
+    if (!_indexSubject.isClosed) _indexSubject.add(v);
+  }
+
+  void _emitPos(Duration v) {
+    if (!_positionSubject.isClosed) _positionSubject.add(v);
+  }
+
+  void _emitDur(Duration? v) {
+    if (!_durationSubject.isClosed) _durationSubject.add(v);
+  }
+
+  void _change() {
+    if (!_changeController.isClosed) _changeController.add(null);
+  }
+
+  void _setState(BackendProcessingState s) {
+    _state = s;
+    if (!_stateSubject.isClosed) _stateSubject.add(s);
+  }
+
+  void _ensureListeners() {
+    _statusSub ??= _client.mediaStatusStream.listen(_onStatus);
+    _positionSub ??= _client.playerPositionStream.listen((pos) {
+      _position = pos;
+      _emitPos(pos);
+      _change();
+    });
+  }
+
+  void _onStatus(GoggleCastMediaStatus? status) {
+    if (status == null) return;
+    final d = status.mediaInformation?.duration;
+    if (d != null) {
+      _duration = d;
+      _emitDur(d);
+    }
+    switch (status.playerState) {
+      case CastMediaPlayerState.playing:
+        _playing = true;
+        _advancing = false;
+        _setState(BackendProcessingState.ready);
+        break;
+      case CastMediaPlayerState.paused:
+        _playing = false;
+        _setState(BackendProcessingState.ready);
+        break;
+      case CastMediaPlayerState.buffering:
+        _setState(BackendProcessingState.buffering);
+        break;
+      case CastMediaPlayerState.loading:
+        _setState(BackendProcessingState.loading);
+        break;
+      case CastMediaPlayerState.idle:
+        // Only a natural FINISH means end-of-track; cancelled/interrupted are
+        // our own load/stop transitions and must not trigger an advance.
+        if (status.idleReason == GoogleCastMediaIdleReason.finished) {
+          _onTrackEnded();
+        }
+        break;
+      case CastMediaPlayerState.unknown:
+        break;
+    }
+    _change();
+  }
+
+  Future<void> _onTrackEnded() async {
+    if (_advancing) return;
+    _advancing = true;
+    final n = _nextIndex();
+    if (n != null) {
+      await _loadIndex(n, play: true);
+    } else {
+      _playing = false;
+      _advancing = false;
+      _setState(BackendProcessingState.completed);
+    }
+  }
+
+  Future<void> _ensureSession() async {
+    if (_sessionStarted && _sessions.hasConnectedSession) return;
+    GoogleCastDevice? device;
+    for (final d in GoogleCastDiscoveryManager.instance.devices) {
+      if (d.deviceID == _deviceId) {
+        device = d;
+        break;
+      }
+    }
+    if (device == null) {
+      throw StateError('Chromecast device $_deviceId not found in discovery');
+    }
+    if (!_sessions.hasConnectedSession) {
+      await _sessions.startSessionWithDevice(device);
+      if (!_sessions.hasConnectedSession) {
+        try {
+          await _sessions.currentSessionStream
+              .firstWhere((_) => _sessions.hasConnectedSession)
+              .timeout(const Duration(seconds: 12));
+        } catch (_) {
+          // Proceed anyway; loadMedia will surface a failure if not connected.
+        }
+      }
+    }
+    _sessionStarted = true;
+  }
+
+  // ── Source list ──
+  @override
+  Future<void> setSources(List<MediaItem> items) async {
+    _items = List<MediaItem>.from(items);
+    _index = _items.isEmpty ? -1 : 0;
+    _loadedIndex = -1;
+    _emitIndex(_index < 0 ? null : _index);
+    _setState(_items.isEmpty
+        ? BackendProcessingState.idle
+        : BackendProcessingState.ready);
+  }
+
+  @override
+  Future<void> addSource(MediaItem item) async {
+    _items.add(item);
+    if (_index == -1) {
+      _index = 0;
+      _emitIndex(0);
+      _setState(BackendProcessingState.ready);
+    }
+  }
+
+  @override
+  Future<void> removeSourceAt(int index) async {
+    if (index < 0 || index >= _items.length) return;
+    _items.removeAt(index);
+    if (_items.isEmpty) {
+      _index = -1;
+      _loadedIndex = -1;
+      _emitIndex(null);
+      await stop();
+      return;
+    }
+    if (index < _index) {
+      _index--;
+      _loadedIndex--;
+      _emitIndex(_index);
+    }
+  }
+
+  @override
+  Future<void> clearSources() async {
+    _items = <MediaItem>[];
+    _index = -1;
+    _loadedIndex = -1;
+    _emitIndex(null);
+    await stop();
+  }
+
+  // ── Media construction ──
+  Uri _uriFor(MediaItem item) => Uri.parse(item.id);
+
+  String _mimeFor(String url) {
+    final path = Uri.parse(url).path.toLowerCase();
+    if (path.endsWith('.flac')) return 'audio/flac';
+    if (path.endsWith('.wav')) return 'audio/wav';
+    if (path.endsWith('.m4a') ||
+        path.endsWith('.aac') ||
+        path.endsWith('.mp4')) return 'audio/mp4';
+    if (path.endsWith('.ogg') || path.endsWith('.opus')) return 'audio/ogg';
+    return 'audio/mpeg';
+  }
+
+  GoogleCastMediaInformation _mediaInfo(MediaItem item) {
+    final url = _uriFor(item).toString();
+    final art = item.artUri?.toString() ?? item.extras?['artUrl'] as String?;
+    return GoogleCastMediaInformation(
+      contentId: url,
+      contentUrl: Uri.parse(url),
+      streamType: CastMediaStreamType.buffered,
+      contentType: _mimeFor(url),
+      duration: item.duration,
+      metadata: GoogleCastMusicMediaMetadata(
+        title: item.title,
+        artist: item.artist,
+        albumName: item.album,
+        images: art != null ? [GoogleCastImage(url: Uri.parse(art))] : null,
+      ),
+    );
+  }
+
+  Future<void> _loadIndex(int index,
+      {required bool play, Duration startAt = Duration.zero}) async {
+    if (index < 0 || index >= _items.length) return;
+    _index = index;
+    _emitIndex(index);
+    _setState(BackendProcessingState.loading);
+    try {
+      await _ensureSession();
+      _ensureListeners();
+      await _client.loadMedia(_mediaInfo(_items[index]),
+          autoPlay: play, playPosition: startAt);
+      _loadedIndex = index;
+      _playing = play;
+      _duration = _items[index].duration;
+      _emitDur(_duration);
+      _position = startAt;
+      _emitPos(startAt);
+    } catch (e) {
+      // ignore: avoid_print
+      print('Chromecast load failed: $e');
+    }
+    _change();
+  }
+
+  // ── Transport ──
+  @override
+  Future<void> play() async {
+    if (_index < 0) return;
+    if (_loadedIndex != _index) {
+      await _loadIndex(_index, play: true);
+      return;
+    }
+    try {
+      await _client.play();
+    } catch (_) {}
+    _playing = true;
+    _change();
+  }
+
+  @override
+  Future<void> pause() async {
+    try {
+      await _client.pause();
+    } catch (_) {}
+    _playing = false;
+    _change();
+  }
+
+  @override
+  Future<void> stop() async {
+    try {
+      await _client.stop();
+    } catch (_) {}
+    _playing = false;
+    _setState(BackendProcessingState.idle);
+    _change();
+  }
+
+  @override
+  Future<void> seek(Duration position, {int? index}) async {
+    final target = index ?? _index;
+    if (target >= 0 && target != _loadedIndex) {
+      await _loadIndex(target, play: _playing, startAt: position);
+      return;
+    }
+    try {
+      await _client.seek(GoogleCastMediaSeekOption(position: position));
+    } catch (_) {}
+    _position = position;
+    _emitPos(position);
+    _change();
+  }
+
+  @override
+  Future<void> seekToNext() async {
+    final n = _nextIndex();
+    if (n != null) await _loadIndex(n, play: _playing);
+  }
+
+  @override
+  Future<void> seekToPrevious() async {
+    if (_index > 0) {
+      await _loadIndex(_index - 1, play: _playing);
+    } else {
+      await seek(Duration.zero);
+    }
+  }
+
+  int? _nextIndex() {
+    if (_items.isEmpty) return null;
+    if (_shuffle && _items.length > 1) {
+      int n;
+      do {
+        n = _rng.nextInt(_items.length);
+      } while (n == _index);
+      return n;
+    }
+    if (_index + 1 < _items.length) return _index + 1;
+    if (_repeatAll) return 0;
+    return null;
+  }
+
+  @override
+  Future<void> setShuffleEnabled(bool enabled) async {
+    _shuffle = enabled;
+    _change();
+  }
+
+  @override
+  Future<void> setRepeatAll(bool enabled) async {
+    _repeatAll = enabled;
+    _change();
+  }
+
+  @override
+  Future<void> setVolume(double volume) async {
+    try {
+      _sessions.setDeviceVolume(volume.clamp(0.0, 1.0));
+    } catch (_) {}
+  }
+
+  // ── Synchronous state ──
+  @override
+  bool get playing => _playing;
+  @override
+  bool get shuffleEnabled => _shuffle;
+  @override
+  bool get repeatAll => _repeatAll;
+  @override
+  Duration get position => _position;
+  @override
+  Duration get bufferedPosition => _position;
+  @override
+  double get speed => 1.0;
+  @override
+  Duration? get duration => _duration;
+  @override
+  int? get currentIndex => _index < 0 ? null : _index;
+  @override
+  BackendProcessingState get processingState => _state;
+
+  // ── Streams ──
+  @override
+  Stream<int?> get currentIndexStream => _indexSubject.stream;
+  @override
+  Stream<Duration> get positionStream => _positionSubject.stream;
+  @override
+  Stream<Duration?> get durationStream => _durationSubject.stream;
+  @override
+  Stream<BackendProcessingState> get processingStateStream =>
+      _stateSubject.stream;
+  @override
+  Stream<void> get changeStream => _changeController.stream;
+
+  // ── Local-only capabilities (N/A while casting) ──
+  @override
+  bool get supportsEqualizer => false;
+  @override
+  AndroidEqualizer? get equalizer => null;
+  @override
+  int? get androidAudioSessionId => null;
+
+  @override
+  Future<void> dispose() async {
+    await _statusSub?.cancel();
+    await _positionSub?.cancel();
+    try {
+      await _sessions.endSessionAndStopCasting();
+    } catch (_) {}
+    await _indexSubject.close();
+    await _positionSubject.close();
+    await _durationSubject.close();
+    await _stateSubject.close();
+    await _changeController.close();
+  }
+}

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -198,6 +198,13 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
       _index--;
       _loadedIndex--;
       _emitIndex(_index);
+    } else if (index == _index) {
+      // Removed the now-playing track — advance to whatever now occupies this
+      // slot (the former next track), clamping if it was the last.
+      if (_index >= _items.length) _index = _items.length - 1;
+      _loadedIndex = -1;
+      _emitIndex(_index);
+      await _loadIndex(_index, play: _playing);
     }
   }
 

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -6,6 +6,7 @@ import 'package:flutter_chrome_cast/flutter_chrome_cast.dart';
 import 'package:just_audio/just_audio.dart' show AndroidEqualizer;
 import 'package:rxdart/rxdart.dart';
 
+import 'cast_art.dart';
 import 'playback_backend.dart';
 
 /// [PlaybackBackend] that plays through a Chromecast / Google Cast device via
@@ -225,7 +226,8 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
 
   GoogleCastMediaInformation _mediaInfo(MediaItem item) {
     final url = _uriFor(item).toString();
-    final art = item.artUri?.toString() ?? item.extras?['artUrl'] as String?;
+    // Full-res art (drop the compress= size param) — looks sharp on a TV.
+    final art = castArtUrl(item);
     return GoogleCastMediaInformation(
       contentId: url,
       contentUrl: Uri.parse(url),

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -7,6 +7,7 @@ import 'package:just_audio/just_audio.dart' show AndroidEqualizer;
 import 'package:rxdart/rxdart.dart';
 
 import 'cast_art.dart';
+import 'cast_log.dart';
 import 'playback_backend.dart';
 
 /// [PlaybackBackend] that plays through a Chromecast / Google Cast device via
@@ -272,8 +273,7 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
       _position = startAt;
       _emitPos(startAt);
     } catch (e) {
-      // ignore: avoid_print
-      print('Chromecast load failed: $e');
+      castLog('Chromecast load failed', error: e);
     }
     _change();
   }

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -238,8 +238,12 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
         title: item.title,
         artist: item.artist,
         albumName: item.album,
+        trackNumber: intExtra(item, 'track'),
+        discNumber: intExtra(item, 'disc'),
+        releaseDate: releaseDateFor(item),
         images: art != null ? [GoogleCastImage(url: Uri.parse(art))] : null,
       ),
+
     );
   }
 

--- a/lib/media/device_discoverer.dart
+++ b/lib/media/device_discoverer.dart
@@ -1,0 +1,27 @@
+import 'cast_target.dart';
+
+/// A source of remote [CastTarget]s on the local network.
+///
+/// Implementations wrap a specific protocol/SDK — DLNA/UPnP via SSDP in
+/// Phase 3, Chromecast via the Cast SDK in Phase 4 — and are aggregated by
+/// [CastManager]. Keeping discovery behind this interface means the manager
+/// and the picker UI never depend on a particular casting package, so the
+/// package choice (e.g. dart_cast vs flutter_chrome_cast) can be made — and
+/// changed — without touching anything above this seam.
+///
+/// Construction must be cheap; real network activity starts on [start] and
+/// must be fully released on [stop]. [devicesStream] must be a broadcast
+/// stream and should emit a fresh list whenever a device appears or vanishes.
+abstract class DeviceDiscoverer {
+  /// Begin scanning. Discovered/lost devices are surfaced via [devicesStream].
+  Future<void> start();
+
+  /// Stop scanning and release sockets / SDK resources.
+  Future<void> stop();
+
+  /// Emits the current set of visible devices, refreshed on every change.
+  Stream<List<CastTarget>> get devicesStream;
+
+  /// Snapshot of the currently-visible devices (for seeding late readers).
+  List<CastTarget> get devices;
+}

--- a/lib/media/dlna_discoverer.dart
+++ b/lib/media/dlna_discoverer.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:media_cast_dlna/media_cast_dlna.dart';
+import 'package:rxdart/rxdart.dart';
+
+import 'cast_target.dart';
+import 'device_discoverer.dart';
+
+/// Discovers DLNA MediaRenderers via the native `media_cast_dlna` plugin and
+/// surfaces them as [CastTarget]s for the [CastManager].
+///
+/// The native plugin owns SSDP/multicast and the per-device AVTransport
+/// control URLs (we address renderers by [DeviceUdn] when controlling them in
+/// [DlnaPlaybackBackend]). Android-only — the plugin has no iOS/desktop impl,
+/// so this is only registered on Android (see MediaManager.start).
+class DlnaDeviceDiscoverer implements DeviceDiscoverer {
+  final MediaCastDlnaApi _api = MediaCastDlnaApi();
+  MediaCastDlnaDiscoveryEvents? _events;
+
+  final Map<String, CastTarget> _devices = {};
+  final BehaviorSubject<List<CastTarget>> _subject =
+      BehaviorSubject<List<CastTarget>>.seeded(const []);
+  final List<StreamSubscription<dynamic>> _subs = [];
+  bool _initialized = false;
+  bool _running = false;
+
+  /// Limit the SSDP search to MediaRenderers (TVs, AV receivers, speakers) —
+  /// we don't want to list MediaServers (which is what mStream itself is).
+  static const _rendererTarget = 'urn:schemas-upnp-org:device:MediaRenderer:1';
+
+  /// Shared handle to the plugin API so [DlnaPlaybackBackend] controls the
+  /// same native UPnP service this discoverer initialized.
+  MediaCastDlnaApi get api => _api;
+
+  @override
+  Stream<List<CastTarget>> get devicesStream => _subject.stream;
+
+  @override
+  List<CastTarget> get devices => _subject.value;
+
+  @override
+  Future<void> start() async {
+    if (_running) return;
+    _running = true;
+    try {
+      if (!_initialized) {
+        await _api.initializeUpnpService();
+        _events = MediaCastDlnaDiscoveryEvents();
+        _subs.add(_events!.onDeviceFound.listen(_onFound));
+        _subs.add(_events!.onDeviceLost.listen(_onLost));
+        _subs.add(_events!.onRendererOffline.listen(_onLost));
+        _initialized = true;
+      }
+      await _api.startDiscovery(
+        DiscoveryOptions(
+          searchTarget: SearchTarget(target: _rendererTarget),
+          timeout: DiscoveryTimeout(seconds: 5),
+        ),
+      );
+    } catch (e) {
+      // Plugin/native failure (e.g. service init) shouldn't crash the picker;
+      // the list just stays empty.
+      _running = false;
+      // ignore: avoid_print
+      print('DLNA discovery start failed: $e');
+    }
+  }
+
+  @override
+  Future<void> stop() async {
+    if (!_running) return;
+    _running = false;
+    try {
+      await _api.stopDiscovery();
+    } catch (_) {/* best-effort */}
+  }
+
+  void _onFound(DlnaDevice device) {
+    // Defensive: only list MediaRenderers even though we scoped the search.
+    if (!device.deviceType.contains('MediaRenderer')) return;
+    _devices[device.udn.value] = CastTarget(
+      id: device.udn.value,
+      name: device.friendlyName,
+      kind: CastTargetKind.dlna,
+    );
+    _emit();
+  }
+
+  void _onLost(DeviceUdn udn) {
+    if (_devices.remove(udn.value) != null) _emit();
+  }
+
+  void _emit() => _subject.add(List<CastTarget>.unmodifiable(_devices.values));
+
+  Future<void> dispose() async {
+    for (final s in _subs) {
+      await s.cancel();
+    }
+    _subs.clear();
+    await _events?.dispose();
+    await _subject.close();
+  }
+}

--- a/lib/media/dlna_discoverer.dart
+++ b/lib/media/dlna_discoverer.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:media_cast_dlna/media_cast_dlna.dart';
 import 'package:rxdart/rxdart.dart';
 
+import 'cast_log.dart';
 import 'cast_target.dart';
 import 'device_discoverer.dart';
 
@@ -61,8 +62,7 @@ class DlnaDeviceDiscoverer implements DeviceDiscoverer {
       // Plugin/native failure (e.g. service init) shouldn't crash the picker;
       // the list just stays empty.
       _running = false;
-      // ignore: avoid_print
-      print('DLNA discovery start failed: $e');
+      castLog('DLNA discovery start failed', error: e);
     }
   }
 

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -8,6 +8,7 @@ import 'package:just_audio/just_audio.dart' show AndroidEqualizer;
 import 'package:media_cast_dlna/media_cast_dlna.dart' hide MediaItem;
 import 'package:rxdart/rxdart.dart';
 
+import 'cast_art.dart';
 import 'playback_backend.dart';
 
 /// [PlaybackBackend] that plays through a DLNA renderer (TV / AV receiver /
@@ -127,7 +128,8 @@ class DlnaPlaybackBackend implements PlaybackBackend {
   Uri _uriFor(MediaItem item) => Uri.parse(item.id);
 
   AudioMetadata _metaFor(MediaItem item) {
-    final art = item.artUri?.toString() ?? item.extras?['artUrl'] as String?;
+    // Full-res art (drop the compress= size param) — looks sharp on a TV.
+    final art = castArtUrl(item);
     return AudioMetadata(
       title: item.title,
       artist: item.artist,

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -71,13 +71,31 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     if (!_stateSubject.isClosed) _stateSubject.add(s);
   }
 
+  // isClosed-guarded emitters: an in-flight poll / auto-advance can complete
+  // after dispose() has closed the subjects (we switched away mid-operation),
+  // and adding to a closed subject throws. Mirrors the Chromecast backend.
+  void _emitIndex(int? v) {
+    final s = _indexSubject;
+    if (!s.isClosed) s.add(v);
+  }
+
+  void _emitPos(Duration v) {
+    final s = _positionSubject;
+    if (!s.isClosed) s.add(v);
+  }
+
+  void _emitDur(Duration? v) {
+    final s = _durationSubject;
+    if (!s.isClosed) s.add(v);
+  }
+
   // ── Source list (mirrors just_audio's playlist API) ──
   @override
   Future<void> setSources(List<MediaItem> items) async {
     _items = List<MediaItem>.from(items);
     _index = _items.isEmpty ? -1 : 0;
     _loadedIndex = -1;
-    _indexSubject.add(_index < 0 ? null : _index);
+    _emitIndex(_index < 0 ? null : _index);
     _setState(_items.isEmpty
         ? BackendProcessingState.idle
         : BackendProcessingState.ready);
@@ -88,7 +106,7 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     _items.add(item);
     if (_index == -1) {
       _index = 0;
-      _indexSubject.add(0);
+      _emitIndex(0);
       _setState(BackendProcessingState.ready);
     }
   }
@@ -100,7 +118,7 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     if (_items.isEmpty) {
       _index = -1;
       _loadedIndex = -1;
-      _indexSubject.add(null);
+      _emitIndex(null);
       await _stopRenderer();
       _setState(BackendProcessingState.idle);
       return;
@@ -108,7 +126,7 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     if (index < _index) {
       _index--;
       _loadedIndex--;
-      _indexSubject.add(_index);
+      _emitIndex(_index);
     }
   }
 
@@ -117,7 +135,7 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     _items = <MediaItem>[];
     _index = -1;
     _loadedIndex = -1;
-    _indexSubject.add(null);
+    _emitIndex(null);
     await _stopRenderer();
     _setState(BackendProcessingState.idle);
   }
@@ -145,7 +163,7 @@ class DlnaPlaybackBackend implements PlaybackBackend {
   Future<void> _loadIndex(int index, {required bool play}) async {
     if (index < 0 || index >= _items.length) return;
     _index = index;
-    _indexSubject.add(index);
+    _emitIndex(index);
     final item = _items[index];
     _confirmedPlaying = false;
     _reachedNearEnd = false;
@@ -155,9 +173,9 @@ class DlnaPlaybackBackend implements PlaybackBackend {
           _udn, Url(value: _uriFor(item).toString()), _metaFor(item));
       _loadedIndex = index;
       _duration = item.duration;
-      _durationSubject.add(_duration);
+      _emitDur(_duration);
       _position = Duration.zero;
-      _positionSubject.add(_position);
+      _emitPos(_position);
       if (play) {
         await _api.play(_udn);
         _playing = true;
@@ -221,7 +239,7 @@ class DlnaPlaybackBackend implements PlaybackBackend {
       await _api.seek(_udn, TimePosition(seconds: position.inSeconds));
     } catch (_) {}
     _position = position;
-    _positionSubject.add(position);
+    _emitPos(position);
     _change();
   }
 
@@ -291,10 +309,10 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     try {
       final info = await _api.getPlaybackInfo(_udn);
       _position = Duration(seconds: info.position.seconds);
-      _positionSubject.add(_position);
+      _emitPos(_position);
       if (info.duration.seconds > 0) {
         _duration = Duration(seconds: info.duration.seconds);
-        _durationSubject.add(_duration);
+        _emitDur(_duration);
       }
       // Latch once we've genuinely reached the end while playing — robust to
       // renderers that reset position to 0 when they stop at track end.

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -134,6 +134,7 @@ class DlnaPlaybackBackend implements PlaybackBackend {
       title: item.title,
       artist: item.artist,
       album: item.album,
+      originalTrackNumber: intExtra(item, 'track'),
       duration: item.duration != null
           ? TimeDuration(seconds: item.duration!.inSeconds)
           : null,

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -1,0 +1,390 @@
+import 'dart:async';
+import 'dart:math' show Random;
+
+import 'package:audio_service/audio_service.dart' show MediaItem;
+import 'package:just_audio/just_audio.dart' show AndroidEqualizer;
+// Hide media_cast_dlna's own MediaItem — we use audio_service's MediaItem for
+// queue items and only need the plugin's control/metadata types here.
+import 'package:media_cast_dlna/media_cast_dlna.dart' hide MediaItem;
+import 'package:rxdart/rxdart.dart';
+
+import 'playback_backend.dart';
+
+/// [PlaybackBackend] that plays through a DLNA renderer (TV / AV receiver /
+/// speaker) via the native `media_cast_dlna` plugin.
+///
+/// A DLNA renderer plays ONE track at a time, so this emulates just_audio's
+/// playlist: it owns the source list + current index, pushes the current track
+/// with `setMediaUri`, and advances to the next when the renderer reports it
+/// has STOPPED near the end. Position/duration/state are polled ~1 Hz via
+/// `getPlaybackInfo` and re-broadcast through the same streams the
+/// AudioPlayerHandler already consumes — so the queue, Auto-DJ and now-playing
+/// UI keep working unchanged while casting.
+///
+/// Shuffle/repeat are emulated here (just_audio handles them natively for the
+/// local backend); the implementation is intentionally simple for a first cut.
+class DlnaPlaybackBackend implements PlaybackBackend {
+  DlnaPlaybackBackend({required String udn, MediaCastDlnaApi? api})
+      : _udn = DeviceUdn(value: udn),
+        _api = api ?? MediaCastDlnaApi();
+
+  final MediaCastDlnaApi _api;
+  final DeviceUdn _udn;
+  final Random _rng = Random();
+
+  List<MediaItem> _items = <MediaItem>[];
+  int _index = -1; // logical current index into _items
+  int _loadedIndex = -1; // index actually pushed to the renderer
+  bool _shuffle = false;
+  bool _repeatAll = false;
+
+  bool _playing = false;
+  bool _advancing = false; // guards against double-advance while a track loads
+  Duration _position = Duration.zero;
+  Duration? _duration;
+  BackendProcessingState _state = BackendProcessingState.idle;
+
+  Timer? _pollTimer;
+  bool _polling = false;
+  bool _disposed = false;
+
+  final BehaviorSubject<int?> _indexSubject = BehaviorSubject<int?>.seeded(null);
+  final BehaviorSubject<Duration> _positionSubject =
+      BehaviorSubject<Duration>.seeded(Duration.zero);
+  final BehaviorSubject<Duration?> _durationSubject =
+      BehaviorSubject<Duration?>.seeded(null);
+  final BehaviorSubject<BackendProcessingState> _stateSubject =
+      BehaviorSubject<BackendProcessingState>.seeded(
+          BackendProcessingState.idle);
+  final StreamController<void> _changeController =
+      StreamController<void>.broadcast();
+
+  void _change() {
+    if (!_changeController.isClosed) _changeController.add(null);
+  }
+
+  void _setState(BackendProcessingState s) {
+    _state = s;
+    if (!_stateSubject.isClosed) _stateSubject.add(s);
+  }
+
+  // ── Source list (mirrors just_audio's playlist API) ──
+  @override
+  Future<void> setSources(List<MediaItem> items) async {
+    _items = List<MediaItem>.from(items);
+    _index = _items.isEmpty ? -1 : 0;
+    _loadedIndex = -1;
+    _indexSubject.add(_index < 0 ? null : _index);
+    _setState(_items.isEmpty
+        ? BackendProcessingState.idle
+        : BackendProcessingState.ready);
+  }
+
+  @override
+  Future<void> addSource(MediaItem item) async {
+    _items.add(item);
+    if (_index == -1) {
+      _index = 0;
+      _indexSubject.add(0);
+      _setState(BackendProcessingState.ready);
+    }
+  }
+
+  @override
+  Future<void> removeSourceAt(int index) async {
+    if (index < 0 || index >= _items.length) return;
+    _items.removeAt(index);
+    if (_items.isEmpty) {
+      _index = -1;
+      _loadedIndex = -1;
+      _indexSubject.add(null);
+      await _stopRenderer();
+      _setState(BackendProcessingState.idle);
+      return;
+    }
+    if (index < _index) {
+      _index--;
+      _loadedIndex--;
+      _indexSubject.add(_index);
+    }
+  }
+
+  @override
+  Future<void> clearSources() async {
+    _items = <MediaItem>[];
+    _index = -1;
+    _loadedIndex = -1;
+    _indexSubject.add(null);
+    await _stopRenderer();
+    _setState(BackendProcessingState.idle);
+  }
+
+  // ── Transport ──
+  // DLNA renderers fetch the URL themselves, so use the network id (not the
+  // localPath download, which the renderer can't reach).
+  Uri _uriFor(MediaItem item) => Uri.parse(item.id);
+
+  AudioMetadata _metaFor(MediaItem item) {
+    final art = item.artUri?.toString() ?? item.extras?['artUrl'] as String?;
+    return AudioMetadata(
+      title: item.title,
+      artist: item.artist,
+      album: item.album,
+      duration: item.duration != null
+          ? TimeDuration(seconds: item.duration!.inSeconds)
+          : null,
+      albumArtUri: art != null ? Url(value: art) : null,
+    );
+  }
+
+  Future<void> _loadIndex(int index, {required bool play}) async {
+    if (index < 0 || index >= _items.length) return;
+    _index = index;
+    _indexSubject.add(index);
+    final item = _items[index];
+    _setState(BackendProcessingState.loading);
+    try {
+      await _api.setMediaUri(
+          _udn, Url(value: _uriFor(item).toString()), _metaFor(item));
+      _loadedIndex = index;
+      _duration = item.duration;
+      _durationSubject.add(_duration);
+      _position = Duration.zero;
+      _positionSubject.add(_position);
+      if (play) {
+        await _api.play(_udn);
+        _playing = true;
+      }
+      _setState(BackendProcessingState.ready);
+      _startPolling();
+    } catch (e) {
+      // ignore: avoid_print
+      print('DLNA load failed: $e');
+    }
+    _change();
+  }
+
+  @override
+  Future<void> play() async {
+    if (_index < 0) return;
+    if (_loadedIndex != _index) {
+      await _loadIndex(_index, play: true);
+      return;
+    }
+    try {
+      await _api.play(_udn);
+    } catch (_) {}
+    _playing = true;
+    _setState(BackendProcessingState.ready);
+    _startPolling();
+    _change();
+  }
+
+  @override
+  Future<void> pause() async {
+    try {
+      await _api.pause(_udn);
+    } catch (_) {}
+    _playing = false;
+    _change();
+  }
+
+  @override
+  Future<void> stop() async {
+    await _stopRenderer();
+    _playing = false;
+    _setState(BackendProcessingState.idle);
+    _change();
+  }
+
+  Future<void> _stopRenderer() async {
+    _stopPolling();
+    try {
+      await _api.stop(_udn);
+    } catch (_) {}
+  }
+
+  @override
+  Future<void> seek(Duration position, {int? index}) async {
+    final target = index ?? _index;
+    if (target >= 0 && target != _loadedIndex) {
+      await _loadIndex(target, play: _playing);
+    }
+    try {
+      await _api.seek(_udn, TimePosition(seconds: position.inSeconds));
+    } catch (_) {}
+    _position = position;
+    _positionSubject.add(position);
+    _change();
+  }
+
+  @override
+  Future<void> seekToNext() async {
+    final n = _nextIndex();
+    if (n != null) await _loadIndex(n, play: _playing || _state == BackendProcessingState.ready);
+  }
+
+  @override
+  Future<void> seekToPrevious() async {
+    if (_index > 0) {
+      await _loadIndex(_index - 1, play: _playing);
+    } else {
+      await seek(Duration.zero);
+    }
+  }
+
+  int? _nextIndex() {
+    if (_items.isEmpty) return null;
+    if (_shuffle && _items.length > 1) {
+      int n;
+      do {
+        n = _rng.nextInt(_items.length);
+      } while (n == _index);
+      return n;
+    }
+    if (_index + 1 < _items.length) return _index + 1;
+    if (_repeatAll) return 0;
+    return null;
+  }
+
+  @override
+  Future<void> setShuffleEnabled(bool enabled) async {
+    _shuffle = enabled;
+    _change();
+  }
+
+  @override
+  Future<void> setRepeatAll(bool enabled) async {
+    _repeatAll = enabled;
+    _change();
+  }
+
+  @override
+  Future<void> setVolume(double volume) async {
+    try {
+      await _api.setVolume(
+          _udn, VolumeLevel(percentage: (volume.clamp(0.0, 1.0) * 100).round()));
+    } catch (_) {}
+  }
+
+  // ── Polling engine: drives position/duration/state + auto-advance ──
+  void _startPolling() {
+    _stopPolling();
+    _pollTimer = Timer.periodic(const Duration(seconds: 1), (_) => _poll());
+  }
+
+  void _stopPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
+  Future<void> _poll() async {
+    if (_polling || _disposed) return;
+    _polling = true;
+    try {
+      final info = await _api.getPlaybackInfo(_udn);
+      _position = Duration(seconds: info.position.seconds);
+      _positionSubject.add(_position);
+      if (info.duration.seconds > 0) {
+        _duration = Duration(seconds: info.duration.seconds);
+        _durationSubject.add(_duration);
+      }
+      switch (info.state) {
+        case TransportState.playing:
+          _playing = true;
+          _advancing = false;
+          _setState(BackendProcessingState.ready);
+          break;
+        case TransportState.paused:
+          _playing = false;
+          break;
+        case TransportState.transitioning:
+          _setState(BackendProcessingState.buffering);
+          break;
+        case TransportState.stopped:
+          await _onRendererStopped();
+          break;
+        case TransportState.noMediaPresent:
+          break;
+      }
+      _change();
+    } catch (_) {
+      // Transient renderer/network error — keep polling.
+    } finally {
+      _polling = false;
+    }
+  }
+
+  Future<void> _onRendererStopped() async {
+    // Ignore stops we caused (pause/stop) or that happen mid-load.
+    if (_advancing || !_playing) return;
+    final dur = _duration;
+    final nearEnd = dur == null ||
+        dur == Duration.zero ||
+        _position >= dur - const Duration(seconds: 3);
+    if (!nearEnd) return; // a transient stop, not end-of-track
+    _advancing = true;
+    final n = _nextIndex();
+    if (n != null) {
+      await _loadIndex(n, play: true); // _advancing cleared when poll sees PLAYING
+    } else {
+      _playing = false;
+      _advancing = false;
+      _setState(BackendProcessingState.completed);
+      _stopPolling();
+    }
+  }
+
+  // ── Synchronous state ──
+  @override
+  bool get playing => _playing;
+  @override
+  bool get shuffleEnabled => _shuffle;
+  @override
+  bool get repeatAll => _repeatAll;
+  @override
+  Duration get position => _position;
+  @override
+  Duration get bufferedPosition => _position; // DLNA exposes no buffer info
+  @override
+  double get speed => 1.0;
+  @override
+  Duration? get duration => _duration;
+  @override
+  int? get currentIndex => _index < 0 ? null : _index;
+  @override
+  BackendProcessingState get processingState => _state;
+
+  // ── Streams ──
+  @override
+  Stream<int?> get currentIndexStream => _indexSubject.stream;
+  @override
+  Stream<Duration> get positionStream => _positionSubject.stream;
+  @override
+  Stream<Duration?> get durationStream => _durationSubject.stream;
+  @override
+  Stream<BackendProcessingState> get processingStateStream =>
+      _stateSubject.stream;
+  @override
+  Stream<void> get changeStream => _changeController.stream;
+
+  // ── Local-only capabilities (N/A while casting) ──
+  @override
+  bool get supportsEqualizer => false;
+  @override
+  AndroidEqualizer? get equalizer => null;
+  @override
+  int? get androidAudioSessionId => null;
+
+  @override
+  Future<void> dispose() async {
+    _disposed = true;
+    _stopPolling();
+    await _stopRenderer();
+    await _indexSubject.close();
+    await _positionSubject.close();
+    await _durationSubject.close();
+    await _stateSubject.close();
+    await _changeController.close();
+  }
+}

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -127,6 +127,13 @@ class DlnaPlaybackBackend implements PlaybackBackend {
       _index--;
       _loadedIndex--;
       _emitIndex(_index);
+    } else if (index == _index) {
+      // Removed the now-playing track — advance to whatever now occupies this
+      // slot (the former next track), clamping if it was the last.
+      if (_index >= _items.length) _index = _items.length - 1;
+      _loadedIndex = -1;
+      _emitIndex(_index);
+      await _loadIndex(_index, play: _playing);
     }
   }
 

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -40,6 +40,8 @@ class DlnaPlaybackBackend implements PlaybackBackend {
 
   bool _playing = false;
   bool _advancing = false; // guards against double-advance while a track loads
+  bool _confirmedPlaying = false; // renderer reached PLAYING for the current track
+  bool _reachedNearEnd = false; // position reached end-of-track while playing
   Duration _position = Duration.zero;
   Duration? _duration;
   BackendProcessingState _state = BackendProcessingState.idle;
@@ -142,6 +144,8 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     _index = index;
     _indexSubject.add(index);
     final item = _items[index];
+    _confirmedPlaying = false;
+    _reachedNearEnd = false;
     _setState(BackendProcessingState.loading);
     try {
       await _api.setMediaUri(
@@ -289,10 +293,19 @@ class DlnaPlaybackBackend implements PlaybackBackend {
         _duration = Duration(seconds: info.duration.seconds);
         _durationSubject.add(_duration);
       }
+      // Latch once we've genuinely reached the end while playing — robust to
+      // renderers that reset position to 0 when they stop at track end.
+      final dur = _duration;
+      if (dur != null &&
+          dur > Duration.zero &&
+          _position >= dur - const Duration(seconds: 5)) {
+        _reachedNearEnd = true;
+      }
       switch (info.state) {
         case TransportState.playing:
           _playing = true;
           _advancing = false;
+          _confirmedPlaying = true;
           _setState(BackendProcessingState.ready);
           break;
         case TransportState.paused:
@@ -316,13 +329,11 @@ class DlnaPlaybackBackend implements PlaybackBackend {
   }
 
   Future<void> _onRendererStopped() async {
-    // Ignore stops we caused (pause/stop) or that happen mid-load.
-    if (_advancing || !_playing) return;
-    final dur = _duration;
-    final nearEnd = dur == null ||
-        dur == Duration.zero ||
-        _position >= dur - const Duration(seconds: 3);
-    if (!nearEnd) return; // a transient stop, not end-of-track
+    // Only treat STOPPED as end-of-track if the track actually started
+    // (ignores the transient STOPPED during the load->play transition that
+    // otherwise skips a freshly-selected track) AND playback reached the end.
+    // Without these guards a just-loaded track skips after a few seconds.
+    if (_advancing || !_confirmedPlaying || !_reachedNearEnd) return;
     _advancing = true;
     final n = _nextIndex();
     if (n != null) {

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -9,6 +9,7 @@ import 'package:media_cast_dlna/media_cast_dlna.dart' hide MediaItem;
 import 'package:rxdart/rxdart.dart';
 
 import 'cast_art.dart';
+import 'cast_log.dart';
 import 'playback_backend.dart';
 
 /// [PlaybackBackend] that plays through a DLNA renderer (TV / AV receiver /
@@ -190,8 +191,7 @@ class DlnaPlaybackBackend implements PlaybackBackend {
       _setState(BackendProcessingState.ready);
       _startPolling();
     } catch (e) {
-      // ignore: avoid_print
-      print('DLNA load failed: $e');
+      castLog('DLNA load failed', error: e);
     }
     _change();
   }

--- a/lib/media/local_playback_backend.dart
+++ b/lib/media/local_playback_backend.dart
@@ -1,5 +1,6 @@
-import 'dart:io' show Platform;
+import 'dart:io' show File, Platform;
 
+import 'package:audio_service/audio_service.dart' show MediaItem;
 import 'package:just_audio/just_audio.dart';
 
 import 'playback_backend.dart';
@@ -25,12 +26,26 @@ class LocalPlaybackBackend implements PlaybackBackend {
   // just_audio 0.10 deprecated ConcatenatingAudioSource; the playlist API now
   // lives on AudioPlayer directly.
   @override
-  Future<void> setSources(List<Uri> uris) =>
-      _player.setAudioSources(uris.map((u) => AudioSource.uri(u)).toList());
+  Future<void> setSources(List<MediaItem> items) => _player.setAudioSources(
+      items.map((i) => AudioSource.uri(_uriFor(i))).toList());
 
   @override
-  Future<void> addSource(Uri uri) =>
-      _player.addAudioSource(AudioSource.uri(uri));
+  Future<void> addSource(MediaItem item) =>
+      _player.addAudioSource(AudioSource.uri(_uriFor(item)));
+
+  // Play the offline copy when it's actually on disk; otherwise stream
+  // (item.id is the server URL). Re-checking existence means a file moved or
+  // deleted after the item was built (mid-migration, SD removed) falls back to
+  // streaming instead of a broken local URI. Uri.file (not Uri.parse) so
+  // user-chosen folder paths with spaces encode correctly. (URI policy moved
+  // here from AudioPlayerHandler.addQueueItem; the File.existsSync()/Uri.file
+  // hardening came from the server-download-folder PR merged into master.)
+  Uri _uriFor(MediaItem item) {
+    final localPath = item.extras?['localPath'];
+    return (localPath != null && File(localPath).existsSync())
+        ? Uri.file(localPath)
+        : Uri.parse(item.id);
+  }
 
   @override
   Future<void> removeSourceAt(int index) => _player.removeAudioSourceAt(index);

--- a/lib/media/local_playback_backend.dart
+++ b/lib/media/local_playback_backend.dart
@@ -1,0 +1,145 @@
+import 'dart:io' show Platform;
+
+import 'package:just_audio/just_audio.dart';
+
+import 'playback_backend.dart';
+
+/// The on-device playback backend: a thin wrapper around a single just_audio
+/// [AudioPlayer]. This is the extraction of the behaviour that previously
+/// lived directly inside [AudioPlayerHandler] — it must remain behaviourally
+/// identical (gapless playlist, native shuffle/repeat, Android equalizer).
+class LocalPlaybackBackend implements PlaybackBackend {
+  // Android-only native equalizer attached to the player's audio pipeline.
+  // just_audio has no iOS/macOS/Linux equivalent, so this stays null on those
+  // platforms and the EQ screen renders an "Android only" empty state.
+  final AndroidEqualizer? _equalizer =
+      Platform.isAndroid ? AndroidEqualizer() : null;
+
+  late final AudioPlayer _player = _equalizer != null
+      ? AudioPlayer(
+          audioPipeline: AudioPipeline(androidAudioEffects: [_equalizer]),
+        )
+      : AudioPlayer();
+
+  // ── Source list ──
+  // just_audio 0.10 deprecated ConcatenatingAudioSource; the playlist API now
+  // lives on AudioPlayer directly.
+  @override
+  Future<void> setSources(List<Uri> uris) =>
+      _player.setAudioSources(uris.map((u) => AudioSource.uri(u)).toList());
+
+  @override
+  Future<void> addSource(Uri uri) =>
+      _player.addAudioSource(AudioSource.uri(uri));
+
+  @override
+  Future<void> removeSourceAt(int index) => _player.removeAudioSourceAt(index);
+
+  @override
+  Future<void> clearSources() => _player.clearAudioSources();
+
+  // ── Transport ──
+  @override
+  Future<void> play() => _player.play();
+
+  @override
+  Future<void> pause() => _player.pause();
+
+  @override
+  Future<void> stop() => _player.stop();
+
+  @override
+  Future<void> seek(Duration position, {int? index}) =>
+      _player.seek(position, index: index);
+
+  @override
+  Future<void> seekToNext() => _player.seekToNext();
+
+  @override
+  Future<void> seekToPrevious() => _player.seekToPrevious();
+
+  @override
+  Future<void> setShuffleEnabled(bool enabled) =>
+      _player.setShuffleModeEnabled(enabled);
+
+  @override
+  Future<void> setRepeatAll(bool enabled) =>
+      _player.setLoopMode(enabled ? LoopMode.all : LoopMode.off);
+
+  @override
+  Future<void> setVolume(double volume) => _player.setVolume(volume);
+
+  // ── Synchronous state ──
+  @override
+  bool get playing => _player.playing;
+
+  @override
+  bool get shuffleEnabled => _player.shuffleModeEnabled;
+
+  @override
+  bool get repeatAll => _player.loopMode == LoopMode.all;
+
+  @override
+  Duration get position => _player.position;
+
+  @override
+  Duration get bufferedPosition => _player.bufferedPosition;
+
+  @override
+  double get speed => _player.speed;
+
+  @override
+  Duration? get duration => _player.duration;
+
+  @override
+  int? get currentIndex => _player.currentIndex;
+
+  @override
+  BackendProcessingState get processingState =>
+      _mapState(_player.processingState);
+
+  // ── Streams ──
+  @override
+  Stream<int?> get currentIndexStream => _player.currentIndexStream;
+
+  @override
+  Stream<Duration> get positionStream => _player.positionStream;
+
+  @override
+  Stream<Duration?> get durationStream => _player.durationStream;
+
+  @override
+  Stream<BackendProcessingState> get processingStateStream =>
+      _player.processingStateStream.map(_mapState);
+
+  @override
+  Stream<void> get changeStream => _player.playbackEventStream.map<void>((_) {});
+
+  // ── Local-only capabilities ──
+  @override
+  bool get supportsEqualizer => _equalizer != null;
+
+  @override
+  AndroidEqualizer? get equalizer => _equalizer;
+
+  @override
+  int? get androidAudioSessionId => _player.androidAudioSessionId;
+
+  @override
+  Future<void> dispose() => _player.dispose();
+
+  static BackendProcessingState _mapState(ProcessingState s) {
+    switch (s) {
+      case ProcessingState.idle:
+        return BackendProcessingState.idle;
+      case ProcessingState.loading:
+        return BackendProcessingState.loading;
+      case ProcessingState.buffering:
+        return BackendProcessingState.buffering;
+      case ProcessingState.ready:
+        return BackendProcessingState.ready;
+      case ProcessingState.completed:
+        return BackendProcessingState.completed;
+    }
+  }
+}

--- a/lib/media/playback_backend.dart
+++ b/lib/media/playback_backend.dart
@@ -1,3 +1,4 @@
+import 'package:audio_service/audio_service.dart' show MediaItem;
 import 'package:just_audio/just_audio.dart' show AndroidEqualizer;
 
 /// Processing state of the active playback backend. Mirrors just_audio's
@@ -23,8 +24,11 @@ enum BackendProcessingState { idle, loading, buffering, ready, completed }
 /// local implementation is a thin pass-through and the handler diff is minimal.
 abstract class PlaybackBackend {
   // ── Source list (mirrors just_audio's on-player playlist API) ──
-  Future<void> setSources(List<Uri> uris);
-  Future<void> addSource(Uri uri);
+  // Takes [MediaItem]s (not bare URIs) so remote backends can build rich
+  // metadata (title/artist/album/art) for the renderer; the local backend
+  // extracts the playable URI itself.
+  Future<void> setSources(List<MediaItem> items);
+  Future<void> addSource(MediaItem item);
   Future<void> removeSourceAt(int index);
   Future<void> clearSources();
 

--- a/lib/media/playback_backend.dart
+++ b/lib/media/playback_backend.dart
@@ -1,0 +1,84 @@
+import 'package:just_audio/just_audio.dart' show AndroidEqualizer;
+
+/// Processing state of the active playback backend. Mirrors just_audio's
+/// `ProcessingState` but is kept independent so remote (DLNA / Chromecast)
+/// backends can report the same lifecycle without depending on just_audio.
+enum BackendProcessingState { idle, loading, buffering, ready, completed }
+
+/// Abstraction over "what actually plays the audio".
+///
+/// [AudioPlayerHandler] owns the queue, current index, shuffle/repeat and
+/// Auto-DJ logic and delegates *only* transport to the active backend, then
+/// re-broadcasts the backend's state through the existing audio_service
+/// streams — so the UI never has to know which backend is active.
+///
+/// Today the only implementation is [LocalPlaybackBackend] (just_audio). The
+/// casting backends (DLNA, Chromecast) will implement this same surface, with
+/// the "single-item push" model hidden behind it: they keep the source list
+/// and current index internally, push one track at a time to the renderer, and
+/// emit [currentIndexStream] / [BackendProcessingState.completed] so the
+/// handler's advance + Auto-DJ logic keeps working unchanged.
+///
+/// The surface deliberately mirrors just_audio's on-player playlist API so the
+/// local implementation is a thin pass-through and the handler diff is minimal.
+abstract class PlaybackBackend {
+  // ── Source list (mirrors just_audio's on-player playlist API) ──
+  Future<void> setSources(List<Uri> uris);
+  Future<void> addSource(Uri uri);
+  Future<void> removeSourceAt(int index);
+  Future<void> clearSources();
+
+  // ── Transport ──
+  Future<void> play();
+  Future<void> pause();
+  Future<void> stop();
+
+  /// Seek within the current track, or (with [index]) jump to another item in
+  /// the source list and seek within it.
+  Future<void> seek(Duration position, {int? index});
+  Future<void> seekToNext();
+  Future<void> seekToPrevious();
+  Future<void> setShuffleEnabled(bool enabled);
+  Future<void> setRepeatAll(bool enabled);
+
+  /// Output volume, 0.0–1.0. (Unused by the handler today; here for the cast
+  /// backends + future ReplayGain/volume-normalization work.)
+  Future<void> setVolume(double volume);
+
+  // ── Synchronous state (read by AudioPlayerHandler._broadcastState) ──
+  bool get playing;
+  bool get shuffleEnabled;
+  bool get repeatAll;
+  Duration get position;
+  Duration get bufferedPosition;
+  double get speed;
+  Duration? get duration;
+  int? get currentIndex;
+  BackendProcessingState get processingState;
+
+  // ── Streams ──
+  Stream<int?> get currentIndexStream;
+  Stream<Duration> get positionStream;
+  Stream<Duration?> get durationStream;
+  Stream<BackendProcessingState> get processingStateStream;
+
+  /// Fires whenever any broadcast-relevant property changes (mirrors
+  /// just_audio's `playbackEventStream`); the handler re-broadcasts its
+  /// audio_service [PlaybackState] on each tick.
+  Stream<void> get changeStream;
+
+  // ── Local-only capabilities (false / null on remote backends) ──
+  bool get supportsEqualizer;
+
+  /// The Android native equalizer, when this backend runs audio on-device.
+  /// Null on non-Android and on remote (cast) backends, where the device's
+  /// own audio chain isn't in the path. Surfaced for the EQ screen.
+  AndroidEqualizer? get equalizer;
+
+  /// Android audio-session id of the on-device player, for the visualizer's
+  /// real-audio capture. Null until a source has loaded, and on remote
+  /// backends (no local audio to tap).
+  int? get androidAudioSessionId;
+
+  Future<void> dispose();
+}

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -232,6 +232,8 @@ class _BrowserState extends State<Browser> {
           'path': i.data,
           if (isLocal) 'localPath': finalString,
           'year': i.metadata?.year,
+          'track': i.metadata?.track,
+          'disc': i.metadata?.disc,
           'artUrl': artUrl,
           // bpm + musicalKey power AutoDJ's BPM-continuity / harmonic-mixing
           // modes — read off the currently playing item.

--- a/lib/screens/eq_screen.dart
+++ b/lib/screens/eq_screen.dart
@@ -24,6 +24,8 @@ import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 
+import '../media/cast_target.dart';
+import '../singletons/cast_manager.dart';
 import '../singletons/media.dart';
 import '../singletons/settings.dart';
 import '../theme/velvet_theme.dart';
@@ -38,6 +40,13 @@ class _EqScreenState extends State<EqScreen> {
   bool _loading = true;
   String? _error;
   StreamSubscription<PlaybackState>? _playbackSub;
+  StreamSubscription<CastTarget>? _castSub;
+
+  // Shown in place of the band sliders when audio is on a cast device: the EQ
+  // is a local-playback effect, so it can't act on what the renderer plays.
+  static const _castingMessage =
+      'The equalizer adjusts audio on this device, so it’s unavailable while '
+      'casting. Disconnect to use it.';
 
   @override
   void initState() {
@@ -51,7 +60,28 @@ class _EqScreenState extends State<EqScreen> {
     // back without having to navigate out and back in.
     _playbackSub = MediaManager().audioHandler.playbackState.listen((state) {
       if (_params == null &&
+          !CastManager().isCasting &&
           state.processingState != AudioProcessingState.idle) {
+        _attemptLoad();
+      }
+    });
+    // The EQ only affects local playback. React to cast connect/disconnect so
+    // the screen swaps between the sliders and an explanatory message instead
+    // of leaving stale, inert controls on screen while audio is on the TV.
+    _castSub = CastManager().activeTargetStream.listen((_) {
+      if (!mounted) return;
+      if (CastManager().isCasting) {
+        setState(() {
+          _params = null;
+          _loading = false;
+          _error = _castingMessage;
+        });
+      } else {
+        setState(() {
+          _params = null;
+          _loading = true;
+          _error = null;
+        });
         _attemptLoad();
       }
     });
@@ -60,10 +90,22 @@ class _EqScreenState extends State<EqScreen> {
   @override
   void dispose() {
     _playbackSub?.cancel();
+    _castSub?.cancel();
     super.dispose();
   }
 
   Future<void> _attemptLoad() async {
+    // While casting, the active backend has no equalizer; show why rather than
+    // the generic "Android only" message (which is wrong — we *are* on Android).
+    if (CastManager().isCasting) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _params = null;
+        _error = _castingMessage;
+      });
+      return;
+    }
     final eq = MediaManager().audioHandler.equalizer;
     if (eq == null) {
       if (!mounted) return;

--- a/lib/singletons/cast_manager.dart
+++ b/lib/singletons/cast_manager.dart
@@ -1,0 +1,121 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+
+import '../media/cast_target.dart';
+import '../media/device_discoverer.dart';
+
+/// Coordinates *where* audio plays: aggregates the remote devices reported by
+/// registered [DeviceDiscoverer]s with the always-present local target, and
+/// tracks which target is currently active.
+///
+/// Phase 2 ships the discovery/selection plumbing + picker UI only — no
+/// discoverers are registered yet, so the picker shows just "This device".
+/// Phase 3 (DLNA) and Phase 4 (Chromecast) register discoverers and set
+/// [onTargetSelected] to perform the actual backend swap on the
+/// AudioPlayerHandler (build the remote backend, hand it the current track +
+/// position, switch `_backend`).
+class CastManager {
+  CastManager._privateConstructor();
+  static final CastManager _instance = CastManager._privateConstructor();
+  factory CastManager() => _instance;
+
+  final List<DeviceDiscoverer> _discoverers = [];
+  final List<StreamSubscription<List<CastTarget>>> _subs = [];
+  bool _discovering = false;
+
+  // Available targets: always the local device first, then whatever the
+  // registered discoverers currently see.
+  final BehaviorSubject<List<CastTarget>> _targets =
+      BehaviorSubject<List<CastTarget>>.seeded(const [CastTarget.local]);
+
+  // Currently-selected target. Seeded local; never null.
+  final BehaviorSubject<CastTarget> _activeTarget =
+      BehaviorSubject<CastTarget>.seeded(CastTarget.local);
+
+  Stream<List<CastTarget>> get targetsStream => _targets.stream;
+  List<CastTarget> get targets => _targets.value;
+  Stream<CastTarget> get activeTargetStream => _activeTarget.stream;
+  CastTarget get activeTarget => _activeTarget.value;
+  bool get isCasting => !_activeTarget.value.isLocal;
+
+  /// True once at least one discoverer is registered — lets the picker decide
+  /// whether to show the "searching…" hint.
+  bool get hasDiscoverers => _discoverers.isNotEmpty;
+
+  /// Invoked when the user picks a target. Phase 3/4 set this to perform the
+  /// backend swap on AudioPlayerHandler. Left null in Phase 2, so selecting a
+  /// target only updates [activeTarget] (and only "This device" is ever
+  /// listed until a discoverer is registered).
+  Future<void> Function(CastTarget target)? onTargetSelected;
+
+  /// Register a discovery source. Call before [startDiscovery].
+  void registerDiscoverer(DeviceDiscoverer d) {
+    _discoverers.add(d);
+  }
+
+  /// Begin scanning on all registered discoverers, recomputing the target list
+  /// as they report changes. Idempotent; safe to call when no discoverers are
+  /// registered (no-op beyond keeping the local target listed).
+  Future<void> startDiscovery() async {
+    if (_discovering) return;
+    _discovering = true;
+    for (final d in _discoverers) {
+      _subs.add(d.devicesStream.listen((_) => _recompute()));
+      await d.start();
+    }
+    _recompute();
+  }
+
+  Future<void> stopDiscovery() async {
+    if (!_discovering) return;
+    _discovering = false;
+    for (final s in _subs) {
+      await s.cancel();
+    }
+    _subs.clear();
+    for (final d in _discoverers) {
+      await d.stop();
+    }
+    _recompute();
+  }
+
+  /// Select a playback target. Updates [activeTarget] and invokes
+  /// [onTargetSelected] (when wired) to perform the actual backend swap.
+  Future<void> selectTarget(CastTarget target) async {
+    if (target == _activeTarget.value) return;
+    _activeTarget.add(target);
+    final cb = onTargetSelected;
+    if (cb != null) {
+      await cb(target);
+    }
+  }
+
+  void _recompute() {
+    // Local always first; then de-duped remote devices (two discoverers could
+    // in principle surface the same physical device).
+    final seen = <String>{CastTarget.localId};
+    final merged = <CastTarget>[CastTarget.local];
+    for (final d in _discoverers) {
+      for (final t in d.devices) {
+        if (seen.add(t.id)) merged.add(t);
+      }
+    }
+    _targets.add(merged);
+
+    // If the active remote target vanished (renderer powered off / left the
+    // network), fall back to local so the UI never points at a gone device.
+    final active = _activeTarget.value;
+    if (!active.isLocal && !merged.contains(active)) {
+      selectTarget(CastTarget.local);
+    }
+  }
+
+  void dispose() {
+    for (final s in _subs) {
+      s.cancel();
+    }
+    _targets.close();
+    _activeTarget.close();
+  }
+}

--- a/lib/singletons/cast_manager.dart
+++ b/lib/singletons/cast_manager.dart
@@ -101,14 +101,21 @@ class CastManager {
         if (seen.add(t.id)) merged.add(t);
       }
     }
-    _targets.add(merged);
-
-    // If the active remote target vanished (renderer powered off / left the
-    // network), fall back to local so the UI never points at a gone device.
+    // Always keep the active remote target listed, even when the current scan
+    // snapshot doesn't include it — SSDP devices flicker in and out, and a
+    // transient gap (notably right after the picker reopens and rescans) must
+    // not drop the device the user is actively casting to. Without this, the
+    // active target fell out of the list and the picker showed "This device"
+    // while audio was still playing on the renderer.
     final active = _activeTarget.value;
-    if (!active.isLocal && !merged.contains(active)) {
-      selectTarget(CastTarget.local);
+    if (!active.isLocal && seen.add(active.id)) {
+      merged.add(active);
     }
+    _targets.add(merged);
+    // NOTE: we intentionally do NOT auto-fall-back to local when a device is
+    // merely absent from a scan (that was the bug above). Graceful handling of
+    // a renderer that genuinely goes offline mid-cast is a future refinement
+    // (drive it off an explicit onRendererOffline for the *active* device).
   }
 
   void dispose() {

--- a/lib/singletons/cast_manager.dart
+++ b/lib/singletons/cast_manager.dart
@@ -33,11 +33,20 @@ class CastManager {
   final BehaviorSubject<CastTarget> _activeTarget =
       BehaviorSubject<CastTarget>.seeded(CastTarget.local);
 
+  // Surfaces "casting failed, fell back to this device" messages for the UI to
+  // show as a toast. PublishSubject so a late listener doesn't replay a stale
+  // error.
+  final PublishSubject<String> _castErrors = PublishSubject<String>();
+
   Stream<List<CastTarget>> get targetsStream => _targets.stream;
   List<CastTarget> get targets => _targets.value;
   Stream<CastTarget> get activeTargetStream => _activeTarget.stream;
   CastTarget get activeTarget => _activeTarget.value;
   bool get isCasting => !_activeTarget.value.isLocal;
+
+  /// Emits a message when a cast attempt failed and playback fell back to this
+  /// device. The UI listens and shows a toast.
+  Stream<String> get castErrorStream => _castErrors.stream;
 
   /// True once at least one discoverer is registered — lets the picker decide
   /// whether to show the "searching…" hint.
@@ -91,6 +100,15 @@ class CastManager {
     }
   }
 
+  /// Called by the handler when a remote backend failed to start. Reflects the
+  /// revert in the UI (active target → local) WITHOUT re-invoking
+  /// [onTargetSelected] (the handler has already reverted the backend), and
+  /// surfaces [message] on [castErrorStream] for a toast.
+  void reportCastFailed(String message) {
+    _activeTarget.add(CastTarget.local);
+    if (!_castErrors.isClosed) _castErrors.add(message);
+  }
+
   void _recompute() {
     // Local always first; then de-duped remote devices (two discoverers could
     // in principle surface the same physical device).
@@ -124,5 +142,6 @@ class CastManager {
     }
     _targets.close();
     _activeTarget.close();
+    _castErrors.close();
   }
 }

--- a/lib/singletons/media.dart
+++ b/lib/singletons/media.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Platform;
 import 'package:audio_service/audio_service.dart';
 import '../media/audio_stuff.dart';
 import '../media/dlna_discoverer.dart';
+import '../media/chromecast_discoverer.dart';
 import 'cast_manager.dart';
 
 class MediaManager {
@@ -28,6 +29,7 @@ class MediaManager {
     // scanning when the cast picker opens (CastManager.startDiscovery).
     if (Platform.isAndroid) {
       CastManager().registerDiscoverer(DlnaDeviceDiscoverer());
+      CastManager().registerDiscoverer(ChromecastDeviceDiscoverer());
     }
   }
 }

--- a/lib/singletons/media.dart
+++ b/lib/singletons/media.dart
@@ -1,5 +1,9 @@
+import 'dart:io' show Platform;
+
 import 'package:audio_service/audio_service.dart';
 import '../media/audio_stuff.dart';
+import '../media/dlna_discoverer.dart';
+import 'cast_manager.dart';
 
 class MediaManager {
   MediaManager._privateConstructor();
@@ -18,5 +22,12 @@ class MediaManager {
         androidNotificationOngoing: true,
       ),
     );
+
+    // DLNA casting discovery is Android-only (media_cast_dlna has no other
+    // platform impl). Registering the discoverer is cheap — it only starts
+    // scanning when the cast picker opens (CastManager.startDiscovery).
+    if (Platform.isAndroid) {
+      CastManager().registerDiscoverer(DlnaDeviceDiscoverer());
+    }
   }
 }

--- a/lib/widgets/cast_picker_sheet.dart
+++ b/lib/widgets/cast_picker_sheet.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:rxdart/rxdart.dart';
+
+import '../media/cast_target.dart';
+import '../singletons/cast_manager.dart';
+import '../theme/velvet_theme.dart';
+
+/// Bottom sheet for choosing where audio plays ("This device" or a discovered
+/// renderer). Discovery runs only while the sheet is open (battery-friendly).
+class CastPickerSheet extends StatefulWidget {
+  @override
+  State<CastPickerSheet> createState() => _CastPickerSheetState();
+}
+
+class _CastPickerSheetState extends State<CastPickerSheet> {
+  @override
+  void initState() {
+    super.initState();
+    // Scan only while the picker is visible.
+    CastManager().startDiscovery();
+  }
+
+  @override
+  void dispose() {
+    CastManager().stopDiscovery();
+    super.dispose();
+  }
+
+  IconData _iconFor(CastTargetKind kind) {
+    switch (kind) {
+      case CastTargetKind.local:
+        return Icons.smartphone;
+      case CastTargetKind.dlna:
+        return Icons.speaker;
+      case CastTargetKind.chromecast:
+        return Icons.cast;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.cast, color: VelvetColors.primary),
+                const SizedBox(width: 10),
+                Text(
+                  'Play on',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                    color: VelvetColors.textPrimary,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            StreamBuilder<(List<CastTarget>, CastTarget)>(
+              stream: Rx.combineLatest2(
+                CastManager().targetsStream,
+                CastManager().activeTargetStream,
+                (List<CastTarget> targets, CastTarget active) =>
+                    (targets, active),
+              ),
+              initialData: (CastManager().targets, CastManager().activeTarget),
+              builder: (context, snapshot) {
+                final (targets, active) = snapshot.data!;
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    for (final t in targets)
+                      _TargetRow(
+                        target: t,
+                        selected: t == active,
+                        icon: _iconFor(t.kind),
+                        onTap: () {
+                          CastManager().selectTarget(t);
+                          Navigator.of(context).pop();
+                        },
+                      ),
+                  ],
+                );
+              },
+            ),
+            // The "searching…" hint only appears once discovery backends are
+            // registered (Phase 3+). Until then the list is just this device.
+            if (CastManager().hasDiscoverers) ...[
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor:
+                          AlwaysStoppedAnimation(VelvetColors.textSecondary),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Text(
+                    'Searching for cast devices…',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: VelvetColors.textSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TargetRow extends StatelessWidget {
+  final CastTarget target;
+  final bool selected;
+  final IconData icon;
+  final VoidCallback onTap;
+  const _TargetRow({
+    required this.target,
+    required this.selected,
+    required this.icon,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: Icon(
+        icon,
+        color: selected ? VelvetColors.primary : VelvetColors.textSecondary,
+      ),
+      title: Text(
+        target.name,
+        style: TextStyle(
+          color: selected ? VelvetColors.primary : VelvetColors.textPrimary,
+          fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+        ),
+      ),
+      trailing:
+          selected ? Icon(Icons.check, color: VelvetColors.primary) : null,
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/widgets/cast_picker_sheet.dart
+++ b/lib/widgets/cast_picker_sheet.dart
@@ -133,6 +133,19 @@ class _TargetRow extends StatelessWidget {
     required this.onTap,
   });
 
+  // Connection type, shown as a subtitle so the same TV appearing as both a
+  // DLNA renderer and a Chromecast device is distinguishable.
+  String get _kindLabel {
+    switch (target.kind) {
+      case CastTargetKind.local:
+        return 'This device';
+      case CastTargetKind.dlna:
+        return 'DLNA';
+      case CastTargetKind.chromecast:
+        return 'Chromecast';
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return ListTile(
@@ -148,6 +161,16 @@ class _TargetRow extends StatelessWidget {
           fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
         ),
       ),
+      // Local's name ("This device") already says it, so only label remotes.
+      subtitle: target.isLocal
+          ? null
+          : Text(
+              _kindLabel,
+              style: TextStyle(
+                color: VelvetColors.textSecondary,
+                fontSize: 12,
+              ),
+            ),
       trailing:
           selected ? Icon(Icons.check, color: VelvetColors.primary) : null,
       onTap: onTap,

--- a/lib/widgets/more_actions_sheet.dart
+++ b/lib/widgets/more_actions_sheet.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+
+import '../objects/server.dart';
+import '../screens/visualizer_screen.dart';
+import '../singletons/media.dart';
+import '../singletons/server_list.dart';
+import '../singletons/sleep_timer.dart';
+import '../theme/velvet_theme.dart';
+import 'sleep_timer_sheet.dart';
+
+/// "More" actions bottom sheet — collects the session/secondary controls that
+/// used to crowd the bottom bar (Auto DJ, sleep timer, visualizer, clear
+/// queue), leaving the bar to transport + shuffle/repeat.
+///
+/// [parentContext] is a context ABOVE this sheet (the bottom bar's), used to
+/// launch follow-on navigation / sheets after this one is dismissed — the
+/// sheet's own context is gone once it's popped.
+class MoreActionsSheet extends StatelessWidget {
+  final BuildContext parentContext;
+  const MoreActionsSheet({required this.parentContext});
+
+  void _toggleAutoDJ(BuildContext context, Server? autoDJState) {
+    final current = ServerManager().currentServer;
+    if (current == null) return;
+    final handler = MediaManager().audioHandler;
+    final messenger = ScaffoldMessenger.of(context);
+    if (autoDJState == null) {
+      handler.customAction('setAutoDJ', {'autoDJServer': current});
+      messenger.showSnackBar(SnackBar(
+          content: Text(ServerManager().serverList.length == 1
+              ? 'Auto DJ Enabled'
+              : 'Auto DJ Enabled For ${current.url}')));
+    } else if (current == autoDJState) {
+      handler.customAction('setAutoDJ', {'autoDJServer': null});
+      messenger
+          .showSnackBar(const SnackBar(content: Text('Auto DJ Disabled')));
+    } else {
+      handler.customAction('setAutoDJ', {'autoDJServer': current});
+      messenger.showSnackBar(
+          SnackBar(content: Text('Auto DJ Enabled For ${current.url}')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SizedBox(height: 8),
+          // Auto DJ — toggles in place; the switch reflects live state.
+          StreamBuilder<dynamic>(
+            stream: MediaManager().audioHandler.customState,
+            builder: (context, snapshot) {
+              final Server? autoDJState =
+                  (snapshot.data?.autoDJState as Server?);
+              final on = autoDJState != null;
+              return SwitchListTile(
+                secondary: Icon(Icons.album,
+                    color: on
+                        ? VelvetColors.primary
+                        : VelvetColors.textSecondary),
+                title: Text('Auto DJ',
+                    style: TextStyle(color: VelvetColors.textPrimary)),
+                subtitle: Text(on ? 'On' : 'Off',
+                    style: TextStyle(color: VelvetColors.textSecondary)),
+                value: on,
+                activeThumbColor: VelvetColors.primary,
+                onChanged: (_) => _toggleAutoDJ(context, autoDJState),
+              );
+            },
+          ),
+          // Sleep timer — opens the timer picker.
+          StreamBuilder<Duration?>(
+            stream: SleepTimerManager().remainingStream,
+            initialData: SleepTimerManager().remaining,
+            builder: (context, snapshot) {
+              final d = snapshot.data;
+              final active = d != null;
+              return ListTile(
+                leading: Icon(active ? Icons.bedtime : Icons.bedtime_outlined,
+                    color: active
+                        ? VelvetColors.primary
+                        : VelvetColors.textSecondary),
+                title: Text('Sleep timer',
+                    style: TextStyle(color: VelvetColors.textPrimary)),
+                subtitle: Text(d != null ? 'Pauses in ${_fmt(d)}' : 'Off',
+                    style: TextStyle(color: VelvetColors.textSecondary)),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  showModalBottomSheet(
+                    context: parentContext,
+                    backgroundColor: VelvetColors.surface,
+                    isScrollControlled: true,
+                    builder: (_) => SleepTimerSheet(),
+                  );
+                },
+              );
+            },
+          ),
+          // Visualizer.
+          ListTile(
+            leading:
+                Icon(Icons.auto_awesome, color: VelvetColors.textSecondary),
+            title: Text('Visualizer',
+                style: TextStyle(color: VelvetColors.textPrimary)),
+            onTap: () {
+              Navigator.of(context).pop();
+              Navigator.of(parentContext).push(
+                MaterialPageRoute(builder: (_) => VisualizerScreen()),
+              );
+            },
+          ),
+          // Clear queue.
+          ListTile(
+            leading: Icon(Icons.delete_sweep, color: VelvetColors.error),
+            title: Text('Clear queue',
+                style: TextStyle(color: VelvetColors.textPrimary)),
+            onTap: () {
+              Navigator.of(context).pop();
+              MediaManager().audioHandler.customAction('clearPlaylist');
+            },
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+
+  static String _fmt(Duration d) {
+    final m = d.inMinutes;
+    final s = d.inSeconds % 60;
+    return '$m:${s.toString().padLeft(2, '0')}';
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -359,6 +359,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  media_cast_dlna:
+    dependency: "direct main"
+    description:
+      name: media_cast_dlna
+      sha256: "6506b11b7a011ae14eb38814c2f20ce61de13ba39ca5f87130e4143ba951b2f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   meta:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -137,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  fading_edge_scrollview:
+    dependency: transitive
+    description:
+      name: fading_edge_scrollview
+      sha256: "1f84fe3ea8e251d00d5735e27502a6a250e4aa3d3b330d3fdcb475af741464ef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
   fake_async:
     dependency: transitive
     description:
@@ -182,6 +190,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
+  flutter_chrome_cast:
+    dependency: "direct main"
+    description:
+      name: flutter_chrome_cast
+      sha256: "3d412fa1831591466df4ae5d61edd8e4fdd8b2992008eed0d44dde5958e21287"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.6"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -218,6 +234,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  get:
+    dependency: transitive
+    description:
+      name: get
+      sha256: "5ed34a7925b85336e15d472cc4cfe7d9ebf4ab8e8b9f688585bf6b50f4c3d79a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.3"
   hooks:
     dependency: transitive
     description:
@@ -343,6 +367,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  marquee:
+    dependency: transitive
+    description:
+      name: marquee
+      sha256: a87e7e80c5d21434f90ad92add9f820cf68be374b226404fe881d2bba7be0862
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   path: any
   # Visualizer: FFI bindings to libprojectM (loaded from jniLibs on Android).
   ffi: ^2.1.4
+  media_cast_dlna: ^0.3.1
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   # Visualizer: FFI bindings to libprojectM (loaded from jniLibs on Android).
   ffi: ^2.1.4
   media_cast_dlna: ^0.3.1
+  flutter_chrome_cast: ^1.4.6
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary

Adds **client-side casting** so playback can move off the phone to a **DLNA renderer** (TV / AV receiver) or a **Chromecast / Google Cast** device — without changing any of the existing queue / Auto-DJ / shuffle / repeat behavior. The phone stays the controller; audio plays on the selected device. No server changes; this is entirely in the Flutter client.

## What you can do

- Tap the **cast button** in the app bar → pick a device in the **cast picker** ("This device" plus discovered DLNA / Chromecast targets, labeled by type).
- Audio continues from the **same track + position** on the selected device; transport (play/pause/seek/next/prev), the queue, Auto-DJ, shuffle and repeat all keep working unchanged.
- Tap cast again → **return to the phone** at the current position.
- Album art + track / album / artist / track-number / disc / year metadata are sent to the renderer.

## Architecture

Everything sits behind a `PlaybackBackend` abstraction so the handler doesn't care *where* audio plays:

- **`PlaybackBackend`** — interface for transport + state streams. Three impls: `LocalPlaybackBackend` (the existing just_audio engine, extracted with behavior unchanged), `DlnaPlaybackBackend`, `ChromecastPlaybackBackend`.
- **`AudioPlayerHandler`** holds one active backend in a `BehaviorSubject` and `switchMap`s its state streams, so existing UI listeners auto-resubscribe on a backend swap — the queue / Auto-DJ / shuffle / repeat logic is untouched.
- **`DeviceDiscoverer`** — package-agnostic discovery seam. `DlnaDiscoverer` (media_cast_dlna) and `ChromecastDiscoverer` (flutter_chrome_cast) plug in; registered only on Android.
- **`CastManager`** — aggregates discovered targets + the always-present local target, tracks the active one, and drives the backend swap.
- Remote backends emulate the just_audio playlist model with a single-item "push" to the renderer (own queue + index, advance on track-end).

## Platform / build changes ⚠️

- **`minSdk` raised to 26** (required by media_cast_dlna). **This drops Android 5.x–7.x.** — flagging for review.
- New permissions: `CHANGE_WIFI_MULTICAST_STATE`, `ACCESS_WIFI_STATE`, `ACCESS_NETWORK_STATE` (DLNA SSDP discovery); Cast `OPTIONS_PROVIDER` meta-data (Default Media Receiver `CC1AD845`).
- New dependencies: `media_cast_dlna ^0.3.1`, `flutter_chrome_cast ^1.4.6`.
- The bottom bar was getting crowded, so cast moved to the app bar and the secondary actions (Auto DJ / sleep timer / visualizer / clear queue) moved into a **More** sheet.

## Testing

Device-tested on hardware (Android phone → real TV + Chromecast):

- DLNA and Chromecast discovery, connect, play, pause, seek, next/prev, and return-to-phone.
- Bugs found and fixed during testing: spurious DLNA track-skip, picker showing "This device" while connected, Chromecast discovery (missing receiver app ID), blurry cast art (compressed URL).
- `flutter analyze` clean (no new issues).

## Known limitations / deferred

- **Casting local-only files isn't supported yet.** Downloaded server tracks cast fine (the renderer streams them from mStream). A local file-explorer track — or casting while the server is offline — can't be fetched by the renderer; that needs an on-device HTTP server (a planned follow-up). If a cast fails to start, playback **falls back to the phone** with a toast.
- The EQ is a local-playback effect, so it's unavailable while casting (the screen says so).
- Graceful handling of a renderer that drops offline *mid-cast* is a future refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
