### PR TITLE
Persist play queue + position across app restarts

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -409,5 +409,7 @@
   "settingsAccentColor": "Akzentfarbe",
   "settingsAccentColorSubtitle": "Die Hervorhebungsfarbe, die in der gesamten App verwendet wird.",
   "accentThemeDefault": "Theme-Standard",
-  "accentCustom": "Benutzerdefiniert"
+  "accentCustom": "Benutzerdefiniert",
+  "settingsResumeQueue": "Warteschlange beim Start fortsetzen",
+  "settingsResumeQueueSubtitle": "Speichert die Wiedergabeliste und deine Position und stellt sie beim erneuten Öffnen der App wieder her."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -636,5 +636,7 @@
   "settingsAccentColor": "Accent color",
   "settingsAccentColorSubtitle": "The highlight color used across the app.",
   "accentThemeDefault": "Theme default",
-  "accentCustom": "Custom"
+  "accentCustom": "Custom",
+  "settingsResumeQueue": "Resume queue on launch",
+  "settingsResumeQueueSubtitle": "Save the play queue and your place, and restore them when you reopen the app."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -351,5 +351,7 @@
   "settingsAccentColor": "Color de acento",
   "settingsAccentColorSubtitle": "El color de resalte que se usa en toda la aplicación.",
   "accentThemeDefault": "Predeterminado del tema",
-  "accentCustom": "Personalizado"
+  "accentCustom": "Personalizado",
+  "settingsResumeQueue": "Reanudar la cola al iniciar",
+  "settingsResumeQueueSubtitle": "Guarda la cola de reproducción y tu posición y las restaura al volver a abrir la app."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -344,5 +344,7 @@
   "settingsAccentColor": "Couleur d'accent",
   "settingsAccentColorSubtitle": "La couleur de mise en évidence utilisée dans toute l'application.",
   "accentThemeDefault": "Par défaut du thème",
-  "accentCustom": "Personnalisé"
+  "accentCustom": "Personnalisé",
+  "settingsResumeQueue": "Reprendre la file au démarrage",
+  "settingsResumeQueueSubtitle": "Enregistre la file de lecture et votre position, puis les restaure à la réouverture de l'application."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -344,5 +344,7 @@
   "settingsAccentColor": "Colore d'accento",
   "settingsAccentColorSubtitle": "Il colore di evidenziazione usato in tutta l'app.",
   "accentThemeDefault": "Predefinito del tema",
-  "accentCustom": "Personalizzato"
+  "accentCustom": "Personalizzato",
+  "settingsResumeQueue": "Riprendi la coda all'avvio",
+  "settingsResumeQueueSubtitle": "Salva la coda di riproduzione e la tua posizione e le ripristina alla riapertura dell'app."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -344,5 +344,7 @@
   "settingsAccentColor": "アクセントカラー",
   "settingsAccentColorSubtitle": "アプリ全体で使用される強調表示の色。",
   "accentThemeDefault": "テーマの既定",
-  "accentCustom": "カスタム"
+  "accentCustom": "カスタム",
+  "settingsResumeQueue": "起動時にキューを復元",
+  "settingsResumeQueueSubtitle": "再生キューと再生位置を保存し、アプリを再び開いたときに復元します。"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2183,6 +2183,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Custom'**
   String get accentCustom;
