### PR TITLE
Browser & Manage Servers UI: home grid, album rows, server list

### DIFF
--- a/lib/objects/display_item.dart
+++ b/lib/objects/display_item.dart
@@ -41,6 +41,52 @@ class DisplayItem {
     return icon;
   }
 
+  // A fixed-size album thumbnail for list rows. Returns the cover art
+  // when present, otherwise a SAME-SIZE placeholder tile — so the row
+  // title/subtitle line up whether or not an album has art. (A bare
+  // Icon is far narrower than a loaded image, which knocks the text out
+  // of alignment between art / no-art rows.) Mirrors getImage's
+  // art-URL building (compress=s for a small thumbnail).
+  Widget getAlbumThumb({double size = 48}) {
+    final String? aaFile = altAlbumArt ?? metadata?.albumArt;
+    final BorderRadius radius =
+        BorderRadius.circular(VelvetColors.radiusSmall);
+    if (server != null && aaFile != null) {
+      final String url = Uri.encodeFull(server!.url +
+          '/album-art/' +
+          aaFile +
+          '?compress=s' +
+          (server!.jwt == null ? '' : '&token=' + server!.jwt!));
+      return ClipRRect(
+        borderRadius: radius,
+        child: Image.network(
+          url,
+          width: size,
+          height: size,
+          fit: BoxFit.cover,
+          errorBuilder: (_, __, ___) => _albumThumbPlaceholder(size, radius),
+        ),
+      );
+    }
+    return _albumThumbPlaceholder(size, radius);
+  }
+
+  Widget _albumThumbPlaceholder(double size, BorderRadius radius) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: VelvetColors.raised,
+        borderRadius: radius,
+      ),
+      child: Icon(
+        Icons.album,
+        color: VelvetColors.textSecondary,
+        size: size * 0.56,
+      ),
+    );
+  }
+
   // Title/subtitle text widgets cap at one line with ellipsis so long
   // directory or song names don't wrap and make their row taller than
   // the others. Keeps the letter-scrub offset math (cumulative sum of

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -2,6 +2,7 @@ import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 import 'package:mstream_music/singletons/file_explorer.dart';
 import '../l10n/app_localizations.dart';
+import '../l10n/enum_labels.dart';
 import '../singletons/browser_list.dart';
 import '../singletons/api.dart';
 import '../singletons/settings.dart';
