### PR TITLE
feat: queue swipe actions + redesigned song-info screen with full track metadata

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1,4 +1,5 @@
 {
+  "mainRemove": "Entfernen",
   "@@locale": "de",
 
   "appTitle": "mStream Music",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,4 +1,5 @@
 {
+  "mainRemove": "Remove",
   "@@locale": "en",
 
   "appTitle": "mStream Music",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,4 +1,5 @@
 {
+  "mainRemove": "Quitar",
   "@@locale": "es",
   "appTitle": "mStream Music",
   "settingsLanguage": "Idioma",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,4 +1,5 @@
 {
+  "mainRemove": "Retirer",
   "@@locale": "fr",
   "appTitle": "mStream Music",
   "settingsLanguage": "Langue",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1,4 +1,5 @@
 {
+  "mainRemove": "Rimuovi",
   "@@locale": "it",
   "appTitle": "mStream Music",
   "settingsLanguage": "Lingua",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,4 +1,5 @@
 {
+  "mainRemove": "削除",
   "@@locale": "ja",
   "appTitle": "mStream Music",
   "settingsLanguage": "言語",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -114,6 +114,12 @@ abstract class AppLocalizations {
     Locale('zh'),
   ];
 
+  /// No description provided for @mainRemove.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove'**
+  String get mainRemove;
+
   /// Application title (brand name; not translated).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -9,6 +9,9 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get mainRemove => 'Entfernen';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get mainRemove => 'Remove';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
+  String get mainRemove => 'Quitar';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -9,6 +9,9 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
+  String get mainRemove => 'Retirer';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -9,6 +9,9 @@ class AppLocalizationsIt extends AppLocalizations {
   AppLocalizationsIt([String locale = 'it']) : super(locale);
 
   @override
+  String get mainRemove => 'Rimuovi';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -9,6 +9,9 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
+  String get mainRemove => '削除';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -9,6 +9,9 @@ class AppLocalizationsPl extends AppLocalizations {
   AppLocalizationsPl([String locale = 'pl']) : super(locale);
 
   @override
+  String get mainRemove => 'Usuń';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -9,6 +9,9 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
+  String get mainRemove => 'Remover';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -9,6 +9,9 @@ class AppLocalizationsRu extends AppLocalizations {
   AppLocalizationsRu([String locale = 'ru']) : super(locale);
 
   @override
+  String get mainRemove => 'Убрать';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -9,6 +9,9 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String get mainRemove => '移除';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1,4 +1,5 @@
 {
+  "mainRemove": "Usuń",
   "@@locale": "pl",
   "appTitle": "mStream Music",
   "settingsLanguage": "Język",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1,4 +1,5 @@
 {
+  "mainRemove": "Remover",
   "@@locale": "pt",
 
   "appTitle": "mStream Music",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,4 +1,5 @@
 {
+  "mainRemove": "Убрать",
   "@@locale": "ru",
   "appTitle": "mStream Music",
   "settingsLanguage": "Язык",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,4 +1,5 @@
 {
+  "mainRemove": "移除",
   "@@locale": "zh",
   "appTitle": "mStream Music",
   "settingsLanguage": "语言",

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -662,6 +662,10 @@ class AudioPlayerHandler extends BaseAudioHandler
       title: metadata['title'] ?? filepath.split('/').last,
       album: metadata['album'],
       artist: metadata['artist'],
+      genre:
+          (metadata['genres'] is List && (metadata['genres'] as List).isNotEmpty)
+              ? (metadata['genres'] as List).join(', ')
+              : null,
       extras: {
         // Tag with the source server so Share Playlist's multi-server
         // detection recognises AutoDJ-added songs as shareable.
@@ -669,7 +673,8 @@ class AudioPlayerHandler extends BaseAudioHandler
         'path': filepath,
         'year': metadata['year'],
         'track': metadata['track'],
-        'disc': metadata['disc'],
+        // Server emits this as `disk`; fall back to `disc` for other servers.
+        'disc': metadata['disk'] ?? metadata['disc'],
         'artUrl': artUrl,
         // bpm + musicalKey power the next AutoDJ pick's continuity
         // payload (see autoDJ() above). 'musical-key' is the wire

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -398,8 +398,14 @@ class AudioPlayerHandler extends BaseAudioHandler
   @override
   Future<void> removeQueueItemAt(int i) async {
     await super.removeQueueItemAt(i);
-    await _backend.removeSourceAt(i);
+    // Update the queue BEFORE the backend. removeSourceAt makes the backend emit
+    // its new currentIndex, and the currentIndexStream listener re-derives the
+    // now-playing item as queue.value[index]. If the queue still held the
+    // removed item, the wrong row would briefly render as the active/playing row
+    // (a flash in the accent colour) before correcting — same root cause as the
+    // reorder flash. Reordering keeps the queue and the emitted index in sync.
     queue.add(queue.value..removeAt(i));
+    await _backend.removeSourceAt(i);
   }
 
   customAction(String name, [Map<String, dynamic>? extras]) async {

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -15,6 +15,7 @@ import 'local_media_server.dart';
 import 'cast_log.dart';
 import 'cast_target.dart';
 import '../objects/server.dart';
+import '../objects/metadata.dart';
 import '../singletons/auto_dj_manager.dart';
 import '../singletons/cast_manager.dart';
 import '../singletons/settings.dart';
@@ -657,31 +658,30 @@ class AudioPlayerHandler extends BaseAudioHandler
             .toString()
         : null;
 
+    // Parse the raw server map once so the genre / disc / key wire quirks are
+    // handled in one place (MusicMetadata.fromServerMap) — the same path that
+    // browse-added items take.
+    final meta = MusicMetadata.fromServerMap(metadata);
     final item = MediaItem(
       id: mediaUrl,
-      title: metadata['title'] ?? filepath.split('/').last,
-      album: metadata['album'],
-      artist: metadata['artist'],
-      genre:
-          (metadata['genres'] is List && (metadata['genres'] as List).isNotEmpty)
-              ? (metadata['genres'] as List).join(', ')
-              : null,
+      title: meta.title ?? filepath.split('/').last,
+      album: meta.album,
+      artist: meta.artist,
+      genre: meta.genreLabel,
       extras: {
         // Tag with the source server so Share Playlist's multi-server
         // detection recognises AutoDJ-added songs as shareable.
         'server': autoDJServer!.localname,
         'path': filepath,
-        'year': metadata['year'],
-        'track': metadata['track'],
-        // Server emits this as `disk`; fall back to `disc` for other servers.
-        'disc': metadata['disk'] ?? metadata['disc'],
+        'year': meta.year,
+        'track': meta.track,
+        'disc': meta.disc,
         'artUrl': artUrl,
-        // bpm + musicalKey power the next AutoDJ pick's continuity
-        // payload (see autoDJ() above). 'musical-key' is the wire
-        // shape from the server — we stash it under our camelCase
-        // key for consistency with browser-added items.
-        'bpm': metadata['bpm'],
-        'musicalKey': metadata['musical-key'],
+        // bpm + musicalKey power the next AutoDJ pick's continuity payload
+        // (see autoDJ() above), stashed under our camelCase keys for
+        // consistency with browser-added items.
+        'bpm': meta.bpm,
+        'musicalKey': meta.musicalKey,
       },
     );
 

--- a/lib/objects/metadata.dart
+++ b/lib/objects/metadata.dart
@@ -36,8 +36,7 @@ class MusicMetadata {
         albumArt = json['albumArt'],
         bpm = json['bpm'],
         musicalKey = json['musicalKey'],
-        genres = (json['genres'] as List?)?.map((g) => g.toString()).toList() ??
-            const [];
+        genres = parseGenres(json['genres']);
 
   Map<String, dynamic> toJson() => {
         'artist': artist,
@@ -53,4 +52,36 @@ class MusicMetadata {
         'musicalKey': musicalKey,
         'genres': genres,
       };
+
+  /// Builds a [MusicMetadata] from a raw server `metadata` map. Centralises the
+  /// wire-shape quirks so every parse site stays in sync: kebab-case keys
+  /// (`album-art`, `musical-key`), the disc field spelled `disk` (with a `disc`
+  /// fallback), a possibly-absent `hash`, and the `genres` string list.
+  factory MusicMetadata.fromServerMap(Map m) => MusicMetadata(
+        m['artist'],
+        m['album'],
+        m['title'],
+        m['track'],
+        m['disk'] ?? m['disc'],
+        m['year'],
+        m['hash'] ?? '',
+        m['rating'],
+        m['album-art'],
+        bpm: m['bpm'],
+        musicalKey: m['musical-key'],
+        genres: parseGenres(m['genres']),
+      );
+
+  /// Parses the server's `genres` value (normally a string list) into a
+  /// `List<String>`, tolerating a bare string or a missing value without
+  /// throwing.
+  static List<String> parseGenres(dynamic value) {
+    if (value is List) return value.map((g) => g.toString()).toList();
+    if (value is String && value.trim().isNotEmpty) return [value.trim()];
+    return const [];
+  }
+
+  /// The genres as a single display string (`"Rock, Electronic"`), or null when
+  /// there are none — convenient for `MediaItem.genre`.
+  String? get genreLabel => genres.isEmpty ? null : genres.join(', ');
 }

--- a/lib/objects/metadata.dart
+++ b/lib/objects/metadata.dart
@@ -15,10 +15,14 @@ class MusicMetadata {
   // mixing + BPM-continuity modes (see audio_stuff.dart#autoDJ).
   int? bpm;
   String? musicalKey;
+  // Genre names for this track. Velvet servers emit `metadata.genres` as a
+  // string list (many-to-many via track_genres); empty when untagged or on
+  // servers that don't surface genres.
+  List<String> genres;
 
   MusicMetadata(this.artist, this.album, this.title, this.track, this.disc,
       this.year, this.hash, this.rating, this.albumArt,
-      {this.bpm, this.musicalKey});
+      {this.bpm, this.musicalKey, this.genres = const []});
 
   MusicMetadata.fromJson(Map<String, dynamic> json)
       : artist = json['artist'],
@@ -31,7 +35,9 @@ class MusicMetadata {
         rating = json['rating'],
         albumArt = json['albumArt'],
         bpm = json['bpm'],
-        musicalKey = json['musicalKey'];
+        musicalKey = json['musicalKey'],
+        genres = (json['genres'] as List?)?.map((g) => g.toString()).toList() ??
+            const [];
 
   Map<String, dynamic> toJson() => {
         'artist': artist,
@@ -45,5 +51,6 @@ class MusicMetadata {
         'albumArt': albumArt,
         'bpm': bpm,
         'musicalKey': musicalKey,
+        'genres': genres,
       };
 }

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -228,9 +228,7 @@ class _BrowserState extends State<Browser> {
         title: i.metadata?.title ?? i.name,
         album: i.metadata?.album,
         artist: i.metadata?.artist,
-        genre: (i.metadata?.genres.isNotEmpty ?? false)
-            ? i.metadata!.genres.join(', ')
-            : null,
+        genre: i.metadata?.genreLabel,
         extras: {
           'server': i.server!.localname,
           'path': i.data,

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -228,6 +228,9 @@ class _BrowserState extends State<Browser> {
         title: i.metadata?.title ?? i.name,
         album: i.metadata?.album,
         artist: i.metadata?.artist,
+        genre: (i.metadata?.genres.isNotEmpty ?? false)
+            ? i.metadata!.genres.join(', ')
+            : null,
         extras: {
           'server': i.server!.localname,
           'path': i.data,

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -1,57 +1,286 @@
+import 'dart:ui' show ImageFilter;
+
+import 'package:audio_service/audio_service.dart' show MediaItem;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
 import '../l10n/app_localizations.dart';
-import '../objects/metadata.dart';
+import '../theme/velvet_theme.dart';
+import '../util/media_format.dart';
 
-class MeteDataScreen extends StatelessWidget {
-  // In the constructor, require a Todo.
-  const MeteDataScreen({Key? key, required this.meta, required this.path})
-      : super(key: key);
+/// Song-info screen shown from the queue row's Info action: a blurred album-art
+/// backdrop, a hero cover, the title / artist / album·year, self-labelling
+/// metadata chips (length, BPM, key, track, disc, genre, source server), and
+/// the file location with a copy button. Reads straight off the [MediaItem], so
+/// every field the queue carries is surfaced — and only when present.
+class MetadataScreen extends StatelessWidget {
+  const MetadataScreen({Key? key, required this.item}) : super(key: key);
 
-  // Declare a field that holds the Todo.
-  final MusicMetadata meta;
-
-  final String? path;
+  final MediaItem item;
 
   @override
   Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final mq = MediaQuery.of(context);
+    final extras = item.extras ?? const <String, dynamic>{};
+
+    final art = extras['artUrl'] as String? ?? item.artUri?.toString();
+    final path = extras['path'] as String?;
+    final year = extras['year'];
+    final key = extras['musicalKey'] as String?;
+    final genre = item.genre;
+    final server = extras['server'] as String?;
+
+    final subtitle = <String>[
+      if (item.album != null && item.album!.trim().isNotEmpty) item.album!.trim(),
+      if (year != null && '$year'.isNotEmpty && '$year' != '0') '$year',
+    ].join('   ·   ');
+
+    // Self-labelling chips (icon + value) — no extra translated strings, shown
+    // only when the field is present.
+    final chips = <Widget>[
+      if (item.duration != null)
+        _chip(Icons.schedule_rounded, formatDuration(item.duration!)),
+      if (extras['bpm'] != null)
+        _chip(Icons.speed_rounded, '${_v(extras['bpm'])} BPM'),
+      if (key != null && key.trim().isNotEmpty)
+        _chip(Icons.music_note_rounded, key.trim()),
+      if (extras['track'] != null)
+        _chip(Icons.tag_rounded, '${_v(extras['track'])}'),
+      if (extras['disc'] != null)
+        _chip(Icons.album_rounded, '${_v(extras['disc'])}'),
+      if (genre != null && genre.trim().isNotEmpty)
+        _chip(Icons.category_rounded, genre.trim()),
+      if (server != null && server.trim().isNotEmpty)
+        _chip(Icons.dns_rounded, server.trim()),
+    ];
+
     return Scaffold(
-        backgroundColor: Color(0xFF3f3f3f),
-        appBar: AppBar(
-          title: Text(AppLocalizations.of(context).songInfoTitle),
+      backgroundColor: VelvetColors.bg,
+      extendBodyBehindAppBar: true,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        foregroundColor: VelvetColors.textPrimary,
+        title: Text(
+          l.songInfoTitle,
+          style: TextStyle(
+            color: VelvetColors.textPrimary,
+            fontSize: 17,
+            fontWeight: FontWeight.w600,
+          ),
         ),
-        body: SafeArea(
-            top: false,
-            child: Container(
-                // padding: EdgeInsets.all(20.0),
-                child: ListView(children: [
-          if (meta.albumArt != null) ...[Image.network(meta.albumArt!)],
-          Container(height: 20),
-          if (meta.title != null) ...[
-            Container(
-                padding: EdgeInsets.symmetric(horizontal: 20.0),
-                child: Text(meta.title!)),
+      ),
+      body: Stack(
+        children: [
+          // Blurred album-art backdrop, faded into the background.
+          if (art != null) ...[
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 400,
+              child: ClipRect(
+                child: ImageFiltered(
+                  imageFilter: ImageFilter.blur(
+                      sigmaX: 48, sigmaY: 48, tileMode: TileMode.decal),
+                  child: Image.network(
+                    art,
+                    fit: BoxFit.cover,
+                    alignment: Alignment.topCenter,
+                    errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                  ),
+                ),
+              ),
+            ),
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 400,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      VelvetColors.bg.withValues(alpha: 0.45),
+                      VelvetColors.bg,
+                    ],
+                  ),
+                ),
+              ),
+            ),
           ],
-          if (meta.artist != null) ...[
-            Container(
-                padding: EdgeInsets.symmetric(horizontal: 20.0),
-                child: Text(meta.artist!))
-          ],
-          if (meta.album != null) ...[
-            Container(
-                padding: EdgeInsets.symmetric(horizontal: 20.0),
-                child: Text(meta.album!)),
-          ],
-          if (meta.year != null) ...[
-            Container(
-                padding: EdgeInsets.symmetric(horizontal: 20.0),
-                child: Text(meta.year!.toString()))
-          ],
-          Container(height: 20),
-          if (path != null) ...[
-            Container(
-                padding: EdgeInsets.symmetric(horizontal: 20.0),
-                child: Text(path!))
-          ]
-        ]))));
+          // Content.
+          ListView(
+            padding: EdgeInsets.fromLTRB(24, mq.padding.top + kToolbarHeight + 12,
+                24, 28 + mq.padding.bottom),
+            children: [
+              // Hero cover.
+              Center(
+                child: Container(
+                  width: 224,
+                  height: 224,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(18),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.55),
+                        blurRadius: 36,
+                        offset: const Offset(0, 16),
+                      ),
+                    ],
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(18),
+                    child: art != null
+                        ? Image.network(
+                            art,
+                            fit: BoxFit.cover,
+                            errorBuilder: (_, __, ___) =>
+                                albumArtFallback(iconSize: 60),
+                          )
+                        : albumArtFallback(iconSize: 60),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 26),
+              // Title.
+              Text(
+                item.title.trim().isNotEmpty ? item.title : '—',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: VelvetColors.textPrimary,
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  height: 1.25,
+                ),
+              ),
+              if (item.artist != null && item.artist!.trim().isNotEmpty) ...[
+                const SizedBox(height: 7),
+                Text(
+                  item.artist!,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: VelvetColors.textSecondary,
+                    fontSize: 15.5,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+              if (subtitle.isNotEmpty) ...[
+                const SizedBox(height: 5),
+                Text(
+                  subtitle,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: VelvetColors.textTertiary,
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+              if (chips.isNotEmpty) ...[
+                const SizedBox(height: 18),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  alignment: WrapAlignment.center,
+                  children: chips,
+                ),
+              ],
+              if (path != null && path.trim().isNotEmpty) ...[
+                const SizedBox(height: 30),
+                _LocationCard(path: path),
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Render a numeric tag value without a trailing ".0" (servers send int or
+  // double); pass strings through unchanged.
+  static String _v(dynamic value) =>
+      value is num ? value.round().toString() : '$value';
+
+  Widget _chip(IconData icon, String text) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 7),
+      decoration: BoxDecoration(
+        color: VelvetColors.raised,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: VelvetColors.border),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: VelvetColors.primary),
+          const SizedBox(width: 6),
+          Text(
+            text,
+            style: TextStyle(
+              color: VelvetColors.textSecondary,
+              fontSize: 12.5,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The file-location row: a folder glyph, the (monospace) path, and a copy
+/// button that drops it on the clipboard.
+class _LocationCard extends StatelessWidget {
+  const _LocationCard({required this.path});
+
+  final String path;
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: VelvetColors.surface,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: VelvetColors.border),
+      ),
+      padding: const EdgeInsets.fromLTRB(14, 12, 6, 12),
+      child: Row(
+        children: [
+          Icon(Icons.folder_outlined,
+              size: 18, color: VelvetColors.textSecondary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              path,
+              style: TextStyle(
+                color: VelvetColors.textSecondary,
+                fontFamily: 'monospace',
+                fontSize: 12,
+                height: 1.45,
+              ),
+            ),
+          ),
+          IconButton(
+            icon: Icon(Icons.copy_rounded,
+                size: 18, color: VelvetColors.textTertiary),
+            tooltip: l.manageServerCopyPath,
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: path));
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                backgroundColor: VelvetColors.raised,
+                content: Text(l.manageServerPathCopied,
+                    style: TextStyle(color: VelvetColors.textPrimary)),
+              ));
+            },
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -229,12 +229,20 @@ class MetadataScreen extends StatelessWidget {
         children: [
           Icon(icon, size: 14, color: VelvetColors.primary),
           const SizedBox(width: 6),
-          Text(
-            text,
-            style: TextStyle(
-              color: VelvetColors.textSecondary,
-              fontSize: 12.5,
-              fontWeight: FontWeight.w600,
+          // Flexible + ellipsis so a long value (notably a multi-genre
+          // "Rock, Electronic, …" string) caps at the available width instead
+          // of overflowing the chip's Row. The Wrap gives each chip a bounded
+          // width, so Flexible resolves correctly here.
+          Flexible(
+            child: Text(
+              text,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: VelvetColors.textSecondary,
+                fontSize: 12.5,
+                fontWeight: FontWeight.w600,
+              ),
             ),
           ),
         ],

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -9,10 +9,10 @@ import '../theme/velvet_theme.dart';
 import '../util/media_format.dart';
 
 /// Song-info screen shown from the queue row's Info action: a blurred album-art
-/// backdrop, a hero cover, the title / artist / album·year, self-labelling
-/// metadata chips (length, BPM, key, track, disc, genre, source server), and
-/// the file location with a copy button. Reads straight off the [MediaItem], so
-/// every field the queue carries is surfaced — and only when present.
+/// backdrop, a hero cover, the title / artist / album·year, a track/disc line,
+/// self-labelling metadata chips (length, BPM, key, genre), and the file
+/// location with a copy button. Reads straight off the [MediaItem], so every
+/// field the queue carries is surfaced — and only when present.
 class MetadataScreen extends StatelessWidget {
   const MetadataScreen({Key? key, required this.item}) : super(key: key);
 
@@ -29,12 +29,17 @@ class MetadataScreen extends StatelessWidget {
     final year = extras['year'];
     final key = extras['musicalKey'] as String?;
     final genre = item.genre;
-    final server = extras['server'] as String?;
 
     final subtitle = <String>[
       if (item.album != null && item.album!.trim().isNotEmpty) item.album!.trim(),
       if (year != null && '$year'.isNotEmpty && '$year' != '0') '$year',
     ].join('   ·   ');
+
+    // Track / disc as a plain line under the album.
+    final trackDisc = <String>[
+      if (extras['track'] != null) 'track: ${_v(extras['track'])}',
+      if (extras['disc'] != null) 'disc: ${_v(extras['disc'])}',
+    ].join(', ');
 
     // Self-labelling chips (icon + value) — no extra translated strings, shown
     // only when the field is present.
@@ -45,14 +50,8 @@ class MetadataScreen extends StatelessWidget {
         _chip(Icons.speed_rounded, '${_v(extras['bpm'])} BPM'),
       if (key != null && key.trim().isNotEmpty)
         _chip(Icons.music_note_rounded, key.trim()),
-      if (extras['track'] != null)
-        _chip(Icons.tag_rounded, '${_v(extras['track'])}'),
-      if (extras['disc'] != null)
-        _chip(Icons.album_rounded, '${_v(extras['disc'])}'),
       if (genre != null && genre.trim().isNotEmpty)
         _chip(Icons.category_rounded, genre.trim()),
-      if (server != null && server.trim().isNotEmpty)
-        _chip(Icons.dns_rounded, server.trim()),
     ];
 
     return Scaffold(
@@ -178,6 +177,17 @@ class MetadataScreen extends StatelessWidget {
                   style: TextStyle(
                     color: VelvetColors.textTertiary,
                     fontSize: 13,
+                  ),
+                ),
+              ],
+              if (trackDisc.isNotEmpty) ...[
+                const SizedBox(height: 4),
+                Text(
+                  trackDisc,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: VelvetColors.textDim,
+                    fontSize: 12.5,
                   ),
                 ),
               ],

--- a/lib/screens/share_playlist_dialog.dart
+++ b/lib/screens/share_playlist_dialog.dart
@@ -10,7 +10,6 @@
 // expressed as a single share. We surface a clear blocker dialog
 // rather than silently dropping items.
 
-import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -288,13 +288,19 @@ class ApiManager {
           e['metadata']['album'],
           e['metadata']['title'],
           e['metadata']['track'],
-          e['metadata']['disc'],
+          // Server emits the disc field as `disk`; keep `disc` as a fallback
+          // for any server that uses the un-quirked name.
+          e['metadata']['disk'] ?? e['metadata']['disc'],
           e['metadata']['year'],
           e['metadata']['hash'],
           e['metadata']['rating'],
           e['metadata']['album-art'],
           bpm: e['metadata']['bpm'],
-          musicalKey: e['metadata']['musical-key']);
+          musicalKey: e['metadata']['musical-key'],
+          genres: (e['metadata']['genres'] as List?)
+                  ?.map((g) => g.toString())
+                  .toList() ??
+              const []);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -332,13 +338,19 @@ class ApiManager {
           e['metadata']['album'],
           e['metadata']['title'],
           e['metadata']['track'],
-          e['metadata']['disc'],
+          // Server emits the disc field as `disk`; keep `disc` as a fallback
+          // for any server that uses the un-quirked name.
+          e['metadata']['disk'] ?? e['metadata']['disc'],
           e['metadata']['year'],
           e['metadata']['hash'],
           e['metadata']['rating'],
           e['metadata']['album-art'],
           bpm: e['metadata']['bpm'],
-          musicalKey: e['metadata']['musical-key']);
+          musicalKey: e['metadata']['musical-key'],
+          genres: (e['metadata']['genres'] as List?)
+                  ?.map((g) => g.toString())
+                  .toList() ??
+              const []);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -374,13 +386,19 @@ class ApiManager {
           e['metadata']['album'],
           e['metadata']['title'],
           e['metadata']['track'],
-          e['metadata']['disc'],
+          // Server emits the disc field as `disk`; keep `disc` as a fallback
+          // for any server that uses the un-quirked name.
+          e['metadata']['disk'] ?? e['metadata']['disc'],
           e['metadata']['year'],
           e['metadata']['hash'],
           e['metadata']['rating'],
           e['metadata']['album-art'],
           bpm: e['metadata']['bpm'],
-          musicalKey: e['metadata']['musical-key']);
+          musicalKey: e['metadata']['musical-key'],
+          genres: (e['metadata']['genres'] as List?)
+                  ?.map((g) => g.toString())
+                  .toList() ??
+              const []);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -470,13 +488,19 @@ class ApiManager {
           e['metadata']['album'],
           e['metadata']['title'],
           e['metadata']['track'],
-          e['metadata']['disc'],
+          // Server emits the disc field as `disk`; keep `disc` as a fallback
+          // for any server that uses the un-quirked name.
+          e['metadata']['disk'] ?? e['metadata']['disc'],
           e['metadata']['year'],
           e['metadata']['hash'],
           e['metadata']['rating'],
           e['metadata']['album-art'],
           bpm: e['metadata']['bpm'],
-          musicalKey: e['metadata']['musical-key']);
+          musicalKey: e['metadata']['musical-key'],
+          genres: (e['metadata']['genres'] as List?)
+                  ?.map((g) => g.toString())
+                  .toList() ??
+              const []);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -556,7 +580,11 @@ class ApiManager {
             inner['rating'],
             inner['album-art'],
             bpm: inner['bpm'],
-            musicalKey: inner['musical-key']);
+            musicalKey: inner['musical-key'],
+            genres: (inner['genres'] as List?)
+                    ?.map((g) => g.toString())
+                    .toList() ??
+                const []);
       }
 
       newList.add(newItem);

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -283,24 +283,7 @@ class ApiManager {
 
     List<DisplayItem> newList = [];
     res.forEach((e) {
-      MusicMetadata m = new MusicMetadata(
-          e['metadata']['artist'],
-          e['metadata']['album'],
-          e['metadata']['title'],
-          e['metadata']['track'],
-          // Server emits the disc field as `disk`; keep `disc` as a fallback
-          // for any server that uses the un-quirked name.
-          e['metadata']['disk'] ?? e['metadata']['disc'],
-          e['metadata']['year'],
-          e['metadata']['hash'],
-          e['metadata']['rating'],
-          e['metadata']['album-art'],
-          bpm: e['metadata']['bpm'],
-          musicalKey: e['metadata']['musical-key'],
-          genres: (e['metadata']['genres'] as List?)
-                  ?.map((g) => g.toString())
-                  .toList() ??
-              const []);
+      MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -333,24 +316,7 @@ class ApiManager {
 
     List<DisplayItem> newList = [];
     res.forEach((e) {
-      MusicMetadata m = new MusicMetadata(
-          e['metadata']['artist'],
-          e['metadata']['album'],
-          e['metadata']['title'],
-          e['metadata']['track'],
-          // Server emits the disc field as `disk`; keep `disc` as a fallback
-          // for any server that uses the un-quirked name.
-          e['metadata']['disk'] ?? e['metadata']['disc'],
-          e['metadata']['year'],
-          e['metadata']['hash'],
-          e['metadata']['rating'],
-          e['metadata']['album-art'],
-          bpm: e['metadata']['bpm'],
-          musicalKey: e['metadata']['musical-key'],
-          genres: (e['metadata']['genres'] as List?)
-                  ?.map((g) => g.toString())
-                  .toList() ??
-              const []);
+      MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -381,24 +347,7 @@ class ApiManager {
 
     List<DisplayItem> newList = [];
     res.forEach((e) {
-      MusicMetadata m = new MusicMetadata(
-          e['metadata']['artist'],
-          e['metadata']['album'],
-          e['metadata']['title'],
-          e['metadata']['track'],
-          // Server emits the disc field as `disk`; keep `disc` as a fallback
-          // for any server that uses the un-quirked name.
-          e['metadata']['disk'] ?? e['metadata']['disc'],
-          e['metadata']['year'],
-          e['metadata']['hash'],
-          e['metadata']['rating'],
-          e['metadata']['album-art'],
-          bpm: e['metadata']['bpm'],
-          musicalKey: e['metadata']['musical-key'],
-          genres: (e['metadata']['genres'] as List?)
-                  ?.map((g) => g.toString())
-                  .toList() ??
-              const []);
+      MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -483,24 +432,7 @@ class ApiManager {
 
     List<DisplayItem> newList = [];
     res.forEach((e) {
-      MusicMetadata m = new MusicMetadata(
-          e['metadata']['artist'],
-          e['metadata']['album'],
-          e['metadata']['title'],
-          e['metadata']['track'],
-          // Server emits the disc field as `disk`; keep `disc` as a fallback
-          // for any server that uses the un-quirked name.
-          e['metadata']['disk'] ?? e['metadata']['disc'],
-          e['metadata']['year'],
-          e['metadata']['hash'],
-          e['metadata']['rating'],
-          e['metadata']['album-art'],
-          bpm: e['metadata']['bpm'],
-          musicalKey: e['metadata']['musical-key'],
-          genres: (e['metadata']['genres'] as List?)
-                  ?.map((g) => g.toString())
-                  .toList() ??
-              const []);
+      MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
 
       DisplayItem newItem = new DisplayItem(
           useThisServer,
@@ -565,26 +497,10 @@ class ApiManager {
       // pullMetadata=true was sent AND the file is in the library DB
       // (unscanned files still arrive without an inner metadata
       // object; we tolerate that and fall back to filename display).
-      // Field name quirk: server uses `disk`, not `disc`.
       final outer = e['metadata'];
       final inner = outer is Map ? outer['metadata'] : null;
       if (inner is Map) {
-        newItem.metadata = MusicMetadata(
-            inner['artist'],
-            inner['album'],
-            inner['title'],
-            inner['track'],
-            inner['disk'] ?? inner['disc'],
-            inner['year'],
-            inner['hash'] ?? '',
-            inner['rating'],
-            inner['album-art'],
-            bpm: inner['bpm'],
-            musicalKey: inner['musical-key'],
-            genres: (inner['genres'] as List?)
-                    ?.map((g) => g.toString())
-                    .toList() ??
-                const []);
+        newItem.metadata = MusicMetadata.fromServerMap(inner);
       }
 
       newList.add(newItem);

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -302,6 +302,7 @@ class BrowserManager {
 
   void dispose() {
     _migrationSub?.cancel();
+    _letterStripSub?.cancel();
     _browserStream.close();
     _browserLabel.close();
     _loading.close();

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -235,26 +235,11 @@ class ServerManager {
     }
 
     await writeServerFile();
-
-    // delete synced files
-    // if (removeSyncedFiles == true) {
-    //   _deleteServeDirectory(removeThisServer);
-    // }
   }
 
   Future<void> callAfterEditServer() async {
     _serverListStream.sink.add(serverList);
     await writeServerFile();
-  }
-
-  Future<void> _deleteServeDirectory(Server removedServer) async {
-    Directory? directory = await FileExplorer().getDownloadDir(
-        removedServer.storageMode, removedServer.storageBasePath);
-    if (directory != null) {
-      Directory dir = new Directory(path.join(
-          directory.path.toString(), "media/${removedServer.localname}"));
-      dir.delete(recursive: true);
-    }
   }
 
   void makeDefault(int i) {

--- a/lib/singletons/sleep_timer.dart
+++ b/lib/singletons/sleep_timer.dart
@@ -14,7 +14,6 @@ class SleepTimerManager {
   factory SleepTimerManager() => _instance;
 
   Timer? _ticker;
-  DateTime? _endsAt;
 
   // null = inactive. Non-null = remaining time, refreshed every second
   // so the picker sheet can show a live countdown.
@@ -28,7 +27,6 @@ class SleepTimerManager {
   void start(Duration d) {
     cancel();
     final ends = DateTime.now().add(d);
-    _endsAt = ends;
     _remaining.add(d);
     _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
       final left = ends.difference(DateTime.now());
@@ -43,14 +41,12 @@ class SleepTimerManager {
   void cancel() {
     _ticker?.cancel();
     _ticker = null;
-    _endsAt = null;
     _remaining.add(null);
   }
 
   void _fire() {
     _ticker?.cancel();
     _ticker = null;
-    _endsAt = null;
     _remaining.add(null);
     MediaManager().audioHandler.pause();
   }

--- a/lib/widgets/queue_list.dart
+++ b/lib/widgets/queue_list.dart
@@ -5,7 +5,6 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../l10n/app_localizations.dart';
-import '../objects/metadata.dart';
 import '../screens/metadata_screen.dart';
 import '../singletons/downloads.dart';
 import '../singletons/media.dart';
@@ -147,22 +146,10 @@ class QueueList extends StatelessWidget {
                     icon: Icons.info,
                     label: l.info,
                     onPressed: (context) {
-                      final m = MusicMetadata(
-                        item.artist,
-                        item.album,
-                        item.title,
-                        null,
-                        null,
-                        item.extras?['year'],
-                        'X',
-                        null,
-                        item.extras?['artUrl'],
-                      );
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (context) => MeteDataScreen(
-                              meta: m, path: item.extras?['path']),
+                          builder: (_) => MetadataScreen(item: item),
                         ),
                       );
                     },

--- a/lib/widgets/queue_list.dart
+++ b/lib/widgets/queue_list.dart
@@ -115,6 +115,19 @@ class QueueList extends StatelessWidget {
             final active = item == current;
             final downloaded = item.extras?['localPath'] != null;
 
+            // Remove this row from the queue. Re-resolves the row's CURRENT
+            // position at dismiss time: the build-time index can be stale if the
+            // queue shifted during the swipe (e.g. the playing track
+            // auto-advanced), so deleting by the stale index would remove the
+            // wrong item. -1 → already gone.
+            void removeItem() {
+              final live = MediaManager().audioHandler.queue.value;
+              final at = live.indexOf(item);
+              if (at >= 0) {
+                MediaManager().audioHandler.removeQueueItemAt(at);
+              }
+            }
+
             return Slidable(
               // Identity key: it follows the *item* across a reorder (an
               // index-based key is positional, so reordering would swap row
@@ -126,6 +139,10 @@ class QueueList extends StatelessWidget {
               startActionPane: ActionPane(
                 motion: const DrawerMotion(),
                 extentRatio: 0.18,
+                // Swiping right past the download action removes the track too,
+                // so a full swipe in EITHER direction dismisses (matching the
+                // end pane). Fixes "swiping right can't remove the song".
+                dismissible: DismissiblePane(onDismissed: removeItem),
                 children: [
                   SlidableAction(
                     backgroundColor: Colors.blueGrey,
@@ -143,19 +160,7 @@ class QueueList extends StatelessWidget {
               endActionPane: ActionPane(
                 motion: const DrawerMotion(),
                 extentRatio: 0.36,
-                dismissible: DismissiblePane(
-                  onDismissed: () {
-                    // Re-resolve the row's CURRENT position at dismiss time: the
-                    // build-time index can be stale if the queue shifted during
-                    // the swipe (e.g. the playing track auto-advanced), which
-                    // would otherwise delete the wrong item. -1 → already gone.
-                    final live = MediaManager().audioHandler.queue.value;
-                    final at = live.indexOf(item);
-                    if (at >= 0) {
-                      MediaManager().audioHandler.removeQueueItemAt(at);
-                    }
-                  },
-                ),
+                dismissible: DismissiblePane(onDismissed: removeItem),
                 children: [
                   SlidableAction(
                     backgroundColor: VelvetColors.raised,

--- a/lib/widgets/queue_list.dart
+++ b/lib/widgets/queue_list.dart
@@ -129,37 +129,16 @@ class QueueList extends StatelessWidget {
             }
 
             return Slidable(
-              // Identity key: it follows the *item* across a reorder (an
-              // index-based key is positional, so reordering would swap row
-              // content instead of animating items to new slots — the jank).
-              // Distinct MediaItem instances (the realistic duplicate-track
-              // case) get distinct keys, so this still avoids the duplicate-key
-              // assertion the index suffix originally guarded against.
+              // Identity key (also the ReorderableListView item key): follows
+              // the *item* across reorders; distinct MediaItem instances avoid a
+              // duplicate-key clash.
               key: ObjectKey(item),
+              // RIGHT swipe (or a grip tap, see _QueueRow) → Info.
               startActionPane: ActionPane(
                 motion: const DrawerMotion(),
-                extentRatio: 0.18,
-                // Swiping right past the download action removes the track too,
-                // so a full swipe in EITHER direction dismisses (matching the
-                // end pane). Fixes "swiping right can't remove the song".
-                dismissible: DismissiblePane(onDismissed: removeItem),
-                children: [
-                  SlidableAction(
-                    backgroundColor: Colors.blueGrey,
-                    icon: Icons.download,
-                    label: l.mainSync,
-                    onPressed: (_) {
-                      if (!downloaded) {
-                        DownloadManager().downloadOneFile(item.id,
-                            item.extras!['server'], item.extras!['path']);
-                      }
-                    },
-                  ),
-                ],
-              ),
-              endActionPane: ActionPane(
-                motion: const DrawerMotion(),
-                extentRatio: 0.36,
+                extentRatio: 0.25,
+                // A full right-swipe past Info also removes the track, so a full
+                // swipe in EITHER direction removes.
                 dismissible: DismissiblePane(onDismissed: removeItem),
                 children: [
                   SlidableAction(
@@ -187,6 +166,22 @@ class QueueList extends StatelessWidget {
                         ),
                       );
                     },
+                  ),
+                ],
+              ),
+              // LEFT swipe → Remove; a full left-swipe also removes (the
+              // DismissiblePane), so swipe-to-remove is back — on this side.
+              endActionPane: ActionPane(
+                motion: const DrawerMotion(),
+                extentRatio: 0.25,
+                dismissible: DismissiblePane(onDismissed: removeItem),
+                children: [
+                  SlidableAction(
+                    backgroundColor: Colors.red.shade700,
+                    foregroundColor: Colors.white,
+                    icon: Icons.delete_outline,
+                    label: l.mainRemove,
+                    onPressed: (_) => removeItem(),
                   ),
                 ],
               ),
@@ -321,15 +316,16 @@ class _QueueRow extends StatelessWidget {
                   color: VelvetColors.textTertiary,
                 ),
               ),
-              // Drag-to-reorder grip — a comfortable 44px touch target. The
-              // ReorderableDragStartListener starts the reorder; the inner
-              // tap-absorbing GestureDetector keeps a tap on the grip from also
-              // triggering row-play (the grip sits inside the row's tap area).
+              // Drag-to-reorder grip — a comfortable 44px touch target. DRAG it
+              // (ReorderableDragStartListener) to reorder, or TAP it to open the
+              // action drawer (the start/left pane). The GestureDetector also
+              // keeps the tap from falling through to the row's play-on-tap.
               ReorderableDragStartListener(
                 index: index,
                 child: GestureDetector(
                   behavior: HitTestBehavior.opaque,
-                  onTap: () {},
+                  // Tap → open the download/info drawer; drag → reorder.
+                  onTap: () => Slidable.of(context)?.openStartActionPane(),
                   child: SizedBox(
                     width: 44,
                     height: 44,

--- a/lib/widgets/queue_list.dart
+++ b/lib/widgets/queue_list.dart
@@ -115,13 +115,17 @@ class QueueList extends StatelessWidget {
             final downloaded = item.extras?['localPath'] != null;
 
             // Remove this row from the queue. Re-resolves the row's CURRENT
-            // position at dismiss time: the build-time index can be stale if the
-            // queue shifted during the swipe (e.g. the playing track
-            // auto-advanced), so deleting by the stale index would remove the
-            // wrong item. -1 → already gone.
+            // position at dismiss time by IDENTITY: the build-time index can be
+            // stale if the queue shifted during the swipe (e.g. the playing
+            // track auto-advanced). We match the exact MediaItem instance —
+            // not `indexOf`, whose `==` is id-only — so that when two entries
+            // share an id (e.g. the same playlist track loaded twice) we delete
+            // the row the user actually swiped, not its twin. The ObjectKey
+            // below guarantees every queue entry is a distinct instance.
+            // -1 → already gone.
             void removeItem() {
               final live = MediaManager().audioHandler.queue.value;
-              final at = live.indexOf(item);
+              final at = live.indexWhere((e) => identical(e, item));
               if (at >= 0) {
                 MediaManager().audioHandler.removeQueueItemAt(at);
               }


### PR DESCRIPTION
## Summary

A queue / now-playing UX pass, iterated and verified on-device. Two main threads — reworked **queue-row swipe actions** and a redesigned **song-info screen** that surfaces all available track metadata — plus the metadata plumbing to feed it, a pre-release audit, and an analyzer cleanup.

## Queue-row swipe actions

- **Right swipe → Info** pane; **left swipe → Remove** pane — one action per side.
- A **full swipe in either direction removes** the track (`DismissiblePane` on both panes).
- **Tap the drag grip** → opens the Info drawer; **drag it** → reorder.
- Drops the per-row **download** action (still available from the queue header's download-all).
- Removal matches the swiped row by **identity** (`indexWhere((e) => identical(e, item))`), so swiping one of two same-id entries — e.g. the same playlist track loaded twice — removes the row you actually swiped, while still re-resolving the live position to survive a mid-swipe queue shift.

### Red-flash fix

`removeQueueItemAt` updated the queue *after* telling the backend to drop the source, so the backend's new `currentIndex` got re-derived against the stale queue — briefly flashing the wrong row as now-playing (in the accent colour) before correcting. Fixed by updating the queue first, so it stays in sync with the emitted index (same root cause as the earlier reorder-flash fix).

## Song-info screen

- Redesigned: blurred album-art backdrop, hero cover, title / artist / **album · year**, a `track: x, disc: y` line, and a copyable file-location card.
- Reads straight off the `MediaItem`, so every field the queue carries is surfaced as a self-labelling chip — shown only when present: **length, BPM, musical key, genre**.
- Chip text ellipsizes instead of overflowing on long values (e.g. a multi-genre string).

## Metadata plumbing (genre + disc)

- **Genre** is now threaded end-to-end. The server emits per-track genre as a `genres` string array; it was previously dropped at every layer (no field on `MusicMetadata`, ignored at parse, never set on `MediaItem`). Added a `genres` list and surface it via `MediaItem.genre`.
- **Disc** fix: the server spells the field `disk`; four parse paths read `disc` and silently lost it (only file-explorer had the workaround). Now read `disk ?? disc` everywhere.
- Centralised all server wire-shape quirks (genres, `disk`/`disc`, kebab-case keys, null `hash`) in one **`MusicMetadata.fromServerMap()`** factory — collapsing 5 duplicated parse sites and converging the browse + AutoDJ `MediaItem` builders onto a shared `genreLabel`.

## Pre-release audit + cleanup

- Multi-angle review of the diff: fixed **2 real bugs** (the identity-removal and chip-overflow above), verified the rest clean (l10n complete, rename consistent, no persistence break).
- Cleared the **4 pre-existing analyzer warnings**: a leaked `_letterStripSub` subscription (now cancelled in `dispose`), a write-only `_endsAt` field, an unreferenced `_deleteServeDirectory()`, and an unused import. `flutter analyze lib/` now reports **no issues**.

## i18n

Adds a localized **"Remove"** string (`mainRemove`) across all 10 locales.

## Validation

- `flutter analyze lib/` → 0 issues
- `flutter build apk --debug` → passing
- Iterated and verified on-device (Android).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