+
+  /// No description provided for @settingsResumeQueue.
+  ///
+  /// In en, this message translates to:
+  /// **'Resume queue on launch'**
+  String get settingsResumeQueue;
+
+  /// No description provided for @settingsResumeQueueSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Save the play queue and your place, and restore them when you reopen the app.'**
+  String get settingsResumeQueueSubtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1262,4 +1262,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get accentCustom => 'Benutzerdefiniert';
+
+  @override
+  String get settingsResumeQueue => 'Warteschlange beim Start fortsetzen';
+
+  @override
+  String get settingsResumeQueueSubtitle =>
+      'Speichert die Wiedergabeliste und deine Position und stellt sie beim erneuten Öffnen der App wieder her.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1245,4 +1245,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get accentCustom => 'Custom';
+
+  @override
+  String get settingsResumeQueue => 'Resume queue on launch';
+
+  @override
+  String get settingsResumeQueueSubtitle =>
+      'Save the play queue and your place, and restore them when you reopen the app.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1261,4 +1261,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get accentCustom => 'Personalizado';
+
+  @override
+  String get settingsResumeQueue => 'Reanudar la cola al iniciar';
+
+  @override
+  String get settingsResumeQueueSubtitle =>
+      'Guarda la cola de reproducción y tu posición y las restaura al volver a abrir la app.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1259,4 +1259,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get accentCustom => 'Personnalisé';
+
+  @override
+  String get settingsResumeQueue => 'Reprendre la file au démarrage';
+
+  @override
+  String get settingsResumeQueueSubtitle =>
+      'Enregistre la file de lecture et votre position, puis les restaure à la réouverture de l\'application.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1261,4 +1261,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get accentCustom => 'Personalizzato';
+
+  @override
+  String get settingsResumeQueue => 'Riprendi la coda all\'avvio';
+
+  @override
+  String get settingsResumeQueueSubtitle =>
+      'Salva la coda di riproduzione e la tua posizione e le ripristina alla riapertura dell\'app.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1203,4 +1203,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get accentCustom => 'カスタム';
+
+  @override
+  String get settingsResumeQueue => '起動時にキューを復元';
+
+  @override
+  String get settingsResumeQueueSubtitle => '再生キューと再生位置を保存し、アプリを再び開いたときに復元します。';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1279,4 +1279,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get accentCustom => 'Niestandardowy';
+
+  @override
+  String get settingsResumeQueue => 'Wznów kolejkę po uruchomieniu';
+
+  @override
+  String get settingsResumeQueueSubtitle =>
+      'Zapisuje kolejkę odtwarzania i pozycję oraz przywraca je po ponownym otwarciu aplikacji.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1257,4 +1257,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get accentCustom => 'Personalizado';
+
+  @override
+  String get settingsResumeQueue => 'Retomar a fila ao iniciar';
+
+  @override
+  String get settingsResumeQueueSubtitle =>
+      'Salva a fila de reprodução e sua posição e as restaura ao reabrir o app.';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1283,4 +1283,11 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get accentCustom => 'Свой';
+
+  @override
+  String get settingsResumeQueue => 'Восстанавливать очередь при запуске';
+
+  @override
+  String get settingsResumeQueueSubtitle =>
+      'Сохраняет очередь воспроизведения и позицию и восстанавливает их при повторном открытии приложения.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1179,4 +1179,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get accentCustom => '自定义';
+
+  @override
+  String get settingsResumeQueue => '启动时恢复播放队列';
+
+  @override
+  String get settingsResumeQueueSubtitle => '保存播放队列和当前播放位置，并在重新打开应用时恢复。';
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -344,5 +344,7 @@
   "settingsAccentColor": "Kolor akcentu",
   "settingsAccentColorSubtitle": "Kolor wyróżnienia używany w całej aplikacji.",
   "accentThemeDefault": "Domyślny motywu",
-  "accentCustom": "Niestandardowy"
+  "accentCustom": "Niestandardowy",
+  "settingsResumeQueue": "Wznów kolejkę po uruchomieniu",
+  "settingsResumeQueueSubtitle": "Zapisuje kolejkę odtwarzania i pozycję oraz przywraca je po ponownym otwarciu aplikacji."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -409,5 +409,7 @@
   "settingsAccentColor": "Cor de destaque",
   "settingsAccentColorSubtitle": "A cor de destaque usada em todo o aplicativo.",
   "accentThemeDefault": "Padrão do tema",
-  "accentCustom": "Personalizado"
+  "accentCustom": "Personalizado",
+  "settingsResumeQueue": "Retomar a fila ao iniciar",
+  "settingsResumeQueueSubtitle": "Salva a fila de reprodução e sua posição e as restaura ao reabrir o app."
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -344,5 +344,7 @@
   "settingsAccentColor": "Акцентный цвет",
   "settingsAccentColorSubtitle": "Цвет выделения, используемый во всём приложении.",
   "accentThemeDefault": "Из темы",
-  "accentCustom": "Свой"
+  "accentCustom": "Свой",
+  "settingsResumeQueue": "Восстанавливать очередь при запуске",
+  "settingsResumeQueueSubtitle": "Сохраняет очередь воспроизведения и позицию и восстанавливает их при повторном открытии приложения."
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -344,5 +344,7 @@
   "settingsAccentColor": "强调色",
   "settingsAccentColorSubtitle": "整个应用中使用的高亮颜色。",
   "accentThemeDefault": "主题默认",
