### PR TITLE
Casting v2: mid-cast offline recovery + on-device HTTP server (local files)

### DIFF
--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -11,6 +11,7 @@ import 'playback_backend.dart';
 import 'local_playback_backend.dart';
 import 'dlna_playback_backend.dart';
 import 'chromecast_playback_backend.dart';
+import 'local_media_server.dart';
 import 'cast_log.dart';
 import 'cast_target.dart';
 import '../objects/server.dart';
@@ -111,6 +112,11 @@ class AudioPlayerHandler extends BaseAudioHandler
     _backendSubject.switchMap((b) => b.processingStateStream).listen((state) {
       if (state == BackendProcessingState.completed) stop();
     });
+    // A remote backend that loses its renderer mid-cast (TV off, Wi-Fi drop)
+    // emits here; fall back to local playback at the same spot + a toast.
+    _backendSubject
+        .switchMap((b) => b.rendererLostStream)
+        .listen(_onRendererLost);
     // Route cast-target selection (from the picker) to a backend swap.
     CastManager().onTargetSelected = _switchToTarget;
     try {
@@ -220,6 +226,11 @@ class AudioPlayerHandler extends BaseAudioHandler
     if (!identical(prev, _localBackend)) {
       await prev.dispose();
     }
+    // Switched back to the phone — tear down the local file server (no-op if it
+    // was never started). A remote→remote switch keeps it up for the new one.
+    if (identical(next, _localBackend)) {
+      await LocalMediaServer().stop();
+    }
   }
 
   // True once a freshly-activated remote backend actually starts (reaches
@@ -257,8 +268,35 @@ class AudioPlayerHandler extends BaseAudioHandler
     if (!identical(prev, _localBackend) && !identical(prev, failed)) {
       await prev.dispose();
     }
+    await LocalMediaServer().stop();
     CastManager().reportCastFailed(
         "Couldn't play on the cast device — back on this phone");
+  }
+
+  // A remote renderer dropped offline *during* playback (not at switch time —
+  // that's _fallBackToLocal). Resume on the phone at the current spot and tell
+  // CastManager (reverts the UI to "This device" + toast). Serialized through
+  // _switchChain so it can't interleave with a user-initiated target switch.
+  void _onRendererLost(String message) {
+    _switchChain = _switchChain.then((_) async {
+      final failed = _backend;
+      if (identical(failed, _localBackend)) return; // already recovered
+      final pos = failed.position;
+      final idx = failed.currentIndex ?? 0;
+      final wasPlaying = failed.playing;
+      await _localBackend.setSources(queue.value);
+      _backendSubject.add(_localBackend);
+      if (queue.value.isNotEmpty) {
+        await _localBackend.seek(pos, index: idx);
+        if (wasPlaying) await _localBackend.play();
+      }
+      _broadcastState();
+      await failed.dispose();
+      await LocalMediaServer().stop();
+      CastManager().reportCastFailed(message);
+    }).catchError((Object e) {
+      castLog('Renderer-lost fallback failed', error: e);
+    });
   }
 
   @override

--- a/lib/media/cast_art.dart
+++ b/lib/media/cast_art.dart
@@ -38,3 +38,20 @@ DateTime? releaseDateFor(MediaItem item) {
   final y = intExtra(item, 'year');
   return (y != null && y > 0) ? DateTime(y) : null;
 }
+
+/// Best-effort audio MIME type from a file path or URL, by extension. Used for
+/// the renderer's contentType (Chromecast) and the on-device media server's
+/// Content-Type header. Falls back to audio/mpeg.
+String mimeForPath(String pathOrUrl) {
+  var p = pathOrUrl.toLowerCase();
+  final q = p.indexOf('?'); // drop any URL query string
+  if (q >= 0) p = p.substring(0, q);
+  if (p.endsWith('.flac')) return 'audio/flac';
+  if (p.endsWith('.wav')) return 'audio/wav';
+  if (p.endsWith('.m4a') || p.endsWith('.aac') || p.endsWith('.mp4')) {
+    return 'audio/mp4';
+  }
+  if (p.endsWith('.ogg') || p.endsWith('.opus')) return 'audio/ogg';
+  if (p.endsWith('.aif') || p.endsWith('.aiff')) return 'audio/aiff';
+  return 'audio/mpeg';
+}

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show File;
 import 'dart:math' show Random;
 
 import 'package:audio_service/audio_service.dart' show MediaItem;