@@ -439,7 +440,7 @@ class _BrowserState extends State<Browser> {
     final allowWrap = b.length < LetterStrip.minItemsToShow;
     return Container(
         decoration: BoxDecoration(
-            border: Border(bottom: BorderSide(color: Color(0xFFbdbdbd)))),
+            border: Border(bottom: BorderSide(color: VelvetColors.border))),
         child: Slidable(
             endActionPane: ActionPane(
               motion: DrawerMotion(),
@@ -503,7 +504,7 @@ class _BrowserState extends State<Browser> {
     final allowWrap = b.length < LetterStrip.minItemsToShow;
     return Container(
         decoration: BoxDecoration(
-            border: Border(bottom: BorderSide(color: Color(0xFFbdbdbd)))),
+            border: Border(bottom: BorderSide(color: VelvetColors.border))),
         child: Slidable(
             endActionPane: ActionPane(
               motion: DrawerMotion(),
@@ -546,7 +547,7 @@ class _BrowserState extends State<Browser> {
     final allowWrap = b.length < LetterStrip.minItemsToShow;
     return Container(
         decoration: BoxDecoration(
-            border: Border(bottom: BorderSide(color: Color(0xFFbdbdbd)))),
+            border: Border(bottom: BorderSide(color: VelvetColors.border))),
         child: Slidable(
             endActionPane: ActionPane(
               motion: DrawerMotion(),
@@ -586,7 +587,7 @@ class _BrowserState extends State<Browser> {
     final l = AppLocalizations.of(c);
     return Container(
         decoration: BoxDecoration(
-            border: Border(bottom: BorderSide(color: Color(0xFFbdbdbd)))),
+            border: Border(bottom: BorderSide(color: VelvetColors.border))),
         child: ListTile(
             leading: b[i].getImage(),
             title: b[i].getText(l: l),
@@ -596,6 +597,67 @@ class _BrowserState extends State<Browser> {
             }));
   }
 
+  // ── Default browser landing: section shortcuts as a modern card grid ──
+  Widget _homeView(BuildContext context, List<DisplayItem> items) {
+    final l = AppLocalizations.of(context);
+    return GridView.builder(
+      padding: const EdgeInsets.fromLTRB(14, 16, 14, 24),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: 12,
+        mainAxisSpacing: 12,
+        childAspectRatio: 1.3,
+      ),
+      itemCount: items.length,
+      itemBuilder: (context, i) {
+        final item = items[i];
+        final iconData = item.icon?.icon ?? Icons.chevron_right;
+        return Material(
+          color: VelvetColors.surface,
+          borderRadius: BorderRadius.circular(VelvetColors.radiusLarge),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: () => handleTap(items, i, context),
+            child: Container(
+              decoration: BoxDecoration(
+                border: Border.all(color: VelvetColors.border),
+                borderRadius: BorderRadius.circular(VelvetColors.radiusLarge),
+              ),
+              padding: const EdgeInsets.all(14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Container(
+                    width: 44,
+                    height: 44,
+                    decoration: BoxDecoration(
+                      color: VelvetColors.primaryDim,
+                      borderRadius:
+                          BorderRadius.circular(VelvetColors.radiusSmall),
+                    ),
+                    child: Icon(iconData,
+                        color: VelvetColors.primary, size: 24),
+                  ),
+                  Text(
+                    browserChromeLabel(l, item.name),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: VelvetColors.textPrimary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
   Widget makeFileWidget(List<DisplayItem> b, int i, BuildContext c) {
     // Same wrap-on-small-list rule as folders: below the letter-strip
     // threshold there's no uniform-row constraint, so long song names
@@ -603,7 +665,7 @@ class _BrowserState extends State<Browser> {
     final allowWrap = b.length < LetterStrip.minItemsToShow;
     return Container(
         decoration: BoxDecoration(
-            border: Border(bottom: BorderSide(color: Color(0xFFbdbdbd)))),
+            border: Border(bottom: BorderSide(color: VelvetColors.border))),
         child: Material(
             color: VelvetColors.bg,
             child: InkWell(
@@ -738,6 +800,12 @@ class _BrowserState extends State<Browser> {
                           ),
                         ),
                       );
+                    }
+
+                    // The default browser landing (section shortcuts) gets a
+                    // modern card grid instead of plain list rows.
+                    if (isHome) {
+                      return _homeView(context, browserList);
                     }
 
                     // The server "Playlists" view gets its own layout: a New-

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -191,6 +191,10 @@ class _BrowserState extends State<Browser> {
 
   Widget makeListItem(List<DisplayItem> b, int i, BuildContext c) {
     switch (b[i].type) {
+      case "album":
+        {
+          return makeAlbumWidget(b, i, c);
+        }
       case "file":
         {
           return makeFileWidget(b, i, c);
@@ -581,6 +585,25 @@ class _BrowserState extends State<Browser> {
                     handleTap(b, i, c);
                   }),
             )));
+  }
+
+  // Album list rows. Unlike makeBasicWidget, the leading is a FIXED-size
+  // thumbnail (cover art or a same-size placeholder) so the title/subtitle
+  // start at the same x whether or not a row has art — getImage() returns a
+  // full-height image for art rows but a tiny Icon for the rest, which
+  // misaligns the text.
+  Widget makeAlbumWidget(List<DisplayItem> b, int i, BuildContext c) {
+    final l = AppLocalizations.of(c);
+    return Container(
+        decoration: BoxDecoration(
+            border: Border(bottom: BorderSide(color: VelvetColors.border))),
+        child: ListTile(
+            leading: b[i].getAlbumThumb(),
+            title: b[i].getText(l: l),
+            subtitle: b[i].getSubText(l: l),
+            onTap: () {
+              handleTap(b, i, c);
+            }));
   }
 
   Widget makeBasicWidget(List<DisplayItem> b, int i, BuildContext c) {

--- a/lib/screens/manage_server.dart
+++ b/lib/screens/manage_server.dart
@@ -9,181 +9,214 @@ import '../theme/velvet_theme.dart';
 import 'add_server.dart';
 
 class ManageServersScreen extends StatelessWidget {
-  Widget generateDropdownMenu(BuildContext context, int index) {
+  void _pushEdit(BuildContext context, int index) {
+    Navigator.push(
+        context,
+        MaterialPageRoute(
+            builder: (context) => EditServerScreen(editThisServer: index)));
+  }
+
+  void _showServerInfo(BuildContext context, int index) {
     final l = AppLocalizations.of(context);
-    return PopupMenuButton(
-        onSelected: (String command) {
-          if (command == 'edit') {
-            Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (context) =>
-                        EditServerScreen(editThisServer: index)));
-          }
-          if (command == 'default') {
-            ServerManager().makeDefault(index);
-          }
-          if (command == 'info') {
-            // SimpleDialog(children: <Widget>[]);
-            FileExplorer()
-                .getServerDir(ServerManager().serverList[index])
-                .then((dir) {
-              showDialog(
-                context: context,
-                builder: (BuildContext context) {
-                  return AlertDialog(
-                      title: Text(l.manageServerInfo),
-                      content: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(ServerManager().serverList[index].url),
-                            Text(''),
-                            Text(l.manageServerDownloadFolder),
-                            Text(''),
-                            Text(dir)
-                          ]),
-                      actions: <Widget>[
-                        TextButton(
-                          child: Text(l.manageServerCopyPath),
-                          onPressed: () {
-                            Clipboard.setData(ClipboardData(text: dir));
-                            Navigator.of(context).pop();
-
-                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                                content: Text(l.manageServerPathCopied)));
-                          },
-                        )
-                      ]);
+    FileExplorer()
+        .getServerDir(ServerManager().serverList[index])
+        .then((dir) {
+      if (!context.mounted) return;
+      showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: Text(l.manageServerInfo),
+            content: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(ServerManager().serverList[index].url,
+                      style: TextStyle(color: VelvetColors.textPrimary)),
+                  const SizedBox(height: 16),
+                  Text(l.manageServerDownloadFolder,
+                      style: TextStyle(
+                          color: VelvetColors.textSecondary, fontSize: 13)),
+                  const SizedBox(height: 4),
+                  Text(dir, style: TextStyle(color: VelvetColors.textPrimary)),
+                ]),
+            actions: <Widget>[
+              TextButton(
+                child: Text(l.manageServerCopyPath),
+                onPressed: () {
+                  Clipboard.setData(ClipboardData(text: dir));
+                  Navigator.of(context).pop();
+                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                      content: Text(l.manageServerPathCopied)));
                 },
-              );
-            });
-          }
-          if (command == 'delete') {
-            showDialog(
-              context: context,
-              builder: (BuildContext context) {
-                // return object of type Dialog
-                return DeleteServerDialog(
-                    cServer: ServerManager().serverList[index]);
-              },
-            );
-          }
+              )
+            ],
+          );
         },
-        icon: Icon(
-          Icons.arrow_drop_down,
-          color: VelvetColors.textPrimary,
+      );
+    });
+  }
+
+  void _showDeleteDialog(BuildContext context, int index) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return DeleteServerDialog(cServer: ServerManager().serverList[index]);
+      },
+    );
+  }
+
+  // A single popup-menu row: leading icon + label, both tintable (used to
+  // flag the destructive Delete action in the error color).
+  PopupMenuItem<String> _menuItem(String value, IconData icon, String label,
+      {Color? color}) {
+    return PopupMenuItem<String>(
+      value: value,
+      child: Row(children: [
+        Icon(icon, size: 20, color: color ?? VelvetColors.textSecondary),
+        const SizedBox(width: 12),
+        Text(label, style: TextStyle(color: color ?? VelvetColors.textPrimary)),
+      ]),
+    );
+  }
+
+  // The per-row ⋮ overflow menu (Make Default / Info / Edit / Delete).
+  Widget _overflowMenu(BuildContext context, int index) {
+    final l = AppLocalizations.of(context);
+    return PopupMenuButton<String>(
+      icon: Icon(Icons.more_vert, color: VelvetColors.textSecondary),
+      color: VelvetColors.surface,
+      tooltip: l.mainMore,
+      onSelected: (String command) {
+        switch (command) {
+          case 'edit':
+            _pushEdit(context, index);
+            break;
+          case 'default':
+            ServerManager().makeDefault(index);
+            break;
+          case 'info':
+            _showServerInfo(context, index);
+            break;
+          case 'delete':
+            _showDeleteDialog(context, index);
+            break;
+        }
+      },
+      itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+        // Index 0 is already the default server, so omit the action.
+        if (index != 0)
+          _menuItem('default', Icons.arrow_upward_rounded, l.makeDefault),
+        _menuItem('info', Icons.info_outline, l.info),
+        _menuItem('edit', Icons.edit_outlined, l.edit),
+        _menuItem('delete', Icons.delete_outline, l.delete,
+            color: VelvetColors.error),
+      ],
+    );
+  }
+
+  // A modern server row, mirroring the playlist rows: an icon tile (tinted
+  // for the default server), the URL, a star marking the default, and the
+  // ⋮ menu. Tapping the row opens the edit screen.
+  Widget _serverRow(BuildContext context, Server server, int index) {
+    final bool isDefault = index == 0;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () => _pushEdit(context, index),
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border(
+                bottom: BorderSide(color: VelvetColors.border, width: 0.5)),
+          ),
+          padding: const EdgeInsets.fromLTRB(12, 10, 4, 10),
+          child: Row(
+            children: [
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color:
+                      isDefault ? VelvetColors.primaryDim : VelvetColors.raised,
+                  borderRadius:
+                      BorderRadius.circular(VelvetColors.radiusSmall),
+                ),
+                child: Icon(Icons.dns,
+                    color: isDefault
+                        ? VelvetColors.primary
+                        : VelvetColors.textSecondary),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  server.url,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: VelvetColors.textPrimary,
+                  ),
+                ),
+              ),
+              if (isDefault)
+                Padding(
+                  padding: const EdgeInsets.only(left: 6),
+                  child:
+                      Icon(Icons.star, size: 16, color: VelvetColors.primary),
+                ),
+              _overflowMenu(context, index),
+            ],
+          ),
         ),