-  "accentCustom": "自定义"
+  "accentCustom": "自定义",
+  "settingsResumeQueue": "启动时恢复播放队列",
+  "settingsResumeQueueSubtitle": "保存播放队列和当前播放位置，并在重新打开应用时恢复。"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'screens/settings_screen.dart';
 import 'screens/share_playlist_dialog.dart';
 import 'singletons/auto_dj_manager.dart';
 import 'singletons/media.dart';
+import 'singletons/queue_store.dart';
 import 'singletons/playlists.dart';
 import 'singletons/settings.dart';
 import 'theme/velvet_theme.dart';
@@ -113,7 +114,11 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
     // and restores this on exit, but a kill mid-immersive can leak that mode to
     // the next launch — asserting here (and on resume) keeps the nav bar up.
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-    ServerManager().loadServerList();
+    // Restore the persisted queue/position once servers are loaded (server
+    // items are matched to a configured server by localname to rebuild their
+    // streaming URLs). loadServerList's future completes after the list is
+    // populated, so the queue comes back at the spot it was left.
+    ServerManager().loadServerList().then((_) => QueueStore().init());
     DownloadManager().initDownloader();
     // Resume a storage move that was interrupted by an app restart.
     MigrationManager().resumeIfNeeded();
@@ -138,6 +143,13 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
     if (state == AppLifecycleState.resumed &&
         (ModalRoute.of(context)?.isCurrent ?? true)) {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    }
+    // Flush the queue/position to disk when leaving the foreground, so a
+    // backgrounded app that's later killed by the OS still reopens in place.
+    if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden ||
+        state == AppLifecycleState.detached) {
+      QueueStore().saveNow();
     }
   }
 

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -50,6 +50,10 @@ class AudioPlayerHandler extends BaseAudioHandler
 
   int? get index => _backend.currentIndex;
 
+  /// Live playback position of the active backend (read by QueueStore so the
+  /// saved snapshot carries the exact spot in the current track).
+  Duration get position => _backend.position;
+
   Stream<Duration> get positionStream =>
       _backendSubject.switchMap((b) => b.positionStream);
 
@@ -327,6 +331,24 @@ class AudioPlayerHandler extends BaseAudioHandler
     if (index < 0 || index > queue.value.length) return;
     // This jumps to the beginning of the queue item at newIndex.
     _backend.seek(Duration.zero, index: index);
+  }
+
+  /// Reinstate a persisted queue at launch WITHOUT auto-playing: seed the queue
+  /// + backend sources, park playback at [index]/[position] paused, and restore
+  /// shuffle/repeat. Used by QueueStore.init() so the app reopens exactly where
+  /// it left off. No-op for an empty list.
+  Future<void> restoreQueue(List<MediaItem> items, int index, Duration position,
+      {bool shuffle = false, bool repeat = false}) async {
+    if (items.isEmpty) return;
+    queue.add(items.toList());
+    await _backend.setSources(items);
+    final int i = index.clamp(0, items.length - 1);
+    // play: false → load paused at the saved spot (don't blast audio on open).
+    await _backend.seek(position, index: i, play: false);
+    if (repeat) await _backend.setRepeatAll(true);
+    if (shuffle) await _backend.setShuffleEnabled(true);
+    _emitCurrentMediaItem();
+    _broadcastState();
   }
 
   @override

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:permission_handler/permission_handler.dart';
 import '../l10n/app_localizations.dart';
 import '../l10n/enum_labels.dart';
 import '../objects/player_layout.dart';
+import '../singletons/queue_store.dart';
 import '../singletons/settings.dart';
 import '../singletons/transcode.dart';
 import '../theme/velvet_theme.dart';
@@ -170,6 +171,24 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 TranscodeManager().transcodeOn = v;
               });
               await SettingsManager().setTranscode(v);
