### PR TITLE
refactor: share renderer-backend queue index math via EmulatedPlaylistBackend

### DIFF
--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -1,18 +1,17 @@
 import 'dart:async';
 import 'dart:io' show Directory, File;
-import 'dart:math' show Random;
 
 import 'package:audio_service/audio_service.dart' show MediaItem;
 import 'package:flutter_chrome_cast/flutter_chrome_cast.dart';
-import 'package:just_audio/just_audio.dart' show AndroidEqualizer;
+import 'package:meta/meta.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:rxdart/rxdart.dart';
 
 import '../native/visualizer_bridge.dart';
 import '../singletons/cast_manager.dart';
 import '../singletons/settings.dart';
 import 'cast_art.dart';
 import 'cast_log.dart';
+import 'emulated_playlist_backend.dart';
 import 'local_media_server.dart';
 import 'playback_backend.dart';
 import 'visualizer_cast_config.dart';
@@ -20,13 +19,15 @@ import 'visualizer_cast_config.dart';
 /// [PlaybackBackend] that plays through a Chromecast / Google Cast device via
 /// the native Cast SDK (flutter_chrome_cast).
 ///
-/// Like the DLNA backend it emulates just_audio's playlist (the receiver plays
-/// one track at a time): it owns the source list + index, loads the current
-/// track with the Remote Media Client, and advances when the receiver reports
-/// IDLE with idleReason FINISHED. Unlike DLNA, the Cast SDK pushes position +
-/// media-status via streams (no polling), and loadMedia takes autoPlay +
-/// playPosition so resume-at-position is native.
-class ChromecastPlaybackBackend implements PlaybackBackend {
+/// Like the DLNA backend it emulates just_audio's playlist through
+/// [EmulatedPlaylistBackend] (the receiver plays one track at a time): the base
+/// owns the source list + index + the add/remove/move/clear arithmetic and the
+/// broadcast streams; this subclass loads the current track with the Remote
+/// Media Client and advances when the receiver reports IDLE with idleReason
+/// FINISHED. Unlike DLNA, the Cast SDK pushes position + media-status via
+/// streams (no polling), and loadMedia takes autoPlay + playPosition so
+/// resume-at-position is native.
+class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   ChromecastPlaybackBackend({required String deviceId, bool visualizer = false})
       : _deviceId = deviceId,
         _visualizer = visualizer;
@@ -36,19 +37,15 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
   // the track's audio (see _resolveVisualizerUri). Only the per-track media
   // construction differs — the playlist/index/session/transport logic is shared.
   final bool _visualizer;
-  final Random _rng = Random();
 
   final _client = GoogleCastRemoteMediaClient.instance;
   final _sessions = GoogleCastSessionManager.instance;
 
-  List<MediaItem> _items = <MediaItem>[];
-  int _index = -1;
-  int _loadedIndex = -1;
   int _loadCounter = 0; // monotonic; names each visualizer transcode's subdir
   String? _currentVizDir; // subdir the active visualizer transcode writes to
   bool _firstVizLoad = true;
   int _visualizerFailures = 0; // consecutive transcode failures → audio fallback
-  // Bumped on every _loadIndex; an in-flight load re-checks it after each await
+  // Bumped on every loadIndex; an in-flight load re-checks it after each await
   // and bails if a newer load superseded it. The visualizer warm-up is seconds
   // long, so a Next/seek during it would otherwise interleave two loads and
   // leave the wrong track casting.
@@ -59,65 +56,26 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
   static const int _kMaxVisualizerFailures = 2;
   // Readiness poll: 20 × 500 ms = 10 s for the first segments before giving up.
   static const int _kReadyPollAttempts = 20;
-  bool _shuffle = false;
-  bool _repeatAll = false;
-  bool _playing = false;
+
   bool _advancing = false;
   bool _sessionStarted = false;
-  Duration _position = Duration.zero;
-  Duration? _duration;
-  BackendProcessingState _state = BackendProcessingState.idle;
 
   StreamSubscription<GoggleCastMediaStatus?>? _statusSub;
   StreamSubscription<Duration>? _positionSub;
   StreamSubscription<dynamic>? _sessionSub;
 
-  final BehaviorSubject<int?> _indexSubject = BehaviorSubject<int?>.seeded(null);
-  final BehaviorSubject<Duration> _positionSubject =
-      BehaviorSubject<Duration>.seeded(Duration.zero);
-  final BehaviorSubject<Duration?> _durationSubject =
-      BehaviorSubject<Duration?>.seeded(null);
-  final BehaviorSubject<BackendProcessingState> _stateSubject =
-      BehaviorSubject<BackendProcessingState>.seeded(
-          BackendProcessingState.idle);
-  final StreamController<void> _changeController =
-      StreamController<void>.broadcast();
-  // Emits when the Cast session drops unexpectedly mid-cast; the handler falls
-  // back to local. _disposing suppresses our own teardown; _lostFired makes it
-  // one-shot (disconnecting → disconnected would otherwise emit twice).
-  final PublishSubject<String> _rendererLost = PublishSubject<String>();
+  // Guards the renderer-lost emit. _disposing suppresses our own teardown;
+  // _lostFired makes it one-shot (disconnecting → disconnected would otherwise
+  // emit twice).
   bool _disposing = false;
   bool _lostFired = false;
-
-  // isClosed-guarded emitters so a late async callback after dispose() can't
-  // add to a closed subject.
-  void _emitIndex(int? v) {
-    if (!_indexSubject.isClosed) _indexSubject.add(v);
-  }
-
-  void _emitPos(Duration v) {
-    if (!_positionSubject.isClosed) _positionSubject.add(v);
-  }
-
-  void _emitDur(Duration? v) {
-    if (!_durationSubject.isClosed) _durationSubject.add(v);
-  }
-
-  void _change() {
-    if (!_changeController.isClosed) _changeController.add(null);
-  }
-
-  void _setState(BackendProcessingState s) {
-    _state = s;
-    if (!_stateSubject.isClosed) _stateSubject.add(s);
-  }
 
   void _ensureListeners() {
     _statusSub ??= _client.mediaStatusStream.listen(_onStatus);
     _positionSub ??= _client.playerPositionStream.listen((pos) {
-      _position = pos;
-      _emitPos(pos);
-      _change();
+      position = pos;
+      emitPos(pos);
+      change();
     });
     // Detect an unexpected session drop (TV off, Wi-Fi lost). Listeners attach
     // only after _ensureSession connected (_sessionStarted), so a transition to
@@ -128,10 +86,8 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
           !_lostFired &&
           !_sessions.hasConnectedSession) {
         _lostFired = true;
-        if (!_rendererLost.isClosed) {
-          _rendererLost
-              .add('Lost connection to the cast device — back on this phone');
-        }
+        emitRendererLost(
+            'Lost connection to the cast device — back on this phone');
       }
     });
   }