-        itemBuilder: (BuildContext context) {
-          List<PopupMenuEntry<String>> popUpWidgetList = [
-            PopupMenuItem(
-              value: 'info',
-              child: Row(children: [
-                Icon(
-                  Icons.info,
-                  color: VelvetColors.textPrimary,
-                ),
-                Text('   ${l.info}',
-                    style: TextStyle(color: VelvetColors.textPrimary))
-              ]),
-            ),
-            PopupMenuItem(
-              value: 'edit',
-              child: Row(children: [
-                Icon(
-                  Icons.edit,
-                  color: VelvetColors.textPrimary,
-                ),
-                Text('   ${l.edit}',
-                    style: TextStyle(color: VelvetColors.textPrimary))
-              ]),
-            ),
-            PopupMenuItem(
-              value: 'delete',
-              child: Row(children: [
-                Icon(
-                  Icons.delete,
-                  color: Colors.redAccent,
-                ),
-                Text('   ${l.delete}',
-                    style: TextStyle(color: VelvetColors.textPrimary))
-              ]),
-            )
-          ];
-
-          if (index != 0) {
-            popUpWidgetList.insert(
-                0,
-                PopupMenuItem(
-                  value: 'default',
-                  child: Row(children: [
-                    Icon(
-                      Icons.arrow_upward_rounded,
-                      color: VelvetColors.textPrimary,
-                    ),
-                    Text('   ${l.makeDefault}',
-                        style: TextStyle(color: VelvetColors.textPrimary))
-                  ]),
-                ));
-          }
-
-          return popUpWidgetList;
-        });
+      ),
+    );
   }
 
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return Scaffold(
-        appBar: AppBar(
-          title: Text(l.manageServersTitle),
+      appBar: AppBar(
+        title: Text(l.manageServersTitle),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => AddServerScreen()),
+          );
+        },
+        child: Icon(
+          Icons.add,
+          color: VelvetColors.onPrimary,
         ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(builder: (context) => AddServerScreen()),
+        backgroundColor: VelvetColors.primary,
+      ),
+      body: SafeArea(
+        top: false,
+        child: StreamBuilder<List<Server>>(
+          stream: ServerManager().serverListStream,
+          builder: (context, snapshot) {
+            final List<Server> cServerList = snapshot.data ?? [];
+            if (cServerList.isEmpty) {
+              return Center(
+                child: Icon(
+                  Icons.dns_outlined,
+                  size: 72,
+                  color: VelvetColors.textSecondary.withValues(alpha: 0.4),
+                ),
+              );
+            }
+            return ListView.builder(
+              physics: const AlwaysScrollableScrollPhysics(),
+              itemCount: cServerList.length,
+              itemBuilder: (BuildContext context, int index) =>
+                  _serverRow(context, cServerList[index], index),
             );
           },
-          child: Icon(
-            Icons.add,
-            color: VelvetColors.onPrimary,
-          ),
-          backgroundColor: VelvetColors.primary,
         ),
-        body: SafeArea(top: false, child: Row(children: [
-          Expanded(
-              child: SizedBox(
-                  child: StreamBuilder<List<Server>>(
-                      stream: ServerManager().serverListStream,
-                      builder: (context, snapshot) {
-                        final List<Server> cServerList = snapshot.data ?? [];
-                        return Container(
-                            decoration: BoxDecoration(
-                                border: Border(
-                                    bottom:
-                                        BorderSide(color: Color(0xFFbdbdbd)))),
-                            child: ListView.separated(
-                                physics: const AlwaysScrollableScrollPhysics(),
-                                itemCount: cServerList.length,
-                                separatorBuilder:
-                                    (BuildContext context, int index) =>
-                                        Divider(height: 3, color: Colors.white),
-                                itemBuilder: (BuildContext context, int index) {
-                                  return Container(
-                                      decoration: BoxDecoration(
-                                          border: Border(
-                                              bottom: BorderSide(
-                                                  color: Color(0xFFbdbdbd)))),
-                                      child: ListTile(
-                                          title: Text(cServerList[index].url,
-                                              style: TextStyle(
-                                                  color: VelvetColors.textPrimary,
-                                                  fontSize: 18)),
-                                          trailing: generateDropdownMenu(
-                                              context, index)));
-                                }));
-                      })))
-        ])));
+      ),
+    );
   }
 }
 
