### PR TITLE
Browser: file-explorer path row + server-playlist management

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1,6 +1,7 @@
 {
   "mainRemove": "Entfernen",
   "@@locale": "de",
+  "playlistActionFailed": "Wiedergabeliste konnte nicht gespeichert werden — der Name ist möglicherweise bereits vergeben.",
   "queueAddNext": "Als Nächstes",
   "queuePlayNow": "Jetzt abspielen",
   "queueAddToEnd": "Ans Ende der Warteschlange",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,8 @@
 {
   "mainRemove": "Remove",
   "@@locale": "en",
+  "playlistActionFailed": "Couldn't save the playlist — the name may already be in use.",
+  "@playlistActionFailed": { "description": "Toast shown when creating or renaming a playlist fails (often a duplicate name)." },
   "queueAddNext": "Add next",
   "@queueAddNext": { "description": "Track row menu: insert after the current track." },
   "queuePlayNow": "Play now",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,6 +1,7 @@
 {
   "mainRemove": "Quitar",
   "@@locale": "es",
+  "playlistActionFailed": "No se pudo guardar la lista: puede que el nombre ya esté en uso.",
   "queueAddNext": "Añadir a continuación",
   "queuePlayNow": "Reproducir ahora",
   "queueAddToEnd": "Añadir al final de la cola",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,6 +1,7 @@
 {
   "mainRemove": "Retirer",
   "@@locale": "fr",
+  "playlistActionFailed": "Impossible d'enregistrer la liste : ce nom est peut-être déjà utilisé.",
   "queueAddNext": "Ajouter à la suite",
   "queuePlayNow": "Lire maintenant",
   "queueAddToEnd": "Ajouter à la fin de la file",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1,6 +1,7 @@
 {
   "mainRemove": "Rimuovi",
   "@@locale": "it",
+  "playlistActionFailed": "Impossibile salvare la playlist: il nome potrebbe essere già in uso.",
   "queueAddNext": "Aggiungi dopo",
   "queuePlayNow": "Riproduci ora",
   "queueAddToEnd": "Aggiungi alla fine della coda",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,6 +1,7 @@
 {
   "mainRemove": "削除",
   "@@locale": "ja",
+  "playlistActionFailed": "プレイリストを保存できませんでした。その名前は既に使われている可能性があります。",
   "queueAddNext": "次に追加",
   "queuePlayNow": "今すぐ再生",
   "queueAddToEnd": "キューの最後に追加",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -120,6 +120,12 @@ abstract class AppLocalizations {
   /// **'Remove'**
   String get mainRemove;
 
+  /// Toast shown when creating or renaming a playlist fails (often a duplicate name).
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t save the playlist — the name may already be in use.'**
+  String get playlistActionFailed;
+
   /// Track row menu: insert after the current track.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -12,6 +12,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mainRemove => 'Entfernen';
 
   @override
+  String get playlistActionFailed =>
+      'Wiedergabeliste konnte nicht gespeichert werden — der Name ist möglicherweise bereits vergeben.';
+
+  @override
   String get queueAddNext => 'Als Nächstes';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -12,6 +12,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mainRemove => 'Remove';
 
   @override
+  String get playlistActionFailed =>
+      'Couldn\'t save the playlist — the name may already be in use.';
+
+  @override
   String get queueAddNext => 'Add next';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -12,6 +12,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mainRemove => 'Quitar';
 
   @override
+  String get playlistActionFailed =>
+      'No se pudo guardar la lista: puede que el nombre ya esté en uso.';
+
+  @override
   String get queueAddNext => 'Añadir a continuación';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -12,6 +12,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mainRemove => 'Retirer';
 
   @override
+  String get playlistActionFailed =>
+      'Impossible d\'enregistrer la liste : ce nom est peut-être déjà utilisé.';
+
+  @override
   String get queueAddNext => 'Ajouter à la suite';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -12,6 +12,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get mainRemove => 'Rimuovi';
 
   @override
+  String get playlistActionFailed =>
+      'Impossibile salvare la playlist: il nome potrebbe essere già in uso.';
+
+  @override
   String get queueAddNext => 'Aggiungi dopo';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -12,6 +12,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mainRemove => '削除';
 
   @override
+  String get playlistActionFailed => 'プレイリストを保存できませんでした。その名前は既に使われている可能性があります。';
+
+  @override
   String get queueAddNext => '次に追加';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -12,6 +12,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get mainRemove => 'Usuń';
 
   @override
+  String get playlistActionFailed =>
+      'Nie udało się zapisać playlisty — nazwa może być już zajęta.';
+
+  @override
   String get queueAddNext => 'Dodaj jako następny';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -12,6 +12,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mainRemove => 'Remover';
 
   @override
+  String get playlistActionFailed =>
+      'Não foi possível guardar a playlist — o nome pode já estar em uso.';
+
+  @override
   String get queueAddNext => 'Adicionar a seguir';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -12,6 +12,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get mainRemove => 'Убрать';
 
   @override
+  String get playlistActionFailed =>
+      'Не удалось сохранить плейлист — возможно, имя уже занято.';
+
+  @override
   String get queueAddNext => 'Добавить следующим';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -12,6 +12,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mainRemove => '移除';
 
   @override
+  String get playlistActionFailed => '无法保存播放列表——该名称可能已被使用。';
+
+  @override
   String get queueAddNext => '添加为下一首';
 
   @override

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1,6 +1,7 @@
 {
   "mainRemove": "Usuń",
   "@@locale": "pl",
+  "playlistActionFailed": "Nie udało się zapisać playlisty — nazwa może być już zajęta.",
   "queueAddNext": "Dodaj jako następny",
   "queuePlayNow": "Odtwórz teraz",
   "queueAddToEnd": "Dodaj na koniec kolejki",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1,6 +1,7 @@
 {
   "mainRemove": "Remover",
   "@@locale": "pt",
+  "playlistActionFailed": "Não foi possível guardar a playlist — o nome pode já estar em uso.",
   "queueAddNext": "Adicionar a seguir",
   "queuePlayNow": "Reproduzir agora",
   "queueAddToEnd": "Adicionar ao fim da fila",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,6 +1,7 @@
 {
   "mainRemove": "Убрать",
   "@@locale": "ru",
+  "playlistActionFailed": "Не удалось сохранить плейлист — возможно, имя уже занято.",
   "queueAddNext": "Добавить следующим",
   "queuePlayNow": "Воспроизвести сейчас",
   "queueAddToEnd": "Добавить в конец очереди",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,6 +1,7 @@
 {
   "mainRemove": "移除",
   "@@locale": "zh",
+  "playlistActionFailed": "无法保存播放列表——该名称可能已被使用。",
   "queueAddNext": "添加为下一首",
   "queuePlayNow": "立即播放",
   "queueAddToEnd": "添加到队列末尾",

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -9,6 +9,7 @@ import '../objects/display_item.dart';
 import '../theme/velvet_theme.dart';
 import '../widgets/album_grid.dart';
 import '../widgets/letter_strip.dart';
+import '../widgets/player_panel.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 
 import '../singletons/media.dart';
@@ -218,66 +219,217 @@ class _BrowserState extends State<Browser> {
 
   Widget makePlaylistWidget(List<DisplayItem> b, int i, BuildContext c) {
     final l = AppLocalizations.of(c);
-    return Container(
-      decoration: BoxDecoration(
-          border: Border(bottom: BorderSide(color: Color(0xFFbdbdbd)))),
-      child: Slidable(
-          endActionPane: ActionPane(
-            motion: DrawerMotion(),
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () => handleTap(b, i, c),
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border(
+                bottom: BorderSide(color: VelvetColors.border, width: 0.5)),
+          ),
+          padding: const EdgeInsets.fromLTRB(12, 8, 4, 8),
+          child: Row(
             children: [
-              SlidableAction(
-                  backgroundColor: Colors.redAccent,
-                  icon: Icons.remove_circle,
-                  label: l.delete,
-                  onPressed: (context) {
-                    showDialog(
-                        context: c,
-                        builder: (BuildContext context) {
-                          return AlertDialog(
-                              title: Text(l.browserConfirmDeletePlaylist),
-                              content: b[i].getText(),
-                              actions: <Widget>[
-                                TextButton(
-                                  child: Text(l.goBack),
-                                  onPressed: () {
-                                    Navigator.of(context).pop();
-                                  },
-                                ),
-                                TextButton(
-                                    child: Text(
-                                      l.delete,
-                                      style: TextStyle(color: Colors.red),
-                                    ),
-                                    onPressed: () {
-                                      ApiManager().removePlaylist(b[i].data!,
-                                          useThisServer: b[i].server);
-                                      Navigator.of(context).pop();
-                                    })
-                              ]);
-                        });
-                  })
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: VelvetColors.raised,
+                  borderRadius: BorderRadius.circular(VelvetColors.radiusSmall),
+                ),
+                child: Icon(Icons.queue_music, color: VelvetColors.primary),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  b[i].name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: VelvetColors.textPrimary,
+                  ),
+                ),
+              ),
+              PopupMenuButton<String>(
+                icon: Icon(Icons.more_vert, color: VelvetColors.textSecondary),
+                color: VelvetColors.surface,
+                tooltip: l.mainMore,
+                onSelected: (v) {
+                  if (v == 'rename') _renamePlaylist(c, b[i]);
+                  if (v == 'delete') _deletePlaylist(c, b[i]);
+                },
+                itemBuilder: (_) => [
+                  PopupMenuItem(value: 'rename', child: Text(l.rename)),
+                  PopupMenuItem(
+                    value: 'delete',
+                    child: Text(l.delete,
+                        style: TextStyle(color: VelvetColors.error)),
+                  ),
+                ],
+              ),
             ],
           ),
-          child: Builder(
-            builder: (context) => ListTile(
-                leading: b[i].icon ?? null,
-                title: b[i].getText(),
-                subtitle: b[i].getSubText(),
-                trailing: IconButton(
-                  icon: Icon(
-                    Icons.keyboard_arrow_left,
-                    size: 20.0,
-                    color: Colors.brown[900],
-                  ),
-                  onPressed: () {
-                    Slidable.of(context)?.openEndActionPane();
-                  },
-                ),
-                onTap: () {
-                  handleTap(b, i, c);
-                }),
-          )),
+        ),
+      ),
     );
+  }
+
+  // ── Server playlists view: New-playlist button + the playlist rows ──
+  Widget _playlistsView(BuildContext context, List<DisplayItem> playlists) {
+    final l = AppLocalizations.of(context);
+    return Container(
+      color: VelvetColors.bg,
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 12, 12, 8),
+            child: SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: () => _createPlaylist(context),
+                icon: const Icon(Icons.add, size: 20),
+                label: Text(l.playlistsNew),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: VelvetColors.primary,
+                  side: BorderSide(
+                      color: VelvetColors.primary.withValues(alpha: 0.5)),
+                  padding: const EdgeInsets.symmetric(vertical: 13),
+                  shape: RoundedRectangleBorder(
+                      borderRadius:
+                          BorderRadius.circular(VelvetColors.radiusSmall)),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: playlists.isEmpty
+                ? Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Text(
+                        l.playlistsEmptyTitle,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                            color: VelvetColors.textSecondary, fontSize: 14),
+                      ),
+                    ),
+                  )
+                : ListView.builder(
+                    controller: BrowserManager().sc,
+                    padding: const EdgeInsets.only(bottom: 8),
+                    itemCount: playlists.length,
+                    itemBuilder: (context, i) =>
+                        makePlaylistWidget(playlists, i, context),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Name-entry dialog shared by create + rename. Returns the trimmed name, or
+  // null if cancelled.
+  Future<String?> _playlistNameDialog(BuildContext context,
+      {required String title, required String action, String? initial}) {
+    final l = AppLocalizations.of(context);
+    final controller = TextEditingController(text: initial ?? '');
+    return showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: VelvetColors.surface,
+        title: Text(title),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          style: TextStyle(color: VelvetColors.textPrimary),
+          decoration: InputDecoration(hintText: l.playlistNameHint),
+          onSubmitted: (v) => Navigator.of(ctx).pop(v.trim()),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text(l.cancel,
+                style: TextStyle(color: VelvetColors.textSecondary)),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(ctx).pop(controller.text.trim()),
+            child: Text(action),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _createPlaylist(BuildContext context) async {
+    final l = AppLocalizations.of(context);
+    final name = await _playlistNameDialog(context,
+        title: l.playlistsNew, action: l.create);
+    if (name == null || name.isEmpty) return;
+    try {
+      await ApiManager().createPlaylist(name);
+    } catch (_) {
+      if (context.mounted) _playlistError(context);
+    }
+  }
+
+  Future<void> _renamePlaylist(BuildContext context, DisplayItem item) async {
+    final l = AppLocalizations.of(context);
+    final name = await _playlistNameDialog(context,
+        title: l.playlistsRename, action: l.rename, initial: item.name);
+    if (name == null || name.isEmpty || name == item.name) return;
+    try {
+      await ApiManager().renamePlaylist(item.name, name);
+    } catch (_) {
+      if (context.mounted) _playlistError(context);
+    }
+  }
+
+  void _deletePlaylist(BuildContext context, DisplayItem item) {
+    final l = AppLocalizations.of(context);
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: VelvetColors.surface,
+        title: Text(l.browserConfirmDeletePlaylist),
+        content:
+            Text(item.name, style: TextStyle(color: VelvetColors.textPrimary)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text(l.cancel,
+                style: TextStyle(color: VelvetColors.textSecondary)),
+          ),
+          TextButton(
+            onPressed: () {
+              ApiManager()
+                  .removePlaylist(item.data!, useThisServer: item.server);
+              Navigator.of(ctx).pop();
+            },
+            child: Text(l.delete, style: TextStyle(color: VelvetColors.error)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Floating so it clears the docked mini-player overlay (a plain bottom
+  // snackbar renders behind it).
+  void _playlistError(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(l.playlistActionFailed),
+      behavior: SnackBarBehavior.floating,
+      margin: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        bottom: PlayerPanel.kCollapsedHeight +
+            MediaQuery.of(context).viewPadding.bottom +
+            8,
+      ),
+    ));
   }
 
   Widget makeLocalFolderWidget(List<DisplayItem> b, int i, BuildContext c) {
@@ -491,6 +643,43 @@ class _BrowserState extends State<Browser> {
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return Column(children: <Widget>[
+      // Current File Explorer path — a thin strip under the toolbar/back button.
+      // Only shown in the file explorer (BrowserManager.currentPath is null
+      // elsewhere); rebuilds on each navigation via browserListStream.
+      StreamBuilder<List<DisplayItem>>(
+        stream: BrowserManager().browserListStream,
+        builder: (context, _) {
+          final path = BrowserManager().currentPath;
+          if (path == null) return const SizedBox.shrink();
+          return Container(
+            width: double.infinity,
+            padding: const EdgeInsets.fromLTRB(14, 4, 12, 5),
+            decoration: BoxDecoration(
+              color: VelvetColors.raised,
+              border: Border(bottom: BorderSide(color: VelvetColors.border)),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.folder_outlined,
+                    size: 13, color: VelvetColors.textTertiary),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    path.isEmpty ? '/' : path,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 11.5,
+                      color: VelvetColors.textSecondary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
       // Thin indeterminate bar while any browser server call is in
       // flight (all go through ApiManager.makeServerCall). Fixed 3px
       // slot — empty when idle — so the list never jumps.
@@ -549,6 +738,18 @@ class _BrowserState extends State<Browser> {
                           ),
                         ),
                       );
+                    }
+
+                    // The server "Playlists" view gets its own layout: a New-
+                    // playlist button + modern rows with a rename/delete menu.
+                    // Detected by item type ('playlist'); the empty-list case is
+                    // keyed off the section label.
+                    final isPlaylistView =
+                        browserList.every((e) => e.type == 'playlist') &&
+                            (browserList.isNotEmpty ||
+                                BrowserManager().listName == 'Playlists');
+                    if (isPlaylistView) {
+                      return _playlistsView(context, browserList);
                     }
 
                     // If the whole list is albums and the user has the

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -151,6 +151,16 @@ class ApiManager {
     });
   }
 
+  // Builds 'playlist' DisplayItems from a getall response.
+  List<DisplayItem> _playlistItems(dynamic res, Server? server) {
+    final List<DisplayItem> newList = [];
+    res.forEach((e) {
+      newList.add(new DisplayItem(server, e['name'], 'playlist', e['name'],
+          Icon(Icons.queue_music, color: VelvetColors.textSecondary), null));
+    });
+    return newList;
+  }
+
   Future<void> getPlaylists({Server? useThisServer}) async {
     var res;
     try {
@@ -163,20 +173,36 @@ class ApiManager {
     }
 
     BrowserManager().setBrowserLabel('Playlists');
+    BrowserManager().addListToStack(_playlistItems(res, useThisServer));
+  }
 
-    List<DisplayItem> newList = [];
-    res.forEach((e) {
-      DisplayItem newItem = new DisplayItem(
-          useThisServer,
-          e['name'],
-          'playlist',
-          e['name'],
-          Icon(Icons.queue_music, color: VelvetColors.textSecondary),
-          null);
-      newList.add(newItem);
-    });
+  /// Re-fetches playlists and replaces the current view in place (no new
+  /// back-stack frame) — used after a create / rename so the list updates
+  /// without pushing a navigation entry.
+  Future<void> refreshPlaylists() async {
+    var res;
+    try {
+      res = await makeServerCall(null, '/api/v1/playlist/getall', {}, 'GET');
+    } catch (err) {
+      print(err);
+      return;
+    }
+    BrowserManager()
+        .replaceTop(_playlistItems(res, ServerManager().currentServer));
+  }
 
-    BrowserManager().addListToStack(newList);
+  /// Creates an empty playlist (POST /playlist/new). Throws on failure (e.g. the
+  /// server's 400 when the name already exists) so the caller can surface it.
+  Future<void> createPlaylist(String title) async {
+    await makeServerCall(null, '/api/v1/playlist/new', {'title': title}, 'POST');
+    await refreshPlaylists();
+  }
+
+  /// Renames a playlist (POST /playlist/rename). Throws on failure.
+  Future<void> renamePlaylist(String oldName, String newName) async {
+    await makeServerCall(null, '/api/v1/playlist/rename',
+        {'oldName': oldName, 'newName': newName}, 'POST');
+    await refreshPlaylists();
   }
 
   Future<void> removePlaylist(String playlistId,
@@ -526,6 +552,7 @@ class ApiManager {
       newList.add(newItem);
     });
 
-    BrowserManager().addListToStack(newList, alphabetical: true);
+    BrowserManager()
+        .addListToStack(newList, alphabetical: true, path: res['path']);
   }
 }

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -17,11 +17,19 @@ class BrowserManager {
   // overlays the current screen. Tracked per stack frame so back-nav
   // brings the strip back when returning to an alphabetical screen.
   final List<bool> alphabeticalCache = [];
+  // 1:1 with browserCache. The File Explorer's current directory path per frame
+  // (null for non-file-explorer frames), so the path row shows the right folder
+  // and reverts on back-nav. Display-only — no navigation logic reads it.
+  final List<String?> pathCache = [];
 
   final List<DisplayItem> browserList = [];
 
   bool get isAlphabetical =>
       alphabeticalCache.isNotEmpty ? alphabeticalCache.last : false;
+
+  /// Current File Explorer directory path for the top frame, or null when the
+  /// current view isn't the file explorer.
+  String? get currentPath => pathCache.isNotEmpty ? pathCache.last : null;
 
   String listName = 'Welcome';
 
@@ -141,6 +149,7 @@ class BrowserManager {
   void clear() {
     List<DisplayItem> hold = browserCache[0];
     bool holdAlpha = alphabeticalCache.isNotEmpty ? alphabeticalCache[0] : false;
+    String? holdPath = pathCache.isNotEmpty ? pathCache[0] : null;
 
     browserCache.clear();
     browserList.clear();
@@ -151,6 +160,9 @@ class BrowserManager {
     alphabeticalCache
       ..clear()
       ..add(holdAlpha);
+    pathCache
+      ..clear()
+      ..add(holdPath);
   }
 
   void goToNavScreen() {
@@ -161,6 +173,7 @@ class BrowserManager {
     // Reset alongside the cache or pops will pull stale offsets.
     scrollCache.clear();
     alphabeticalCache.clear();
+    pathCache.clear();
 
     if (ServerManager().currentServer == null) {
       return;
@@ -226,6 +239,7 @@ class BrowserManager {
         [newItem1, newItem2, newItem3, newItem4, newItem5, newItem6, newItem7]);
     // Nav screen isn't alphabetical content — just the section list.
     alphabeticalCache.add(false);
+    pathCache.add(null); // home nav isn't the file explorer — no path row
     browserList.add(newItem1);
     browserList.add(newItem2);
     browserList.add(newItem3);
@@ -244,6 +258,7 @@ class BrowserManager {
     browserList.clear();
     scrollCache.clear();
     alphabeticalCache.clear();
+    pathCache.clear();
 
     browserList.add(new DisplayItem(null, 'Welcome To mStream', 'addServer', '',
         Icon(Icons.add, color: VelvetColors.textSecondary), 'Click here to add server'));
@@ -251,7 +266,8 @@ class BrowserManager {
     _browserStream.sink.add(browserList);
   }
 
-  void addListToStack(List<DisplayItem> newList, {bool alphabetical = false}) {
+  void addListToStack(List<DisplayItem> newList,
+      {bool alphabetical = false, String? path}) {
     // Capture the current screen's scroll position before navigating
     // forward. sc.hasClients is false when navigation is triggered
     // from a non-Browser context (e.g. tapping File Explorer in the
@@ -263,6 +279,7 @@ class BrowserManager {
 
     browserCache.add(newList);
     alphabeticalCache.add(alphabetical);
+    pathCache.add(path);
 
     browserList.clear();
     newList.forEach((element) {
@@ -279,6 +296,19 @@ class BrowserManager {
   }
 
   updateStream() {
+    _browserStream.sink.add(browserList);
+  }
+
+  /// Replaces the current (top) frame's list in place — no push/pop, so the
+  /// back-stack is unchanged. Used to refresh a view (e.g. after a playlist
+  /// create/rename) without adding a navigation entry.
+  void replaceTop(List<DisplayItem> newList) {
+    if (browserCache.isNotEmpty) {
+      browserCache[browserCache.length - 1] = newList;
+    }
+    browserList
+      ..clear()
+      ..addAll(newList);
     _browserStream.sink.add(browserList);
   }
 
@@ -315,6 +345,7 @@ class BrowserManager {
 
     browserCache.removeLast();
     if (alphabeticalCache.isNotEmpty) alphabeticalCache.removeLast();
+    if (pathCache.isNotEmpty) pathCache.removeLast();
     browserList.clear();
     browserCache[browserCache.length - 1].forEach((el) {
       browserList.add(el);


### PR DESCRIPTION
Two browser improvements stacked together.

## File Explorer — current path row
A thin strip at the top of the file-explorer body (under the toolbar) shows the current directory, so you always know where you are. Tracked per nav-stack frame (new `BrowserManager.pathCache`, 1:1 with the stack like `alphabeticalCache`, populated from `getFileList`'s `res['path']`), so it updates as you drill in and **reverts on Back**. Shown only in the file explorer; display-only (no navigation logic reads it).

## Playlists — management + modern rows
The server Playlists view is now manageable:
- **New playlist** button + modal → `POST /api/v1/playlist/new`.
- Each row has a **⋮ menu** with **Rename** (→ `POST /playlist/rename`) and **Delete** (→ `POST /playlist/delete`, shown in red).
- Create/rename refresh the list **in place** (`BrowserManager.replaceTop` — no extra back-stack frame). Failures (e.g. a duplicate name → the server's 400) show a floating toast that clears the docked mini-player.
- Rows modernized: dropped the swipe `Slidable` + `ListTile` + chevron for a clean row (rounded icon tile, name, ⋮ menu) plus an empty state.

All three endpoints exist in the mStream server (`src/api/playlist.js`).

## Testing
- `flutter analyze` clean; `flutter test` 27/27; `flutter build apk --debug` OK; smoke-tested on device (install / launch / logcat clean).

## Notes
- Generated `lib/l10n/app_localizations*.dart` committed (repo convention); one new string `playlistActionFailed` across all 10 locales.
- Create/rename need the server's `/new` + `/rename` endpoints (present in current mStream); older servers degrade gracefully to the error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