@@ -140,24 +96,24 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
     if (status == null) return;
     final d = status.mediaInformation?.duration;
     if (d != null) {
-      _duration = d;
-      _emitDur(d);
+      duration = d;
+      emitDur(d);
     }
     switch (status.playerState) {
       case CastMediaPlayerState.playing:
-        _playing = true;
+        playing = true;
         _advancing = false;
-        _setState(BackendProcessingState.ready);
+        setProcessingState(BackendProcessingState.ready);
         break;
       case CastMediaPlayerState.paused:
-        _playing = false;
-        _setState(BackendProcessingState.ready);
+        playing = false;
+        setProcessingState(BackendProcessingState.ready);
         break;
       case CastMediaPlayerState.buffering:
-        _setState(BackendProcessingState.buffering);
+        setProcessingState(BackendProcessingState.buffering);
         break;
       case CastMediaPlayerState.loading:
-        _setState(BackendProcessingState.loading);
+        setProcessingState(BackendProcessingState.loading);
         break;
       case CastMediaPlayerState.idle:
         // Only a natural FINISH means end-of-track; cancelled/interrupted are
@@ -169,19 +125,19 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
       case CastMediaPlayerState.unknown:
         break;
     }
-    _change();
+    change();
   }
 
   Future<void> _onTrackEnded() async {
     if (_advancing) return;
     _advancing = true;
-    final n = _nextIndex();
+    final n = nextIndex();
     if (n != null) {
-      await _loadIndex(n, play: true);
+      await loadIndex(n, play: true);
     } else {
-      _playing = false;
+      playing = false;
       _advancing = false;
-      _setState(BackendProcessingState.completed);
+      setProcessingState(BackendProcessingState.completed);
     }
   }
 
@@ -210,92 +166,6 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
       }
     }
     _sessionStarted = true;
-  }
-
-  // ── Source list ──
-  @override
-  Future<void> setSources(List<MediaItem> items) async {
-    _items = List<MediaItem>.from(items);
-    _index = _items.isEmpty ? -1 : 0;
-    _loadedIndex = -1;
-    _emitIndex(_index < 0 ? null : _index);
-    _setState(_items.isEmpty
-        ? BackendProcessingState.idle
-        : BackendProcessingState.ready);
-  }
-
-  @override
-  Future<void> addSource(MediaItem item) async {
-    _items.add(item);
-    if (_index == -1) {
-      _index = 0;
-      _emitIndex(0);
-      _setState(BackendProcessingState.ready);
-    }
-  }
-
-  @override
-  Future<void> removeSourceAt(int index) async {
-    if (index < 0 || index >= _items.length) return;
-    _items.removeAt(index);
-    if (_items.isEmpty) {
-      _index = -1;
-      _loadedIndex = -1;
-      _emitIndex(null);
-      await stop();
-      return;
-    }
-    if (index < _index) {
-      _index--;
-      _loadedIndex--;
-      _emitIndex(_index);
-    } else if (index == _index) {
-      // Removed the now-playing track — advance to whatever now occupies this
-      // slot (the former next track), clamping if it was the last.
-      if (_index >= _items.length) _index = _items.length - 1;
-      _loadedIndex = -1;
-      _emitIndex(_index);
-      await _loadIndex(_index, play: _playing);
-    }
-  }
-
-  @override
-  Future<void> moveSource(int from, int to) async {
-    if (from < 0 ||
-        from >= _items.length ||
-        to < 0 ||
-        to >= _items.length ||
-        from == to) {
-      return;
-    }
-    // Single-item-push model: reorder the internal list and shift the current /
-    // loaded pointers so they follow the still-playing track to its new slot.
-    // The renderer keeps playing that track — only the upcoming order changes,
-    // so nothing is reloaded; the next advance just loads the new next item.
-    final item = _items.removeAt(from);
-    _items.insert(to, item);
-    if (_index == from) {
-      _index = to;
-    } else if (_index >= 0) {
-      if (from < _index) _index--;
-      if (to <= _index) _index++;
-    }
-    if (_loadedIndex == from) {
-      _loadedIndex = to;
-    } else if (_loadedIndex >= 0) {
-      if (from < _loadedIndex) _loadedIndex--;
-      if (to <= _loadedIndex) _loadedIndex++;
-    }
-    if (_index >= 0) _emitIndex(_index);
-  }
-
-  @override
-  Future<void> clearSources() async {
-    _items = <MediaItem>[];
-    _index = -1;
-    _loadedIndex = -1;
-    _emitIndex(null);
-    await stop();
   }
 
   // ── Media construction ──
@@ -331,17 +201,18 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
         releaseDate: releaseDateFor(item),
         images: art != null ? [GoogleCastImage(url: Uri.parse(art))] : null,
       ),
-
     );
   }
 
