### PR TITLE
Albums: in-browser album detail view + consolidated browser toolbar

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1,6 +1,11 @@
 {
   "mainRemove": "Entfernen",
   "@@locale": "de",
+  "queueAddNext": "Als Nächstes",
+  "queuePlayNow": "Jetzt abspielen",
+  "queueAddToEnd": "Ans Ende der Warteschlange",
+  "shuffle": "Zufallswiedergabe",
+  "variousArtists": "Verschiedene Interpreten",
 
   "appTitle": "mStream Music",
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,16 @@
 {
   "mainRemove": "Remove",
   "@@locale": "en",
+  "queueAddNext": "Add next",
+  "@queueAddNext": { "description": "Track row menu: insert after the current track." },
+  "queuePlayNow": "Play now",
+  "@queuePlayNow": { "description": "Track row menu: play this track immediately." },
+  "queueAddToEnd": "Add to end of queue",
+  "@queueAddToEnd": { "description": "Track row menu: append to the end of the queue." },
+  "shuffle": "Shuffle",
+  "@shuffle": { "description": "Shuffle-play button on the album detail screen." },
+  "variousArtists": "Various Artists",
+  "@variousArtists": { "description": "Shown as the album artist when an album's tracks span multiple artists." },
 
   "appTitle": "mStream Music",
   "@appTitle": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,6 +1,11 @@
 {
   "mainRemove": "Quitar",
   "@@locale": "es",
+  "queueAddNext": "Añadir a continuación",
+  "queuePlayNow": "Reproducir ahora",
+  "queueAddToEnd": "Añadir al final de la cola",
+  "shuffle": "Aleatorio",
+  "variousArtists": "Varios artistas",
   "appTitle": "mStream Music",
   "settingsLanguage": "Idioma",
   "languageSystemDefault": "Predeterminado del sistema",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,6 +1,11 @@
 {
   "mainRemove": "Retirer",
   "@@locale": "fr",
+  "queueAddNext": "Ajouter à la suite",
+  "queuePlayNow": "Lire maintenant",
+  "queueAddToEnd": "Ajouter à la fin de la file",
+  "shuffle": "Aléatoire",
+  "variousArtists": "Artistes divers",
   "appTitle": "mStream Music",
   "settingsLanguage": "Langue",
   "languageSystemDefault": "Langue du système",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1,6 +1,11 @@
 {
   "mainRemove": "Rimuovi",
   "@@locale": "it",
+  "queueAddNext": "Aggiungi dopo",
+  "queuePlayNow": "Riproduci ora",
+  "queueAddToEnd": "Aggiungi alla fine della coda",
+  "shuffle": "Casuale",
+  "variousArtists": "Artisti vari",
   "appTitle": "mStream Music",
   "settingsLanguage": "Lingua",
   "languageSystemDefault": "Predefinita di sistema",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,6 +1,11 @@
 {
   "mainRemove": "削除",
   "@@locale": "ja",
+  "queueAddNext": "次に追加",
+  "queuePlayNow": "今すぐ再生",
+  "queueAddToEnd": "キューの最後に追加",
+  "shuffle": "シャッフル",
+  "variousArtists": "様々なアーティスト",
   "appTitle": "mStream Music",
   "settingsLanguage": "言語",
   "languageSystemDefault": "システムのデフォルト",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -120,6 +120,36 @@ abstract class AppLocalizations {
   /// **'Remove'**
   String get mainRemove;
 
+  /// Track row menu: insert after the current track.
+  ///
+  /// In en, this message translates to:
+  /// **'Add next'**
+  String get queueAddNext;
+
+  /// Track row menu: play this track immediately.
+  ///
+  /// In en, this message translates to:
+  /// **'Play now'**
+  String get queuePlayNow;
+
+  /// Track row menu: append to the end of the queue.
+  ///
+  /// In en, this message translates to:
+  /// **'Add to end of queue'**
+  String get queueAddToEnd;
+
+  /// Shuffle-play button on the album detail screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Shuffle'**
+  String get shuffle;
+
+  /// Shown as the album artist when an album's tracks span multiple artists.
+  ///
+  /// In en, this message translates to:
+  /// **'Various Artists'**
+  String get variousArtists;
+
   /// Application title (brand name; not translated).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -12,6 +12,21 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mainRemove => 'Entfernen';
 
   @override
+  String get queueAddNext => 'Als Nächstes';
+
+  @override
+  String get queuePlayNow => 'Jetzt abspielen';
+
+  @override
+  String get queueAddToEnd => 'Ans Ende der Warteschlange';
+
+  @override
+  String get shuffle => 'Zufallswiedergabe';
+
+  @override
+  String get variousArtists => 'Verschiedene Interpreten';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -12,6 +12,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mainRemove => 'Remove';
 
   @override
+  String get queueAddNext => 'Add next';
+
+  @override
+  String get queuePlayNow => 'Play now';
+
+  @override
+  String get queueAddToEnd => 'Add to end of queue';
+
+  @override
+  String get shuffle => 'Shuffle';
+
+  @override
+  String get variousArtists => 'Various Artists';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -12,6 +12,21 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mainRemove => 'Quitar';
 
   @override
+  String get queueAddNext => 'Añadir a continuación';
+
+  @override
+  String get queuePlayNow => 'Reproducir ahora';
+
+  @override
+  String get queueAddToEnd => 'Añadir al final de la cola';
+
+  @override
+  String get shuffle => 'Aleatorio';
+
+  @override
+  String get variousArtists => 'Varios artistas';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -12,6 +12,21 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mainRemove => 'Retirer';
 
   @override
+  String get queueAddNext => 'Ajouter à la suite';
+
+  @override
+  String get queuePlayNow => 'Lire maintenant';
+
+  @override
+  String get queueAddToEnd => 'Ajouter à la fin de la file';
+
+  @override
+  String get shuffle => 'Aléatoire';
+
+  @override
+  String get variousArtists => 'Artistes divers';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -12,6 +12,21 @@ class AppLocalizationsIt extends AppLocalizations {
   String get mainRemove => 'Rimuovi';
 
   @override
+  String get queueAddNext => 'Aggiungi dopo';
+
+  @override
+  String get queuePlayNow => 'Riproduci ora';
+
+  @override
+  String get queueAddToEnd => 'Aggiungi alla fine della coda';
+
+  @override
+  String get shuffle => 'Casuale';
+
+  @override
+  String get variousArtists => 'Artisti vari';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -12,6 +12,21 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mainRemove => '削除';
 
   @override
+  String get queueAddNext => '次に追加';
+
+  @override
+  String get queuePlayNow => '今すぐ再生';
+
+  @override
+  String get queueAddToEnd => 'キューの最後に追加';
+
+  @override
+  String get shuffle => 'シャッフル';
+
+  @override
+  String get variousArtists => '様々なアーティスト';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -12,6 +12,21 @@ class AppLocalizationsPl extends AppLocalizations {
   String get mainRemove => 'Usuń';
 
   @override
+  String get queueAddNext => 'Dodaj jako następny';
+
+  @override
+  String get queuePlayNow => 'Odtwórz teraz';
+
+  @override
+  String get queueAddToEnd => 'Dodaj na koniec kolejki';
+
+  @override
+  String get shuffle => 'Odtwarzanie losowe';
+
+  @override
+  String get variousArtists => 'Różni wykonawcy';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -12,6 +12,21 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mainRemove => 'Remover';
 
   @override
+  String get queueAddNext => 'Adicionar a seguir';
+
+  @override
+  String get queuePlayNow => 'Reproduzir agora';
+
+  @override
+  String get queueAddToEnd => 'Adicionar ao fim da fila';
+
+  @override
+  String get shuffle => 'Aleatório';
+
+  @override
+  String get variousArtists => 'Vários artistas';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -12,6 +12,21 @@ class AppLocalizationsRu extends AppLocalizations {
   String get mainRemove => 'Убрать';
 
   @override
+  String get queueAddNext => 'Добавить следующим';
+
+  @override
+  String get queuePlayNow => 'Воспроизвести сейчас';
+
+  @override
+  String get queueAddToEnd => 'Добавить в конец очереди';
+
+  @override
+  String get shuffle => 'Перемешать';
+
+  @override
+  String get variousArtists => 'Разные исполнители';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -12,6 +12,21 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mainRemove => '移除';
 
   @override
+  String get queueAddNext => '添加为下一首';
+
+  @override
+  String get queuePlayNow => '立即播放';
+
+  @override
+  String get queueAddToEnd => '添加到队列末尾';
+
+  @override
+  String get shuffle => '随机播放';
+
+  @override
+  String get variousArtists => '群星';
+
+  @override
   String get appTitle => 'mStream Music';
 
   @override

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1,6 +1,11 @@
 {
   "mainRemove": "Usuń",
   "@@locale": "pl",
+  "queueAddNext": "Dodaj jako następny",
+  "queuePlayNow": "Odtwórz teraz",
+  "queueAddToEnd": "Dodaj na koniec kolejki",
+  "shuffle": "Odtwarzanie losowe",
+  "variousArtists": "Różni wykonawcy",
   "appTitle": "mStream Music",
   "settingsLanguage": "Język",
   "languageSystemDefault": "Domyślny systemu",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1,6 +1,11 @@
 {
   "mainRemove": "Remover",
   "@@locale": "pt",
+  "queueAddNext": "Adicionar a seguir",
+  "queuePlayNow": "Reproduzir agora",
+  "queueAddToEnd": "Adicionar ao fim da fila",
+  "shuffle": "Aleatório",
+  "variousArtists": "Vários artistas",
 
   "appTitle": "mStream Music",
 

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,6 +1,11 @@
 {
   "mainRemove": "Убрать",
   "@@locale": "ru",
+  "queueAddNext": "Добавить следующим",
+  "queuePlayNow": "Воспроизвести сейчас",
+  "queueAddToEnd": "Добавить в конец очереди",
+  "shuffle": "Перемешать",
+  "variousArtists": "Разные исполнители",
   "appTitle": "mStream Music",
   "settingsLanguage": "Язык",
   "languageSystemDefault": "Системный по умолчанию",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,6 +1,11 @@
 {
   "mainRemove": "移除",
   "@@locale": "zh",
+  "queueAddNext": "添加为下一首",
+  "queuePlayNow": "立即播放",
+  "queueAddToEnd": "添加到队列末尾",
+  "shuffle": "随机播放",
+  "variousArtists": "群星",
   "appTitle": "mStream Music",
   "settingsLanguage": "语言",
   "languageSystemDefault": "跟随系统",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,8 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:rxdart/rxdart.dart';
 
 import 'screens/browser.dart';
+import 'screens/album_detail_view.dart';
+import 'objects/display_item.dart';
 import 'singletons/server_list.dart';
 import 'objects/server.dart';
 import 'screens/about_screen.dart';
@@ -28,8 +30,8 @@ import 'media/cast_target.dart';
 import 'singletons/cast_manager.dart';
 import 'widgets/cast_picker_sheet.dart';
 import 'l10n/app_localizations.dart';
-import 'l10n/enum_labels.dart';
 import 'widgets/player_panel.dart';
+import 'widgets/browser_toolbar.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -238,6 +240,8 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
           final panel = _panelKey.currentState;
           if (panel != null && panel.isExpanded) {
             panel.collapse();
+          } else if (BrowserManager().albumDetail != null) {
+            BrowserManager().closeAlbumDetail();
           } else if (BrowserManager().browserCache.length > 1) {
             BrowserManager().popBrowser();
           } else {
@@ -360,30 +364,10 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
                       );
                     }),
               ],
-              bottom: PreferredSize(
-                preferredSize: const Size.fromHeight(34),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-                    child: StreamBuilder<String>(
-                        stream: BrowserManager().browserLabelStream,
-                        builder: (context, snapshot) {
-                          final String? label = snapshot.data;
-                          return Text(
-                            browserChromeLabel(l, label),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                                color: VelvetColors.appBarTextSecondary,
-                                fontSize: 13,
-                                fontWeight: FontWeight.w600,
-                                letterSpacing: 0.3),
-                          );
-                        }),
-                  ),
-                ),
-              ),
+              // Consolidated browser chrome (back · label/album · search ·
+              // download · add-all) — replaces both the old label-only strip and
+              // the Browser's in-body header row. See widgets/browser_toolbar.dart.
+              bottom: const BrowserToolbar(),
             ),
             drawer: Drawer(
                 child: ListView(padding: EdgeInsets.zero, children: <Widget>[
@@ -527,7 +511,28 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
                   padding: EdgeInsets.only(
                       bottom: PlayerPanel.kCollapsedHeight +
                           MediaQuery.of(context).viewPadding.bottom),
-                  child: Browser(),
+                  child: StreamBuilder<DisplayItem?>(
+                    stream: BrowserManager().albumDetailStream,
+                    initialData: BrowserManager().albumDetail,
+                    builder: (context, snap) {
+                      final album = snap.data;
+                      // Album detail renders over the browser, which stays alive
+                      // in the IndexedStack so its scroll/search survive. Same
+                      // browser model (no route), so the mini-player overlay —
+                      // which sits above this Scaffold — stays visible.
+                      return IndexedStack(
+                        index: album == null ? 0 : 1,
+                        sizing: StackFit.expand,
+                        children: [
+                          Browser(),
+                          album == null
+                              ? const SizedBox.shrink()
+                              : AlbumDetailView(
+                                  key: ValueKey(album), album: album),
+                        ],
+                      );
+                    },
+                  ),
                 ),
               ),
             ]),

--- a/lib/objects/metadata.dart
+++ b/lib/objects/metadata.dart
@@ -15,6 +15,14 @@ class MusicMetadata {
   // mixing + BPM-continuity modes (see audio_stuff.dart#autoDJ).
   int? bpm;
   String? musicalKey;
+  // Per-track audio specs — present only on newer servers (and tagged files);
+  // null on older API builds, so callers must treat them as optional. Used by
+  // the album detail screen for per-track times, album runtime, and the
+  // FLAC · kbps · kHz readout. durationSeconds is exposed as a [Duration] via
+  // the [duration] getter.
+  double? durationSeconds;
+  int? bitrate; // kbps
+  int? sampleRate; // Hz
   // Genre names for this track. Velvet servers emit `metadata.genres` as a
   // string list (many-to-many via track_genres); empty when untagged or on
   // servers that don't surface genres.
@@ -22,7 +30,12 @@ class MusicMetadata {
 
   MusicMetadata(this.artist, this.album, this.title, this.track, this.disc,
       this.year, this.hash, this.rating, this.albumArt,
-      {this.bpm, this.musicalKey, this.genres = const []});
+      {this.bpm,
+      this.musicalKey,
+      this.genres = const [],
+      this.durationSeconds,
+      this.bitrate,
+      this.sampleRate});
 
   MusicMetadata.fromJson(Map<String, dynamic> json)
       : artist = json['artist'],
@@ -36,6 +49,9 @@ class MusicMetadata {
         albumArt = json['albumArt'],
         bpm = json['bpm'],
         musicalKey = json['musicalKey'],
+        durationSeconds = (json['durationSeconds'] as num?)?.toDouble(),
+        bitrate = json['bitrate'],
+        sampleRate = json['sampleRate'],
         genres = parseGenres(json['genres']);
 
   Map<String, dynamic> toJson() => {
@@ -50,6 +66,9 @@ class MusicMetadata {
         'albumArt': albumArt,
         'bpm': bpm,
         'musicalKey': musicalKey,
+        'durationSeconds': durationSeconds,
+        'bitrate': bitrate,
+        'sampleRate': sampleRate,
         'genres': genres,
       };
 
@@ -70,6 +89,14 @@ class MusicMetadata {
         bpm: m['bpm'],
         musicalKey: m['musical-key'],
         genres: parseGenres(m['genres']),
+        // Progressive-enhancement fields — tolerate several key spellings and a
+        // numeric-or-string wire type; absent on older servers → left null.
+        durationSeconds: _seconds(m['duration'] ?? m['length']),
+        bitrate: _asInt(m['bitrate'] ?? m['bit-rate'] ?? m['bitRate']),
+        sampleRate: _asInt(m['sample-rate'] ??
+            m['sampleRate'] ??
+            m['samplerate'] ??
+            m['sample_rate']),
       );
 
   /// Parses the server's `genres` value (normally a string list) into a
@@ -84,4 +111,29 @@ class MusicMetadata {
   /// The genres as a single display string (`"Rock, Electronic"`), or null when
   /// there are none — convenient for `MediaItem.genre`.
   String? get genreLabel => genres.isEmpty ? null : genres.join(', ');
+
+  /// Track length as a [Duration], or null when the server didn't report it
+  /// (older API builds / untagged files).
+  Duration? get duration => durationSeconds == null
+      ? null
+      : Duration(milliseconds: (durationSeconds! * 1000).round());
+
+  /// Parses a numeric seconds value (num or numeric string) to a positive
+  /// double, or null when absent / non-numeric / non-positive.
+  static double? _seconds(dynamic v) {
+    if (v is num) return v > 0 ? v.toDouble() : null;
+    if (v is String) {
+      final d = double.tryParse(v);
+      return (d != null && d > 0) ? d : null;
+    }
+    return null;
+  }
+
+  /// Parses an int from a num or numeric string, or null.
+  static int? _asInt(dynamic v) {
+    if (v is int) return v;
+    if (v is num) return v.toInt();
+    if (v is String) return int.tryParse(v);
+    return null;
+  }
 }

--- a/lib/screens/album_detail_view.dart
+++ b/lib/screens/album_detail_view.dart
@@ -1,0 +1,575 @@
+// album_detail_view.dart — album detail rendered INSIDE the browser body (not a
+// route), so the global mini-player stays visible. Driven by
+// BrowserManager.albumDetail: when set, main.dart shows this over the file list
+// (in an IndexedStack) and Back dismisses it via BrowserManager.closeAlbumDetail.
+//
+// Layout (simplified from the original route screen): a medium-player-style
+// banner — album art left, title/artist/meta right, Play + Shuffle — painted
+// over the album-art colour splash, then the track list. Per-track duration,
+// album runtime, and the kbps · kHz readout render only when the server reports
+// them (older API builds omit them; see MusicMetadata).
+
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter/material.dart';
+import 'package:rxdart/rxdart.dart';
+
+import '../l10n/app_localizations.dart';
+import '../objects/display_item.dart';
+import '../singletons/api.dart';
+import '../singletons/browser_list.dart';
+import '../singletons/media.dart';
+import '../singletons/settings.dart';
+import '../theme/velvet_theme.dart';
+import '../util/ambient_color.dart';
+import '../util/media_format.dart';
+import '../util/queue_actions.dart';
+import '../widgets/player_panel.dart';
+
+/// Ink on top of the accent-filled Play button: dark espresso on bright accents,
+/// white on a dark custom accent (mirrors player_panel's `_kAmberInk`).
+Color get _accentInk => VelvetColors.primary.computeLuminance() > 0.42
+    ? const Color(0xFF1A1206)
+    : Colors.white;
+
+class AlbumDetailView extends StatefulWidget {
+  /// The tapped album row — carries name, server, altAlbumArt (`album_art_file`)
+  /// and subtext, from getAlbums().
+  final DisplayItem album;
+
+  const AlbumDetailView({Key? key, required this.album}) : super(key: key);
+
+  @override
+  State<AlbumDetailView> createState() => _AlbumDetailViewState();
+}
+
+class _AlbumDetailViewState extends State<AlbumDetailView> {
+  List<DisplayItem>? _songs; // null while loading
+  bool _error = false;
+  Gradient? _ambient; // null until the seed resolves (or stays null = no tint)
+
+  // Current-track path + playing flag, distinct() so per-position playbackState
+  // ticks don't rebuild the list (only a track change / play-pause flips the
+  // highlight). Path matches buildServerFileMediaItem's extras['path'].
+  late final Stream<({String? path, bool playing})> _nowStream =
+      Rx.combineLatest2<MediaItem?, PlaybackState,
+          ({String? path, bool playing})>(
+        MediaManager().audioHandler.mediaItem,
+        MediaManager().audioHandler.playbackState,
+        (m, s) => (path: m?.extras?['path'] as String?, playing: s.playing),
+      ).distinct((a, b) => a.path == b.path && a.playing == b.playing);
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+    _loadAmbient();
+  }
+
+  Future<void> _load() async {
+    try {
+      final songs = await ApiManager()
+          .fetchAlbumSongs(widget.album.data, useThisServer: widget.album.server);
+      // Publish to BrowserManager so the top toolbar's download / add-all act on
+      // these songs.
+      BrowserManager().albumDetailSongs = songs;
+      if (!mounted) return;
+      setState(() => _songs = songs);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _songs = const [];
+        _error = true;
+      });
+    }
+  }
+
+  // Colour splash seeded from the cover (vibrant, falling back to dominant);
+  // anchored top-left to glow from the art. Stays null on missing / near-
+  // grayscale art (the engine's grayscale fallback).
+  Future<void> _loadAmbient() async {
+    final url = _artUrl();
+    if (url == null) return;
+    final seed = await dominantAlbumColor(url, vibrant: true) ??
+        await dominantAlbumColor(url);
+    if (!mounted || seed == null) return;
+    final grad = ambientGradient(seed,
+        base: VelvetColors.bg,
+        vibrant: true,
+        center: Alignment.topLeft,
+        radius: 1.0); // 80% of the engine default (1.25)
+    if (grad == null) return;
+    setState(() => _ambient = grad);
+  }
+
+  String? _artUrl([String compress = 'l']) {
+    final aa = widget.album.altAlbumArt;
+    final server = widget.album.server;
+    if (server == null || aa == null) return null;
+    return Uri.encodeFull(server.url +
+        '/album-art/' +
+        aa +
+        '?compress=' +
+        compress +
+        (server.jwt == null ? '' : '&token=' + server.jwt!));
+  }
+
+  // ── derived metadata ──
+  String _artistLabel(List<DisplayItem> songs, AppLocalizations l) {
+    final artists = songs
+        .map((s) => s.metadata?.artist)
+        .where((a) => a != null && a.trim().isNotEmpty)
+        .toSet();
+    if (artists.isEmpty) return '';
+    if (artists.length == 1) return artists.first!;
+    return l.variousArtists;
+  }
+
+  String? _yearLabel(List<DisplayItem> songs) {
+    for (final song in songs) {
+      if (song.metadata?.year != null) return song.metadata!.year.toString();
+    }
+    return null;
+  }
+
+  // Format from the first track's file extension (e.g. ".flac" → "FLAC").
+  String? _formatLabel(List<DisplayItem> songs) {
+    for (final s in songs) {
+      final fp = s.data ?? '';
+      final dot = fp.lastIndexOf('.');
+      if (dot > 0 && dot < fp.length - 1) {
+        return fp.substring(dot + 1).toUpperCase();
+      }
+    }
+    return null;
+  }
+
+  // Album runtime — only when EVERY track reports a duration (newer servers),
+  // so a partial sum never shows a misleading total.
+  Duration? _runtime(List<DisplayItem> songs) {
+    if (songs.isEmpty) return null;
+    int ms = 0;
+    for (final s in songs) {
+      final d = s.metadata?.duration;
+      if (d == null) return null;
+      ms += d.inMilliseconds;
+    }
+    return Duration(milliseconds: ms);
+  }
+
+  String _runtimeLabel(Duration d) {
+    final mins = (d.inSeconds / 60).round();
+    if (mins < 60) return '$mins min';
+    return '${mins ~/ 60} hr ${mins % 60} min';
+  }
+
+  int? _bitrate(List<DisplayItem> songs) {
+    for (final s in songs) {
+      if (s.metadata?.bitrate != null) return s.metadata!.bitrate;
+    }
+    return null;
+  }
+
+  int? _sampleRate(List<DisplayItem> songs) {
+    for (final s in songs) {
+      if (s.metadata?.sampleRate != null) return s.metadata!.sampleRate;
+    }
+    return null;
+  }
+
+  // 44100 → "44.1 kHz", 48000 → "48 kHz".
+  String _khzLabel(int hz) {
+    final k = hz / 1000.0;
+    final s = k == k.roundToDouble() ? k.toStringAsFixed(0) : k.toStringAsFixed(1);
+    return '$s kHz';
+  }
+
+  // ── actions ──
+  void _playFrom(int index, {bool shuffle = false}) {
+    final songs = _songs;
+    if (songs == null || songs.isEmpty) return;
+    playFromHere(songs, index, shuffle: shuffle);
+  }
+
+  // Row tap: defer to the shared TapBehavior setting (the same one the file
+  // browser uses). A pure add-to-queue shows a confirmation toast.
+  Future<void> _onRowTap(int index) async {
+    final songs = _songs;
+    if (songs == null) return;
+    if (await handleTrackTap(songs, index)) _toast();
+  }
+
+  // ── per-row play-options menu ──
+  Future<void> _rowAddNext(int index) async {
+    final songs = _songs;
+    if (songs == null || index < 0 || index >= songs.length) return;
+    await addNext(songs[index]);
+    _toast();
+  }
+
+  void _rowPlayNow(int index) {
+    final songs = _songs;
+    if (songs == null || index < 0 || index >= songs.length) return;
+    playNow(songs[index]);
+  }
+
+  Future<void> _rowAddToEnd(int index) async {
+    final songs = _songs;
+    if (songs == null || index < 0 || index >= songs.length) return;
+    await addToQueueEnd(songs[index]);
+    _toast();
+  }
+
+  // "Added to queue" confirmation. Floats above the docked mini-player — that
+  // overlay sits in a higher layer at the bottom and would otherwise hide a
+  // standard bottom snackbar (the bug this fixes).
+  void _toast() {
+    if (!mounted) return;
+    final l = AppLocalizations.of(context);
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(l.browserSongsAdded(1)),
+      behavior: SnackBarBehavior.floating,
+      margin: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        bottom: PlayerPanel.kCollapsedHeight +
+            MediaQuery.of(context).viewPadding.bottom +
+            8,
+      ),
+    ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final songs = _songs;
+    // Ambient colour splash spans the whole view (banner + track list), glowing
+    // from the top-left and fading down across the song list. The rows are
+    // transparent, so it shows through; the engine's contrast floor keeps titles
+    // legible, and it fades to bg (opaque) so the offstage browser never shows.
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 700),
+      curve: Curves.easeOut,
+      decoration: BoxDecoration(
+        gradient: _ambient ??
+            LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [VelvetColors.surface, VelvetColors.bg],
+            ),
+      ),
+      child: Column(
+        children: [
+          _banner(l, songs),
+          Expanded(
+            child: songs == null
+                ? const Center(child: CircularProgressIndicator())
+                : songs.isEmpty
+                    ? Center(
+                        child: Padding(
+                          padding: const EdgeInsets.all(24),
+                          child: Text(
+                            _error ? l.mainFailedToConnect : l.mainQueueEmpty,
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                                color: VelvetColors.textSecondary, fontSize: 14),
+                          ),
+                        ),
+                      )
+                    : _trackList(songs),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── banner: back/overflow + medium-player-style art-left header over the splash ──
+  Widget _banner(AppLocalizations l, List<DisplayItem>? songs) {
+    final enabled = songs != null && songs.isNotEmpty;
+    final artUrl = _artUrl();
+    final artist = songs == null ? '' : _artistLabel(songs, l);
+
+    final metaParts = <String>[];
+    if (songs != null) {
+      final year = _yearLabel(songs);
+      if (year != null) metaParts.add(year);
+      metaParts.add(l.trackCount(songs.length));
+      final rt = _runtime(songs);
+      if (rt != null) metaParts.add(_runtimeLabel(rt));
+      final fmt = _formatLabel(songs);
+      if (fmt != null) metaParts.add(fmt);
+      final br = _bitrate(songs);
+      if (br != null) metaParts.add('$br kbps');
+      final sr = _sampleRate(songs);
+      if (sr != null) metaParts.add(_khzLabel(sr));
+    }
+
+    return Container(
+      // The splash is painted by the root now; the banner just carries the
+      // hairline divider and lets the gradient show through.
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: VelvetColors.border)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Back + overflow live in the top toolbar now; the banner is just the
+          // art-left header. Top pad clears the AppBar toolbar above it.
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 12, 16),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: SizedBox(
+                    width: 86,
+                    height: 86,
+                    child: artUrl != null
+                        ? Image.network(artUrl,
+                            fit: BoxFit.cover,
+                            errorBuilder: (_, __, ___) =>
+                                albumArtFallback(iconSize: 30))
+                        : albumArtFallback(iconSize: 30),
+                  ),
+                ),
+                const SizedBox(width: 14),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        widget.album.name,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.w700,
+                          height: 1.12,
+                          letterSpacing: -0.2,
+                          color: VelvetColors.textPrimary,
+                        ),
+                      ),
+                      if (artist.isNotEmpty) ...[
+                        const SizedBox(height: 3),
+                        Text(
+                          artist,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                              fontSize: 13.5,
+                              color: VelvetColors.textSecondary),
+                        ),
+                      ],
+                      if (metaParts.isNotEmpty) ...[
+                        const SizedBox(height: 5),
+                        Text(
+                          metaParts.join('  ·  '),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontFamily: 'monospace',
+                            fontSize: 10,
+                            letterSpacing: 0.2,
+                            color: VelvetColors.textTertiary,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                // Play (filled) + Shuffle, stacked to keep the banner compact.
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton.filled(
+                      onPressed: enabled ? () => _playFrom(0) : null,
+                      tooltip: l.play,
+                      icon: Icon(Icons.play_arrow, color: _accentInk),
+                      style: IconButton.styleFrom(
+                        backgroundColor: VelvetColors.primary,
+                        disabledBackgroundColor:
+                            VelvetColors.primary.withValues(alpha: 0.4),
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    IconButton(
+                      onPressed:
+                          enabled ? () => _playFrom(0, shuffle: true) : null,
+                      tooltip: l.shuffle,
+                      icon: const Icon(Icons.shuffle),
+                      color: VelvetColors.textSecondary,
+                      style: IconButton.styleFrom(
+                        shape: CircleBorder(
+                            side: BorderSide(color: VelvetColors.border)),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _trackList(List<DisplayItem> songs) {
+    return StreamBuilder<({String? path, bool playing})>(
+      stream: _nowStream,
+      initialData: (path: null, playing: false),
+      builder: (context, snap) {
+        final now = snap.data ?? (path: null, playing: false);
+        return ListView.builder(
+          padding: const EdgeInsets.only(top: 4, bottom: 12),
+          itemCount: songs.length,
+          itemBuilder: (context, i) {
+            final s = songs[i];
+            return _SongRow(
+              number: i + 1,
+              title: s.metadata?.title ?? (s.data ?? '').split('/').last,
+              active: now.path != null && now.path == s.data,
+              playing: now.playing,
+              duration: s.metadata?.duration,
+              onTap: () => _onRowTap(i),
+              onAddNext: () => _rowAddNext(i),
+              onPlayNow: () => _rowPlayNow(i),
+              onAddToEnd: () => _rowAddToEnd(i),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+/// One track row: number (or active EQ/play indicator), title, duration (when
+/// reported), and a play-options menu (Add next / Play now, plus Add to end of
+/// queue when the row tap is in play-from-here mode). The row tap itself follows
+/// the shared TapBehavior setting.
+class _SongRow extends StatelessWidget {
+  final int number;
+  final String title;
+  final bool active;
+  final bool playing;
+  final Duration? duration;
+  final VoidCallback onTap;
+  final VoidCallback onAddNext;
+  final VoidCallback onPlayNow;
+  final VoidCallback onAddToEnd;
+
+  const _SongRow({
+    required this.number,
+    required this.title,
+    required this.active,
+    required this.playing,
+    required this.onTap,
+    required this.onAddNext,
+    required this.onPlayNow,
+    required this.onAddToEnd,
+    this.duration,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Material(
+      color: active ? VelvetColors.primaryDim : Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border(
+              left: BorderSide(
+                  color: active ? VelvetColors.primary : Colors.transparent,
+                  width: 2),
+              bottom: BorderSide(color: VelvetColors.border, width: 0.5),
+            ),
+          ),
+          padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 24,
+                child: Center(
+                  child: active
+                      ? Icon(playing ? Icons.graphic_eq : Icons.play_arrow,
+                          size: playing ? 18 : 16, color: VelvetColors.primary)
+                      : Text(
+                          number.toString().padLeft(2, '0'),
+                          style: TextStyle(
+                            fontFamily: 'monospace',
+                            fontSize: 13,
+                            color: VelvetColors.textTertiary,
+                          ),
+                        ),
+                ),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Text(
+                  title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: active ? FontWeight.w500 : FontWeight.w400,
+                    color:
+                        active ? VelvetColors.primary : VelvetColors.textPrimary,
+                  ),
+                ),
+              ),
+              if (duration != null) ...[
+                const SizedBox(width: 10),
+                Text(
+                  formatDuration(duration!, padMinutes: false),
+                  style: TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 12,
+                    color: VelvetColors.textTertiary,
+                  ),
+                ),
+              ],
+              const SizedBox(width: 4),
+              // Play-options menu: Add next / Play now (+ Add to end of queue
+              // when the row tap is play-from-here, so every queue action stays
+              // reachable).
+              PopupMenuButton<String>(
+                icon: Icon(Icons.play_arrow_rounded,
+                    color: VelvetColors.textSecondary),
+                iconSize: 24,
+                color: VelvetColors.surface,
+                tooltip: l.play,
+                padding: EdgeInsets.zero,
+                constraints:
+                    const BoxConstraints(minWidth: 40, minHeight: 40),
+                onSelected: (v) {
+                  switch (v) {
+                    case 'next':
+                      onAddNext();
+                      break;
+                    case 'now':
+                      onPlayNow();
+                      break;
+                    case 'end':
+                      onAddToEnd();
+                      break;
+                  }
+                },
+                itemBuilder: (context) => [
+                  PopupMenuItem(value: 'next', child: Text(l.queueAddNext)),
+                  PopupMenuItem(value: 'now', child: Text(l.queuePlayNow)),
+                  if (SettingsManager().tapBehavior ==
+                      TapBehavior.playFromHere)
+                    PopupMenuItem(
+                        value: 'end', child: Text(l.queueAddToEnd)),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -1,23 +1,18 @@
 import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
-import 'package:mstream_music/singletons/downloads.dart';
 import 'package:mstream_music/singletons/file_explorer.dart';
 import '../l10n/app_localizations.dart';
 import '../singletons/browser_list.dart';
 import '../singletons/api.dart';
 import '../singletons/settings.dart';
-import '../singletons/transcode.dart';
 import '../objects/display_item.dart';
 import '../theme/velvet_theme.dart';
 import '../widgets/album_grid.dart';
 import '../widgets/letter_strip.dart';
-import '../widgets/local_search_bar.dart';
-import 'package:uuid/uuid.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 
-import 'dart:io';
-
 import '../singletons/media.dart';
+import '../util/queue_actions.dart';
 
 import 'add_server.dart';
 
@@ -27,15 +22,6 @@ class Browser extends StatefulWidget {
 }
 
 class _BrowserState extends State<Browser> {
-  // Local-search state. _searchOpen toggles the header search field;
-  // _searchQuery filters the *displayed* list only — BrowserManager's
-  // browserList and back-stack are never mutated, so navigation, the
-  // letter-strip math and scroll restore all stay intact. Any
-  // navigation (folder/album/etc. tap, or Back) clears both via
-  // _closeSearch() so a filter never carries over into a new view.
-  String _searchQuery = '';
-  bool _searchOpen = false;
-
   // Item types whose tap loads a new list (vs. file/localFile, which
   // just enqueue and leave the current list in place). Tapping any of
   // these closes local search.
@@ -49,18 +35,10 @@ class _BrowserState extends State<Browser> {
     'localDirectory',
   };
 
-  void _closeSearch() {
-    if (!_searchOpen && _searchQuery.isEmpty) return;
-    setState(() {
-      _searchOpen = false;
-      _searchQuery = '';
-    });
-  }
-
   void handleTap(
       List<DisplayItem> browserList, int index, BuildContext context) {
     if (_navTypes.contains(browserList[index].type)) {
-      _closeSearch();
+      BrowserManager().closeSearch();
     }
 
     if (browserList[index].type == 'addServer') {
@@ -132,8 +110,10 @@ class _BrowserState extends State<Browser> {
     }
 
     if (browserList[index].type == 'album') {
-      ApiManager().getAlbumSongs(browserList[index].data,
-          useThisServer: browserList[index].server);
+      // Open the album detail over the browser body (no route) — keeps the
+      // file-explorer model and the mini-player visible. See main.dart's
+      // IndexedStack and BrowserManager.albumDetail.
+      BrowserManager().openAlbumDetail(browserList[index]);
       return;
     }
 
@@ -165,85 +145,12 @@ class _BrowserState extends State<Browser> {
   // Side-effect entry points. Build the MediaItem then run it through
   // _enqueue, which applies the user's tap behavior preference.
   Future<void> addLocalFile(DisplayItem i) async {
-    await _enqueue(_buildLocalFileItem(i));
+    await _enqueue(buildLocalFileMediaItem(i));
   }
 
   Future<void> addFile(DisplayItem i) async {
-    final item = await _buildFileItem(i);
+    final item = await buildServerFileMediaItem(i);
     if (item != null) await _enqueue(item);
-  }
-
-  // Pure builder for a localFile MediaItem. No I/O.
-  MediaItem _buildLocalFileItem(DisplayItem i) {
-    return new MediaItem(
-        id: Uuid().v4(),
-        title: i.name.split('/').last,
-        extras: {'path': i.data, 'localPath': i.data!});
-  }
-
-  // Builder for a server-file MediaItem. Async because it has to check
-  // whether the file is already cached locally to decide between a
-  // local path and a streaming URL. Returns null if the download dir
-  // isn't available.
-  Future<MediaItem?> _buildFileItem(DisplayItem i) async {
-    String downloadDirectory = i.server!.localname + i.data!;
-    final dir = await FileExplorer()
-        .getDownloadDir(i.server!.storageMode, i.server!.storageBasePath);
-    // A null dir means the configured location is unavailable (SD card
-    // removed / folder deleted) — treat as "not downloaded".
-    final String? finalString =
-        dir == null ? null : '${dir.path}/media/$downloadDirectory';
-    final bool isLocal =
-        finalString != null && new File(finalString).existsSync() == true;
-
-    // Streaming URL — used as the MediaItem id for BOTH local and online
-    // items, so playback can fall back to streaming if the local file goes
-    // missing (moved mid-migration, SD removed, deleted externally). The
-    // local path lives in extras and is re-checked for existence at play time.
-    String p = '';
-    i.data!.split("/").forEach((element) {
-      if (element.length == 0) return;
-      p += "/" + Uri.encodeComponent(element);
-    });
-    final String prefix =
-        TranscodeManager().transcodeOn == true ? '/transcode' : '/media';
-    final String streamUrl = i.server!.url +
-        prefix +
-        p +
-        '?app_uuid=' +
-        Uuid().v4() +
-        (i.server!.jwt == null ? '' : '&token=' + i.server!.jwt!);
-
-    final String? artUrl = i.metadata?.albumArt != null
-        ? Uri.parse(i.server!.url.toString())
-            .resolve('/album-art/' +
-                i.metadata!.albumArt! +
-                '?compress=l&token=' +
-                (i.server!.jwt ?? ''))
-            .toString()
-        : null;
-
-    return new MediaItem(
-        id: streamUrl,
-        title: i.metadata?.title ?? i.name,
-        album: i.metadata?.album,
-        artist: i.metadata?.artist,
-        genre: i.metadata?.genreLabel,
-        extras: {
-          'server': i.server!.localname,
-          'path': i.data,
-          if (isLocal) 'localPath': finalString,
-          'year': i.metadata?.year,
-          'track': i.metadata?.track,
-          'disc': i.metadata?.disc,
-          'artUrl': artUrl,
-          // bpm + musicalKey power AutoDJ's BPM-continuity / harmonic-mixing
-          // modes — read off the currently playing item.
-          'bpm': i.metadata?.bpm,
-          'musicalKey': i.metadata?.musicalKey,
-        });
-
-    // TODO: Fire of request for metadata
   }
 
   // Adds the item to the queue, then dispatches on the user's tap
@@ -273,41 +180,12 @@ class _BrowserState extends State<Browser> {
     }
   }
 
-  // Pattern A: clear the queue, fill it with every playable item from
-  // the current browser view (in order), jump to the tapped one, play.
-  Future<void> _playFromHere(
-      List<DisplayItem> browserList, int tappedIndex) async {
-    // Filter to playable rows, remember where the tap lands within
-    // the filtered list. Non-song rows (folders, headers) are skipped.
-    final playable = <DisplayItem>[];
-    int newIndex = 0;
-    for (var j = 0; j < browserList.length; j++) {
-      final t = browserList[j].type;
-      if (t == 'file' || t == 'localFile') {
-        if (j == tappedIndex) newIndex = playable.length;
-        playable.add(browserList[j]);
-      }
-    }
-    if (playable.isEmpty) return;
-
-    // Build all MediaItems first so a failed build doesn't leave us
-    // with a half-replaced queue.
-    final items = <MediaItem>[];
-    for (final i in playable) {
-      final m = i.type == 'localFile'
-          ? _buildLocalFileItem(i)
-          : await _buildFileItem(i);
-      if (m != null) items.add(m);
-    }
-    if (items.isEmpty) return;
-
-    await MediaManager().audioHandler.customAction('clearPlaylist');
-    for (final m in items) {
-      await MediaManager().audioHandler.addQueueItem(m);
-    }
-    await MediaManager().audioHandler.skipToQueueItem(newIndex);
-    await MediaManager().audioHandler.play();
-  }
+  // Pattern A: clear the queue, fill it with every playable item from the
+  // current browser view (in order), jump to the tapped one, play. Delegates to
+  // the shared helper (util/queue_actions.dart) so the album-detail screen plays
+  // albums with identical semantics.
+  Future<void> _playFromHere(List<DisplayItem> browserList, int tappedIndex) =>
+      playFromHere(browserList, tappedIndex);
 
   Widget makeListItem(List<DisplayItem> b, int i, BuildContext c) {
     switch (b[i].type) {
@@ -610,173 +488,9 @@ class _BrowserState extends State<Browser> {
                     ])))));
   }
 
-  // Browser "Download all": same confirm + empty-state UX as the queue's
-  // button. Counts the file rows in the *current* list (folders / headers
-  // are ignored); alerts if there are none, otherwise confirms the count
-  // before enqueueing. downloadOneFile no-ops on files already on disk.
-  void _downloadAll(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    final files =
-        BrowserManager().browserList.where((e) => e.type == 'file').toList();
-    if (files.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l.browserNothingToDownload)));
-      return;
-    }
-    final n = files.length;
-    showDialog<void>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: VelvetColors.surface,
-        title: Text(l.browserDownloadAllTitle),
-        content: Text(l.browserDownloadAllConfirm(n)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: Text(l.cancel,
-                style: TextStyle(color: VelvetColors.textSecondary)),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.of(ctx).pop();
-              for (final e in files) {
-                String downloadUrl = e.server!.url +
-                    '/media' +
-                    e.data! +
-                    (e.server!.jwt == null ? '' : '?token=' + e.server!.jwt!);
-                DownloadManager().downloadOneFile(
-                    downloadUrl, e.server!.localname, e.data!,
-                    referenceItem: e);
-              }
-              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                  content: Text(l.browserDownloadsStarted(n))));
-            },
-            child: Text(l.download),
-          ),
-        ],
-      ),
-    );
-  }
-
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return Column(children: <Widget>[
-      Material(
-        color: VelvetColors.surface,
-        child: StreamBuilder<List<DisplayItem>>(
-            stream: BrowserManager().browserListStream,
-            builder: (context, snapshot) {
-              final List<DisplayItem> browserList = snapshot.data ?? [];
-
-              if (browserList.length > 0) {
-                print(browserList[0].type);
-              }
-              return Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    if (browserList.length == 0 ||
-                        browserList[0].type != 'execAction') ...[
-                      if (_searchOpen) ...[
-                        // Search mode: a close button + the live-filtering
-                        // field fill the header. Download / Add All are
-                        // hidden here so they always act on the full list,
-                        // never the filtered subset.
-                        IconButton(
-                            icon: Icon(Icons.close,
-                                color: VelvetColors.textSecondary),
-                            tooltip: l.browserCloseSearch,
-                            onPressed: _closeSearch),
-                        Expanded(
-                            child: LocalSearchBar(
-                                hintText: l.browserSearchThisList,
-                                onChanged: (q) =>
-                                    setState(() => _searchQuery = q))),
-                      ] else ...[
-                      IconButton(
-                          icon: Icon(Icons.keyboard_arrow_left,
-                              color: VelvetColors.textSecondary),
-                          tooltip: l.goBack,
-                          onPressed: () {
-                            _closeSearch();
-                            BrowserManager().popBrowser();
-                          }),
-                      Row(children: <Widget>[
-                        IconButton(
-                            icon: Icon(Icons.search,
-                                color: VelvetColors.textSecondary),
-                            tooltip: l.browserSearchList,
-                            onPressed: () =>
-                                setState(() => _searchOpen = true)),
-                        IconButton(
-                            icon: Icon(
-                              Icons.download_sharp,
-                              color: VelvetColors.textSecondary,
-                            ),
-                            tooltip: l.download,
-                            onPressed: () => _downloadAll(context)),
-                        IconButton(
-                            icon: Icon(
-                              Icons.library_add,
-                              color: VelvetColors.textSecondary,
-                            ),
-                            tooltip: l.addAll,
-                            onPressed: () {
-                              int n = 0;
-
-                              BrowserManager().browserList.forEach((element) {
-                                if (element.type == 'localFile') {
-                                  if (element.data!.substring(
-                                          element.data!.length - 4) ==
-                                      '.m3u') {
-                                    return;
-                                  }
-                                  addLocalFile(element);
-                                  n++;
-                                } else if (element.type == 'file') {
-                                  if (element.data!.substring(
-                                          element.data!.length - 4) ==
-                                      '.m3u') {
-                                    return;
-                                  }
-                                  addFile(element);
-                                  n++;
-                                }
-                              });
-
-                              if (n > 0) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                        content:
-                                            Text(l.browserSongsAdded(n))));
-                              }
-                            })
-                      ])
-                      ],
-                    ] else ...[
-                      Expanded(
-                          child: TextField(
-                              onSubmitted: (text) {
-                                ApiManager().searchServer(text);
-                                print('First text field: $text');
-                              },
-                              style: TextStyle(color: VelvetColors.textSecondary),
-                              decoration: InputDecoration(
-                                prefixIcon: Icon(
-                                  Icons.search,
-                                  color: VelvetColors.textSecondary,
-                                ),
-                                hintStyle: TextStyle(
-                                  color: VelvetColors.textSecondary,
-                                ),
-                                labelStyle: TextStyle(
-                                  color: VelvetColors.textSecondary,
-                                ),
-                                hintText: l.browserSearchHint,
-                              )))
-                    ]
-                  ]);
-            }),
-      ),
       // Thin indeterminate bar while any browser server call is in
       // flight (all go through ApiManager.makeServerCall). Fixed 3px
       // slot — empty when idle — so the list never jumps.
@@ -811,9 +525,13 @@ class _BrowserState extends State<Browser> {
                     // is never filtered.
                     final bool isHome = rawList.isNotEmpty &&
                         rawList[0].type == 'execAction';
-                    final String q = _searchQuery.trim();
+                    // Search state lives in BrowserManager (the top toolbar owns
+                    // the field) and re-emits this list on every change, so
+                    // reading it synchronously here re-filters live.
+                    final search = BrowserManager().search;
+                    final String q = search.query.trim();
                     final bool filtering =
-                        _searchOpen && q.isNotEmpty && !isHome;
+                        search.open && q.isNotEmpty && !isHome;
                     final List<DisplayItem> browserList = filtering
                         ? rawList.where((it) => it.matchesQuery(q)).toList()
                         : rawList;

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -256,13 +256,24 @@ class ApiManager {
 
     List<DisplayItem> newList = [];
     res['albums'].forEach((e) {
+      // Newer servers include `album_artist`; fold it into the subtitle as
+      // "Artist · Year" for the browse card/list. Older servers omit it, so the
+      // subtitle gracefully falls back to just the year.
+      final artist = (e['album_artist'] ?? e['albumArtist'] ?? e['artist'])
+          ?.toString()
+          .trim();
+      final year = e['year']?.toString().trim();
+      final subtitle = [
+        if (artist != null && artist.isNotEmpty) artist,
+        if (year != null && year.isNotEmpty) year,
+      ].join(' · ');
       DisplayItem newItem = new DisplayItem(
           useThisServer,
           e['name'],
           'album',
           e['name'],
           Icon(Icons.album, color: VelvetColors.textSecondary),
-          e['year']?.toString() ?? '');
+          subtitle);
       newItem.altAlbumArt = e['album_art_file'];
       newList.add(newItem);
     });
@@ -270,18 +281,15 @@ class ApiManager {
     BrowserManager().addListToStack(newList, alphabetical: true);
   }
 
-  Future<void> getAlbumSongs(String? album, {Server? useThisServer}) async {
-    var res;
-    try {
-      res = await makeServerCall(
-          useThisServer, '/api/v1/db/album-songs', {'album': album}, 'POST');
-    } catch (err) {
-      // TODO: Handle Errors
-      print(err);
-      return;
-    }
+  /// Fetches an album's songs as a list of `file` DisplayItems WITHOUT touching
+  /// the browser stack — used by the album detail screen, which renders its own
+  /// tracklist. Throws on a server error so the caller can show its own state.
+  Future<List<DisplayItem>> fetchAlbumSongs(String? album,
+      {Server? useThisServer}) async {
+    final res = await makeServerCall(
+        useThisServer, '/api/v1/db/album-songs', {'album': album}, 'POST');
 
-    List<DisplayItem> newList = [];
+    final List<DisplayItem> newList = [];
     res.forEach((e) {
       MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
 
@@ -297,6 +305,18 @@ class ApiManager {
 
       newList.add(newItem);
     });
+    return newList;
+  }
+
+  Future<void> getAlbumSongs(String? album, {Server? useThisServer}) async {
+    List<DisplayItem> newList;
+    try {
+      newList = await fetchAlbumSongs(album, useThisServer: useThisServer);
+    } catch (err) {
+      // TODO: Handle Errors
+      print(err);
+      return;
+    }
 
     BrowserManager().addListToStack(newList);
   }

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -51,6 +51,22 @@ class BrowserManager {
   late final BehaviorSubject<String> _browserLabel =
       BehaviorSubject<String>.seeded(listName);
 
+  // Album-detail overlay. When non-null, the browser body shows the album detail
+  // view over the file list (same browser model — no Navigator route — so the
+  // mini-player stays visible). Cleared by Back and by a server switch.
+  late final BehaviorSubject<DisplayItem?> _albumDetail =
+      BehaviorSubject<DisplayItem?>.seeded(null);
+
+  // The album-detail view publishes its loaded songs here so the top toolbar's
+  // download / add-all act on them (the songs live in the view's state).
+  List<DisplayItem>? albumDetailSongs;
+
+  // Browser local-search state, shared so the top toolbar owns the field/toggle
+  // while the body does the filtering. open = field shown; query = filter text.
+  late final BehaviorSubject<({bool open, String query})> _search =
+      BehaviorSubject<({bool open, String query})>.seeded(
+          (open: false, query: ''));
+
   StreamSubscription<int>? _letterStripSub;
   StreamSubscription<MigrationProgress?>? _migrationSub;
 
@@ -83,6 +99,45 @@ class BrowserManager {
     _browserLabel.sink.add(label);
   }
 
+  /// Show the album-detail view over the browser body (no route).
+  void openAlbumDetail(DisplayItem album) {
+    albumDetailSongs = null; // new album — its songs load asynchronously
+    _albumDetail.add(album);
+  }
+
+  /// Hide the album-detail view. Returns true if it was open, so the back
+  /// handler knows it consumed the gesture.
+  bool closeAlbumDetail() {
+    if (_albumDetail.value == null) return false;
+    albumDetailSongs = null;
+    _albumDetail.add(null);
+    return true;
+  }
+
+  // ── browser local search (field lives in the top toolbar) ──
+  // Each mutation re-emits the browser list so the body re-filters live (the
+  // body reads `search` synchronously at build time).
+  void openSearch() {
+    if (_search.value.open) return;
+    _search.add((open: true, query: ''));
+    updateStream();
+  }
+
+  void setSearchQuery(String q) {
+    _search.add((open: _search.value.open, query: q));
+    updateStream();
+  }
+
+  /// Clears an active search. Returns true if there was one (so the back
+  /// handler can consume the gesture).
+  bool closeSearch() {
+    final s = _search.value;
+    if (!s.open && s.query.isEmpty) return false;
+    _search.add((open: false, query: ''));
+    updateStream();
+    return true;
+  }
+
   void clear() {
     List<DisplayItem> hold = browserCache[0];
     bool holdAlpha = alphabeticalCache.isNotEmpty ? alphabeticalCache[0] : false;
@@ -99,6 +154,7 @@ class BrowserManager {
   }
 
   void goToNavScreen() {
+    _albumDetail.add(null);
     browserCache.clear();
     browserList.clear();
     // Invariant: scrollCache.length == browserCache.length - 1.
@@ -183,6 +239,7 @@ class BrowserManager {
   }
 
   void noServerScreen() {
+    _albumDetail.add(null);
     browserCache.clear();
     browserList.clear();
     scrollCache.clear();
@@ -305,9 +362,15 @@ class BrowserManager {
     _letterStripSub?.cancel();
     _browserStream.close();
     _browserLabel.close();
+    _albumDetail.close();
+    _search.close();
     _loading.close();
   }
 
   Stream<List<DisplayItem>> get browserListStream => _browserStream.stream;
   Stream<String> get browserLabelStream => _browserLabel.stream;
+  Stream<DisplayItem?> get albumDetailStream => _albumDetail.stream;
+  DisplayItem? get albumDetail => _albumDetail.value;
+  Stream<({bool open, String query})> get searchStream => _search.stream;
+  ({bool open, String query}) get search => _search.value;
 }

--- a/lib/util/ambient_color.dart
+++ b/lib/util/ambient_color.dart
@@ -97,7 +97,8 @@ double _contrastWhite(int r, int g, int b) => 1.05 / (_relLum(r, g, b) + 0.05);
 Gradient? ambientGradient(Color seed,
     {required Color base,
     bool vibrant = false,
-    Alignment center = Alignment.topCenter}) {
+    Alignment center = Alignment.topCenter,
+    double radius = 1.25}) {
   final r = (seed.r * 255.0).round(),
       g = (seed.g * 255.0).round(),
       b = (seed.b * 255.0).round();
@@ -135,7 +136,7 @@ Gradient? ambientGradient(Color seed,
   // dark base over the lower half, keeping the queue list legible.
   return RadialGradient(
     center: center,
-    radius: 1.25,
+    radius: radius,
     colors: [brightColor, midColor, base],
     stops: const [0.0, 0.40, 0.82],
   );

--- a/lib/util/queue_actions.dart
+++ b/lib/util/queue_actions.dart
@@ -1,0 +1,221 @@
+// queue_actions.dart — shared queue/playback actions.
+//
+// Extracted from browser.dart so the album-detail screen and the file browser
+// build identical MediaItems and run identical "play from here" semantics
+// (clear the queue → enqueue the list in order → jump to the tapped track →
+// play). Keeping one source of truth means a fix to the streaming-URL / local-
+// cache logic lands everywhere at once.
+
+import 'dart:io';
+
+import 'package:audio_service/audio_service.dart';
+import 'package:uuid/uuid.dart';
+
+import '../objects/display_item.dart';
+import '../singletons/file_explorer.dart';
+import '../singletons/media.dart';
+import '../singletons/settings.dart';
+import '../singletons/transcode.dart';
+
+/// Pure builder for a localFile MediaItem (no I/O).
+MediaItem buildLocalFileMediaItem(DisplayItem i) {
+  return MediaItem(
+    id: Uuid().v4(),
+    title: i.name.split('/').last,
+    extras: {'path': i.data, 'localPath': i.data!},
+  );
+}
+
+/// Builds a server-file MediaItem, preferring a locally-cached copy when one is
+/// present. Async because it has to check the download directory to decide
+/// between a local path and a streaming URL. Returns null only if the configured
+/// download location is unavailable (SD card removed / folder deleted).
+///
+/// The streaming URL is the MediaItem id for BOTH local and online items, so
+/// playback can fall back to streaming if the local file goes missing; the local
+/// path lives in extras and is re-checked at play time.
+Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
+  final String downloadDirectory = i.server!.localname + i.data!;
+  final dir = await FileExplorer()
+      .getDownloadDir(i.server!.storageMode, i.server!.storageBasePath);
+  final String? finalString =
+      dir == null ? null : '${dir.path}/media/$downloadDirectory';
+  final bool isLocal =
+      finalString != null && File(finalString).existsSync() == true;
+
+  String p = '';
+  i.data!.split('/').forEach((element) {
+    if (element.isEmpty) return;
+    p += '/' + Uri.encodeComponent(element);
+  });
+  final String prefix =
+      TranscodeManager().transcodeOn == true ? '/transcode' : '/media';
+  final String streamUrl = i.server!.url +
+      prefix +
+      p +
+      '?app_uuid=' +
+      Uuid().v4() +
+      (i.server!.jwt == null ? '' : '&token=' + i.server!.jwt!);
+
+  final String? artUrl = i.metadata?.albumArt != null
+      ? Uri.parse(i.server!.url.toString())
+          .resolve('/album-art/' +
+              i.metadata!.albumArt! +
+              '?compress=l&token=' +
+              (i.server!.jwt ?? ''))
+          .toString()
+      : null;
+
+  return MediaItem(
+    id: streamUrl,
+    title: i.metadata?.title ?? i.name,
+    album: i.metadata?.album,
+    artist: i.metadata?.artist,
+    genre: i.metadata?.genreLabel,
+    // Duration when the server reported it — surfaces in the queue list and the
+    // now-playing readout before playback loads (just_audio refines it later).
+    duration: i.metadata?.duration,
+    extras: {
+      'server': i.server!.localname,
+      'path': i.data,
+      if (isLocal) 'localPath': finalString,
+      'year': i.metadata?.year,
+      'track': i.metadata?.track,
+      'disc': i.metadata?.disc,
+      'artUrl': artUrl,
+      // bpm + musicalKey power AutoDJ's BPM-continuity / harmonic-mixing modes.
+      'bpm': i.metadata?.bpm,
+      'musicalKey': i.metadata?.musicalKey,
+    },
+  );
+}
+
+/// Builds the MediaItem for any playable row (file / localFile), or null for a
+/// non-playable row / unavailable download dir.
+Future<MediaItem?> buildMediaItemForRow(DisplayItem i) => i.type == 'localFile'
+    ? Future.value(buildLocalFileMediaItem(i))
+    : buildServerFileMediaItem(i);
+
+/// Clears the queue, fills it with every playable item from [rows] (in order),
+/// jumps to the one at [tappedIndex], and plays. When [shuffle] is true the
+/// playable order is shuffled first and playback starts from the top.
+///
+/// Non-playable rows (folders, headers) are skipped, and [tappedIndex] is
+/// remapped onto the filtered list. All MediaItems are built before the queue is
+/// touched, so a failed build never leaves a half-replaced queue.
+Future<void> playFromHere(List<DisplayItem> rows, int tappedIndex,
+    {bool shuffle = false}) async {
+  final playable = <DisplayItem>[];
+  int newIndex = 0;
+  for (var j = 0; j < rows.length; j++) {
+    final t = rows[j].type;
+    if (t == 'file' || t == 'localFile') {
+      if (j == tappedIndex) newIndex = playable.length;
+      playable.add(rows[j]);
+    }
+  }
+  if (playable.isEmpty) return;
+
+  if (shuffle) {
+    playable.shuffle();
+    newIndex = 0;
+  }
+
+  final items = <MediaItem>[];
+  for (final i in playable) {
+    final m = await buildMediaItemForRow(i);
+    if (m != null) items.add(m);
+  }
+  if (items.isEmpty) return;
+
+  await MediaManager().audioHandler.customAction('clearPlaylist');
+  for (final m in items) {
+    await MediaManager().audioHandler.addQueueItem(m);
+  }
+  await MediaManager().audioHandler.skipToQueueItem(newIndex);
+  await MediaManager().audioHandler.play();
+}
+
+/// Appends every playable item from [rows] to the queue WITHOUT clearing it.
+/// If the queue was empty, playback starts automatically (so a first "add"
+/// from a fresh state doesn't require a separate play press). Returns the
+/// number of tracks enqueued.
+Future<int> addRowsToQueue(List<DisplayItem> rows) async {
+  final wasEmpty = MediaManager().audioHandler.queue.value.isEmpty;
+  int n = 0;
+  for (final i in rows) {
+    if (i.type != 'file' && i.type != 'localFile') continue;
+    final m = await buildMediaItemForRow(i);
+    if (m == null) continue;
+    await MediaManager().audioHandler.addQueueItem(m);
+    n++;
+  }
+  if (n > 0 && wasEmpty) {
+    await MediaManager().audioHandler.play();
+  }
+  return n;
+}
+
+/// Applies the user's TapBehavior (Settings — the same setting the file browser
+/// uses) to a single-row tap within [rows] at [index]:
+///   • playFromHere  → play the whole list from [index]
+///   • appendAndJump → append the row, jump to it, and play
+///   • addToQueue    → append the row (play only if the queue was empty)
+/// Returns true only for a pure append (addToQueue onto a non-empty queue), so
+/// the caller can show an "added to queue" toast.
+Future<bool> handleTrackTap(List<DisplayItem> rows, int index) async {
+  if (index < 0 || index >= rows.length) return false;
+  final behavior = SettingsManager().tapBehavior;
+  if (behavior == TapBehavior.playFromHere) {
+    await playFromHere(rows, index);
+    return false;
+  }
+  final handler = MediaManager().audioHandler;
+  final wasEmpty = handler.queue.value.isEmpty;
+  final m = await buildMediaItemForRow(rows[index]);
+  if (m == null) return false;
+  await handler.addQueueItem(m);
+  if (behavior == TapBehavior.appendAndJump) {
+    await handler.skipToQueueItem(handler.queue.value.length - 1);
+    await handler.play();
+    return false;
+  }
+  // addToQueue: also start playback when the queue was empty. Always report a
+  // queued result so the caller shows the "added to queue" toast.
+  if (wasEmpty) await handler.play();
+  return true;
+}
+
+/// Inserts [row] immediately after the current track WITHOUT changing playback
+/// ("add next"). The handler has no insert wired to the backend, so we append
+/// then move the new item up to right after the current track; the original
+/// tracks continue after it. Returns the index it landed at (or null on build
+/// failure). Falls back to the end when nothing is playing / current is last.
+Future<int?> addNext(DisplayItem row) async {
+  final handler = MediaManager().audioHandler;
+  final m = await buildMediaItemForRow(row);
+  if (m == null) return null;
+  final before = handler.queue.value.length; // index of the appended item
+  final current = handler.playbackState.value.queueIndex;
+  await handler.addQueueItem(m);
+  final target = (current == null || current < 0) ? before : current + 1;
+  if (target < before) {
+    await handler.customAction('moveQueueItem', {'from': before, 'to': target});
+  }
+  return target;
+}
+
+/// Inserts [row] next (via [addNext]) and starts playing it immediately.
+Future<void> playNow(DisplayItem row) async {
+  final target = await addNext(row);
+  if (target == null) return;
+  await MediaManager().audioHandler.skipToQueueItem(target);
+  await MediaManager().audioHandler.play();
+}
+
+/// Appends [row] to the END of the queue WITHOUT playing.
+Future<void> addToQueueEnd(DisplayItem row) async {
+  final m = await buildMediaItemForRow(row);
+  if (m == null) return;
+  await MediaManager().audioHandler.addQueueItem(m);
+}

--- a/lib/widgets/browser_toolbar.dart
+++ b/lib/widgets/browser_toolbar.dart
@@ -1,0 +1,258 @@
+// browser_toolbar.dart — the consolidated chrome that lives in the AppBar's
+// bottom slot (replacing the old label-only strip AND the Browser's in-body
+// header row). One context-aware bar frees the vertical space those two used to
+// take and lets the album detail view drop its own back/overflow.
+//
+// Contexts (driven by BrowserManager streams):
+//   • album detail open → back · album name · download · add-all
+//   • local search open → close · filter field
+//   • home (section list) → the "search the whole server" field
+//   • normal list        → back · label · search · download · add-all
+//
+// Search state lives in BrowserManager (the body does the filtering); the
+// download / add-all actions operate on the current list — the album's loaded
+// songs when the detail view is up, otherwise the browser list.
+
+import 'package:flutter/material.dart';
+import 'package:rxdart/rxdart.dart';
+
+import '../l10n/app_localizations.dart';
+import '../l10n/enum_labels.dart';
+import '../objects/display_item.dart';
+import '../singletons/api.dart';
+import '../singletons/browser_list.dart';
+import '../singletons/downloads.dart';
+import '../theme/velvet_theme.dart';
+import '../util/queue_actions.dart';
+import 'local_search_bar.dart';
+
+// Combined snapshot the toolbar renders from.
+typedef _Tb = ({
+  DisplayItem? album,
+  ({bool open, String query}) search,
+  String label,
+  List<DisplayItem> list,
+});
+
+class BrowserToolbar extends StatefulWidget implements PreferredSizeWidget {
+  const BrowserToolbar({Key? key}) : super(key: key);
+
+  @override
+  Size get preferredSize => const Size.fromHeight(50);
+
+  @override
+  State<BrowserToolbar> createState() => _BrowserToolbarState();
+}
+
+class _BrowserToolbarState extends State<BrowserToolbar> {
+  late final Stream<_Tb> _stream = Rx.combineLatest4<
+      DisplayItem?,
+      ({bool open, String query}),
+      String,
+      List<DisplayItem>,
+      _Tb>(
+    BrowserManager().albumDetailStream,
+    BrowserManager().searchStream,
+    BrowserManager().browserLabelStream,
+    BrowserManager().browserListStream,
+    (album, search, label, list) =>
+        (album: album, search: search, label: label, list: list),
+  );
+
+  // Files in [all] that can be downloaded (server files only), de-noised of
+  // playlists. Album songs and browse rows both flow through here.
+  List<DisplayItem> _downloadable(List<DisplayItem> all) => all
+      .where((e) =>
+          e.type == 'file' &&
+          e.server != null &&
+          e.data != null &&
+          !e.data!.toLowerCase().endsWith('.m3u'))
+      .toList();
+
+  // Playable rows for add-all (server + local files), minus playlists.
+  List<DisplayItem> _enqueueable(List<DisplayItem> all) => all
+      .where((e) =>
+          (e.type == 'file' || e.type == 'localFile') &&
+          e.data != null &&
+          !e.data!.toLowerCase().endsWith('.m3u'))
+      .toList();
+
+  // Mirrors the old browser "Download all": confirm the count, then enqueue
+  // downloads (downloadOneFile no-ops on files already on disk).
+  void _downloadAll(BuildContext context, List<DisplayItem> all) {
+    final l = AppLocalizations.of(context);
+    final files = _downloadable(all);
+    if (files.isEmpty) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(l.browserNothingToDownload)));
+      return;
+    }
+    final n = files.length;
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: VelvetColors.surface,
+        title: Text(l.browserDownloadAllTitle),
+        content: Text(l.browserDownloadAllConfirm(n)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text(l.cancel,
+                style: TextStyle(color: VelvetColors.textSecondary)),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              for (final e in files) {
+                final downloadUrl = e.server!.url +
+                    '/media' +
+                    e.data! +
+                    (e.server!.jwt == null ? '' : '?token=' + e.server!.jwt!);
+                DownloadManager().downloadOneFile(
+                    downloadUrl, e.server!.localname, e.data!,
+                    referenceItem: e);
+              }
+              ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(l.browserDownloadsStarted(n))));
+            },
+            child: Text(l.download),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _addAll(BuildContext context, List<DisplayItem> all) async {
+    final l = AppLocalizations.of(context);
+    final n = await addRowsToQueue(_enqueueable(all));
+    if (!context.mounted || n == 0) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(l.browserSongsAdded(n))));
+  }
+
+  // The list the download / add-all actions act on right now.
+  List<DisplayItem> get _actionTargets => BrowserManager().albumDetail != null
+      ? (BrowserManager().albumDetailSongs ?? const [])
+      : BrowserManager().browserList;
+
+  Widget _icon(IconData icon, String tooltip, VoidCallback onTap) => IconButton(
+        icon: Icon(icon, size: 22),
+        color: VelvetColors.appBarTextSecondary,
+        tooltip: tooltip,
+        onPressed: onTap,
+      );
+
+  Widget _title(String text) => Expanded(
+        child: Text(
+          text,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: VelvetColors.appBarText,
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.2,
+          ),
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return SizedBox(
+      height: widget.preferredSize.height,
+      child: StreamBuilder<_Tb>(
+        stream: _stream,
+        initialData: (
+          album: BrowserManager().albumDetail,
+          search: BrowserManager().search,
+          label: BrowserManager().listName,
+          list: BrowserManager().browserList,
+        ),
+        builder: (context, snap) {
+          final s = snap.data!;
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(4, 0, 4, 6),
+            child: _content(context, l, s),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _content(BuildContext context, AppLocalizations l, _Tb s) {
+    // Album detail: back · name · download · add-all (Play/Shuffle stay in the
+    // banner). Acts on the album's loaded songs.
+    if (s.album != null) {
+      return Row(children: [
+        _icon(Icons.arrow_back, l.goBack,
+            () => BrowserManager().closeAlbumDetail()),
+        _title(s.album!.name),
+        _icon(Icons.download_sharp, l.download,
+            () => _downloadAll(context, _actionTargets)),
+        _icon(Icons.library_add, l.addAll,
+            () => _addAll(context, _actionTargets)),
+      ]);
+    }
+
+    // Local search active: close · live filter field.
+    if (s.search.open) {
+      return Row(children: [
+        _icon(Icons.close, l.browserCloseSearch,
+            () => BrowserManager().closeSearch()),
+        Expanded(
+          child: LocalSearchBar(
+            key: const ValueKey('browser-search'),
+            hintText: l.browserSearchThisList,
+            onChanged: BrowserManager().setSearchQuery,
+          ),
+        ),
+        const SizedBox(width: 4),
+      ]);
+    }
+
+    // Home section list: the "search the whole server" field.
+    final isHome = s.list.isNotEmpty && s.list[0].type == 'execAction';
+    if (isHome) {
+      return Row(children: [
+        const SizedBox(width: 8),
+        Expanded(
+          child: TextField(
+            textInputAction: TextInputAction.search,
+            onSubmitted: (text) => ApiManager().searchServer(text),
+            style: TextStyle(color: VelvetColors.appBarText, fontSize: 15),
+            cursorColor: VelvetColors.primary,
+            decoration: InputDecoration(
+              isDense: true,
+              border: InputBorder.none,
+              prefixIcon:
+                  Icon(Icons.search, color: VelvetColors.appBarTextSecondary),
+              hintText: l.browserSearchHint,
+              hintStyle: TextStyle(color: VelvetColors.appBarTextSecondary),
+            ),
+          ),
+        ),
+      ]);
+    }
+
+    // Normal list: back (when there's somewhere to go) · label · search ·
+    // download · add-all.
+    final canBack = BrowserManager().browserCache.length > 1;
+    return Row(children: [
+      if (canBack)
+        _icon(Icons.arrow_back, l.goBack, () {
+          BrowserManager().closeSearch();
+          BrowserManager().popBrowser();
+        })
+      else
+        const SizedBox(width: 12),
+      _title(browserChromeLabel(l, s.label)),
+      _icon(Icons.search, l.browserSearchList,
+          () => BrowserManager().openSearch()),
+      _icon(Icons.download_sharp, l.download,
+          () => _downloadAll(context, _actionTargets)),
+      _icon(Icons.library_add, l.addAll,
+          () => _addAll(context, _actionTargets)),
+    ]);
+  }
+}

--- a/test/objects/metadata_test.dart
+++ b/test/objects/metadata_test.dart
@@ -61,5 +61,64 @@ void main() {
       expect(reparsed.rating, original.rating);
       expect(reparsed.albumArt, original.albumArt);
     });
+
+    test('round-trips the audio-spec fields', () {
+      final original = MusicMetadata(
+          'A', 'Al', 'Ti', 1, 1, 2020, 'h', 5, 'art.jpg',
+          durationSeconds: 200.0, bitrate: 1000, sampleRate: 44100);
+      final reparsed = MusicMetadata.fromJson(original.toJson());
+      expect(reparsed.durationSeconds, 200.0);
+      expect(reparsed.bitrate, 1000);
+      expect(reparsed.sampleRate, 44100);
+    });
+  });
+
+  // The album detail screen renders duration / bitrate / sample-rate only when
+  // present, so the client must parse them off newer servers AND leave them null
+  // on older builds that don't send them.
+  group('MusicMetadata.fromServerMap progressive fields', () {
+    test('reads duration / bitrate / sample-rate when present', () {
+      final m = MusicMetadata.fromServerMap({
+        'artist': 'A',
+        'title': 'T',
+        'album-art': 'x.jpg',
+        'duration': 225,
+        'bitrate': 1411,
+        'sample-rate': 44100,
+      });
+      expect(m.durationSeconds, 225);
+      expect(m.duration, const Duration(seconds: 225));
+      expect(m.bitrate, 1411);
+      expect(m.sampleRate, 44100);
+    });
+
+    test('tolerates alternate key spellings and numeric strings', () {
+      final m = MusicMetadata.fromServerMap({
+        'hash': 'h',
+        'length': '180.5',
+        'bit-rate': '320',
+        'sampleRate': 48000,
+      });
+      expect(m.durationSeconds, 180.5);
+      expect(m.duration, const Duration(milliseconds: 180500));
+      expect(m.bitrate, 320);
+      expect(m.sampleRate, 48000);
+    });
+
+    test('leaves the new fields null on an older server (keys absent)', () {
+      final m = MusicMetadata.fromServerMap({'hash': 'h', 'title': 'T'});
+      expect(m.durationSeconds, isNull);
+      expect(m.duration, isNull);
+      expect(m.bitrate, isNull);
+      expect(m.sampleRate, isNull);
+    });
+
+    test('rejects non-positive / non-numeric values', () {
+      final m = MusicMetadata.fromServerMap(
+          {'hash': 'h', 'duration': 0, 'bitrate': 'abc'});
+      expect(m.durationSeconds, isNull);
+      expect(m.duration, isNull);
+      expect(m.bitrate, isNull);
+    });
   });
 }


### PR DESCRIPTION
## What & why

Builds the **Albums detail** design (from a Claude Design handoff) into the app, and — because the detail view needed a home for back/actions — **consolidates the browser chrome** into the app bar. Tapping an album now opens a real detail view (art, tracklist, play/queue actions) instead of dumping its songs into the file list.

It deliberately stays on the file-explorer **"browser" model** (no `Navigator` route): the detail renders over the browser via `BrowserManager.albumDetail` + an `IndexedStack`, so the global mini-player stays visible and the browser's scroll/search survive.

## Changes

**Album detail — `lib/screens/album_detail_view.dart` (new)**
- Medium-player-style banner (art left; title/artist/meta right; Play + Shuffle) over the album-art colour splash (OKLCH engine; top-left, 0.8× radius), then the track list.
- Row tap follows the shared **Tap behavior** setting (the same one the file browser uses — no duplicate setting). An "added to queue" toast floats above the docked mini-player.
- Per-row **play-options popup**: Add next / Play now / Add to end of queue (the last only in *play-from-here* mode, so every queue action stays reachable).

**Browser toolbar — `lib/widgets/browser_toolbar.dart` (new)**
- One context-aware toolbar in `AppBar.bottom` (back · label/album · search · download · add-all) replacing both the old label strip and the Browser's in-body header row, reclaiming vertical space. Local-search state moved to `BrowserManager`.

**Progressive metadata (backwards-compatible)**
- `MusicMetadata` gains nullable `durationSeconds` / `bitrate` / `sampleRate`, parsed defensively; per-track times, album runtime, kbps·kHz, and the browse album-artist render only when the server sends them. Older servers are unaffected.

**Shared helpers**
- `lib/util/queue_actions.dart` (new): MediaItem building + "play from here" extracted from the browser (now delegated), plus `handleTrackTap` / `addNext` / `playNow` / `addToQueueEnd`.
- `ApiManager.fetchAlbumSongs` returns songs without touching the browser stack.

**l10n**: `shuffle`, `variousArtists`, `queueAddNext`, `queuePlayNow`, `queueAddToEnd` across all 10 locales (generated files regenerated).

## Testing
- `flutter analyze` clean; `flutter test` 27/27 (added progressive-metadata parsing tests).
- `flutter build apk --debug` OK; smoke-tested on a physical device (install / launch / logcat clean) throughout.

## Reviewer notes
- Generated `lib/l10n/app_localizations*.dart` are committed (repo convention).
- Server fields that would unlock more optional metadata (per-track `duration`/`bitrate`/`sample-rate` on `album-songs`; per-album `album_artist` on `albums`) are consumed when present but not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
