### PR TITLE
Visualizer cast: fix transcode cancellation (encoder overlap) + MPEG-TS muxer tests

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,6 +39,11 @@ android {
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
+        test.java.srcDirs += 'src/test/kotlin'
+    }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
     }
 
     lintOptions {
@@ -115,4 +120,7 @@ kotlin {
 
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
+    // JVM unit tests for the hand-written MPEG-TS muxer (TsHlsSinkTest). Only
+    // compiled/run by the test*UnitTest tasks, never bundled into the APK.
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/android/app/src/main/kotlin/com/example/mstream_music/AudioDecoder.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/AudioDecoder.kt
@@ -9,9 +9,8 @@ import android.media.MediaFormat
  * 16-bit PCM. Pull-based: call [read] repeatedly until it returns null (EOS).
  *
  * Part of the visualizer-cast transcode — the PCM drives the off-screen
- * visualizer (and, once audio muxing lands, is re-encoded to AAC for the cast
- * stream), all on one presentation-time timeline so audio and the rendered
- * video stay in sync.
+ * visualizer and is re-encoded to AAC for the cast stream, all on one
+ * presentation-time timeline so audio and the rendered video stay in sync.
  */
 class AudioDecoder(source: String) {
     private val extractor = MediaExtractor()

--- a/android/app/src/main/kotlin/com/example/mstream_music/AvSink.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/AvSink.kt
@@ -2,19 +2,16 @@ package com.example.mstream_music
 
 import android.media.MediaCodec
 import android.media.MediaFormat
-import android.media.MediaMuxer
 import java.nio.ByteBuffer
 
 /**
  * Where [VisualizerTranscoder]'s encoded H.264 + AAC samples are written.
- *
- * Two implementations: [Mp4Sink] (one MP4 via MediaMuxer — the on-phone spike)
- * and [TsHlsSink] (live MPEG-TS/HLS segments — for casting to a renderer).
+ * Implemented by [TsHlsSink], which writes live MPEG-TS/HLS segments to cast.
  *
  * Call order: [init] once, then [onVideoFormat]/[onAudioFormat] (each fires
  * before that stream's first sample), [writeVideo]/[writeAudio] as samples
- * arrive, and [finish] at the end. [finish] returns the playable output (a file
- * path for MP4, the `.m3u8` path for HLS).
+ * arrive, and [finish] at the end. [finish] returns the playable output (the
+ * `.m3u8` path for HLS).
  */
 interface AvSink {
     /** [audioEnabled] = false → video-only output (no audio track). */
@@ -24,94 +21,4 @@ interface AvSink {
     fun writeVideo(buffer: ByteBuffer, info: MediaCodec.BufferInfo)
     fun writeAudio(buffer: ByteBuffer, info: MediaCodec.BufferInfo)
     fun finish(): String
-}
-
-/**
- * MediaMuxer → single MP4. MediaMuxer can't start until every track's format is
- * known, so samples produced before then are buffered and flushed on start.
- * (Behaviourally identical to the inline muxing the transcoder used before the
- * AvSink refactor.)
- */
-class Mp4Sink(private val outputPath: String) : AvSink {
-    private val muxer =
-        MediaMuxer(outputPath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
-    private var audioEnabled = false
-    private var videoTrack = -1
-    private var audioTrack = -1
-    private var videoFormat: MediaFormat? = null
-    private var audioFormat: MediaFormat? = null
-    private var started = false
-    private val pending = ArrayList<Sample>()
-
-    private class Sample(
-        val isVideo: Boolean,
-        val bytes: ByteArray,
-        val ptsUs: Long,
-        val flags: Int,
-    )
-
-    override fun init(audioEnabled: Boolean) {
-        this.audioEnabled = audioEnabled
-    }
-
-    override fun onVideoFormat(format: MediaFormat) {
-        videoFormat = format
-        maybeStart()
-    }
-
-    override fun onAudioFormat(format: MediaFormat) {
-        audioFormat = format
-        maybeStart()
-    }
-
-    private fun maybeStart() {
-        if (started) return
-        val vf = videoFormat ?: return
-        if (audioEnabled && audioFormat == null) return
-        videoTrack = muxer.addTrack(vf)
-        audioFormat?.let { audioTrack = muxer.addTrack(it) }
-        muxer.start()
-        started = true
-        flushPending()
-    }
-
-    override fun writeVideo(buffer: ByteBuffer, info: MediaCodec.BufferInfo) =
-        write(true, buffer, info)
-
-    override fun writeAudio(buffer: ByteBuffer, info: MediaCodec.BufferInfo) =
-        write(false, buffer, info)
-
-    private fun write(isVideo: Boolean, buf: ByteBuffer, info: MediaCodec.BufferInfo) {
-        if (info.size <= 0) return
-        if (started) {
-            val track = if (isVideo) videoTrack else audioTrack
-            if (track >= 0) muxer.writeSampleData(track, buf, info)
-        } else {
-            val bytes = ByteArray(info.size)
-            buf.position(info.offset)
-            buf.get(bytes, 0, info.size)
-            pending.add(Sample(isVideo, bytes, info.presentationTimeUs, info.flags))
-        }
-    }
-
-    private fun flushPending() {
-        val info = MediaCodec.BufferInfo()
-        for (s in pending) {
-            val track = if (s.isVideo) videoTrack else audioTrack
-            if (track < 0) continue
-            info.set(0, s.bytes.size, s.ptsUs, s.flags)
-            muxer.writeSampleData(track, ByteBuffer.wrap(s.bytes), info)
-        }
-        pending.clear()
-    }
-
-    override fun finish(): String {
-        maybeStart()
-        flushPending()
-        if (started) {
-            try { muxer.stop() } catch (_: Throwable) {}
-        }
-        try { muxer.release() } catch (_: Throwable) {}
-        return outputPath
-    }
 }

--- a/android/app/src/main/kotlin/com/example/mstream_music/TsHlsSink.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/TsHlsSink.kt
@@ -2,6 +2,7 @@ package com.example.mstream_music
 
 import android.media.MediaCodec
 import android.media.MediaFormat
+import android.util.Log
 import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -16,10 +17,9 @@ import kotlin.math.ceil
  * `.ts` segments (each starting at a keyframe with PAT/PMT) plus an `index.m3u8`
  * playlist in [dir]. Hand-written because Android has no live TS muxer.
  *
- * This first cut writes a complete VOD playlist (ENDLIST on [finish]); the
- * transcoder runs to completion before the playlist is cast. Making it a *live*
- * (incrementally-written, cast-while-growing) playlist is a follow-up — this
- * step exists to validate the muxer + Chromecast HLS playback.
+ * The playlist is written incrementally as a live EVENT playlist: each completed
+ * segment is published as soon as it closes (ENDLIST only on [finish]), so the
+ * receiver can start casting while the transcode is still running.
  *
  * Assumes the video has no B-frames (PTS == DTS), which holds for our encoder.
  */
@@ -47,8 +47,9 @@ class TsHlsSink(private val dir: String) : AvSink {
     private var lastVideoUs = 0L
     private val segments = ArrayList<Pair<String, Double>>() // name, duration (s)
     // Audio (pts90, ADTS+AAC) produced before the first segment opens; flushed
-    // into it so audio and video both start near PTS 0.
-    private val pendingAudio = ArrayList<Pair<Long, ByteArray>>()
+    // into it so audio and video both start near PTS 0. ArrayDeque so the
+    // over-capacity trim drops the oldest in O(1) (vs ArrayList.removeAt(0)).
+    private val pendingAudio = ArrayDeque<Pair<Long, ByteArray>>()
     // H.264 Access Unit Delimiter (NAL type 9). The Cast receiver's TS
     // transmuxer (mux.js) uses AUDs to find access-unit boundaries; MediaCodec
     // doesn't emit them, so prepend one to every frame.
@@ -57,6 +58,11 @@ class TsHlsSink(private val dir: String) : AvSink {
     // (the muxer runs on a single thread) — at 1080p this avoids ~6k packet
     // allocations/sec (~16k at 4K). Every byte is overwritten per packet.
     private val tsPacket = ByteArray(188)
+    // Reused scratch for the current PES (header + ES), grown to the largest
+    // keyframe seen and kept — so we don't allocate a fresh hundreds-of-KB array
+    // per video frame. Single-threaded, like tsPacket. internal (not private) so
+    // the unit tests can read the bytes buildPesInto wrote.
+    internal var pesBuf = ByteArray(64 * 1024)
 
     override fun init(audioEnabled: Boolean) {
         this.audioEnabled = audioEnabled
@@ -114,9 +120,10 @@ class TsHlsSink(private val dir: String) : AvSink {
         // keyframe keeps each segment independently decodable (decoders tolerate
         // repeats). Passed as parts so we don't allocate a combined frame array.
         val sps = if (keyframe) spsPps else null
-        val pes = if (sps != null) buildPes(0xE0, pts90, pts90, audNal, sps, frame)
-        else buildPes(0xE0, pts90, pts90, audNal, frame)
-        writePes(s, VIDEO_PID, videoCc, pes, pts90)
+        // len first: buildPesInto may regrow pesBuf, so read pesBuf only after.
+        val len = if (sps != null) buildPesInto(0xE0, pts90, pts90, audNal, sps, frame)
+        else buildPesInto(0xE0, pts90, pts90, audNal, frame)
+        writePes(s, VIDEO_PID, videoCc, pesBuf, len, pts90)
         lastVideoUs = ptsUs
     }
 
@@ -134,10 +141,11 @@ class TsHlsSink(private val dir: String) : AvSink {
             pendingAudio.add(Pair(pts90, es))
             // Defensive: if no keyframe ever opens a segment (video wedged), don't
             // grow without bound — keep only the most recent frames.
-            while (pendingAudio.size > MAX_PENDING_AUDIO) pendingAudio.removeAt(0)
+            while (pendingAudio.size > MAX_PENDING_AUDIO) pendingAudio.removeFirst()
             return
         }
-        writePes(s, AUDIO_PID, audioCc, buildPes(0xC0, pts90, null, es), null)
+        val len = buildPesInto(0xC0, pts90, null, es)
+        writePes(s, AUDIO_PID, audioCc, pesBuf, len, null)
     }
 
     override fun finish(): String {
@@ -167,7 +175,18 @@ class TsHlsSink(private val dir: String) : AvSink {
         // half-written playlist.
         val tmp = File(dir, "$PLAYLIST.tmp")
         tmp.writeText(sb.toString())
-        tmp.renameTo(File(dir, PLAYLIST))
+        val dst = File(dir, PLAYLIST)
+        if (!tmp.renameTo(dst)) {
+            // Rename can fail (returns false rather than throwing). Fall back to a
+            // direct overwrite so the live playlist keeps updating instead of
+            // silently freezing at the last good version.
+            try {
+                tmp.copyTo(dst, overwrite = true)
+            } catch (e: Throwable) {
+                Log.w(TAG, "playlist publish failed", e)
+            }
+            tmp.delete()
+        }
     }
 
     // ── segmenting ──
@@ -186,7 +205,8 @@ class TsHlsSink(private val dir: String) : AvSink {
         // Flush audio that arrived before this (first) segment opened.
         if (pendingAudio.isNotEmpty()) {
             for ((pts90, es) in pendingAudio) {
-                writePes(s, AUDIO_PID, audioCc, buildPes(0xC0, pts90, null, es), null)
+                val len = buildPesInto(0xC0, pts90, null, es)
+                writePes(s, AUDIO_PID, audioCc, pesBuf, len, null)
             }
             pendingAudio.clear()
         }
@@ -208,59 +228,67 @@ class TsHlsSink(private val dir: String) : AvSink {
     // in src/test can exercise this bit-level packing directly (it has no Android
     // dependencies). There is no other caller in the module.
 
-    // [esParts] are concatenated as the PES payload — passed as parts (e.g.
-    // AUD + SPS/PPS + frame) so callers don't allocate a combined ES array.
-    internal fun buildPes(streamId: Int, pts90: Long, dts90: Long?, vararg esParts: ByteArray): ByteArray {
+    // Build a PES packet — header from the timing args + [esParts] as the ES
+    // payload — into the reused [pesBuf], returning its length. Callers hand
+    // pesBuf + len to [writePes]. Parts are passed separately (AUD + SPS/PPS +
+    // frame) so we never materialise a combined ES array.
+    internal fun buildPesInto(streamId: Int, pts90: Long, dts90: Long?, vararg esParts: ByteArray): Int {
         var esLen = 0
         for (p in esParts) esLen += p.size
-        val out = ByteArrayOutputStream(esLen + 19)
-        out.write(0x00); out.write(0x00); out.write(0x01) // start code prefix
-        out.write(streamId)
         val ptsDtsBytes = if (dts90 != null) 10 else 5
+        val total = 9 + ptsDtsBytes + esLen // 3 startcode +1 id +2 len +1 +1 +1 +PTS/DTS
+        if (pesBuf.size < total) pesBuf = ByteArray(total) // grow + keep for reuse
+        val b = pesBuf
+        var o = 0
+        b[o++] = 0x00; b[o++] = 0x00; b[o++] = 0x01 // start code prefix
+        b[o++] = streamId.toByte()
         // PES_packet_length: video uses 0 (unbounded — frames can exceed 64 KB);
         // audio carries its real length.
         val pesLen = if (streamId == 0xE0) 0 else (3 + ptsDtsBytes + esLen)
-        out.write((pesLen ushr 8) and 0xFF); out.write(pesLen and 0xFF)
-        out.write(0x80) // '10' marker, no scrambling/priority flags
-        out.write(if (dts90 != null) 0xC0 else 0x80) // PTS+DTS or PTS-only flag
-        out.write(ptsDtsBytes) // PES_header_data_length
-        if (dts90 != null) {
-            out.write(encodeTs(pts90, 0x3))
-            out.write(encodeTs(dts90, 0x1))
-        } else {
-            out.write(encodeTs(pts90, 0x2))
-        }
-        for (p in esParts) out.write(p)
-        return out.toByteArray()
+        b[o++] = ((pesLen ushr 8) and 0xFF).toByte()
+        b[o++] = (pesLen and 0xFF).toByte()
+        b[o++] = 0x80.toByte() // '10' marker, no scrambling/priority flags
+        b[o++] = (if (dts90 != null) 0xC0 else 0x80).toByte() // PTS+DTS or PTS-only
+        b[o++] = ptsDtsBytes.toByte() // PES_header_data_length
+        o = encodeTsInto(b, o, pts90, if (dts90 != null) 0x3 else 0x2)
+        if (dts90 != null) o = encodeTsInto(b, o, dts90, 0x1)
+        for (p in esParts) { System.arraycopy(p, 0, b, o, p.size); o += p.size }
+        return o
     }
 
     // 5-byte PTS/DTS field with the given 4-bit prefix nibble.
     internal fun encodeTs(value: Long, prefix: Int): ByteArray {
-        val v = value and 0x1FFFFFFFFL
-        return byteArrayOf(
-            (((prefix and 0xF) shl 4) or (((v ushr 30).toInt() and 0x7) shl 1) or 1).toByte(),
-            ((v ushr 22) and 0xFF).toByte(),
-            ((((v ushr 15) and 0x7F) shl 1) or 1).toByte(),
-            ((v ushr 7) and 0xFF).toByte(),
-            (((v and 0x7F) shl 1) or 1).toByte(),
-        )
+        val out = ByteArray(5)
+        encodeTsInto(out, 0, value, prefix)
+        return out
     }
 
-    // Emit [pes] as 188-byte TS packets on [pid]. The first packet sets PUSI; if
-    // [pcr90] != null it carries a PCR in its adaptation field; the last packet
-    // is padded with an adaptation-field stuffing region to fill 188.
-    internal fun writePes(out: OutputStream, pid: Int, cc: IntArray, pes: ByteArray, pcr90: Long?) {
+    // Write the 5-byte PTS/DTS field into [dst] at [off]; returns off + 5.
+    private fun encodeTsInto(dst: ByteArray, off: Int, value: Long, prefix: Int): Int {
+        val v = value and 0x1FFFFFFFFL
+        dst[off] = (((prefix and 0xF) shl 4) or (((v ushr 30).toInt() and 0x7) shl 1) or 1).toByte()
+        dst[off + 1] = ((v ushr 22) and 0xFF).toByte()
+        dst[off + 2] = ((((v ushr 15) and 0x7F) shl 1) or 1).toByte()
+        dst[off + 3] = ((v ushr 7) and 0xFF).toByte()
+        dst[off + 4] = (((v and 0x7F) shl 1) or 1).toByte()
+        return off + 5
+    }
+
+    // Emit [pes] (its first [len] bytes) as 188-byte TS packets on [pid]. The
+    // first packet sets PUSI; if [pcr90] != null it carries a PCR in its
+    // adaptation field; the last packet is padded with adaptation-field stuffing.
+    internal fun writePes(out: OutputStream, pid: Int, cc: IntArray, pes: ByteArray, len: Int, pcr90: Long?) {
         var pos = 0
         var first = true
         val pkt = tsPacket // reused; every byte below is overwritten per packet
-        while (pos < pes.size) {
+        while (pos < len) {
             pkt[0] = 0x47
             pkt[1] = (((if (first) 0x40 else 0x00)) or ((pid ushr 8) and 0x1F)).toByte()
             pkt[2] = (pid and 0xFF).toByte()
             val counter = cc[0] and 0x0F
             cc[0] = (cc[0] + 1) and 0x0F
 
-            val remaining = pes.size - pos
+            val remaining = len - pos
             val wantPcr = first && pcr90 != null
             val afControl: Int
             if (!wantPcr && remaining >= 184) {
@@ -392,6 +420,7 @@ class TsHlsSink(private val dir: String) : AvSink {
     }
 
     companion object {
+        private const val TAG = "mstream/viz-xcode"
         private const val PAT_PID = 0x0000
         private const val PMT_PID = 0x1000
         private const val VIDEO_PID = 0x0100

--- a/android/app/src/main/kotlin/com/example/mstream_music/TsHlsSink.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/TsHlsSink.kt
@@ -202,10 +202,15 @@ class TsHlsSink(private val dir: String) : AvSink {
     }
 
     // ── PES / TS packetization ──
+    //
+    // The pure byte-encoding helpers below — and the PSI / ADTS / CRC ones
+    // further down — are `internal` rather than `private` so the JVM unit tests
+    // in src/test can exercise this bit-level packing directly (it has no Android
+    // dependencies). There is no other caller in the module.
 
     // [esParts] are concatenated as the PES payload — passed as parts (e.g.
     // AUD + SPS/PPS + frame) so callers don't allocate a combined ES array.
-    private fun buildPes(streamId: Int, pts90: Long, dts90: Long?, vararg esParts: ByteArray): ByteArray {
+    internal fun buildPes(streamId: Int, pts90: Long, dts90: Long?, vararg esParts: ByteArray): ByteArray {
         var esLen = 0
         for (p in esParts) esLen += p.size
         val out = ByteArrayOutputStream(esLen + 19)
@@ -230,7 +235,7 @@ class TsHlsSink(private val dir: String) : AvSink {
     }
 
     // 5-byte PTS/DTS field with the given 4-bit prefix nibble.
-    private fun encodeTs(value: Long, prefix: Int): ByteArray {
+    internal fun encodeTs(value: Long, prefix: Int): ByteArray {
         val v = value and 0x1FFFFFFFFL
         return byteArrayOf(
             (((prefix and 0xF) shl 4) or (((v ushr 30).toInt() and 0x7) shl 1) or 1).toByte(),
@@ -244,7 +249,7 @@ class TsHlsSink(private val dir: String) : AvSink {
     // Emit [pes] as 188-byte TS packets on [pid]. The first packet sets PUSI; if
     // [pcr90] != null it carries a PCR in its adaptation field; the last packet
     // is padded with an adaptation-field stuffing region to fill 188.
-    private fun writePes(out: OutputStream, pid: Int, cc: IntArray, pes: ByteArray, pcr90: Long?) {
+    internal fun writePes(out: OutputStream, pid: Int, cc: IntArray, pes: ByteArray, pcr90: Long?) {
         var pos = 0
         var first = true
         val pkt = tsPacket // reused; every byte below is overwritten per packet
@@ -307,7 +312,7 @@ class TsHlsSink(private val dir: String) : AvSink {
 
     // ── PSI tables ──
 
-    private fun buildPat(): ByteArray {
+    internal fun buildPat(): ByteArray {
         val body = ByteArrayOutputStream()
         body.write(0x00); body.write(0x01) // transport_stream_id = 1
         body.write(0xC1) // reserved(11) + version(0) + current_next(1)
@@ -318,7 +323,7 @@ class TsHlsSink(private val dir: String) : AvSink {
         return wrapSection(0x00, body.toByteArray())
     }
 
-    private fun buildPmt(): ByteArray {
+    internal fun buildPmt(): ByteArray {
         val body = ByteArrayOutputStream()
         body.write(0x00); body.write(0x01) // program_number = 1
         body.write(0xC1)
@@ -340,7 +345,7 @@ class TsHlsSink(private val dir: String) : AvSink {
     }
 
     // Prepend table_id + section_length header and append the MPEG CRC-32.
-    private fun wrapSection(tableId: Int, body: ByteArray): ByteArray {
+    internal fun wrapSection(tableId: Int, body: ByteArray): ByteArray {
         val sectionLength = body.size + 4 // + CRC
         val head = ByteArrayOutputStream()
         head.write(tableId)
@@ -358,7 +363,7 @@ class TsHlsSink(private val dir: String) : AvSink {
 
     // ── ADTS ──
 
-    private fun adtsHeader(frameLen: Int): ByteArray {
+    internal fun adtsHeader(frameLen: Int): ByteArray {
         val full = frameLen + 7
         val profile = 1 // AAC-LC (audio object type 2 → ADTS profile 1)
         return byteArrayOf(
@@ -380,7 +385,7 @@ class TsHlsSink(private val dir: String) : AvSink {
         return b
     }
 
-    private fun freqIndex(rate: Int): Int = when (rate) {
+    internal fun freqIndex(rate: Int): Int = when (rate) {
         96000 -> 0; 88200 -> 1; 64000 -> 2; 48000 -> 3; 44100 -> 4; 32000 -> 5
         24000 -> 6; 22050 -> 7; 16000 -> 8; 12000 -> 9; 11025 -> 10; 8000 -> 11
         7350 -> 12; else -> 4
@@ -405,7 +410,7 @@ class TsHlsSink(private val dir: String) : AvSink {
 }
 
 /** MPEG CRC-32 (poly 0x04C11DB7, init 0xFFFFFFFF, MSB-first) for PSI sections. */
-private object Crc32Mpeg {
+internal object Crc32Mpeg {
     private val table = IntArray(256)
 
     init {

--- a/android/app/src/main/kotlin/com/example/mstream_music/TsHlsSink.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/TsHlsSink.kt
@@ -178,10 +178,13 @@ class TsHlsSink(private val dir: String) : AvSink {
         val dst = File(dir, PLAYLIST)
         if (!tmp.renameTo(dst)) {
             // Rename can fail (returns false rather than throwing). Fall back to a
-            // direct overwrite so the live playlist keeps updating instead of
-            // silently freezing at the last good version.
+            // single-write overwrite of the in-memory content: one write() call,
+            // so a concurrent HTTP reader is far less likely to catch a partial
+            // file than the previous chunked copyTo (open-truncate + 8 KiB loop).
+            // Not atomic — the rename above is — but it keeps the live playlist
+            // updating instead of freezing at the last good version.
             try {
-                tmp.copyTo(dst, overwrite = true)
+                dst.writeText(sb.toString())
             } catch (e: Throwable) {
                 Log.w(TAG, "playlist publish failed", e)
             }

--- a/android/app/src/main/kotlin/com/example/mstream_music/VideoEncoder.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VideoEncoder.kt
@@ -14,9 +14,9 @@ import java.nio.ByteBuffer
  * render thread draws each frame into [inputSurface] (an EGL window surface; see
  * the C++ `nativeRenderFrameAt`, which stamps the presentation time the encoder
  * reads), and encoded access units are delivered to [onOutput] when [drain] is
- * called. The compressed video is then muxed with the song's AAC audio — to a
- * local MP4 for the Phase 0a spike, and to a live MPEG-TS/HLS stream once that's
- * proven — and served to the cast renderer via LocalMediaServer.
+ * called. The compressed video is then muxed with the song's AAC audio into a
+ * live MPEG-TS/HLS stream ([TsHlsSink]) and served to the cast renderer via
+ * LocalMediaServer.
  *
  * Lifecycle: construct (configures + starts the codec, exposes [inputSurface]),
  * call [drain] from the render loop as frames are produced, [drain(endOfStream
@@ -31,6 +31,9 @@ class VideoEncoder(
     private val onOutput: (ByteBuffer, MediaCodec.BufferInfo) -> Unit,
 ) {
     private var codec: MediaCodec? = null
+    // Reused across drain() calls (single-threaded; dequeueOutputBuffer fully
+    // overwrites it each time) instead of allocating one per drained frame.
+    private val drainInfo = MediaCodec.BufferInfo()
 
     /** EGL-renderable surface the visualizer draws into. Valid until [release]. */
     val inputSurface: Surface
@@ -121,7 +124,7 @@ class VideoEncoder(
     fun drain(endOfStream: Boolean = false) {
         val c = codec ?: return
         if (endOfStream) c.signalEndOfInputStream()
-        val info = MediaCodec.BufferInfo()
+        val info = drainInfo
         while (true) {
             val index = c.dequeueOutputBuffer(info, if (endOfStream) TIMEOUT_US else 0)
             when {

--- a/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
@@ -142,9 +142,11 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
         realAudio = null
     }
 
-    // Visualizer-cast Phase 0a spike: transcode a track to an MP4 of the
-    // visualizer reacting to it (off-screen, on its own thread). Replies with
-    // the output path on success. See VisualizerTranscoder.
+    // Visualizer cast: transcode a track into a live MPEG-TS/HLS stream of the
+    // visualizer reacting to it (off-screen, on its own thread), writing segments
+    // into the `output` directory. Replies with the playlist path right away so
+    // the caller can start casting while transcoding continues. See
+    // VisualizerTranscoder.
     private fun handleStartTranscode(call: MethodCall, result: MethodChannel.Result) {
         val source = call.argument<String>("source")
         val output = call.argument<String>("output")
@@ -156,7 +158,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
         val h = (call.argument<Int>("height") ?: 720).coerceAtLeast(2)
         val engine = call.argument<Int>("engine") ?: 0
         val fps = (call.argument<Int>("fps") ?: 30).coerceIn(1, 60)
-        val maxMs = (call.argument<Int>("maxMs") ?: 20_000).toLong()
+        val maxMs = (call.argument<Int>("maxMs") ?: 0).toLong() // 0 = whole track
         val preset = call.argument<String>("preset")
         val tuningRaw = call.argument<Any>("tuning")
         val tuning: FloatArray? = when (tuningRaw) {
@@ -166,11 +168,8 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
             else -> null
         }
 
-        // mode "hls" → MPEG-TS/HLS segments in the `output` directory (for
-        // casting); anything else → a single MP4 file at `output`.
-        val mode = call.argument<String>("mode") ?: "mp4"
         val sink: AvSink = try {
-            if (mode == "hls") TsHlsSink(output) else Mp4Sink(output)
+            TsHlsSink(output)
         } catch (e: Throwable) {
             result.error("sink_failed", e.message, null)
             return
@@ -193,7 +192,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
             engineKind = engine,
             fps = fps,
             maxDurationUs = maxMs * 1000L,
-            pace = mode == "hls", // live cast → throttle to ~realtime (battery/thermal)
+            pace = true, // live cast → throttle to ~realtime (battery/thermal)
             presetData = preset,
             tuning = tuning,
             initEncoder = ::nativeInitEncoder,
@@ -210,25 +209,18 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
                 // nulling that would orphan it (a later stopTranscode couldn't
                 // cancel it).
                 if (transcoder === created) transcoder = null
-                // HLS replies immediately below (so the caller can start casting
-                // while we keep transcoding the live playlist); only non-HLS
-                // reports its result here.
-                if (mode != "hls") {
-                    if (ok) result.success(payload)
-                    else result.error("transcode_failed", payload, null)
-                } else if (!ok) {
-                    Log.w("mstream/viz-xcode", "HLS transcode ended: $payload")
-                }
+                // We already replied with the playlist path below (so the caller
+                // could start casting while the live playlist keeps growing), so
+                // there's nothing to reply here — just note an early end.
+                if (!ok) Log.w(TAG, "transcode ended: $payload")
             }
         }
         created = t
         transcoder = t
         t.start()
-        if (mode == "hls") {
-            // The playlist grows as segments are written; reply now so the caller
-            // can poll it and cast while transcoding continues in the background.
-            result.success("$output/index.m3u8")
-        }
+        // The playlist grows as segments are written; reply now so the caller can
+        // poll it and cast while transcoding continues in the background.
+        result.success("$output/index.m3u8")
     }
 
     private fun handleLoadPreset(call: MethodCall, result: MethodChannel.Result) {

--- a/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
@@ -26,6 +26,8 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 private const val TAG = "mstream/viz"
 private const val CHANNEL = "mstream/visualizer"
+// Bounded wait for the transcode thread to wind down on plugin teardown.
+private const val TRANSCODE_JOIN_TIMEOUT_MS = 1_000L
 
 class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
 
@@ -66,7 +68,16 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        transcoder?.cancelTranscode()
+        // Cancel and (briefly) join the transcode so it can't outlive the plugin
+        // still holding an EGL context + hardware encoder. Bounded like the
+        // render thread's shutdown so a wedged transcode can't hang teardown.
+        transcoder?.let {
+            it.cancelTranscode()
+            try {
+                it.join(TRANSCODE_JOIN_TIMEOUT_MS)
+            } catch (_: InterruptedException) {
+            }
+        }
         transcoder = null
         teardown()
         channel?.setMethodCallHandler(null)
@@ -165,7 +176,13 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
             return
         }
 
-        transcoder?.cancelTranscode()
+        // Hand the outgoing transcode to the new one as its predecessor: the new
+        // thread waits for it to release the hardware encoder before grabbing its
+        // own (cancelTranscode interrupts, so the wind-down is prompt). We must
+        // NOT join here — this is the main thread and the outgoing decode may
+        // briefly block.
+        val previous = transcoder
+        previous?.cancelTranscode()
         val main = Handler(Looper.getMainLooper())
         var created: VisualizerTranscoder? = null
         val t = VisualizerTranscoder(
@@ -185,6 +202,7 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
             loadPreset = ::nativeLoadPresetData,
             setTuning = ::nativeSetTuning,
             dispose = ::nativeDispose,
+            predecessor = previous,
         ) { ok, payload ->
             main.post {
                 // Only clear the handle if it still points at THIS transcode — a

--- a/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
@@ -77,6 +77,17 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
                 it.join(TRANSCODE_JOIN_TIMEOUT_MS)
             } catch (_: InterruptedException) {
             }
+            // A transcode wedged in a non-interruptible blocking native call (a
+            // stalled remote source) can't be force-stopped — interrupt() won't
+            // free it. The bounded join keeps teardown from hanging, but the
+            // thread then briefly outlives the plugin, still holding its encoder +
+            // EGL context until its I/O returns. It self-releases via its finally
+            // (its native ctx is per-transcode, so no use-after-teardown); log the
+            // window so it's visible rather than a silent leak.
+            if (it.isAlive) {
+                Log.w(TAG, "transcode still running after ${TRANSCODE_JOIN_TIMEOUT_MS}ms " +
+                    "join; it will release its encoder when its blocking I/O returns")
+            }
         }
         transcoder = null
         teardown()

--- a/android/app/src/main/kotlin/com/example/mstream_music/VisualizerTranscoder.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VisualizerTranscoder.kt
@@ -74,6 +74,21 @@ class VisualizerTranscoder(
                     // we were cancelled while waiting — the check below bails
                     // out before we grab the encoder
                 }
+                // Fail-fast if it's STILL alive after the bounded wait. interrupt()
+                // can't break a blocking native call (a stalled remote
+                // setDataSource / readSampleData), so a wedged predecessor keeps
+                // its AVC encoder past the timeout. Allocating ours now would
+                // recreate the two-encoder overlap this join exists to prevent
+                // (and configure() throws on single-encoder SoCs, leaving a
+                // half-set-up codec). Bail cleanly so the cast falls back to audio
+                // instead of churning a doomed encoder. (let is inline, so this
+                // returns from run(); the finally still releases the decoder.)
+                if (it.isAlive) {
+                    Log.w(TAG, "predecessor transcode still active after " +
+                        "${PREDECESSOR_JOIN_TIMEOUT_MS}ms; aborting to avoid encoder overlap")
+                    onDone(false, "predecessor still active")
+                    return
+                }
             }
             if (cancelled) {
                 onDone(false, "cancelled")

--- a/android/app/src/main/kotlin/com/example/mstream_music/VisualizerTranscoder.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VisualizerTranscoder.kt
@@ -33,11 +33,21 @@ class VisualizerTranscoder(
     private val loadPreset: (Long, String, Boolean) -> Unit,
     private val setTuning: (Long, FloatArray) -> Unit,
     private val dispose: (Long) -> Unit,
+    // The just-cancelled previous transcode, if any. We join it (bounded) before
+    // allocating our own hardware encoder so two never coexist — see run().
+    private val predecessor: Thread? = null,
     private val onDone: (Boolean, String?) -> Unit,
 ) : Thread("mstream-viz-transcode") {
 
     @Volatile private var cancelled = false
-    fun cancelTranscode() { cancelled = true }
+
+    /** Request cancellation. Sets the flag *and* interrupts the thread, so one
+     *  parked in the pacing sleep (or a predecessor join) wakes immediately to
+     *  observe it instead of finishing the current sleep first. */
+    fun cancelTranscode() {
+        cancelled = true
+        interrupt()
+    }
 
     override fun run() {
         var decoder: AudioDecoder? = null
@@ -49,6 +59,26 @@ class VisualizerTranscoder(
             val firstChunk =
                 decoder.read() ?: throw IllegalStateException("no audio decoded")
             val startPtsUs = firstChunk.presentationTimeUs
+
+            // A just-cancelled previous transcode may still hold the hardware
+            // H.264 encoder, and many SoCs allow only one AVC encoder instance —
+            // so allocating ours now could fail its configure(). Wait (bounded)
+            // for it to release first. cancelTranscode() interrupts, so this is
+            // normally instant; the timeout guards a predecessor wedged in a
+            // blocking decode. Opening our decoder above already overlapped with
+            // its teardown, so the join usually returns with no extra delay.
+            predecessor?.let {
+                try {
+                    it.join(PREDECESSOR_JOIN_TIMEOUT_MS)
+                } catch (_: InterruptedException) {
+                    // we were cancelled while waiting — the check below bails
+                    // out before we grab the encoder
+                }
+            }
+            if (cancelled) {
+                onDone(false, "cancelled")
+                return
+            }
 
             video = VideoEncoder(
                 width = width,
@@ -113,8 +143,14 @@ class VisualizerTranscoder(
                 pcm = decoder.read()
             }
 
-            aac?.finish()
-            video.drain(true) // signal EOS + flush remaining video
+            // On cancel, skip the encoders' EOS flush: the output is about to be
+            // discarded, and we want to release the hardware encoder ASAP so a
+            // replacement transcode's predecessor join returns quickly. Still
+            // close the sink, so its open segment file / muxer isn't leaked.
+            if (!cancelled) {
+                aac?.finish()
+                video.drain(true) // signal EOS + flush remaining video
+            }
             val out = sink.finish()
             onDone(!cancelled, if (cancelled) "cancelled" else out)
         } catch (e: Throwable) {
@@ -152,5 +188,8 @@ class VisualizerTranscoder(
         private const val TAG = "mstream/viz-xcode"
         // When pacing a live cast, stay at most this far ahead of realtime.
         private const val PACING_LEAD_US = 5_000_000L
+        // Cap the wait for a cancelled predecessor to release its hardware
+        // encoder before we allocate ours (see run()).
+        private const val PREDECESSOR_JOIN_TIMEOUT_MS = 3_000L
     }
 }

--- a/android/app/src/main/kotlin/com/example/mstream_music/VisualizerTranscoder.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VisualizerTranscoder.kt
@@ -8,8 +8,8 @@ import android.view.Surface
  * it. Decodes the source audio to PCM; that PCM both drives an off-screen
  * visualizer engine (rendering into an H.264 encoder's input Surface, stamped
  * from the audio clock) and is re-encoded to AAC. The two elementary streams
- * are handed to an [AvSink] — [Mp4Sink] for an on-phone MP4, or [TsHlsSink] for
- * MPEG-TS/HLS segments to cast.
+ * are handed to an [AvSink] ([TsHlsSink]), which writes the live MPEG-TS/HLS
+ * segments to cast.
  *
  * Runs on its own thread (owns the EGL context via the native bridge). Audio is
  * best-effort: if the AAC encoder can't be set up, the output is video-only.

--- a/android/app/src/test/kotlin/com/example/mstream_music/TsHlsSinkTest.kt
+++ b/android/app/src/test/kotlin/com/example/mstream_music/TsHlsSinkTest.kt
@@ -1,0 +1,202 @@
+package com.example.mstream_music
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayOutputStream
+
+/**
+ * Pure-JVM unit tests for the hand-written MPEG-TS / PES / ADTS / PSI byte
+ * encoding in [TsHlsSink]. Android has no live TS muxer, so this code is written
+ * from scratch — these tests are its safety net for spec-compliance.
+ *
+ * They exercise only the bit-level packing, which has no Android dependencies
+ * (no MediaCodec/MediaFormat), so they run under plain `testDebugUnitTest` with
+ * just JUnit on the classpath. Each PSI section's CRC and each timestamp field
+ * is checked against an independent reference implementation, so a transcription
+ * slip in the production encoder can't pass by matching itself.
+ */
+class TsHlsSinkTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    // A real (empty) temp dir is enough for init() — it only touches java.io.File.
+    private fun newSink(audioEnabled: Boolean = true): TsHlsSink {
+        val sink = TsHlsSink(tmp.newFolder().absolutePath)
+        sink.init(audioEnabled)
+        return sink
+    }
+
+    private fun u(b: Byte): Int = b.toInt() and 0xFF
+
+    // Reference MPEG CRC-32 (bit-at-a-time; poly 0x04C11DB7, init 0xFFFFFFFF,
+    // MSB-first, no final XOR) — an independent take on the table-driven one.
+    private fun refCrc(data: ByteArray): Int {
+        var crc = -1 // 0xFFFFFFFF
+        for (byte in data) {
+            crc = crc xor (u(byte) shl 24)
+            repeat(8) {
+                crc = if (crc and 0x80000000.toInt() != 0) (crc shl 1) xor 0x04C11DB7
+                else crc shl 1
+            }
+        }
+        return crc
+    }
+
+    // The trailing 4 bytes of a PSI section are the MPEG CRC-32 over everything
+    // before them — verify with the independent reference.
+    private fun assertCrcTrailer(section: ByteArray) {
+        val body = section.copyOfRange(0, section.size - 4)
+        val stored = (u(section[section.size - 4]) shl 24) or
+            (u(section[section.size - 3]) shl 16) or
+            (u(section[section.size - 2]) shl 8) or
+            u(section[section.size - 1])
+        assertEquals(refCrc(body), stored)
+    }
+
+    @Test
+    fun crc32MatchesIndependentImplementation() {
+        val samples = listOf(
+            byteArrayOf(0x00, 0x01, 0xC1.toByte(), 0x00, 0x00),
+            "the quick brown fox".toByteArray(),
+            ByteArray(0),
+            ByteArray(256) { it.toByte() },
+        )
+        for (s in samples) {
+            assertEquals(refCrc(s), Crc32Mpeg.compute(s, 0, s.size))
+        }
+    }
+
+    @Test
+    fun encodeTsRoundTrips() {
+        val sink = newSink()
+        val pts = 5_000_000_000L // exercises the top (33rd) bit
+        val b = sink.encodeTs(pts, 0x2)
+        assertEquals(5, b.size)
+        assertEquals(0x2, u(b[0]) ushr 4)        // prefix nibble
+        assertEquals(1, u(b[0]) and 1)           // marker bits on bytes 0, 2, 4
+        assertEquals(1, u(b[2]) and 1)
+        assertEquals(1, u(b[4]) and 1)
+        val hi = ((u(b[0]) ushr 1) and 0x7).toLong()
+        val b29 = u(b[1]).toLong()
+        val b21 = ((u(b[2]) ushr 1) and 0x7F).toLong()
+        val b14 = u(b[3]).toLong()
+        val b6 = ((u(b[4]) ushr 1) and 0x7F).toLong()
+        val decoded = (hi shl 30) or (b29 shl 22) or (b21 shl 15) or (b14 shl 7) or b6
+        assertEquals(pts, decoded)
+    }
+
+    @Test
+    fun audioPesHeaderIsWellFormed() {
+        val sink = newSink()
+        val payload = ByteArray(20) { (it + 1).toByte() }
+        val pes = sink.buildPes(0xC0, 90_000L, null, payload)
+        assertEquals(0x00, u(pes[0])); assertEquals(0x00, u(pes[1])); assertEquals(0x01, u(pes[2]))
+        assertEquals(0xC0, u(pes[3]))                          // audio stream id
+        val pesLen = (u(pes[4]) shl 8) or u(pes[5])
+        assertEquals(3 + 5 + payload.size, pesLen)             // flags+hdrlen + PTS + ES
+        assertEquals(0x80, u(pes[6]))                          // '10' marker
+        assertEquals(0x80, u(pes[7]))                          // PTS-only flag
+        assertEquals(5, u(pes[8]))                             // PES_header_data_length
+        assertArrayEquals(payload, pes.copyOfRange(9 + 5, pes.size))
+    }
+
+    @Test
+    fun videoPesUsesUnboundedLengthAndDts() {
+        val sink = newSink()
+        val es = ByteArray(10) { it.toByte() }
+        val pes = sink.buildPes(0xE0, 90_000L, 90_000L, es)
+        assertEquals(0xE0, u(pes[3]))
+        assertEquals(0, (u(pes[4]) shl 8) or u(pes[5]))        // unbounded for video
+        assertEquals(0xC0, u(pes[7]))                          // PTS+DTS flag
+        assertEquals(10, u(pes[8]))                            // header_data_length = 2×5
+    }
+
+    @Test
+    fun writePesEmitsValid188BytePacketsWithContinuity() {
+        val sink = newSink()
+        val pes = ByteArray(500) { (it and 0xFF).toByte() } // spans several packets
+        val out = ByteArrayOutputStream()
+        val cc = intArrayOf(0)
+        sink.writePes(out, 0x0100, cc, pes, null)
+        val ts = out.toByteArray()
+        assertEquals(0, ts.size % 188)                        // whole 188-byte packets
+        val packets = ts.size / 188
+        assertTrue(packets >= 3)
+        for (p in 0 until packets) {
+            val off = p * 188
+            assertEquals(0x47, u(ts[off]))                    // sync byte
+            assertEquals(p == 0, (u(ts[off + 1]) and 0x40) != 0) // PUSI only on first
+            val pid = ((u(ts[off + 1]) and 0x1F) shl 8) or u(ts[off + 2])
+            assertEquals(0x0100, pid)
+            assertEquals(p and 0x0F, u(ts[off + 3]) and 0x0F) // continuity counter
+        }
+        assertEquals(packets and 0x0F, cc[0])                 // counter advanced per packet
+    }
+
+    @Test
+    fun writePesFirstPacketCarriesPcr() {
+        val sink = newSink()
+        val pcr = 1_234_567L
+        val out = ByteArrayOutputStream()
+        sink.writePes(out, 0x0100, intArrayOf(0), ByteArray(50), pcr)
+        val ts = out.toByteArray()
+        assertEquals(0x3, (u(ts[3]) ushr 4) and 0x3)          // adaptation field + payload
+        assertTrue(u(ts[4]) >= 7)                             // af_len ≥ flags(1)+PCR(6)
+        assertTrue((u(ts[5]) and 0x10) != 0)                  // PCR_flag
+        val base = (u(ts[6]).toLong() shl 25) or
+            (u(ts[7]).toLong() shl 17) or
+            (u(ts[8]).toLong() shl 9) or
+            (u(ts[9]).toLong() shl 1) or
+            ((u(ts[10]).toLong() ushr 7) and 0x1)
+        assertEquals(pcr, base)
+    }
+
+    @Test
+    fun patSectionHasValidCrc() {
+        val pat = newSink().buildPat()
+        assertEquals(0x00, u(pat[0]))                         // table_id = PAT
+        assertTrue((u(pat[1]) and 0x80) != 0)                 // section_syntax_indicator
+        val sectionLength = ((u(pat[1]) and 0x0F) shl 8) or u(pat[2])
+        assertEquals(pat.size - 3, sectionLength)             // counts bytes after the length field
+        assertCrcTrailer(pat)
+    }
+
+    @Test
+    fun pmtIncludesAudioOnlyWhenEnabled() {
+        val withAudio = newSink(audioEnabled = true).buildPmt()
+        val videoOnly = newSink(audioEnabled = false).buildPmt()
+        assertEquals(0x02, u(withAudio[0]))                   // table_id = PMT
+        assertCrcTrailer(withAudio)
+        assertCrcTrailer(videoOnly)
+        // The audio ES entry (stream_type + 4 descriptor bytes) is exactly 5 bytes.
+        assertEquals(videoOnly.size + 5, withAudio.size)
+    }
+
+    @Test
+    fun adtsHeaderEncodesSyncwordRateAndLength() {
+        val sink = newSink()                                  // defaults: 44100 Hz, stereo
+        val frameLen = 200
+        val h = sink.adtsHeader(frameLen)
+        assertEquals(7, h.size)
+        assertEquals(0xFF, u(h[0]))                           // syncword high byte
+        assertEquals(0xF0, u(h[1]) and 0xF0)                  // syncword low nibble
+        assertEquals(4, (u(h[2]) ushr 2) and 0x0F)           // 44100 → freq index 4
+        val chan = ((u(h[2]) and 0x1) shl 2) or ((u(h[3]) ushr 6) and 0x3)
+        assertEquals(2, chan)                                 // stereo
+        val full = ((u(h[3]) and 0x3) shl 11) or (u(h[4]) shl 3) or ((u(h[5]) ushr 5) and 0x7)
+        assertEquals(frameLen + 7, full)                      // frame length includes the 7-byte header
+    }
+
+    @Test
+    fun freqIndexMapsKnownRatesAndFallsBack() {
+        val sink = newSink()
+        assertEquals(3, sink.freqIndex(48000))
+        assertEquals(4, sink.freqIndex(44100))
+        assertEquals(8, sink.freqIndex(16000))
+        assertEquals(4, sink.freqIndex(12345))                // unknown rate → 44100 default
+    }
+}

--- a/android/app/src/test/kotlin/com/example/mstream_music/TsHlsSinkTest.kt
+++ b/android/app/src/test/kotlin/com/example/mstream_music/TsHlsSinkTest.kt
@@ -93,7 +93,8 @@ class TsHlsSinkTest {
     fun audioPesHeaderIsWellFormed() {
         val sink = newSink()
         val payload = ByteArray(20) { (it + 1).toByte() }
-        val pes = sink.buildPes(0xC0, 90_000L, null, payload)
+        val len = sink.buildPesInto(0xC0, 90_000L, null, payload)
+        val pes = sink.pesBuf.copyOf(len)
         assertEquals(0x00, u(pes[0])); assertEquals(0x00, u(pes[1])); assertEquals(0x01, u(pes[2]))
         assertEquals(0xC0, u(pes[3]))                          // audio stream id
         val pesLen = (u(pes[4]) shl 8) or u(pes[5])
@@ -108,7 +109,8 @@ class TsHlsSinkTest {
     fun videoPesUsesUnboundedLengthAndDts() {
         val sink = newSink()
         val es = ByteArray(10) { it.toByte() }
-        val pes = sink.buildPes(0xE0, 90_000L, 90_000L, es)
+        val len = sink.buildPesInto(0xE0, 90_000L, 90_000L, es)
+        val pes = sink.pesBuf.copyOf(len)
         assertEquals(0xE0, u(pes[3]))
         assertEquals(0, (u(pes[4]) shl 8) or u(pes[5]))        // unbounded for video
         assertEquals(0xC0, u(pes[7]))                          // PTS+DTS flag
@@ -121,7 +123,7 @@ class TsHlsSinkTest {
         val pes = ByteArray(500) { (it and 0xFF).toByte() } // spans several packets
         val out = ByteArrayOutputStream()
         val cc = intArrayOf(0)
-        sink.writePes(out, 0x0100, cc, pes, null)
+        sink.writePes(out, 0x0100, cc, pes, pes.size, null)
         val ts = out.toByteArray()
         assertEquals(0, ts.size % 188)                        // whole 188-byte packets
         val packets = ts.size / 188
@@ -142,7 +144,7 @@ class TsHlsSinkTest {
         val sink = newSink()
         val pcr = 1_234_567L
         val out = ByteArrayOutputStream()
-        sink.writePes(out, 0x0100, intArrayOf(0), ByteArray(50), pcr)
+        sink.writePes(out, 0x0100, intArrayOf(0), ByteArray(50), 50, pcr)
         val ts = out.toByteArray()
         assertEquals(0x3, (u(ts[3]) ushr 4) and 0x3)          // adaptation field + payload
         assertTrue(u(ts[4]) >= 7)                             // af_len ≥ flags(1)+PCR(6)

--- a/android/app/src/test/kotlin/com/example/mstream_music/TsHlsSinkTest.kt
+++ b/android/app/src/test/kotlin/com/example/mstream_music/TsHlsSinkTest.kt
@@ -201,4 +201,34 @@ class TsHlsSinkTest {
         assertEquals(8, sink.freqIndex(16000))
         assertEquals(4, sink.freqIndex(12345))                // unknown rate → 44100 default
     }
+
+    @Test
+    fun crc32MatchesCanonicalMpeg2CheckVector() {
+        // The published CRC-32/MPEG-2 check value for ASCII "123456789" is
+        // 0x0376E6E7. Pins the table-driven impl to a constant, not just to our
+        // own reference encoder (which could share a transcription slip).
+        val data = "123456789".toByteArray(Charsets.US_ASCII)
+        assertEquals(0x0376E6E7, Crc32Mpeg.compute(data, 0, data.size))
+    }
+
+    @Test
+    fun pesBufReuseAcrossLargeThenSmallFrameLeavesNoStaleBytes() {
+        // pesBuf is grown to the largest frame seen and reused. A large frame
+        // (forcing growth past the 64 KiB initial size) followed by a small one
+        // must produce a correct small PES in [0, len) — none of the large
+        // frame's bytes bleeding into the region callers actually read.
+        val sink = newSink()
+        val big = ByteArray(96 * 1024) { (it and 0xFF).toByte() }
+        val bigLen = sink.buildPesInto(0xE0, 90_000L, 90_000L, big)
+        assertTrue(bigLen > 64 * 1024)
+        assertTrue(sink.pesBuf.size >= bigLen)                 // buffer grew + retained
+
+        val small = ByteArray(8) { (0xA0 + it).toByte() }
+        val smallLen = sink.buildPesInto(0xC0, 180_000L, null, small)
+        val pes = sink.pesBuf.copyOf(smallLen)
+        assertEquals(9 + 5 + small.size, smallLen)             // audio PES header + ES only
+        assertEquals(0xC0, u(pes[3]))                          // audio stream id
+        assertEquals(5, u(pes[8]))                             // PTS-only header_data_length
+        assertArrayEquals(small, pes.copyOfRange(9 + 5, smallLen)) // ES is `small`, not `big`
+    }
 }

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -310,7 +310,6 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       height: quality.height,
       maxMs: 0, // whole track
       tuning: cfg.tuning,
-      mode: 'hls',
     );
     if (playlist == null) {
       throw StateError('visualizer transcode failed to start');
@@ -325,8 +324,10 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       await Future<void>.delayed(const Duration(milliseconds: 500));
       if (gen != _loadGen) throw StateError('superseded');
       try {
+        // Count #EXTINF tags — one per segment — rather than '.ts' substrings,
+        // which would also match anything else in the playlist ending in .ts.
         if (await plFile.exists() &&
-            '.ts'.allMatches(await plFile.readAsString()).length >= 2) {
+            '#EXTINF'.allMatches(await plFile.readAsString()).length >= 2) {
           ready = true;
         }
       } catch (_) {/* mid-write / not ready yet — try again */}
@@ -361,7 +362,8 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       contentId: url,
       contentUrl: Uri.parse(url),
       streamType: CastMediaStreamType.buffered,
-      contentType: 'application/x-mpegurl', // HLS (validated on the receiver)
+      contentType:
+          'application/vnd.apple.mpegurl', // HLS (IANA type; matches LocalMediaServer)
       metadata: GoogleCastGenericMediaMetadata(
         title: item.title,
         subtitle: item.artist,

--- a/lib/native/visualizer_bridge.dart
+++ b/lib/native/visualizer_bridge.dart
@@ -129,11 +129,12 @@ class VisualizerBridge {
     }
   }
 
-  /// Visualizer-cast Phase 0a spike: ask Kotlin to transcode [source] (a local
-  /// file path or http URL) into an MP4 at [output] of the visualizer reacting
-  /// to the track, rendered with the in-memory [preset]/shader text. Caps at
-  /// [maxMs] of audio so the test stays quick. Returns the output path on
-  /// success, or null on failure. (Audio + video; live HLS streaming next.)
+  /// Ask Kotlin to transcode [source] (a local file path or http URL) into a
+  /// live MPEG-TS/HLS stream in the [output] directory — the app's visualizer
+  /// reacting to the track, rendered with the in-memory [preset]/shader text.
+  /// [maxMs] caps the transcoded duration (0 = whole track). Returns the
+  /// playlist (`.m3u8`) path, available as soon as transcoding starts (segments
+  /// keep being written in the background), or null on failure.
   static Future<String?> startTranscode({
     required String source,
     required String output,
@@ -142,9 +143,8 @@ class VisualizerBridge {
     int width = 1280,
     int height = 720,
     int fps = 30,
-    int maxMs = 20000,
+    int maxMs = 0,
     List<double>? tuning,
-    String mode = 'mp4',
   }) async {
     try {
       return await _channel.invokeMethod<String>('startTranscode', {
@@ -157,7 +157,6 @@ class VisualizerBridge {
         'fps': fps,
         'maxMs': maxMs,
         'tuning': tuning != null ? Float32List.fromList(tuning) : null,
-        'mode': mode, // 'mp4' (single file) or 'hls' (segments in `output` dir)
       });
     } on PlatformException catch (e) {
       // ignore: avoid_print


### PR DESCRIPTION
## What

Addresses **all** findings from an audit of the visualizer-cast transcode pipeline — the app's native `MediaCodec`/HLS stand-in for ffmpeg. Three commits: the two High-severity items first, then the remaining Medium/Low cleanup, robustness, and perf items.

Net **−dead code** (the MP4 path removal outweighs the additions, excluding the new test file).

## High

**1. Transcode cancellation didn't preempt → overlapping hardware encoders.** `cancelTranscode()` only set a flag, so a track-skip started a new transcode (grabbing a second AVC encoder) while the old one was still parked in the pacing `sleep`/a blocking decode. On SoCs that allow only one encoder instance the new `configure()` could fail and the cast silently dropped to audio. Now: `cancelTranscode()` also `interrupt()`s; the new transcode joins the outgoing one (bounded) before allocating its encoder; the EOS flush is skipped on cancel to release the encoder ASAP (sink still closed, no leak); and plugin teardown joins the transcode.

**2. Zero tests for the hand-written MPEG-TS muxer.** Added `TsHlsSinkTest` — pure-JVM JUnit coverage of CRC-32, PTS round-trip, PES headers, TS packetization (sync/PUSI/PID/continuity/188-byte alignment), PCR, PAT/PMT, and ADTS. Tested helpers widened `private` → `internal`; `build.gradle` gains the test source set + `junit`.

## Remaining (this update)

**Robustness**
- `TsHlsSink.writePlaylist` falls back to a direct overwrite (and logs) if the atomic rename fails, instead of silently freezing the live playlist. (#5)
- The Chromecast readiness poll counts `#EXTINF` tags rather than `.ts` substrings. (#6)

**Performance**
- Reuse a PES scratch buffer instead of allocating a per-frame array (hundreds of KB for keyframes → ~no per-frame GC). (#7)
- `VideoEncoder.drain` reuses a `BufferInfo`. (#8)
- `pendingAudio` is an `ArrayDeque`, so the over-capacity trim is O(1). (#9)

**Cleanup / dead code**
- Drop the unused MP4 transcode path — `Mp4Sink` and the `mode=="mp4"` plumbing across `AvSink` / `VisualizerBridge` / `visualizer_bridge.dart`. The sole caller always streams HLS. (#10)
- Refresh stale "Phase 0a spike / MP4 / VOD" doc comments (#11), replace a hard-coded log-tag literal with `TAG` (#12), and unify the two HLS MIME strings on `application/vnd.apple.mpegurl` (#13).

## Validation

- **Dart:** `flutter analyze` on the changed files — no issues.
- **PES refactor (#7):** proven **byte-for-byte identical** to the old `buildPes`/`writePes` across 20 input shapes (audio/video, with/without SPS, keyframe-sized payloads that exercise buffer growth, and 183/184/185 packet-boundary sizes) via an independent port.
- **Muxer tests:** validated against an independent encoder port (couldn't run the AGP 9 Gradle stack in the worktree — no `gradlew`/`local.properties`/`JAVA_HOME`). Run locally: `flutter pub get`, then `cd android && ./gradlew :app:testDebugUnitTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