-  Future<void> _loadIndex(int index,
+  @protected
+  @override
+  Future<void> loadIndex(int target,
       {required bool play, Duration startAt = Duration.zero}) async {
-    if (index < 0 || index >= _items.length) return;
+    if (target < 0 || target >= items.length) return;
     final gen = ++_loadGen; // this load owns the pipeline until a newer one starts
-    _index = index;
-    _emitIndex(index);
-    _setState(BackendProcessingState.loading);
+    index = target;
+    emitIndex(target);
+    setProcessingState(BackendProcessingState.loading);
     try {
       await _ensureSession();
       if (gen != _loadGen) return; // superseded by a newer load
@@ -354,9 +225,9 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
           // A freshly-started live transcode begins at 0; seeking into it isn't
           // possible, so startAt is ignored for the visualizer.
           final url =
-              (await _resolveVisualizerUri(_items[index], gen)).toString();
+              (await _resolveVisualizerUri(items[target], gen)).toString();
           if (gen != _loadGen) return; // superseded during the warm-up
-          await _client.loadMedia(_visualizerMediaInfo(_items[index], url),
+          await _client.loadMedia(_visualizerMediaInfo(items[target], url),
               autoPlay: play);
           servedVisualizer = true;
           _visualizerFailures = 0; // recovered — a transient failure won't stick
@@ -373,28 +244,28 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
           _deleteDir(_currentVizDir);
           CastManager().reportCastInfo(
               "Couldn't start the visualizer — casting audio to the TV");
-          final url = (await _resolveUri(_items[index])).toString();
+          final url = (await _resolveUri(items[target])).toString();
           if (gen != _loadGen) return;
-          await _client.loadMedia(_mediaInfo(_items[index], url),
+          await _client.loadMedia(_mediaInfo(items[target], url),
               autoPlay: play, playPosition: startAt);
         }
       } else {
-        final url = (await _resolveUri(_items[index])).toString();
+        final url = (await _resolveUri(items[target])).toString();
         if (gen != _loadGen) return;
-        await _client.loadMedia(_mediaInfo(_items[index], url),
+        await _client.loadMedia(_mediaInfo(items[target], url),
             autoPlay: play, playPosition: startAt);
       }
       if (gen != _loadGen) return;
-      _loadedIndex = index;
-      _playing = play;
-      _duration = _items[index].duration;
-      _emitDur(_duration);
-      _position = servedVisualizer ? Duration.zero : startAt;
-      _emitPos(_position);
+      loadedIndex = target;
+      playing = play;
+      duration = items[target].duration;
+      emitDur(duration);
+      position = servedVisualizer ? Duration.zero : startAt;
+      emitPos(position);
     } catch (e) {
       castLog('Chromecast load failed', error: e);
     }
-    _change();
+    change();
   }
 
   // ── Visualizer cast ──
@@ -402,7 +273,7 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
   // reacting to it (rendered on-device), serve it from LocalMediaServer, and
   // return the playlist URL for the receiver. One transcode at a time — each
   // call cancels the previous track's first, so track-change (which routes
-  // through _loadIndex) restarts the pipeline cleanly. Blocks until a couple of
+  // through loadIndex) restarts the pipeline cleanly. Blocks until a couple of
   // segments exist so the receiver never loads an empty playlist.
   Future<Uri> _resolveVisualizerUri(MediaItem item, int gen) async {
     _loadCounter++;
@@ -501,16 +372,16 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
   // ── Transport ──
   @override
   Future<void> play() async {
-    if (_index < 0) return;
-    if (_loadedIndex != _index) {
-      await _loadIndex(_index, play: true);
+    if (index < 0) return;
+    if (loadedIndex != index) {
+      await loadIndex(index, play: true);
       return;
     }
     try {
       await _client.play();
     } catch (_) {}
-    _playing = true;
-    _change();
+    playing = true;
+    change();
   }
 
   @override
@@ -518,8 +389,8 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
     try {
       await _client.pause();
     } catch (_) {}
-    _playing = false;
-    _change();
+    playing = false;
+    change();
   }
 
   @override
@@ -527,65 +398,43 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
     try {
       await _client.stop();
     } catch (_) {}
-    _playing = false;
-    _setState(BackendProcessingState.idle);
-    _change();
+    playing = false;
+    setProcessingState(BackendProcessingState.idle);
+    change();
   }
+
+  @protected
+  @override
+  Future<void> stopForEmptyList() => stop();
 
   @override
   Future<void> seek(Duration position, {int? index, bool? play}) async {
-    final target = index ?? _index;
-    if (target >= 0 && target != _loadedIndex) {
-      await _loadIndex(target, play: play ?? _playing, startAt: position);
+    final target = index ?? this.index;
+    if (target >= 0 && target != loadedIndex) {
+      await loadIndex(target, play: play ?? playing, startAt: position);
       return;
     }
     try {
       await _client.seek(GoogleCastMediaSeekOption(position: position));
     } catch (_) {}
-    _position = position;
-    _emitPos(position);
-    _change();
+    this.position = position;
+    emitPos(position);
+    change();
   }
 
   @override
   Future<void> seekToNext() async {
-    final n = _nextIndex();
-    if (n != null) await _loadIndex(n, play: _playing);
+    final n = nextIndex();
+    if (n != null) await loadIndex(n, play: playing);
   }
 
   @override
   Future<void> seekToPrevious() async {
-    if (_index > 0) {
-      await _loadIndex(_index - 1, play: _playing);
+    if (index > 0) {
+      await loadIndex(index - 1, play: playing);
     } else {
       await seek(Duration.zero);
     }
-  }
-
-  int? _nextIndex() {
-    if (_items.isEmpty) return null;
-    if (_shuffle && _items.length > 1) {
-      int n;
-      do {
-        n = _rng.nextInt(_items.length);
-      } while (n == _index);
-      return n;
-    }
-    if (_index + 1 < _items.length) return _index + 1;
-    if (_repeatAll) return 0;
-    return null;
-  }
-
-  @override
-  Future<void> setShuffleEnabled(bool enabled) async {
-    _shuffle = enabled;
-    _change();
-  }
-
-  @override
-  Future<void> setRepeatAll(bool enabled) async {
-    _repeatAll = enabled;
-    _change();
   }
 
   @override
@@ -595,52 +444,9 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
     } catch (_) {}
   }
 
-  // ── Synchronous state ──
+  @protected
   @override
-  bool get playing => _playing;
-  @override
-  bool get shuffleEnabled => _shuffle;
-  @override
-  bool get repeatAll => _repeatAll;
-  @override
-  Duration get position => _position;
-  @override
-  Duration get bufferedPosition => _position;
-  @override
-  double get speed => 1.0;
-  @override
-  Duration? get duration => _duration;
-  @override
-  int? get currentIndex => _index < 0 ? null : _index;
-  @override
-  BackendProcessingState get processingState => _state;
-
-  // ── Streams ──
-  @override
-  Stream<int?> get currentIndexStream => _indexSubject.stream;
-  @override
-  Stream<Duration> get positionStream => _positionSubject.stream;
-  @override
-  Stream<Duration?> get durationStream => _durationSubject.stream;
-  @override
-  Stream<BackendProcessingState> get processingStateStream =>
-      _stateSubject.stream;
-  @override
-  Stream<void> get changeStream => _changeController.stream;
-
-  @override
-  Stream<String> get rendererLostStream => _rendererLost.stream;
-
-  // ── Local-only capabilities (N/A while casting) ──
-  @override
-  bool get supportsEqualizer => false;
-  @override
-  AndroidEqualizer? get equalizer => null;
-  @override
-  int? get androidAudioSessionId => null;
-
-  @override
-  Future<void> dispose() async {
+  Future<void> disposeRenderer() async {
     _disposing = true;
     if (_visualizer) {
       // Stop the off-screen transcode so it isn't left encoding after we switch
@@ -656,11 +462,5 @@ class ChromecastPlaybackBackend implements PlaybackBackend {
     try {
       await _sessions.endSessionAndStopCasting();
     } catch (_) {}
-    await _indexSubject.close();
-    await _positionSubject.close();
-    await _durationSubject.close();
-    await _stateSubject.close();
-    await _changeController.close();
-    await _rendererLost.close();
   }
 }

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -1,16 +1,15 @@
 import 'dart:async';
 import 'dart:io' show File;
-import 'dart:math' show Random;
 
 import 'package:audio_service/audio_service.dart' show MediaItem;
-import 'package:just_audio/just_audio.dart' show AndroidEqualizer;
 // Hide media_cast_dlna's own MediaItem — we use audio_service's MediaItem for
 // queue items and only need the plugin's control/metadata types here.
 import 'package:media_cast_dlna/media_cast_dlna.dart' hide MediaItem;
-import 'package:rxdart/rxdart.dart';
+import 'package:meta/meta.dart';
 
 import 'cast_art.dart';
 import 'cast_log.dart';
+import 'emulated_playlist_backend.dart';
 import 'local_media_server.dart';
 import 'playback_backend.dart';
 
@@ -18,37 +17,28 @@ import 'playback_backend.dart';
 /// speaker) via the native `media_cast_dlna` plugin.
 ///
 /// A DLNA renderer plays ONE track at a time, so this emulates just_audio's
-/// playlist: it owns the source list + current index, pushes the current track
-/// with `setMediaUri`, and advances to the next when the renderer reports it
-/// has STOPPED near the end. Position/duration/state are polled ~1 Hz via
-/// `getPlaybackInfo` and re-broadcast through the same streams the
-/// AudioPlayerHandler already consumes — so the queue, Auto-DJ and now-playing
-/// UI keep working unchanged while casting.
+/// playlist through [EmulatedPlaylistBackend]: the base owns the source list +
+/// current index and the add/remove/move/clear arithmetic; this subclass pushes
+/// the current track with `setMediaUri`, polls position/duration/state ~1 Hz via
+/// `getPlaybackInfo`, and advances to the next track when the renderer reports
+/// it has STOPPED near the end. Position/duration/state are re-broadcast through
+/// the base's streams (the same ones the AudioPlayerHandler already consumes) —
+/// so the queue, Auto-DJ and now-playing UI keep working unchanged while
+/// casting.
 ///
-/// Shuffle/repeat are emulated here (just_audio handles them natively for the
-/// local backend); the implementation is intentionally simple for a first cut.
-class DlnaPlaybackBackend implements PlaybackBackend {
+/// Shuffle/repeat are emulated by the base (just_audio handles them natively for
+/// the local backend).
+class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
   DlnaPlaybackBackend({required String udn, MediaCastDlnaApi? api})
       : _udn = DeviceUdn(value: udn),
         _api = api ?? MediaCastDlnaApi();
 
   final MediaCastDlnaApi _api;
   final DeviceUdn _udn;
-  final Random _rng = Random();
 
-  List<MediaItem> _items = <MediaItem>[];
-  int _index = -1; // logical current index into _items
-  int _loadedIndex = -1; // index actually pushed to the renderer
-  bool _shuffle = false;
-  bool _repeatAll = false;
-
-  bool _playing = false;
   bool _advancing = false; // guards against double-advance while a track loads
   bool _confirmedPlaying = false; // renderer reached PLAYING for the current track
   bool _reachedNearEnd = false; // position reached end-of-track while playing
-  Duration _position = Duration.zero;
-  Duration? _duration;
-  BackendProcessingState _state = BackendProcessingState.idle;
 
   Timer? _pollTimer;
   bool _polling = false;
@@ -58,135 +48,6 @@ class DlnaPlaybackBackend implements PlaybackBackend {
   // fallback once it crosses _kMaxPollFailures (so a single Wi-Fi blip doesn't).
   int _pollFailures = 0;
   static const int _kMaxPollFailures = 4;
-
-  final BehaviorSubject<int?> _indexSubject = BehaviorSubject<int?>.seeded(null);
-  final BehaviorSubject<Duration> _positionSubject =
-      BehaviorSubject<Duration>.seeded(Duration.zero);
-  final BehaviorSubject<Duration?> _durationSubject =
-      BehaviorSubject<Duration?>.seeded(null);
-  final BehaviorSubject<BackendProcessingState> _stateSubject =
-      BehaviorSubject<BackendProcessingState>.seeded(
-          BackendProcessingState.idle);
-  final StreamController<void> _changeController =
-      StreamController<void>.broadcast();
-  // Emits when the renderer is lost mid-cast (see _poll); the handler listens
-  // and falls back to local playback.
-  final PublishSubject<String> _rendererLost = PublishSubject<String>();
-
-  void _change() {
-    if (!_changeController.isClosed) _changeController.add(null);
-  }
-
-  void _setState(BackendProcessingState s) {
-    _state = s;
-    if (!_stateSubject.isClosed) _stateSubject.add(s);
-  }
-
-  // isClosed-guarded emitters: an in-flight poll / auto-advance can complete
-  // after dispose() has closed the subjects (we switched away mid-operation),
-  // and adding to a closed subject throws. Mirrors the Chromecast backend.
-  void _emitIndex(int? v) {
-    final s = _indexSubject;
-    if (!s.isClosed) s.add(v);
-  }
-
-  void _emitPos(Duration v) {
-    final s = _positionSubject;
-    if (!s.isClosed) s.add(v);
-  }
-
-  void _emitDur(Duration? v) {
-    final s = _durationSubject;
-    if (!s.isClosed) s.add(v);
-  }
-
-  // ── Source list (mirrors just_audio's playlist API) ──
-  @override
-  Future<void> setSources(List<MediaItem> items) async {
-    _items = List<MediaItem>.from(items);
-    _index = _items.isEmpty ? -1 : 0;
-    _loadedIndex = -1;
-    _emitIndex(_index < 0 ? null : _index);
-    _setState(_items.isEmpty
-        ? BackendProcessingState.idle
-        : BackendProcessingState.ready);
-  }
-
-  @override
-  Future<void> addSource(MediaItem item) async {
-    _items.add(item);
-    if (_index == -1) {
-      _index = 0;
-      _emitIndex(0);
-      _setState(BackendProcessingState.ready);
-    }
-  }
-
-  @override
-  Future<void> removeSourceAt(int index) async {
-    if (index < 0 || index >= _items.length) return;
-    _items.removeAt(index);
-    if (_items.isEmpty) {
-      _index = -1;
-      _loadedIndex = -1;
-      _emitIndex(null);
-      await _stopRenderer();
-      _setState(BackendProcessingState.idle);
-      return;
-    }
-    if (index < _index) {
-      _index--;
-      _loadedIndex--;
-      _emitIndex(_index);
-    } else if (index == _index) {
-      // Removed the now-playing track — advance to whatever now occupies this
-      // slot (the former next track), clamping if it was the last.
-      if (_index >= _items.length) _index = _items.length - 1;
-      _loadedIndex = -1;
-      _emitIndex(_index);
-      await _loadIndex(_index, play: _playing);
-    }
-  }
-
-  @override
-  Future<void> moveSource(int from, int to) async {
-    if (from < 0 ||
-        from >= _items.length ||
-        to < 0 ||
-        to >= _items.length ||
-        from == to) {
-      return;
-    }
-    // Single-item-push model: reorder the internal list and shift the current /
-    // loaded pointers so they follow the still-playing track to its new slot.
-    // The renderer keeps playing that track — only the upcoming order changes,
-    // so nothing is reloaded; the next advance just loads the new next item.
-    final item = _items.removeAt(from);
-    _items.insert(to, item);
-    if (_index == from) {
-      _index = to;
-    } else if (_index >= 0) {
-      if (from < _index) _index--;
-      if (to <= _index) _index++;
-    }
-    if (_loadedIndex == from) {
-      _loadedIndex = to;
-    } else if (_loadedIndex >= 0) {
-      if (from < _loadedIndex) _loadedIndex--;
-      if (to <= _loadedIndex) _loadedIndex++;
-    }
-    if (_index >= 0) _emitIndex(_index);
-  }
-
-  @override
-  Future<void> clearSources() async {
-    _items = <MediaItem>[];
-    _index = -1;
-    _loadedIndex = -1;
-    _emitIndex(null);
-    await _stopRenderer();
-    _setState(BackendProcessingState.idle);
-  }
 
   // ── Transport ──
   // DLNA renderers fetch the URL themselves. A network id (server URL) is
@@ -218,48 +79,50 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     );
   }
 
-  Future<void> _loadIndex(int index, {required bool play}) async {
-    if (index < 0 || index >= _items.length) return;
-    _index = index;
-    _emitIndex(index);
-    final item = _items[index];
+  @protected
+  @override
+  Future<void> loadIndex(int target, {required bool play}) async {
+    if (target < 0 || target >= items.length) return;
+    index = target;
+    emitIndex(target);
+    final item = items[target];
     _confirmedPlaying = false;
     _reachedNearEnd = false;
-    _setState(BackendProcessingState.loading);
+    setProcessingState(BackendProcessingState.loading);
     try {
       final uri = await _resolveUri(item);
       await _api.setMediaUri(_udn, Url(value: uri.toString()), _metaFor(item));
-      _loadedIndex = index;
-      _duration = item.duration;
-      _emitDur(_duration);
-      _position = Duration.zero;
-      _emitPos(_position);
+      loadedIndex = target;
+      duration = item.duration;
+      emitDur(duration);
+      position = Duration.zero;
+      emitPos(position);
       if (play) {
         await _api.play(_udn);
-        _playing = true;
+        playing = true;
       }
-      _setState(BackendProcessingState.ready);
+      setProcessingState(BackendProcessingState.ready);
       _startPolling();
     } catch (e) {
       castLog('DLNA load failed', error: e);
     }
-    _change();
+    change();
   }
 
   @override
   Future<void> play() async {
-    if (_index < 0) return;
-    if (_loadedIndex != _index) {
-      await _loadIndex(_index, play: true);
+    if (index < 0) return;
+    if (loadedIndex != index) {
+      await loadIndex(index, play: true);
       return;
     }
     try {
       await _api.play(_udn);
     } catch (_) {}
-    _playing = true;
-    _setState(BackendProcessingState.ready);
+    playing = true;
+    setProcessingState(BackendProcessingState.ready);
     _startPolling();
-    _change();
+    change();
   }
 
   @override
@@ -267,16 +130,16 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     try {
       await _api.pause(_udn);
     } catch (_) {}
-    _playing = false;
-    _change();
+    playing = false;
+    change();
   }
 
   @override
   Future<void> stop() async {
     await _stopRenderer();
-    _playing = false;
-    _setState(BackendProcessingState.idle);
-    _change();
+    playing = false;
+    setProcessingState(BackendProcessingState.idle);
+    change();
   }
 
   Future<void> _stopRenderer() async {
@@ -286,59 +149,43 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     } catch (_) {}
   }
 
+  @protected
+  @override
+  Future<void> stopForEmptyList() async {
+    await _stopRenderer();
+    setProcessingState(BackendProcessingState.idle);
+  }
+
   @override
   Future<void> seek(Duration position, {int? index, bool? play}) async {
-    final target = index ?? _index;
-    if (target >= 0 && target != _loadedIndex) {
-      await _loadIndex(target, play: play ?? _playing);
+    final target = index ?? this.index;
+    if (target >= 0 && target != loadedIndex) {
+      await loadIndex(target, play: play ?? playing);
     }
     try {
       await _api.seek(_udn, TimePosition(seconds: position.inSeconds));
     } catch (_) {}
-    _position = position;
-    _emitPos(position);
-    _change();
+    this.position = position;
+    emitPos(position);
+    change();
   }
 
   @override
   Future<void> seekToNext() async {
-    final n = _nextIndex();
-    if (n != null) await _loadIndex(n, play: _playing || _state == BackendProcessingState.ready);
+    final n = nextIndex();
+    if (n != null) {
+      await loadIndex(n,
+          play: playing || processingState == BackendProcessingState.ready);
+    }
   }
 
   @override
   Future<void> seekToPrevious() async {
-    if (_index > 0) {
-      await _loadIndex(_index - 1, play: _playing);
+    if (index > 0) {
+      await loadIndex(index - 1, play: playing);
     } else {
       await seek(Duration.zero);
     }
-  }
-
-  int? _nextIndex() {
-    if (_items.isEmpty) return null;
-    if (_shuffle && _items.length > 1) {
-      int n;
-      do {
-        n = _rng.nextInt(_items.length);
-      } while (n == _index);
-      return n;
-    }
-    if (_index + 1 < _items.length) return _index + 1;
-    if (_repeatAll) return 0;
-    return null;
-  }
-
-  @override
-  Future<void> setShuffleEnabled(bool enabled) async {
-    _shuffle = enabled;
-    _change();
-  }
-
-  @override
-  Future<void> setRepeatAll(bool enabled) async {
-    _repeatAll = enabled;
-    _change();
   }
 
   @override
@@ -367,32 +214,32 @@ class DlnaPlaybackBackend implements PlaybackBackend {
       final info =
           await _api.getPlaybackInfo(_udn).timeout(const Duration(seconds: 2));
       _pollFailures = 0;
-      _position = Duration(seconds: info.position.seconds);
-      _emitPos(_position);
+      position = Duration(seconds: info.position.seconds);
+      emitPos(position);
       if (info.duration.seconds > 0) {
-        _duration = Duration(seconds: info.duration.seconds);
-        _emitDur(_duration);
+        duration = Duration(seconds: info.duration.seconds);
+        emitDur(duration);
       }
       // Latch once we've genuinely reached the end while playing — robust to
       // renderers that reset position to 0 when they stop at track end.
-      final dur = _duration;
+      final dur = duration;
       if (dur != null &&
           dur > Duration.zero &&
-          _position >= dur - const Duration(seconds: 5)) {
+          position >= dur - const Duration(seconds: 5)) {
         _reachedNearEnd = true;
       }
       switch (info.state) {
         case TransportState.playing:
-          _playing = true;
+          playing = true;
           _advancing = false;
           _confirmedPlaying = true;
-          _setState(BackendProcessingState.ready);
+          setProcessingState(BackendProcessingState.ready);
           break;
         case TransportState.paused:
-          _playing = false;
+          playing = false;
           break;
         case TransportState.transitioning:
-          _setState(BackendProcessingState.buffering);
+          setProcessingState(BackendProcessingState.buffering);
           break;
         case TransportState.stopped:
           await _onRendererStopped();
@@ -400,7 +247,7 @@ class DlnaPlaybackBackend implements PlaybackBackend {
         case TransportState.noMediaPresent:
           break;
       }
-      _change();
+      change();
     } catch (_) {
       // A single failure is usually a transient renderer/network blip — keep
       // polling. But a renderer that's genuinely gone (TV off, Wi-Fi dropped)
@@ -408,10 +255,8 @@ class DlnaPlaybackBackend implements PlaybackBackend {
       // the handler can fall back to local playback.
       if (!_disposed && ++_pollFailures >= _kMaxPollFailures) {
         _stopPolling();
-        if (!_rendererLost.isClosed) {
-          _rendererLost
-              .add('Lost connection to the cast device — back on this phone');
-        }
+        emitRendererLost(
+            'Lost connection to the cast device — back on this phone');
       }
     } finally {
       _polling = false;
@@ -425,71 +270,22 @@ class DlnaPlaybackBackend implements PlaybackBackend {
     // Without these guards a just-loaded track skips after a few seconds.
     if (_advancing || !_confirmedPlaying || !_reachedNearEnd) return;
     _advancing = true;
-    final n = _nextIndex();
+    final n = nextIndex();
     if (n != null) {
-      await _loadIndex(n, play: true); // _advancing cleared when poll sees PLAYING
+      await loadIndex(n, play: true); // _advancing cleared when poll sees PLAYING
     } else {
-      _playing = false;
+      playing = false;
       _advancing = false;
-      _setState(BackendProcessingState.completed);
+      setProcessingState(BackendProcessingState.completed);
       _stopPolling();
     }
   }
 
-  // ── Synchronous state ──
+  @protected
   @override
-  bool get playing => _playing;
-  @override
-  bool get shuffleEnabled => _shuffle;
-  @override
-  bool get repeatAll => _repeatAll;
-  @override
-  Duration get position => _position;
-  @override
-  Duration get bufferedPosition => _position; // DLNA exposes no buffer info
-  @override
-  double get speed => 1.0;
-  @override
-  Duration? get duration => _duration;
-  @override
-  int? get currentIndex => _index < 0 ? null : _index;
-  @override
-  BackendProcessingState get processingState => _state;
-
-  // ── Streams ──
-  @override
-  Stream<int?> get currentIndexStream => _indexSubject.stream;
-  @override
-  Stream<Duration> get positionStream => _positionSubject.stream;
-  @override
-  Stream<Duration?> get durationStream => _durationSubject.stream;
-  @override
-  Stream<BackendProcessingState> get processingStateStream =>
-      _stateSubject.stream;
-  @override
-  Stream<void> get changeStream => _changeController.stream;
-
-  @override
-  Stream<String> get rendererLostStream => _rendererLost.stream;
-
-  // ── Local-only capabilities (N/A while casting) ──
-  @override
-  bool get supportsEqualizer => false;
-  @override
-  AndroidEqualizer? get equalizer => null;
-  @override
-  int? get androidAudioSessionId => null;
-
-  @override
-  Future<void> dispose() async {
+  Future<void> disposeRenderer() async {
     _disposed = true;
     _stopPolling();
     await _stopRenderer();
-    await _indexSubject.close();
-    await _positionSubject.close();
-    await _durationSubject.close();
-    await _stateSubject.close();
-    await _changeController.close();
-    await _rendererLost.close();
   }
 }

--- a/lib/media/emulated_playlist_backend.dart
+++ b/lib/media/emulated_playlist_backend.dart
@@ -1,0 +1,312 @@
+import 'dart:async';
+import 'dart:math' show Random;
+
+import 'package:audio_service/audio_service.dart' show MediaItem;
+import 'package:just_audio/just_audio.dart' show AndroidEqualizer;
+import 'package:meta/meta.dart';
+import 'package:rxdart/rxdart.dart';
+
+import 'playback_backend.dart';
+
+/// Shared base for the renderer backends (DLNA, Chromecast) that *emulate*
+/// just_audio's playlist: the remote device plays one track at a time, so each
+/// backend keeps the source list + current index on the phone, pushes the
+/// current track to the renderer, and advances when the renderer reports the
+/// track ended.
+///
+/// This base owns the parts that are identical across those backends and must
+/// never silently drift between them:
+///   * the source list ([items]) and the two index pointers ([index] /
+///     [loadedIndex]), plus all the add / remove / move / clear index
+///     arithmetic (the subtle asymmetric shift in [moveSource] in particular);
+///   * shuffle / repeat state and the [nextIndex] selection;
+///   * the rxdart subjects and the broadcast / emit boilerplate.
+///
+/// Renderer-specific work — actually loading a track onto the device,
+/// transport, position/duration/state tracking, teardown — is left to
+/// subclasses through a few hooks ([loadIndex], [stopForEmptyList],
+/// [disposeRenderer]) plus the [PlaybackBackend] transport methods the base
+/// leaves abstract (play/pause/stop/seek/…/setVolume).
+///
+/// The local just_audio backend does NOT extend this: just_audio owns its own
+/// playlist and index math, so `LocalPlaybackBackend` stays a thin
+/// pass-through.
+abstract class EmulatedPlaylistBackend implements PlaybackBackend {
+  // ── Source list + index state (the single source of truth) ──
+  List<MediaItem> _items = <MediaItem>[];
+  int _index = -1; // logical current index into _items
+  int _loadedIndex = -1; // index actually pushed to the renderer
+  bool _shuffle = false;
+  bool _repeatAll = false;
+  bool _playing = false;
+  Duration _position = Duration.zero;
+  Duration? _duration;
+  BackendProcessingState _state = BackendProcessingState.idle;
+  final Random _rng = Random();
+
+  /// Read-only view of the source list for subclasses. The list is mutated
+  /// only by the source-list methods below; subclasses read it
+  /// (`items[index]`, `items.length`) from their renderer / transport code.
+  @protected
+  List<MediaItem> get items => _items;
+
+  /// Logical current index into [items] (the track the handler considers
+  /// "current"). Subclasses set it as they load tracks / advance.
+  @protected
+  int get index => _index;
+  @protected
+  set index(int value) => _index = value;
+
+  /// Index actually pushed to the renderer. Kept in lockstep with [index] once
+  /// a track is loaded (the `loadedIndex == index` invariant), and reset to -1
+  /// when the loaded track is invalidated (removed, or list emptied).
+  @protected
+  int get loadedIndex => _loadedIndex;
+  @protected
+  set loadedIndex(int value) => _loadedIndex = value;
+
+  // ── rxdart subjects (owned here; subclasses emit via the helpers below) ──
+  final BehaviorSubject<int?> _indexSubject = BehaviorSubject<int?>.seeded(null);
+  final BehaviorSubject<Duration> _positionSubject =
+      BehaviorSubject<Duration>.seeded(Duration.zero);
+  final BehaviorSubject<Duration?> _durationSubject =
+      BehaviorSubject<Duration?>.seeded(null);
+  final BehaviorSubject<BackendProcessingState> _stateSubject =
+      BehaviorSubject<BackendProcessingState>.seeded(
+          BackendProcessingState.idle);
+  final StreamController<void> _changeController =
+      StreamController<void>.broadcast();
+  // Emits when the renderer is lost mid-cast (TV powered off, Wi-Fi dropped,
+  // Cast session ended unexpectedly); the handler falls back to local playback.
+  final PublishSubject<String> _rendererLost = PublishSubject<String>();
+
+  // isClosed-guarded emitters: an in-flight poll / status callback / auto-advance
+  // can complete after dispose() has closed the subjects (we switched away
+  // mid-operation), and adding to a closed subject throws.
+  @protected
+  void emitIndex(int? value) {
+    if (!_indexSubject.isClosed) _indexSubject.add(value);
+  }
+
+  @protected
+  void emitPos(Duration value) {
+    if (!_positionSubject.isClosed) _positionSubject.add(value);
+  }
+
+  @protected
+  void emitDur(Duration? value) {
+    if (!_durationSubject.isClosed) _durationSubject.add(value);
+  }
+
+  @protected
+  void change() {
+    if (!_changeController.isClosed) _changeController.add(null);
+  }
+
+  @protected
+  void setProcessingState(BackendProcessingState s) {
+    _state = s;
+    if (!_stateSubject.isClosed) _stateSubject.add(s);
+  }
+
+  @protected
+  void emitRendererLost(String message) {
+    if (!_rendererLost.isClosed) _rendererLost.add(message);
+  }
+
+  // ── Renderer hooks (implemented by each backend) ──
+  /// Push [index] to the renderer and start / queue playback. Called both by a
+  /// backend's own transport and by [removeSourceAt] when the playing track is
+  /// removed and the slot it left behind must be (re)loaded.
+  @protected
+  Future<void> loadIndex(int index, {required bool play});
+
+  /// Stop the renderer and settle the terminal (idle) state after the source
+  /// list has been emptied (clearSources, or removing the last item). A hook
+  /// because each backend stops differently (Cast `stop()` vs DLNA
+  /// stop-renderer + idle state).
+  @protected
+  Future<void> stopForEmptyList();
+
+  /// Backend-specific teardown (cancel subscriptions / polling, end the cast
+  /// session). Called by [dispose] *before* the shared subjects are closed.
+  @protected
+  Future<void> disposeRenderer();
+
+  // ── Source list (mirrors just_audio's on-player playlist API) ──
+  @override
+  Future<void> setSources(List<MediaItem> items) async {
+    _items = List<MediaItem>.from(items);
+    _index = _items.isEmpty ? -1 : 0;
+    _loadedIndex = -1;
+    emitIndex(_index < 0 ? null : _index);
+    setProcessingState(_items.isEmpty
+        ? BackendProcessingState.idle
+        : BackendProcessingState.ready);
+  }
+
+  @override
+  Future<void> addSource(MediaItem item) async {
+    _items.add(item);
+    if (_index == -1) {
+      _index = 0;
+      emitIndex(0);
+      setProcessingState(BackendProcessingState.ready);
+    }
+  }
+
+  @override
+  Future<void> removeSourceAt(int index) async {
+    if (index < 0 || index >= _items.length) return;
+    _items.removeAt(index);
+    if (_items.isEmpty) {
+      _index = -1;
+      _loadedIndex = -1;
+      emitIndex(null);
+      await stopForEmptyList();
+      return;
+    }
+    if (index < _index) {
+      _index--;
+      _loadedIndex--;
+      emitIndex(_index);
+    } else if (index == _index) {
+      // Removed the now-playing track — advance to whatever now occupies this
+      // slot (the former next track), clamping if it was the last.
+      if (_index >= _items.length) _index = _items.length - 1;
+      _loadedIndex = -1;
+      emitIndex(_index);
+      await loadIndex(_index, play: _playing);
+    }
+  }
+
+  @override
+  Future<void> moveSource(int from, int to) async {
+    if (from < 0 ||
+        from >= _items.length ||
+        to < 0 ||
+        to >= _items.length ||
+        from == to) {
+      return;
+    }
+    // Single-item-push model: reorder the internal list and shift the current /
+    // loaded pointers so they follow the still-playing track to its new slot.
+    // The renderer keeps playing that track — only the upcoming order changes,
+    // so nothing is reloaded; the next advance just loads the new next item.
+    final item = _items.removeAt(from);
+    _items.insert(to, item);
+    if (_index == from) {
+      _index = to;
+    } else if (_index >= 0) {
+      if (from < _index) _index--;
+      if (to <= _index) _index++;
+    }
+    if (_loadedIndex == from) {
+      _loadedIndex = to;
+    } else if (_loadedIndex >= 0) {
+      if (from < _loadedIndex) _loadedIndex--;
+      if (to <= _loadedIndex) _loadedIndex++;
+    }
+    if (_index >= 0) emitIndex(_index);
+  }
+
+  @override
+  Future<void> clearSources() async {
+    _items = <MediaItem>[];
+    _index = -1;
+    _loadedIndex = -1;
+    emitIndex(null);
+    await stopForEmptyList();
+  }
+
+  // ── Shuffle / repeat + next-track selection ──
+  /// The index to advance to after the current track, honouring shuffle and
+  /// repeat-all. Null means "nothing more to play" (end of a non-repeating
+  /// list). Used by each backend's auto-advance and seekToNext.
+  @protected
+  int? nextIndex() {
+    if (_items.isEmpty) return null;
+    if (_shuffle && _items.length > 1) {
+      int n;
+      do {
+        n = _rng.nextInt(_items.length);
+      } while (n == _index);
+      return n;
+    }
+    if (_index + 1 < _items.length) return _index + 1;
+    if (_repeatAll) return 0;
+    return null;
+  }
+
+  @override
+  Future<void> setShuffleEnabled(bool enabled) async {
+    _shuffle = enabled;
+    change();
+  }
+
+  @override
+  Future<void> setRepeatAll(bool enabled) async {
+    _repeatAll = enabled;
+    change();
+  }
+
+  // ── Synchronous state (read by AudioPlayerHandler._broadcastState) ──
+  @override
+  bool get playing => _playing;
+  @protected
+  set playing(bool value) => _playing = value;
+  @override
+  bool get shuffleEnabled => _shuffle;
+  @override
+  bool get repeatAll => _repeatAll;
+  @override
+  Duration get position => _position;
+  @protected
+  set position(Duration value) => _position = value;
+  @override
+  Duration get bufferedPosition => _position; // renderers expose no buffer info
+  @override
+  double get speed => 1.0;
+  @override
+  Duration? get duration => _duration;
+  @protected
+  set duration(Duration? value) => _duration = value;
+  @override
+  int? get currentIndex => _index < 0 ? null : _index;
+  @override
+  BackendProcessingState get processingState => _state;
+
+  // ── Streams ──
+  @override
+  Stream<int?> get currentIndexStream => _indexSubject.stream;
+  @override
+  Stream<Duration> get positionStream => _positionSubject.stream;
+  @override
+  Stream<Duration?> get durationStream => _durationSubject.stream;
+  @override
+  Stream<BackendProcessingState> get processingStateStream =>
+      _stateSubject.stream;
+  @override
+  Stream<void> get changeStream => _changeController.stream;
+  @override
+  Stream<String> get rendererLostStream => _rendererLost.stream;
+
+  // ── Local-only capabilities (N/A while casting) ──
+  @override
+  bool get supportsEqualizer => false;
+  @override
+  AndroidEqualizer? get equalizer => null;
+  @override
+  int? get androidAudioSessionId => null;
+
+  @override
+  Future<void> dispose() async {
+    await disposeRenderer();
+    await _indexSubject.close();
+    await _positionSubject.close();
+    await _durationSubject.close();
+    await _stateSubject.close();
+    await _changeController.close();
+    await _rendererLost.close();
+  }
+}


### PR DESCRIPTION
## What

The DLNA and Chromecast playback backends each kept a **byte-identical copy** of the emulated-playlist bookkeeping — the source list, the `_index` / `_loadedIndex` pointers, the `setSources` / `addSource` / `removeSourceAt` / `moveSource` / `clearSources` index arithmetic, and the rxdart subject + emitter boilerplate. The queue-reorder `moveSource` (#32), with its asymmetric `from`/`to` shift, made it a *fifth* duplicated method — two copies that can silently drift.

This extracts a shared abstract base, **`EmulatedPlaylistBackend`**, that owns all of it **once**. Both renderer backends now `extend` it.

## How

`EmulatedPlaylistBackend implements PlaybackBackend` and owns:
- the source list + `index` / `loadedIndex` pointers and the full add / remove / **move** / clear arithmetic — including the asymmetric `if (from < index) index--; if (to <= index) index++;` applied to *both* pointers, and the `loadedIndex == index` invariant;
- shuffle / repeat state + `nextIndex()` selection;
- the rxdart subjects and the `emit*` / `change` / `setProcessingState` boilerplate, and the whole stream / getter surface.

Renderer-specific work stays in each subclass behind three `@protected` hooks — **`loadIndex`**, **`stopForEmptyList`**, **`disposeRenderer`** (template-method). The deliberate per-backend differences are preserved exactly: DLNA's `seek` falls through to `_api.seek` (no early return), and its empty-list stop is `_stopRenderer()` + idle vs Cast's full `stop()`.

The local just_audio backend (`LocalPlaybackBackend`) is untouched — just_audio owns its own playlist + index math, so it stays a thin pass-through. The `PlaybackBackend` interface is unchanged.

## Result

- **−564 / +472 lines** across the two backends; the two ~280-line copies of shared logic collapse into one ~312-line base.
- Behaviour-preserving: the change is mechanical renames + the template hooks; no renderer logic (visualizer transcode pipeline, DLNA poll engine, transport, dispose ordering) was altered.

## Verification

- `flutter analyze` → **No issues found**.
- Line-by-line diff review confirmed the kept renderer paths changed only by renames; `moveSource`'s asymmetric shift and the `loadedIndex == index` invariant are preserved.
- No backend unit tests exist today; a follow-up to unit-test the now-isolated index math is worthwhile (the base class is trivially testable via a fake subclass implementing the three hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