@@ -225,7 +258,7 @@ class _DeleteServerDialogState extends State<DeleteServerDialog> {
         TextButton(
           child: Text(
             l.delete,
-            style: TextStyle(color: Colors.red),
+            style: TextStyle(color: VelvetColors.error),
           ),
           onPressed: () {
             try {

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -242,13 +242,24 @@ class ServerManager {
     await writeServerFile();
   }
 
-  void makeDefault(int i) {
+  Future<void> makeDefault(int i) async {
     Server s = serverList[i];
 
     serverList.remove(s);
     serverList.insert(0, s);
-
     _serverListStream.sink.add(serverList);
+
+    // Switch the active server to it right away (not just on next launch)
+    // and reset the browser onto the new server — mirrors
+    // changeCurrentServer().
+    currentServer = s;
+    _currentServerStream.sink.add(currentServer);
+    BrowserManager().goToNavScreen();
+
+    // Persist the new order so serverList[0] — the default loaded on the
+    // next launch — is this server. Without this the choice was lost on
+    // restart (every other mutator writes the file; this one didn't).
+    await writeServerFile();
   }
 
   Server lookupServer(String id) {


### PR DESCRIPTION
Modernization pass over a few browser/settings screens. Based on `master` (PR #41 is merged).

## Changes

**1. Home-landing card grid** (`f0485bf`)
The default browser landing (section shortcuts: File Explorer, Playlists, Albums, Artists, etc.) was plain `ListTile` rows. Now a 2-column card grid — surface fill, subtle border, rounded corners, ink ripple, accent icon tile, localized label. Gated on `execAction` items so it only triggers on the landing screen, never inside folders/albums/playlists. Also swaps the file-explorer / local-file row borders from a hardcoded `Color(0xFFbdbdbd)` (reads as white on the dark theme) to theme-aware `VelvetColors.border`.

**2. Album list thumbnails** (`e088e9a`)
Album rows fell through to `makeBasicWidget`, whose leading is a full-height image for rows with art but a tiny icon for rows without — misaligning the text. Added `DisplayItem.getAlbumThumb()` (fixed 48×48 cover art or same-size placeholder tile) and a dedicated `makeAlbumWidget`, so every album row has a uniform leading and the title/subtitle line up. Row height unchanged, so the letter-strip scroll math stays correct.

**3. Manage Servers modernization** (`9fd370e`)
Killed pure-white dividers (`Divider(color: Colors.white)` + two `0xFFbdbdbd` borders), removed an odd `Row > Expanded > SizedBox` nest wrapped in a stray-bordered `Container`, and replaced dated `ListTile` + `arrow_drop_down` rows with playlist-style rows: `Icons.dns` tile + URL + `⋮` overflow menu (tap row → edit). The default server is highlighted (primary-tinted tile + ★, no new l10n string). Overflow menu restyled (surface bg, tooltip, outline icons), Delete in `error` color. Added an icon-only empty state and tidied the info dialog.

**4. "Make Default" fix** (`b5e686b`)
`ServerManager.makeDefault` only reordered the in-memory list, so the choice was lost on restart (never persisted) and the active server didn't actually change. It now sets `currentServer`, emits on `_currentServerStream`, resets the browser via `goToNavScreen()`, and `await writeServerFile()` — so picking a default takes effect immediately and survives a restart.

## Test plan
- `flutter analyze lib` → No issues found
- `flutter test` → 27/27 passed
- `flutter build apk --debug` → built
- Installed & launched on a physical device after each change — no exceptions in logcat

🤖 Generated with [Claude Code](https://claude.com/claude-code)