+            },
+            activeThumbColor: VelvetColors.primary,
+          ),
+          SwitchListTile(
+            title: Text(l.settingsResumeQueue),
+            subtitle: Text(
+              l.settingsResumeQueueSubtitle,
+              style: TextStyle(
+                  color: VelvetColors.textSecondary, fontSize: 12),
+            ),
+            value: SettingsManager().resumeQueue,
+            onChanged: (v) async {
+              setState(() {});
+              await SettingsManager().setResumeQueue(v);
+              // Apply immediately: persist the current queue when turning on,
+              // or delete the stored queue when turning off.
+              await QueueStore().saveNow();
+              setState(() {});
             },
             activeThumbColor: VelvetColors.primary,
           ),

--- a/lib/singletons/queue_store.dart
+++ b/lib/singletons/queue_store.dart
@@ -1,0 +1,214 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:audio_service/audio_service.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../objects/server.dart';
+import '../util/queue_actions.dart';
+import 'media.dart';
+import 'server_list.dart';
+
+/// Persists the play queue + current track/position so they survive the app
+/// being closed and reopened. Mirrors the servers.json approach: a single JSON
+/// file (`queue.json`) in the app documents directory.
+///
+/// Server items are stored by their stable bits (server localname + path +
+/// display metadata); the streaming URL is rebuilt on restore with the current
+/// token/transcode setting — the per-build `app_uuid` and token baked into a
+/// saved URL would otherwise go stale. Local files keep their `localPath`; the
+/// playback backend re-checks existence at play time and streams as a fallback.
+class QueueStore {
+  QueueStore._();
+  static final QueueStore _instance = QueueStore._();
+  factory QueueStore() => _instance;
+
+  // Bump if the on-disk shape changes incompatibly; an older file is then
+  // ignored (not crashed on) at restore.
+  static const int _schemaVersion = 1;
+  // Coalesce bursts of change events (a "play from here" fires one queue edit
+  // per track) into a single write.
+  static const Duration _debounce = Duration(milliseconds: 800);
+  // Position checkpoint cadence while playing — covers a hard kill that fires
+  // no lifecycle callback (otherwise we'd lose position since the last edit).
+  static const Duration _tick = Duration(seconds: 10);
+
+  bool _restoring = false;
+  bool _started = false;
+  Timer? _debounceTimer;
+  Timer? _ticker;
+  final List<StreamSubscription> _subs = [];
+
+  Future<File> get _file async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/queue.json');
+  }
+
+  /// Restore the saved queue (if any) into the audio handler, then start
+  /// listening so the file stays current. Call ONCE at startup AFTER servers
+  /// have loaded — server items are matched to a configured server by localname.
+  Future<void> init() async {
+    if (_started) return;
+    _started = true;
+    _restoring = true;
+    try {
+      await _restore();
+    } catch (e) {
+      // A corrupt / incompatible file must never block startup.
+      print('QueueStore restore failed: $e');
+    }
+    _restoring = false;
+    _attachListeners();
+  }
+
+  Future<void> _restore() async {
+    final file = await _file;
+    if (!await file.exists()) return;
+
+    final dynamic raw = jsonDecode(await file.readAsString());
+    if (raw is! Map) return;
+    if (raw['version'] != _schemaVersion) return;
+    final dynamic rawItems = raw['items'];
+    if (rawItems is! List) return;
+
+    final items = <MediaItem>[];
+    for (final entry in rawItems) {
+      if (entry is! Map) continue;
+      final m = itemFromJson(Map<String, dynamic>.from(entry));
+      if (m != null) items.add(m); // null = its server is no longer configured
+    }
+    if (items.isEmpty) return;
+
+    int index = (raw['index'] is int) ? raw['index'] as int : 0;
+    if (index < 0 || index >= items.length) index = 0;
+    final int positionMs = (raw['positionMs'] is int) ? raw['positionMs'] as int : 0;
+
+    await MediaManager().audioHandler.restoreQueue(
+          items,
+          index,
+          Duration(milliseconds: positionMs),
+          shuffle: raw['shuffle'] == true,
+          repeat: raw['repeat'] == true,
+        );
+  }
+
+  void _attachListeners() {
+    final handler = MediaManager().audioHandler;
+    // Queue edits (add / remove / reorder / clear) and track changes.
+    _subs.add(handler.queue.listen((_) => _schedule()));
+    _subs.add(handler.mediaItem.listen((_) => _schedule()));
+    // Periodic position checkpoint while actually playing.
+    _ticker = Timer.periodic(_tick, (_) {
+      if (handler.queue.value.isNotEmpty &&
+          handler.playbackState.value.playing) {
+        _schedule();
+      }
+    });
+  }
+
+  void _schedule() {
+    if (_restoring) return;
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(_debounce, saveNow);
+  }
+
+  /// Cancel the checkpoint timer + change listeners. The singleton normally
+  /// lives for the app's lifetime; this exists so the resources are releasable
+  /// (and to keep the ticker reference meaningfully held).
+  void dispose() {
+    _debounceTimer?.cancel();
+    _ticker?.cancel();
+    for (final s in _subs) {
+      s.cancel();
+    }
+    _subs.clear();
+  }
+
+  /// Write the current snapshot immediately (flush). Called on app pause/detach
+  /// so a backgrounded-then-killed app keeps its place. Deletes the file when
+  /// the queue is empty so a cleared queue doesn't resurrect on next launch.
+  Future<void> saveNow() async {
+    if (_restoring) return;
+    _debounceTimer?.cancel();
+    try {
+      final handler = MediaManager().audioHandler;
+      final queue = handler.queue.value;
+      final file = await _file;
+      if (queue.isEmpty) {
+        if (await file.exists()) await file.delete();
+        return;
+      }
+      final state = handler.playbackState.value;
+      final snapshot = <String, dynamic>{
+        'version': _schemaVersion,
+        'index': state.queueIndex ?? 0,
+        'positionMs': handler.position.inMilliseconds,
+        'shuffle': state.shuffleMode == AudioServiceShuffleMode.all,
+        'repeat': state.repeatMode == AudioServiceRepeatMode.all,
+        'items': queue.map(itemToJson).toList(),
+      };
+      await file.writeAsString(jsonEncode(snapshot));
+    } catch (e) {
+      print('QueueStore save failed: $e');
+    }
+  }
+
+  // ── (de)serialization — pure & static so they're unit-testable ──
+
+  /// Serialize a [MediaItem] to a JSON-safe map.
+  static Map<String, dynamic> itemToJson(MediaItem m) => {
+        'id': m.id,
+        'title': m.title,
+        'album': m.album,
+        'artist': m.artist,
+        'genre': m.genre,
+        'durationMs': m.duration?.inMilliseconds,
+        'extras': m.extras ?? const <String, dynamic>{},
+      };
+
+  /// Rebuild a [MediaItem] from its saved map. A server item (carries
+  /// `extras['server']`) gets a freshly-built streaming URL via [resolveServer]
+  /// — returns null if that server is no longer configured. A local item is
+  /// rebuilt as-is (the backend resolves its localPath at play time).
+  /// [resolveServer] defaults to a ServerManager lookup; injectable for tests.
+  static MediaItem? itemFromJson(Map<String, dynamic> j,
+      {Server? Function(String localname)? resolveServer}) {
+    final extras = Map<String, dynamic>.from(j['extras'] ?? const {});
+    final serverName = extras['server'] as String?;
+
+    String id;
+    if (serverName != null) {
+      final server = (resolveServer ?? _defaultResolve)(serverName);
+      if (server == null) return null; // server removed since the queue was saved
+      final path = extras['path'] as String?;
+      if (path == null) return null;
+      id = buildServerStreamUrl(server, path);
+    } else {
+      // Local file: id is unused for playback (localPath drives it), but keep a
+      // stable value when present.
+      id = (j['id'] as String?) ?? Uuid().v4();
+    }
+
+    return MediaItem(
+      id: id,
+      title: (j['title'] as String?) ??
+          (extras['path'] as String?)?.split('/').last ??
+          'Unknown',
+      album: j['album'] as String?,
+      artist: j['artist'] as String?,
+      genre: j['genre'] as String?,
+      duration:
+          j['durationMs'] is int ? Duration(milliseconds: j['durationMs'] as int) : null,
+      extras: extras,
+    );
+  }
+
+  static Server? _defaultResolve(String localname) {
+    for (final s in ServerManager().serverList) {
+      if (s.localname == localname) return s;
+    }
+    return null;
+  }
+}