@@ -8,6 +9,7 @@ import 'package:rxdart/rxdart.dart';
 
 import 'cast_art.dart';
 import 'cast_log.dart';
+import 'local_media_server.dart';
 import 'playback_backend.dart';
 
 /// [PlaybackBackend] that plays through a Chromecast / Google Cast device via
@@ -42,6 +44,7 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
 
   StreamSubscription<GoggleCastMediaStatus?>? _statusSub;
   StreamSubscription<Duration>? _positionSub;
+  StreamSubscription<dynamic>? _sessionSub;
 
   final BehaviorSubject<int?> _indexSubject = BehaviorSubject<int?>.seeded(null);
   final BehaviorSubject<Duration> _positionSubject =
@@ -53,6 +56,12 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
           BackendProcessingState.idle);
   final StreamController<void> _changeController =
       StreamController<void>.broadcast();
+  // Emits when the Cast session drops unexpectedly mid-cast; the handler falls
+  // back to local. _disposing suppresses our own teardown; _lostFired makes it
+  // one-shot (disconnecting → disconnected would otherwise emit twice).
+  final PublishSubject<String> _rendererLost = PublishSubject<String>();
+  bool _disposing = false;
+  bool _lostFired = false;
 
   // isClosed-guarded emitters so a late async callback after dispose() can't
   // add to a closed subject.
@@ -83,6 +92,21 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
       _position = pos;
       _emitPos(pos);
       _change();
+    });
+    // Detect an unexpected session drop (TV off, Wi-Fi lost). Listeners attach
+    // only after _ensureSession connected (_sessionStarted), so a transition to
+    // not-connected we didn't initiate means the renderer is gone.
+    _sessionSub ??= _sessions.currentSessionStream.listen((_) {
+      if (_sessionStarted &&
+          !_disposing &&
+          !_lostFired &&
+          !_sessions.hasConnectedSession) {
+        _lostFired = true;
+        if (!_rendererLost.isClosed) {
+          _rendererLost
+              .add('Lost connection to the cast device — back on this phone');
+        }
+      }
     });
   }
 
@@ -219,28 +243,28 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
   }
 
   // ── Media construction ──
