### PR TITLE
perf(visualizer): stop double-pacing the on-screen render (eglSwapInterval 0)

### DIFF
--- a/android/app/src/main/cpp/visualizer_bridge.cpp
+++ b/android/app/src/main/cpp/visualizer_bridge.cpp
@@ -95,6 +95,17 @@ bool setupEgl(BridgeContext* ctx) {
         LOGE("eglMakeCurrent failed: 0x%x", eglGetError());
         return false;
     }
+    // Don't vsync-block the buffer swap. The render thread already paces itself
+    // to a fixed frame budget (RenderThread.frameNanos), and the surface is
+    // consumed by Flutter's compositor, which does its own vsync-synced present.
+    // At the default swap interval (1), eglSwapBuffers *also* waits for vsync, so
+    // the loop is double-paced — and on a demanding shader that vsync stall
+    // stacks on top of the GPU render time, roughly halving the achievable
+    // framerate. Interval 0 makes the manual pacer the sole authority; the
+    // SurfaceTexture buffer queue still back-pressures if we ever outrun the
+    // consumer, and Flutter's compositor prevents tearing. (No-op on the encoder
+    // path's MediaCodec input surface, which has no display vsync.)
+    eglSwapInterval(ctx->display, 0);
     return true;
 }
 


### PR DESCRIPTION
## What

The on-screen visualizer's render loop was **double-paced**: the render thread already sleeps to a fixed 60fps budget (`RenderThread.frameNanos`), but `eglSwapBuffers` *also* vsync-blocked at the default swap interval (1). On a demanding shader that vsync stall stacks on top of the GPU render time — roughly halving the achievable framerate and adding uneven cadence.

## Fix

One line in `setupEgl`: `eglSwapInterval(ctx->display, 0)`, making the manual pacer the sole authority. Safe because:

- The surface is a **Flutter Texture** — Flutter's compositor does its own vsync-synced present, so **no tearing**.
- The SurfaceTexture **buffer queue still back-pressures** if the producer ever outruns the consumer.
- The **60fps cap is unchanged** (the intended battery/thermal budget) — we just drop the redundant per-frame vsync stall.
- **No-op on the encoder path**: `setupEgl` is shared with the cast transcode, but a MediaCodec input surface has no display vsync, and that path is paced by `VisualizerTranscoder` anyway.

## Expected effect

A demanding shader (e.g. the hexagon preset) that was effectively limited by `GPU time + vsync wait` is now limited by `GPU time` alone → higher, steadier framerate. Light shaders stay capped at 60fps.

## Considered, left as-is

- The per-frame `eglMakeCurrent` in `nativeRenderFrame` is a near-no-op when the context is already current, and its comment indicates it intentionally guards a cross-thread case (resize). Left it to avoid a regression for marginal gain.
- Raising the 60fps cap to the display refresh (90/120Hz) would help *light* shaders on high-refresh panels but adds battery/thermal cost and doesn't help demanding shaders (GPU-bound). Out of scope.

## Validation

- `flutter build apk --debug` → compiles.
- **Wants on-device confirmation** — framerate isn't externally measurable in this environment, so this is reasoned + compile-verified, not perf-measured. Smoke test: open the Visualizer with a demanding preset (hexagon) and confirm it feels smoother / higher-fps than before, with no tearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