--- a/lib/singletons/queue_store.dart
+++ b/lib/singletons/queue_store.dart
@@ -10,6 +10,7 @@ import '../objects/server.dart';
 import '../util/queue_actions.dart';
 import 'media.dart';
 import 'server_list.dart';
+import 'settings.dart';
 
 /// Persists the play queue + current track/position so they survive the app
 /// being closed and reopened. Mirrors the servers.json approach: a single JSON
@@ -64,6 +65,7 @@ class QueueStore {
   }
 
   Future<void> _restore() async {
+    if (!SettingsManager().resumeQueue) return; // feature disabled
     final file = await _file;
     if (!await file.exists()) return;
 
@@ -133,9 +135,14 @@ class QueueStore {
     if (_restoring) return;
     _debounceTimer?.cancel();
     try {
+      final file = await _file;
+      if (!SettingsManager().resumeQueue) {
+        // Feature disabled — drop any saved queue so it can't be restored.
+        if (await file.exists()) await file.delete();
+        return;
+      }
       final handler = MediaManager().audioHandler;
       final queue = handler.queue.value;
-      final file = await _file;
       if (queue.isEmpty) {
         if (await file.exists()) await file.delete();
         return;

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -118,6 +118,9 @@ class SettingsManager {
   // AndroidEqualizer.parameters.
   bool eqEnabled = false;
   List<double> eqBandGains = const [];
+  // Whether the play queue + position are persisted and restored on the next
+  // launch (see QueueStore). On by default.
+  bool resumeQueue = true;
   // Visualizer audio source — synthesized is the default so the
   // visualizer Just Works without prompting for RECORD_AUDIO. Users
   // can opt into real audio in Settings; the toggle there walks them
@@ -208,6 +211,7 @@ class SettingsManager {
       final accent = m['accentColor'];
       accentColor = accent is int ? accent : null;
       eqEnabled = m['eqEnabled'] ?? false;
+      resumeQueue = m['resumeQueue'] ?? true;
       final rawGains = m['eqBandGains'];
       eqBandGains = rawGains is List
           ? rawGains.whereType<num>().map((n) => n.toDouble()).toList()
@@ -321,6 +325,7 @@ class SettingsManager {
       'playerLayout': playerLayout.name,
       'accentColor': accentColor,
       'eqEnabled': eqEnabled,
+      'resumeQueue': resumeQueue,
       'eqBandGains': eqBandGains,
       'visualizerAudioSource': visualizerAudioSource.name,
       'visualizerEngine': visualizerEngine.name,
@@ -392,6 +397,11 @@ class SettingsManager {
     await _save();
   }
 
+  Future<void> setResumeQueue(bool v) async {
+    resumeQueue = v;
+    await _save();
+  }
+
   Future<void> setEqBandGains(List<double> v) async {
     eqBandGains = v;
     await _save();
@@ -451,6 +461,7 @@ class SettingsManager {
     playerLayout = PlayerLayout.medium;
     accentColor = null;
     eqEnabled = false;
+    resumeQueue = true;
     eqBandGains = const [];
     visualizerAudioSource = VisualizerAudioSource.synthesized;
     visualizerEngine = VisualizerEngine.milkdrop;

--- a/lib/util/queue_actions.dart
+++ b/lib/util/queue_actions.dart
@@ -12,6 +12,7 @@ import 'package:audio_service/audio_service.dart';
 import 'package:uuid/uuid.dart';
 
 import '../objects/display_item.dart';
+import '../objects/server.dart';
 import '../singletons/file_explorer.dart';
 import '../singletons/media.dart';
 import '../singletons/settings.dart';
@@ -24,6 +25,28 @@ MediaItem buildLocalFileMediaItem(DisplayItem i) {
     title: i.name.split('/').last,
     extras: {'path': i.data, 'localPath': i.data!},
   );
+}
+
+/// Builds the streaming URL for a server file [path] (the leading-slash data
+/// path, e.g. "/Music/foo.mp3"). Honors the current transcode setting and
+/// appends a fresh cache-busting app_uuid plus the server token. Shared by the
+/// browse-time MediaItem builder and the queue-restore rebuild so both stay in
+/// lockstep — and so the rebuilt URL always carries the CURRENT token (a saved
+/// URL's token can go stale between sessions).
+String buildServerStreamUrl(Server server, String path) {
+  String p = '';
+  path.split('/').forEach((element) {
+    if (element.isEmpty) return;
+    p += '/' + Uri.encodeComponent(element);
+  });
+  final String prefix =
+      TranscodeManager().transcodeOn == true ? '/transcode' : '/media';
+  return server.url +
+      prefix +
+      p +
+      '?app_uuid=' +
+      Uuid().v4() +
+      (server.jwt == null ? '' : '&token=' + server.jwt!);
 }
 
 /// Builds a server-file MediaItem, preferring a locally-cached copy when one is
@@ -43,19 +66,7 @@ Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
   final bool isLocal =
       finalString != null && File(finalString).existsSync() == true;
 
-  String p = '';
-  i.data!.split('/').forEach((element) {
-    if (element.isEmpty) return;
-    p += '/' + Uri.encodeComponent(element);
-  });
-  final String prefix =
-      TranscodeManager().transcodeOn == true ? '/transcode' : '/media';
-  final String streamUrl = i.server!.url +
-      prefix +
-      p +
-      '?app_uuid=' +
-      Uuid().v4() +
-      (i.server!.jwt == null ? '' : '&token=' + i.server!.jwt!);
+  final String streamUrl = buildServerStreamUrl(i.server!, i.data!);
 
   final String? artUrl = i.metadata?.albumArt != null
       ? Uri.parse(i.server!.url.toString())

--- a/test/singletons/queue_store_test.dart
+++ b/test/singletons/queue_store_test.dart
@@ -1,0 +1,142 @@
+import 'dart:convert';
+
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/singletons/queue_store.dart';
+
+void main() {
+  // Simulate a real save→load: encode to JSON text and back, the way the file
+  // round-trips it, before rebuilding.
+  Map<String, dynamic> roundTripJson(MediaItem m) =>
+      Map<String, dynamic>.from(jsonDecode(jsonEncode(QueueStore.itemToJson(m))));
+
+  group('QueueStore.itemToJson', () {
+    test('captures the display fields, duration (ms) and extras', () {
+      final m = MediaItem(
+        id: 'http://host/media/x',
+        title: 'Title',
+        album: 'Album',
+        artist: 'Artist',
+        genre: 'Genre',
+        duration: const Duration(milliseconds: 1234),
+        extras: {'server': 's', 'path': '/x', 'track': 3},
+      );
+
+      final json = QueueStore.itemToJson(m);
+
+      expect(json['title'], 'Title');
+      expect(json['album'], 'Album');
+      expect(json['artist'], 'Artist');
+      expect(json['genre'], 'Genre');
+      expect(json['durationMs'], 1234);
+      expect(json['extras'], {'server': 's', 'path': '/x', 'track': 3});
+      // The whole thing must survive a JSON text round-trip.
+      expect(() => jsonEncode(json), returnsNormally);
+    });
+
+    test('null duration serializes as null durationMs', () {
+      final m = MediaItem(id: 'id', title: 'T', extras: {'path': '/p'});
+      expect(QueueStore.itemToJson(m)['durationMs'], isNull);
+    });
+  });
+
+  group('QueueStore.itemFromJson — local files', () {
+    test('round-trips and keeps the id + localPath as-is', () {
+      final original = MediaItem(
+        id: 'local-uuid-1',
+        title: 'song.mp3',
+        extras: {
+          'path': '/sdcard/Music/song.mp3',
+          'localPath': '/sdcard/Music/song.mp3',
+        },
+      );
+
+      final restored = QueueStore.itemFromJson(roundTripJson(original));
+
+      expect(restored, isNotNull);
+      expect(restored!.id, 'local-uuid-1');
+      expect(restored.title, 'song.mp3');
+      expect(restored.extras!['localPath'], '/sdcard/Music/song.mp3');
+    });
+  });
+
+  group('QueueStore.itemFromJson — server files', () {
+    final server = Server('http://host:3000', null, null, 'tok123', 'myserver');
+
+    test('rebuilds the streaming URL with the CURRENT token + encoded path', () {
+      final original = MediaItem(
+        // A stale URL with an old token — must NOT be reused.
+        id: 'http://host:3000/media/Music/foo%20bar.mp3?app_uuid=OLD&token=STALE',
+        title: 'Foo Bar',
+        album: 'The Album',
+        artist: 'The Artist',
+        genre: 'Rock',
+        duration: const Duration(milliseconds: 215000),
+        extras: {
+          'server': 'myserver',
+          'path': '/Music/foo bar.mp3',
+          'year': 2021,
+          'track': 3,
+          'disc': 1,
+          'artUrl': 'http://host:3000/album-art/abc?token=STALE',
+          'bpm': 128,
+          'musicalKey': '8A',
+        },
+      );
+
+      final restored = QueueStore.itemFromJson(
+        roundTripJson(original),
+        resolveServer: (name) => name == 'myserver' ? server : null,
+      );
+
+      expect(restored, isNotNull);
+      // Display fields preserved.
+      expect(restored!.title, 'Foo Bar');
+      expect(restored.album, 'The Album');
+      expect(restored.artist, 'The Artist');
+      expect(restored.genre, 'Rock');
+      expect(restored.duration, const Duration(milliseconds: 215000));
+      // Extras preserved.
+      expect(restored.extras!['path'], '/Music/foo bar.mp3');
+      expect(restored.extras!['bpm'], 128);
+      expect(restored.extras!['musicalKey'], '8A');
+      // URL rebuilt fresh: correct host + transcode-off prefix + encoded path,
+      // the current token, a new app_uuid — and crucially NOT the stale token.
+      expect(restored.id, startsWith('http://host:3000/media/Music/foo%20bar.mp3'));
+      expect(restored.id, contains('token=tok123'));
+      expect(restored.id, contains('app_uuid='));
+      expect(restored.id, isNot(contains('STALE')));
+    });
+
+    test('returns null when the server is no longer configured', () {
+      final original = MediaItem(
+        id: 'http://host:3000/media/x',
+        title: 'Orphan',
+        extras: {'server': 'goneserver', 'path': '/x'},
+      );
+
+      final restored = QueueStore.itemFromJson(
+        roundTripJson(original),
+        resolveServer: (_) => null,
+      );
+
+      expect(restored, isNull);
+    });
+
+    test('returns null when a server item is missing its path', () {
+      final original = MediaItem(
+        id: 'http://host:3000/media/x',
+        title: 'No Path',
+        extras: {'server': 'myserver'},
+      );
+
+      final restored = QueueStore.itemFromJson(
+        roundTripJson(original),
+        resolveServer: (_) => server,
+      );
+
+      expect(restored, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closing the app no longer loses your place — the play queue and the current track/position are saved to disk and restored on reopen.

## How it works

**Storage** — a new `QueueStore` singleton serializes the queue + current index + position (+ shuffle/repeat) to `queue.json` in the app documents dir (same approach as `servers.json`).

**Server items** are stored by their stable bits (server localname + path + display metadata); the streaming URL is **rebuilt on restore** with the current token/transcode setting via a new shared `buildServerStreamUrl` helper (extracted from `buildServerFileMediaItem` so browse-time and restore-time stay in lockstep). A saved URL's per-build `app_uuid` + token would otherwise go stale between sessions. **Local files** keep their `localPath`; the backend already re-checks existence at play time and streams as a fallback. Items whose server is no longer configured are dropped on restore.

**When it saves** — debounced on queue edits + track changes, a periodic position checkpoint while playing, and an immediate flush on app pause/detach (covers a backgrounded-then-killed app). Clearing the queue deletes the file so a stale queue can't resurrect.

**When it restores** — `AudioPlayerHandler.restoreQueue` seeds the queue + backend, parks playback at the saved index/position **paused** (no audio blast on open), and reapplies shuffle/repeat. Wired in `main()` after servers load (server items need the configured server to rebuild URLs).

## Files
- `lib/singletons/queue_store.dart` (new) — persistence + (de)serialization
- `lib/media/audio_stuff.dart` — `position` getter + `restoreQueue()`
- `lib/util/queue_actions.dart` — extracted `buildServerStreamUrl`
- `lib/main.dart` — restore after servers load + flush on lifecycle pause/detach
- `test/singletons/queue_store_test.dart` (new) — 6 round-trip tests

## Test plan
- `flutter analyze lib test` → No issues found
- `flutter test` → 33/33 (6 new: local round-trip, server URL rebuild with fresh token, server-removed → null, missing-path → null, JSON shape)
- `flutter build apk --debug` → built
- **End-to-end on a device:** planted a 2-track queue at index 1 / 45s, relaunched → media session came back `PAUSED`, `active item id=1`, `position=45000`, queue `size=2`, local file buffered and ready. No auto-play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)