-  Uri _uriFor(MediaItem item) => Uri.parse(item.id);
-
-  String _mimeFor(String url) {
-    final path = Uri.parse(url).path.toLowerCase();
-    if (path.endsWith('.flac')) return 'audio/flac';
-    if (path.endsWith('.wav')) return 'audio/wav';
-    if (path.endsWith('.m4a') ||
-        path.endsWith('.aac') ||
-        path.endsWith('.mp4')) return 'audio/mp4';
-    if (path.endsWith('.ogg') || path.endsWith('.opus')) return 'audio/ogg';
-    return 'audio/mpeg';
+  // A network id (server URL) is sent as-is; a local-only item (file-explorer
+  // track — id is a UUID) is served from the phone's LocalMediaServer so the
+  // receiver can reach it.
+  Future<Uri> _resolveUri(MediaItem item) async {
+    final localPath = item.extras?['localPath'] as String?;
+    final isNetwork =
+        item.id.startsWith('http://') || item.id.startsWith('https://');
+    if (!isNetwork && localPath != null && File(localPath).existsSync()) {
+      await LocalMediaServer().ensureStarted();
+      return LocalMediaServer().registerFile(localPath);
+    }
+    return Uri.parse(item.id);
   }
 
-  GoogleCastMediaInformation _mediaInfo(MediaItem item) {
-    final url = _uriFor(item).toString();
+  GoogleCastMediaInformation _mediaInfo(MediaItem item, String url) {
     // Full-res art (drop the compress= size param) — looks sharp on a TV.
     final art = castArtUrl(item);
     return GoogleCastMediaInformation(
       contentId: url,
       contentUrl: Uri.parse(url),
       streamType: CastMediaStreamType.buffered,
-      contentType: _mimeFor(url),
+      contentType: mimeForPath(url),
       duration: item.duration,
       metadata: GoogleCastMusicMediaMetadata(
         title: item.title,
@@ -264,7 +288,8 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
     try {
       await _ensureSession();
       _ensureListeners();
-      await _client.loadMedia(_mediaInfo(_items[index]),
+      final url = (await _resolveUri(_items[index])).toString();
+      await _client.loadMedia(_mediaInfo(_items[index], url),
           autoPlay: play, playPosition: startAt);
       _loadedIndex = index;
       _playing = play;
@@ -408,6 +433,9 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
   @override
   Stream<void> get changeStream => _changeController.stream;
 
+  @override
+  Stream<String> get rendererLostStream => _rendererLost.stream;
+
   // ── Local-only capabilities (N/A while casting) ──
   @override
   bool get supportsEqualizer => false;
@@ -418,8 +446,10 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
 
   @override
   Future<void> dispose() async {
+    _disposing = true;
     await _statusSub?.cancel();
     await _positionSub?.cancel();
+    await _sessionSub?.cancel();
     try {
       await _sessions.endSessionAndStopCasting();
     } catch (_) {}
@@ -428,5 +458,6 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
     await _durationSubject.close();
     await _stateSubject.close();
     await _changeController.close();
+    await _rendererLost.close();
   }
 }

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show File;
 import 'dart:math' show Random;
 
 import 'package:audio_service/audio_service.dart' show MediaItem;
@@ -10,6 +11,7 @@ import 'package:rxdart/rxdart.dart';
 
 import 'cast_art.dart';
 import 'cast_log.dart';
+import 'local_media_server.dart';
 import 'playback_backend.dart';
 
 /// [PlaybackBackend] that plays through a DLNA renderer (TV / AV receiver /
@@ -52,6 +54,11 @@ class DlnaPlaybackBackend implements PlaybackBackend {
   bool _polling = false;
   bool _disposed = false;
 
+  // Consecutive getPlaybackInfo failures; trips a mid-cast "renderer lost"
+  // fallback once it crosses _kMaxPollFailures (so a single Wi-Fi blip doesn't).
+  int _pollFailures = 0;
+  static const int _kMaxPollFailures = 4;
+
   final BehaviorSubject<int?> _indexSubject = BehaviorSubject<int?>.seeded(null);
   final BehaviorSubject<Duration> _positionSubject =
       BehaviorSubject<Duration>.seeded(Duration.zero);
@@ -62,6 +69,9 @@ class DlnaPlaybackBackend implements PlaybackBackend {
           BackendProcessingState.idle);
   final StreamController<void> _changeController =
       StreamController<void>.broadcast();
+  // Emits when the renderer is lost mid-cast (see _poll); the handler listens
+  // and falls back to local playback.
+  final PublishSubject<String> _rendererLost = PublishSubject<String>();
 
   void _change() {
     if (!_changeController.isClosed) _changeController.add(null);
@@ -149,9 +159,19 @@ class DlnaPlaybackBackend implements PlaybackBackend {
   }
 
   // ── Transport ──
-  // DLNA renderers fetch the URL themselves, so use the network id (not the
-  // localPath download, which the renderer can't reach).
-  Uri _uriFor(MediaItem item) => Uri.parse(item.id);
+  // DLNA renderers fetch the URL themselves. A network id (server URL) is
+  // handed over as-is; a local-only item (file-explorer track — id is a UUID)
+  // is served from the phone's LocalMediaServer so the renderer can reach it.
+  Future<Uri> _resolveUri(MediaItem item) async {
+    final localPath = item.extras?['localPath'] as String?;
+    final isNetwork =
+        item.id.startsWith('http://') || item.id.startsWith('https://');
+    if (!isNetwork && localPath != null && File(localPath).existsSync()) {
+      await LocalMediaServer().ensureStarted();
+      return LocalMediaServer().registerFile(localPath);
+    }
+    return Uri.parse(item.id);
+  }
 
   AudioMetadata _metaFor(MediaItem item) {
     // Full-res art (drop the compress= size param) — looks sharp on a TV.
@@ -177,8 +197,8 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     _reachedNearEnd = false;
     _setState(BackendProcessingState.loading);
     try {
-      await _api.setMediaUri(
-          _udn, Url(value: _uriFor(item).toString()), _metaFor(item));
+      final uri = await _resolveUri(item);
+      await _api.setMediaUri(_udn, Url(value: uri.toString()), _metaFor(item));
       _loadedIndex = index;
       _duration = item.duration;
       _emitDur(_duration);
@@ -314,7 +334,9 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     if (_polling || _disposed) return;
     _polling = true;
     try {
-      final info = await _api.getPlaybackInfo(_udn);
+      final info =
+          await _api.getPlaybackInfo(_udn).timeout(const Duration(seconds: 2));
+      _pollFailures = 0;
       _position = Duration(seconds: info.position.seconds);
       _emitPos(_position);
       if (info.duration.seconds > 0) {
@@ -350,7 +372,17 @@ class DlnaPlaybackBackend implements PlaybackBackend {
       }
       _change();
     } catch (_) {
-      // Transient renderer/network error — keep polling.
+      // A single failure is usually a transient renderer/network blip — keep
+      // polling. But a renderer that's genuinely gone (TV off, Wi-Fi dropped)
+      // fails every poll; after _kMaxPollFailures in a row, declare it lost so
+      // the handler can fall back to local playback.
+      if (!_disposed && ++_pollFailures >= _kMaxPollFailures) {
+        _stopPolling();
+        if (!_rendererLost.isClosed) {
+          _rendererLost
+              .add('Lost connection to the cast device — back on this phone');
+        }
+      }
     } finally {
       _polling = false;
     }
@@ -407,6 +439,9 @@ class DlnaPlaybackBackend implements PlaybackBackend {
   @override
   Stream<void> get changeStream => _changeController.stream;
 
+  @override
+  Stream<String> get rendererLostStream => _rendererLost.stream;
+
   // ── Local-only capabilities (N/A while casting) ──
   @override
   bool get supportsEqualizer => false;
@@ -425,5 +460,6 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     await _durationSubject.close();
     await _stateSubject.close();
     await _changeController.close();
+    await _rendererLost.close();
   }
 }

--- a/lib/media/local_media_server.dart
+++ b/lib/media/local_media_server.dart
@@ -1,0 +1,199 @@
+import 'dart:io';
+import 'dart:math' show Random;
+
+import 'cast_art.dart' show mimeForPath;
+import 'cast_log.dart';
+
+/// On-device HTTP server that streams phone-local audio files to a cast
+/// renderer over the LAN.
+///
+/// DLNA / Chromecast renderers fetch media by URL and can't reach a file on the
+/// phone's storage, so a local file-explorer track (whose `MediaItem.id` is a
+/// UUID, not a URL) can't be cast directly. This server exposes such a file at
+/// `http://<phone-lan-ip>:<port>/<token>/<name>.<ext>` for the duration of the
+/// cast session; the cast backends [registerFile] a local file and hand the
+/// renderer that URL instead of the unreachable id.
+///
+/// Scope / security: only files explicitly [registerFile]d are served (random
+/// per-file token in the path; unknown tokens → 404), and the server runs only
+/// while casting (started lazily by [ensureStarted], [stop]ped when playback
+/// returns to the phone). Range requests are honoured so renderers can seek.
+class LocalMediaServer {
+  LocalMediaServer._();
+  static final LocalMediaServer _instance = LocalMediaServer._();
+  factory LocalMediaServer() => _instance;
+
+  HttpServer? _server;
+  String? _host; // LAN IPv4 the renderer connects back to
+  final Random _rng = Random();
+  final Map<String, String> _files = <String, String>{}; // token -> abs path
+
+  bool get isRunning => _server != null;
+
+  /// Bind the server (idempotent) and cache the LAN host + port. Call before
+  /// each [registerFile]. Throws if the phone has no usable LAN address.
+  Future<void> ensureStarted() async {
+    if (_server != null) return;
+    final host = await _lanAddress();
+    if (host == null) {
+      throw StateError('No LAN IPv4 address available (not on Wi-Fi?)');
+    }
+    final server = await HttpServer.bind(InternetAddress.anyIPv4, 0);
+    _server = server;
+    _host = host;
+    server.listen(_handle,
+        onError: (Object e) => castLog('LocalMediaServer listen error', error: e));
+  }
+
+  /// Register [absPath] for serving and return the URL the renderer fetches.
+  /// Reuses the token for an already-registered path. Requires [ensureStarted].
+  Uri registerFile(String absPath) {
+    final server = _server;
+    final host = _host;
+    if (server == null || host == null) {
+      throw StateError('registerFile called before ensureStarted');
+    }
+    for (final e in _files.entries) {
+      if (e.value == absPath) return _urlFor(host, server.port, e.key, absPath);
+    }
+    final token = _newToken();
+    _files[token] = absPath;
+    return _urlFor(host, server.port, token, absPath);
+  }
+
+  /// Close the server and forget all registered files. Called when casting ends.
+  Future<void> stop() async {
+    final s = _server;
+    _server = null;
+    _host = null;
+    _files.clear();
+    if (s != null) {
+      try {
+        await s.close(force: true);
+      } catch (_) {}
+    }
+  }
+
+  // ── internals ──
+
+  Uri _urlFor(String host, int port, String token, String absPath) => Uri(
+        scheme: 'http',
+        host: host,
+        port: port,
+        pathSegments: [token, _basename(absPath)],
+      );
+
+  String _newToken() {
+    const chars = '0123456789abcdef';
+    final sb = StringBuffer();
+    for (var i = 0; i < 16; i++) {
+      sb.write(chars[_rng.nextInt(chars.length)]);
+    }
+    final t = sb.toString();
+    return _files.containsKey(t) ? _newToken() : t;
+  }
+
+  String _basename(String path) {
+    final slash = path.lastIndexOf('/');
+    final back = path.lastIndexOf('\\');
+    final cut = slash > back ? slash : back;
+    return cut >= 0 ? path.substring(cut + 1) : path;
+  }
+
+  Future<String?> _lanAddress() async {
+    try {
+      final ifaces = await NetworkInterface.list(
+          type: InternetAddressType.IPv4, includeLoopback: false);
+      // Prefer a private (RFC1918) address — the one a renderer on the same
+      // Wi-Fi can reach.
+      for (final iface in ifaces) {
+        for (final addr in iface.addresses) {
+          if (_isPrivate(addr.address)) return addr.address;
+        }
+      }
+      // Fallback: first non-loopback IPv4.
+      for (final iface in ifaces) {
+        for (final addr in iface.addresses) {
+          return addr.address;
+        }
+      }
+    } catch (e) {
+      castLog('LocalMediaServer LAN address lookup failed', error: e);
+    }
+    return null;
+  }
+
+  bool _isPrivate(String ip) =>
+      ip.startsWith('192.168.') || ip.startsWith('10.') || _is172Private(ip);
+
+  bool _is172Private(String ip) {
+    if (!ip.startsWith('172.')) return false;
+    final parts = ip.split('.');
+    if (parts.length < 2) return false;
+    final second = int.tryParse(parts[1]) ?? 0;
+    return second >= 16 && second <= 31;
+  }
+
+  Future<void> _handle(HttpRequest req) async {
+    final res = req.response;
+    try {
+      final seg = req.uri.pathSegments;
+      final path = seg.isEmpty ? null : _files[seg.first];
+      if (path == null) return _notFound(res);
+      final file = File(path);
+      if (!await file.exists()) return _notFound(res);
+
+      final length = await file.length();
+      res.headers
+        ..set(HttpHeaders.acceptRangesHeader, 'bytes')
+        ..set(HttpHeaders.contentTypeHeader, mimeForPath(path));
+
+      // Parse a single byte range (renderers send `bytes=start-` or
+      // `bytes=start-end`); multi-range isn't used by media renderers.
+      var start = 0;
+      var end = length - 1;
+      final range = req.headers.value(HttpHeaders.rangeHeader);
+      if (range != null && range.startsWith('bytes=')) {
+        final spec = range.substring(6).split('-');
+        if (spec[0].isNotEmpty) start = int.tryParse(spec[0]) ?? 0;
+        if (spec.length > 1 && spec[1].isNotEmpty) {
+          end = int.tryParse(spec[1]) ?? end;
+        }
+        if (start < 0 || start >= length || start > end) {
+          res.statusCode = HttpStatus.requestedRangeNotSatisfiable;
+          res.headers.set(HttpHeaders.contentRangeHeader, 'bytes */$length');
+          await res.close();
+          return;
+        }
+        if (end > length - 1) end = length - 1;
+        res.statusCode = HttpStatus.partialContent;
+        res.headers
+            .set(HttpHeaders.contentRangeHeader, 'bytes $start-$end/$length');
+      } else {
+        res.statusCode = HttpStatus.ok;
+      }
+
+      final len = end - start + 1;
+      if (req.method == 'HEAD') {
+        // Set the length as a raw header (not res.contentLength, which would
+        // make close() enforce a matching body size on this empty response).
+        res.headers.set(HttpHeaders.contentLengthHeader, '$len');
+        await res.close();
+        return;
+      }
+      res.contentLength = len;
+      await res.addStream(file.openRead(start, end + 1));
+      await res.close();
+    } catch (e) {
+      castLog('LocalMediaServer request failed', error: e);
+      try {
+        await res.close();
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _notFound(HttpResponse res) async {
+    res.statusCode = HttpStatus.notFound;
+    await res.close();
+  }
+}

--- a/lib/media/local_playback_backend.dart
+++ b/lib/media/local_playback_backend.dart
@@ -130,6 +130,10 @@ class LocalPlaybackBackend implements PlaybackBackend {
   @override
   Stream<void> get changeStream => _player.playbackEventStream.map<void>((_) {});
 
+  // On-device playback never "loses a renderer", so this never emits.
+  @override
+  Stream<String> get rendererLostStream => const Stream<String>.empty();
+
   // ── Local-only capabilities ──
   @override
   bool get supportsEqualizer => _equalizer != null;

--- a/lib/media/playback_backend.dart
+++ b/lib/media/playback_backend.dart
@@ -71,6 +71,12 @@ abstract class PlaybackBackend {
   /// audio_service [PlaybackState] on each tick.
   Stream<void> get changeStream;
 
+  /// Emits a user-facing reason when a remote renderer is lost *mid-playback*
+  /// (TV powered off, Wi-Fi dropped, Cast session ended unexpectedly). The
+  /// handler listens to the active backend's stream and falls back to local
+  /// playback + a toast. Never emits on the local backend.
+  Stream<String> get rendererLostStream;
+
   // ── Local-only capabilities (false / null on remote backends) ──
   bool get supportsEqualizer;
 

--- a/lib/widgets/cast_picker_sheet.dart
+++ b/lib/widgets/cast_picker_sheet.dart
@@ -114,6 +114,32 @@ class _CastPickerSheetState extends State<CastPickerSheet> {
                 ],
               ),
             ],
+            const Divider(height: 24),
+            // Deferred feature: streaming the on-screen visualizer to the cast
+            // device. Shown disabled so the capability is discoverable; the
+            // wiring lands in a follow-up (it needs on-device A/V encoding plus
+            // the local media server added in this change).
+            Opacity(
+              opacity: 0.5,
+              child: CheckboxListTile(
+                contentPadding: EdgeInsets.zero,
+                controlAffinity: ListTileControlAffinity.leading,
+                dense: true,
+                value: false,
+                onChanged: null,
+                title: Text(
+                  'Cast visualizer',
+                  style: TextStyle(color: VelvetColors.textPrimary),
+                ),
+                subtitle: Text(
+                  'Coming soon',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: VelvetColors.textSecondary,
+                  ),
+                ),
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary

Follow-up to the casting feature (#27). Closes the two gaps from the release audit and lays the groundwork for visualizer casting. **No new dependencies; no manifest/permission changes.**

## Phase 1 — recover when a renderer drops mid-cast

Previously, if a renderer died *during* playback (TV powered off, Wi-Fi dropped), nothing noticed — DLNA swallowed every poll error as "transient" and Chromecast had no session-state listener, so playback froze on a dead target until you manually reselected "This device".

- Backends now expose a `rendererLostStream`; the handler subscribes via the backend subject and **falls back to local playback at the same position + a toast** (reusing `reportCastFailed`).
- **DLNA**: `getPlaybackInfo` gets a 2s timeout (so a black-holed renderer can't hang the poll) and a consecutive-failure counter — 4 in a row (~4–8s) stops polling and signals lost. A single Wi-Fi blip won't trip it (tunable via `_kMaxPollFailures`).
- **Chromecast**: subscribes to the session manager's `currentSessionStream`; an unexpected disconnect fires once (`_lostFired` latch), with our own teardown suppressed via a `_disposing` flag.

## Phase 2 — cast phone-local files (on-device HTTP server)

A renderer can only fetch *network* URLs, so a file-explorer track (whose `MediaItem.id` is a UUID) couldn't be cast at all. New **`LocalMediaServer`** (pure `dart:io`) serves the file over the LAN:

- Binds an ephemeral port on the Wi-Fi IP; **HTTP range support** (renderers seek via byte ranges and some refuse to play without it); correct `Content-Type`; random per-file tokens (only registered files are served); starts lazily, stops when casting ends.
- Both backends resolve a local-only item (non-URL id + existing `localPath`) to a `http://<phone-ip>:<port>/<token>/<name>` URL at their one shared `_uriFor` seam, instead of handing the renderer an unreachable UUID. Streamed/downloaded tracks are unchanged.
- Shared `mimeForPath` extracted into `cast_art.dart`.

## Phase 3 — visualizer cast (deferred)

A disabled **"Cast visualizer — Coming soon"** checkbox in the picker. The full implementation (real-time A/V stream of the app's own projectM/shader visuals) reuses this same `LocalMediaServer` and is planned as a follow-up.

## Testing

`flutter analyze` clean (no new issues); builds and launches on device. The cast paths need hardware validation:

- **Offline recovery**: cast → power the TV off → playback resumes on the phone within ~5–10s with the "Lost connection…" toast. Normal disconnect (reselect "This device") must **not** spuriously toast.
- **Local-file casting**: queue a file-explorer track, cast to DLNA *and* Chromecast → plays (served from the phone); **seek mid-track** to exercise range. Confirm streamed/downloaded tracks still cast. Test **FLAC** (some DLNA renderers are MIME-picky).
- Detection thresholds (`_kMaxPollFailures`, the 2s poll timeout) are tuning knobs — validate on real hardware so transient blips don't force a fallback.

## Files

New: `lib/media/local_media_server.dart`. Modified: `playback_backend.dart`, `local_playback_backend.dart`, `dlna_playback_backend.dart`, `chromecast_playback_backend.dart`, `audio_stuff.dart`, `cast_art.dart`, `widgets/cast_picker_sheet.dart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
