### PR TITLE
fix: queue active-highlight + track-change jank, and lock to portrait (supersedes #33)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,6 +42,7 @@
             android:exported="true"
             android:name=".MainActivity"
             android:launchMode="singleTop"
+            android:screenOrientation="portrait"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,11 @@ Future<void> main() async {
   // inherits a leftover immersive mode (e.g. the app was killed while the
   // Visualizer had the nav bar hidden) still comes up with the nav bar visible.
   SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+  // Lock to portrait: the player panel, queue, and browser layouts are designed
+  // for a tall aspect ratio and are unusable in landscape. Also pinned in the
+  // Android manifest (android:screenOrientation) so the launch splash can't
+  // flash sideways before Flutter starts.
+  SystemChrome.setPreferredOrientations(const [DeviceOrientation.portraitUp]);
   // Settings load must come before MediaManager.start() so the audio
   // handler's _init() can read persisted EQ state when it attaches the
   // AndroidEqualizer to the player.

--- a/lib/widgets/queue_list.dart
+++ b/lib/widgets/queue_list.dart
@@ -11,43 +11,25 @@ import '../singletons/media.dart';
 import '../theme/velvet_theme.dart';
 import '../util/media_format.dart';
 
-/// Combined snapshot of the queue, the index of the currently-playing slot,
-/// and whether playback is running — so a row can render the list, highlight
-/// the active track, and show a live EQ / paused badge over its art.
+/// Active-row state — which queue slot is playing, and whether it's playing —
+/// pushed down to each row (see [QueueList.build]) so a track advancing rebuilds
+/// only the two rows whose highlight flips, never the ReorderableListView /
+/// Slidable rows above them (which used to hitch the whole queue on every
+/// advance, because the active flag lived in the list-wide snapshot).
 ///
-/// The active row is keyed off [activeIndex] (the queue position, from
-/// PlaybackState.queueIndex) rather than by matching the playing MediaItem:
-/// MediaItem.== is id-based, so a queue that legitimately holds the same track
-/// id more than once would light up every matching row at once. A position is
-/// unambiguous.
-class _QueueSnapshot {
-  final List<MediaItem> queue;
-  final int? activeIndex;
-  final bool playing;
-  const _QueueSnapshot(this.queue, this.activeIndex, this.playing);
-}
-
-/// Memoised as a single broadcast subject (mirrors player_panel's _mediaPos):
-/// the queue list is rebuilt by the panel's drag AnimationController, so a fresh
-/// combineLatest per build would re-subscribe three handler streams every frame.
-/// One shared upstream subscription, replayed to each new listener so a freshly
-/// (re)mounted list paints the current queue immediately.
-final Stream<_QueueSnapshot> _queueStream = BehaviorSubject<_QueueSnapshot>()
-  ..addStream(Rx.combineLatest3<List<MediaItem>, int?, bool, _QueueSnapshot>(
-    MediaManager().audioHandler.queue,
-    // The playing queue *position* drives the active highlight (not the playing
-    // MediaItem — MediaItem.== is id-based, so a queue holding the same track id
-    // twice would light up every matching row). queueIndex updates off the same
-    // playbackEvent that drives mediaItem, so the highlight is just as prompt;
-    // distinct() so the position ticks below don't rebuild the queue.
-    MediaManager().audioHandler.playbackState.map((s) => s.queueIndex).distinct(),
-    // Only the play/pause flag from playbackState, distinct() — playbackState
-    // re-emits on every position tick (several times a second), and we don't
-    // want that rebuilding the whole reorderable queue (jank). The queue only
-    // cares whether playback is running, for the active-row EQ/pause badge.
-    MediaManager().audioHandler.playbackState.map((s) => s.playing).distinct(),
-    (q, activeIndex, playing) => _QueueSnapshot(q, activeIndex, playing),
-  ));
+/// queueIndex is the playing *position*, not the playing MediaItem: MediaItem.==
+/// is id-based, so a queue that legitimately holds the same track id more than
+/// once would light up every matching row at once. A position is unambiguous.
+///
+/// Memoised as a single broadcast subject + distinct() so the per-position-tick
+/// playbackState emissions (several a second) don't churn it.
+final BehaviorSubject<({int? index, bool playing})> _activeStream =
+    BehaviorSubject<({int? index, bool playing})>()
+      ..addStream(MediaManager()
+          .audioHandler
+          .playbackState
+          .map((s) => (index: s.queueIndex, playing: s.playing))
+          .distinct());
 
 Widget _artFallback() => albumArtFallback(iconSize: 20);
 
@@ -63,12 +45,15 @@ class QueueList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    return StreamBuilder<_QueueSnapshot>(
-      stream: _queueStream,
+    return StreamBuilder<List<MediaItem>>(
+      // The list depends ONLY on the queue, so a track advancing (which just
+      // moves the active highlight — handled per-row via _activeStream below)
+      // never rebuilds the ReorderableListView. queue is already a
+      // BehaviorSubject on the handler.
+      stream: MediaManager().audioHandler.queue,
+      initialData: MediaManager().audioHandler.queue.valueOrNull,
       builder: (context, snapshot) {
-        final queue = snapshot.data?.queue ?? const <MediaItem>[];
-        final activeIndex = snapshot.data?.activeIndex;
-        final playing = snapshot.data?.playing ?? false;
+        final queue = snapshot.data ?? const <MediaItem>[];
 
         if (queue.isEmpty) {
           return Center(
@@ -121,8 +106,18 @@ class QueueList extends StatelessWidget {
           },
           itemBuilder: (BuildContext context, int index) {
             final item = queue[index];
-            final active = index == activeIndex;
             final downloaded = item.extras?['localPath'] != null;
+
+            // This row's (active, playing) from the shared active-state stream,
+            // distinct() per row so only the two rows whose active flag actually
+            // flips rebuild on a track change (not the whole visible list).
+            ({bool active, bool playing}) rowState(
+                ({int? index, bool playing}) s) {
+              final on = s.index == index;
+              return (active: on, playing: on && s.playing);
+            }
+
+            final activeNow = _activeStream.valueOrNull;
 
             // Remove this row from the queue. Re-resolves the row's CURRENT
             // position at dismiss time by IDENTITY: the build-time index can be
@@ -186,16 +181,30 @@ class QueueList extends StatelessWidget {
                   ),
                 ],
               ),
-              child: _QueueRow(
-                item: item,
-                index: index,
-                active: active,
-                playing: playing,
-                downloaded: downloaded,
-                onTap: () {
-                  MediaManager().audioHandler.skipToQueueItem(index);
-                  MediaManager().audioHandler.play();
-                },
+              // RepaintBoundary so a highlight flip repaints only this row's
+              // layer — the panel wraps QueueList in one RepaintBoundary, so
+              // without this every advance would re-raster all visible rows.
+              child: RepaintBoundary(
+                child: StreamBuilder<({bool active, bool playing})>(
+                  initialData: activeNow == null
+                      ? (active: false, playing: false)
+                      : rowState(activeNow),
+                  stream: _activeStream.map(rowState).distinct(),
+                  builder: (context, snap) {
+                    final st = snap.data ?? (active: false, playing: false);
+                    return _QueueRow(
+                      item: item,
+                      index: index,
+                      active: st.active,
+                      playing: st.playing,
+                      downloaded: downloaded,
+                      onTap: () {
+                        MediaManager().audioHandler.skipToQueueItem(index);
+                        MediaManager().audioHandler.play();
+                      },
+                    );
+                  },
+                ),
               ),
             );
           },

--- a/lib/widgets/queue_list.dart
+++ b/lib/widgets/queue_list.dart
@@ -11,14 +11,20 @@ import '../singletons/media.dart';
 import '../theme/velvet_theme.dart';
 import '../util/media_format.dart';
 
-/// Combined snapshot of the queue, the currently-playing item, and whether
-/// playback is running — so a row can render the list, highlight the active
-/// track, and show a live EQ / paused badge over its art.
+/// Combined snapshot of the queue, the index of the currently-playing slot,
+/// and whether playback is running — so a row can render the list, highlight
+/// the active track, and show a live EQ / paused badge over its art.
+///
+/// The active row is keyed off [activeIndex] (the queue position, from
+/// PlaybackState.queueIndex) rather than by matching the playing MediaItem:
+/// MediaItem.== is id-based, so a queue that legitimately holds the same track
+/// id more than once would light up every matching row at once. A position is
+/// unambiguous.
 class _QueueSnapshot {
   final List<MediaItem> queue;
-  final MediaItem? current;
+  final int? activeIndex;
   final bool playing;
-  const _QueueSnapshot(this.queue, this.current, this.playing);
+  const _QueueSnapshot(this.queue, this.activeIndex, this.playing);
 }
 
 /// Memoised as a single broadcast subject (mirrors player_panel's _mediaPos):
@@ -27,16 +33,20 @@ class _QueueSnapshot {
 /// One shared upstream subscription, replayed to each new listener so a freshly
 /// (re)mounted list paints the current queue immediately.
 final Stream<_QueueSnapshot> _queueStream = BehaviorSubject<_QueueSnapshot>()
-  ..addStream(Rx.combineLatest3<List<MediaItem>, MediaItem?, bool,
-      _QueueSnapshot>(
+  ..addStream(Rx.combineLatest3<List<MediaItem>, int?, bool, _QueueSnapshot>(
     MediaManager().audioHandler.queue,
-    MediaManager().audioHandler.mediaItem,
+    // The playing queue *position* drives the active highlight (not the playing
+    // MediaItem — MediaItem.== is id-based, so a queue holding the same track id
+    // twice would light up every matching row). queueIndex updates off the same
+    // playbackEvent that drives mediaItem, so the highlight is just as prompt;
+    // distinct() so the position ticks below don't rebuild the queue.
+    MediaManager().audioHandler.playbackState.map((s) => s.queueIndex).distinct(),
     // Only the play/pause flag from playbackState, distinct() — playbackState
     // re-emits on every position tick (several times a second), and we don't
     // want that rebuilding the whole reorderable queue (jank). The queue only
     // cares whether playback is running, for the active-row EQ/pause badge.
     MediaManager().audioHandler.playbackState.map((s) => s.playing).distinct(),
-    (q, m, playing) => _QueueSnapshot(q, m, playing),
+    (q, activeIndex, playing) => _QueueSnapshot(q, activeIndex, playing),
   ));
 
 Widget _artFallback() => albumArtFallback(iconSize: 20);
@@ -57,7 +67,7 @@ class QueueList extends StatelessWidget {
       stream: _queueStream,
       builder: (context, snapshot) {
         final queue = snapshot.data?.queue ?? const <MediaItem>[];
-        final current = snapshot.data?.current;
+        final activeIndex = snapshot.data?.activeIndex;
         final playing = snapshot.data?.playing ?? false;
 
         if (queue.isEmpty) {
@@ -111,7 +121,7 @@ class QueueList extends StatelessWidget {
           },
           itemBuilder: (BuildContext context, int index) {
             final item = queue[index];
-            final active = item == current;
+            final active = index == activeIndex;
             final downloaded = item.extras?['localPath'] != null;
 
             // Remove this row from the queue. Re-resolves the row's CURRENT


### PR DESCRIPTION
## Summary

Three queue / UX fixes on top of the just-merged queue work, all verified on-device:

1. **Active-row highlight by position** (the #33 supersede)
2. **Track-change queue jank** eliminated
3. **App locked to portrait**

---

## 1. Active highlight by position (supersedes #33)

The "Up Next" active-row highlight + EQ/pause badge lit up **every** row that shared the playing track's id, not just the row actually playing — reachable when the queue legitimately holds the same track id more than once (e.g. a playlist that contains the same track twice). Root cause: `MediaItem.==` is **id-based**, and the active check used `item == current`.

Key the active row off the queue **position** instead: compare `index == queueIndex` (`PlaybackState.queueIndex`, set from the backend's `currentIndex` on the same `playbackEvent` that drives `mediaItem`, so it stays just as prompt but unambiguous).

> Supersedes #33, which fixed the same family of bug but had drifted out of sync with `master`: it was conflicting, its other two changes (`indexWhere(identical)` dismiss + `ObjectKey` key) already landed via #34, and as written it would have dropped the `distinct()` rebuild throttle.

## 2. Track-change queue jank

The active flag previously lived in a **list-wide** snapshot, so every track advance rebuilt the entire `ReorderableListView` + every `Slidable` row and re-rastered the whole queue layer — a visible hitch each time the playing song moved.

Decouple the list from the active index:
- The list `StreamBuilder` now depends **only on the queue**, so a track advance never rebuilds the `ReorderableListView`/`Slidable` rows.
- `active`/`playing` is pushed to each row via a **per-row `distinct()` stream** wrapped in a **`RepaintBoundary`**, so a track change rebuilds + repaints only the **two** rows whose highlight flips.

Safe because `QueueList` is the panel's `AnimatedBuilder` `child` (built once, not per drag frame), so the per-row streams don't churn during a drag.

## 3. Lock to portrait

The player panel, queue, and browser layouts are built for a tall aspect ratio and are unusable in landscape. Pin portrait two ways:
- `SystemChrome.setPreferredOrientations([portraitUp])` in `main()` (idiomatic Flutter lock; also covers iOS).
- `android:screenOrientation="portrait"` on `MainActivity` (locks the native activity from launch, so the splash can't appear sideways).

---

## Validation

- `flutter analyze lib/` → no issues; debug APK builds.
- Verified on a device: duplicate-id rows highlight only the playing copy; the queue stays smooth as the playing song advances; the app holds portrait across panel / queue / browser / visualizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
