### PR TITLE
Fix browser navigation race + Back-to-cancel a long load

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -254,6 +254,10 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
             panel.collapse();
           } else if (BrowserManager().albumDetail != null) {
             BrowserManager().closeAlbumDetail();
+          } else if (BrowserManager().isLoading) {
+            // A browse fetch is in flight — Back stops it (and re-enables taps)
+            // instead of navigating away.
+            BrowserManager().cancelLoading();
           } else if (BrowserManager().browserCache.length > 1) {
             BrowserManager().popBrowser();
           } else {

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -39,6 +39,16 @@ class _BrowserState extends State<Browser> {
 
   void handleTap(
       List<DisplayItem> browserList, int index, BuildContext context) {
+    // A browse fetch is already in flight — ignore taps until it resolves (or
+    // is cancelled with Back). Without this, tapping a second folder before the
+    // first finished kicked off a racing request and the screen showed whichever
+    // returned last. addServer stays actionable (the no-server screen never has
+    // a load in flight, but never lock the user out of adding a server).
+    if (BrowserManager().isLoading &&
+        browserList[index].type != 'addServer') {
+      return;
+    }
+
     if (_navTypes.contains(browserList[index].type)) {
       BrowserManager().closeSearch();
     }

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -81,15 +81,20 @@ class ApiManager {
   }
 
   Future makeServerCall(Server? currentServer, String location, Map payload,
-      String getOrPost) async {
+      String getOrPost,
+      {bool cancelable = true}) async {
     // Bracket every browse fetch so the browser can show one global loading bar,
-    // block taps while it's in flight, and let Back cancel it. The per-call
-    // http.Client is what makes cancelLoading() actually abort the request:
-    // closing the client makes the pending get/post throw. The finally balances
-    // the in-flight set and closes the client on every path (throw / HTTP error
-    // / cancel) so a socket is never leaked.
+    // block taps while it's in flight, and (when [cancelable]) let Back cancel
+    // it. The per-call http.Client is what makes cancelLoading() actually abort
+    // the request: closing the client makes the pending get/post throw. Mutating
+    // calls (playlist create / rename / delete) pass cancelable: false so Back
+    // can't abort them mid-flight — they still show the bar + block taps, they
+    // just run to completion. The finally balances the in-flight set and closes
+    // the client on every path (throw / HTTP error / cancel) so a socket is
+    // never leaked.
     final client = http.Client();
-    final int loadToken = BrowserManager().beginLoading(onCancel: client.close);
+    final int loadToken = BrowserManager()
+        .beginLoading(onCancel: cancelable ? client.close : null);
     try {
       Server server = ServerManager().currentServer ??
           (throw Exception('No Server Selected'));
@@ -119,7 +124,8 @@ class ApiManager {
 
       // Back was pressed while this was in flight: drop the result so a slow
       // folder can't pop onto the stack after the user cancelled / navigated.
-      if (BrowserManager().isLoadCancelled(loadToken)) {
+      // Skipped for non-cancelable mutations — those must run to completion.
+      if (cancelable && BrowserManager().isLoadCancelled(loadToken)) {
         throw Exception('Navigation cancelled');
       }
 
@@ -205,14 +211,15 @@ class ApiManager {
   /// Creates an empty playlist (POST /playlist/new). Throws on failure (e.g. the
   /// server's 400 when the name already exists) so the caller can surface it.
   Future<void> createPlaylist(String title) async {
-    await makeServerCall(null, '/api/v1/playlist/new', {'title': title}, 'POST');
+    await makeServerCall(null, '/api/v1/playlist/new', {'title': title}, 'POST',
+        cancelable: false);
     await refreshPlaylists();
   }
 
   /// Renames a playlist (POST /playlist/rename). Throws on failure.
   Future<void> renamePlaylist(String oldName, String newName) async {
     await makeServerCall(null, '/api/v1/playlist/rename',
-        {'oldName': oldName, 'newName': newName}, 'POST');
+        {'oldName': oldName, 'newName': newName}, 'POST', cancelable: false);
     await refreshPlaylists();
   }
 
@@ -220,7 +227,7 @@ class ApiManager {
       {Server? useThisServer}) async {
     try {
       await makeServerCall(useThisServer, '/api/v1/playlist/delete',
-          {'playlistname': playlistId}, 'POST');
+          {'playlistname': playlistId}, 'POST', cancelable: false);
     } catch (err) {
       // TODO: Handle Errors
       print(err);

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -82,10 +82,14 @@ class ApiManager {
 
   Future makeServerCall(Server? currentServer, String location, Map payload,
       String getOrPost) async {
-    // Bracket every browse fetch so the browser can show one global
-    // loading bar. The finally guarantees the in-flight counter is
-    // balanced even on the early throws / HTTP-error / network paths.
-    BrowserManager().beginLoading();
+    // Bracket every browse fetch so the browser can show one global loading bar,
+    // block taps while it's in flight, and let Back cancel it. The per-call
+    // http.Client is what makes cancelLoading() actually abort the request:
+    // closing the client makes the pending get/post throw. The finally balances
+    // the in-flight set and closes the client on every path (throw / HTTP error
+    // / cancel) so a socket is never leaked.
+    final client = http.Client();
+    final int loadToken = BrowserManager().beginLoading(onCancel: client.close);
     try {
       Server server = ServerManager().currentServer ??
           (throw Exception('No Server Selected'));
@@ -98,10 +102,10 @@ class ApiManager {
 
       var response;
       if (getOrPost == 'GET') {
-        response = await http
+        response = await client
             .get(currentUri, headers: {'x-access-token': server.jwt ?? ''});
       } else {
-        response = await http.post(currentUri,
+        response = await client.post(currentUri,
             body: json.encode(payload),
             headers: {
               'Content-Type': 'application/json',
@@ -113,9 +117,16 @@ class ApiManager {
         throw Exception('Server Call Failed');
       }
 
+      // Back was pressed while this was in flight: drop the result so a slow
+      // folder can't pop onto the stack after the user cancelled / navigated.
+      if (BrowserManager().isLoadCancelled(loadToken)) {
+        throw Exception('Navigation cancelled');
+      }
+
       return jsonDecode(response.body);
     } finally {
-      BrowserManager().endLoading();
+      client.close();
+      BrowserManager().endLoading(loadToken);
     }
   }
 

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -33,25 +33,63 @@ class BrowserManager {
 
   String listName = 'Welcome';
 
-  // In-flight server-call tracking for the browser's global loading bar.
-  // makeServerCall (the chokepoint every browse fetch passes through)
-  // brackets each request with beginLoading()/endLoading(); the counter
-  // keeps the bar up across overlapping calls and flips the stream only
-  // on the 0<->1 transition, so there are no redundant rebuilds.
-  int _inFlightCalls = 0;
+  // In-flight server-call tracking. makeServerCall (the chokepoint every browse
+  // fetch passes through) brackets each request with beginLoading()/endLoading().
+  // This drives three things:
+  //   1. the browser's global loading bar (the _loading stream),
+  //   2. the tap-guard — the browser ignores item taps while [isLoading] is
+  //      true, so tapping a second folder before the first resolves can't kick
+  //      off a racing request (whichever finished last used to win the screen),
+  //   3. Back-to-cancel — [cancelLoading] aborts every in-flight request via the
+  //      registered cancelers (which close the http client) and marks their
+  //      tokens cancelled so a late response is dropped instead of navigated to.
+  // Each call gets a monotonic token and we track the live set (not a bare
+  // counter) so a cancelled call's late endLoading() can't zero out a newer one.
+  final Set<int> _inFlight = {};
+  final Map<int, void Function()> _loadCancelers = {};
+  int _lastLoadToken = 0;
+  // Tokens <= this were cancelled by Back; their results must be discarded.
+  int _cancelledThrough = 0;
   late final BehaviorSubject<bool> _loading =
       BehaviorSubject<bool>.seeded(false);
   Stream<bool> get loadingStream => _loading.stream;
-  bool get isLoading => _loading.value;
+  bool get isLoading => _inFlight.isNotEmpty;
 
-  void beginLoading() {
-    _inFlightCalls++;
-    if (_inFlightCalls == 1) _loading.add(true);
+  /// Begin tracking a server call. [onCancel] (e.g. closing the http client) is
+  /// invoked if Back cancels the load while it's still in flight. Returns a
+  /// token to pass to [endLoading] / [isLoadCancelled].
+  int beginLoading({void Function()? onCancel}) {
+    final token = ++_lastLoadToken;
+    _inFlight.add(token);
+    if (onCancel != null) _loadCancelers[token] = onCancel;
+    if (_inFlight.length == 1) _loading.add(true);
+    return token;
   }
 
-  void endLoading() {
-    if (_inFlightCalls > 0) _inFlightCalls--;
-    if (_inFlightCalls == 0) _loading.add(false);
+  void endLoading(int token) {
+    _loadCancelers.remove(token);
+    if (_inFlight.remove(token) && _inFlight.isEmpty) _loading.add(false);
+  }
+
+  /// True if load [token] was cancelled (Back pressed) — the caller should drop
+  /// whatever the request returned rather than pushing it onto the stack.
+  bool isLoadCancelled(int token) => token <= _cancelledThrough;
+
+  /// Cancel every in-flight server call — used by Back to stop a long load.
+  /// Fires each canceler (aborting the http request) and marks the tokens
+  /// cancelled so any response that still lands is discarded. Returns true if
+  /// anything was in flight (so the Back handler knows it consumed the press).
+  bool cancelLoading() {
+    if (_inFlight.isEmpty) return false;
+    _cancelledThrough = _lastLoadToken;
+    final cancelers = List.of(_loadCancelers.values);
+    _loadCancelers.clear();
+    _inFlight.clear();
+    _loading.add(false);
+    for (final c in cancelers) {
+      c(); // closes the http client → the pending request throws → dropped
+    }
+    return true;
   }
 
   late final BehaviorSubject<List<DisplayItem>> _browserStream =

--- a/test/singletons/browser_load_test.dart
+++ b/test/singletons/browser_load_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/singletons/browser_list.dart';
+
+// Covers the in-flight load tracking that backs the browser's tap-guard and
+// Back-to-cancel behavior (the fix for the folder-load race where a second tap
+// kicked off a second request and the screen showed whichever finished last).
+//
+// BrowserManager is a singleton, so the load token / cancelledThrough state is
+// shared across the isolate. Tokens and the cancel watermark are monotonic, so
+// this runs as ONE ordered test rather than fighting cross-test state.
+void main() {
+  test('load tokens: tracking, cancellation, and late-endLoad safety', () {
+    final bm = BrowserManager();
+    expect(bm.isLoading, isFalse);
+
+    // 1. Concurrent loads are tracked independently; isLoading stays true until
+    //    the last one ends. Tokens are monotonic.
+    final a = bm.beginLoading();
+    expect(bm.isLoading, isTrue);
+    final b = bm.beginLoading();
+    expect(b, greaterThan(a));
+    bm.endLoading(a);
+    expect(bm.isLoading, isTrue, reason: 'b is still in flight');
+    bm.endLoading(b);
+    expect(bm.isLoading, isFalse);
+
+    // 2. Cancel fires the registered canceler, clears the loading state, and
+    //    marks the in-flight token cancelled (so its late result is dropped).
+    var cancelerFired = false;
+    final c = bm.beginLoading(onCancel: () => cancelerFired = true);
+    expect(bm.isLoadCancelled(c), isFalse);
+    expect(bm.cancelLoading(), isTrue);
+    expect(cancelerFired, isTrue);
+    expect(bm.isLoadCancelled(c), isTrue);
+    expect(bm.isLoading, isFalse);
+
+    // 3. A load started AFTER a cancel is NOT considered cancelled, and the
+    //    cancelled load's late endLoading() must not zero out the newer one
+    //    (the bug a bare counter would have: cancel sets count 0, then the old
+    //    finally decrements the new load's count).
+    final d = bm.beginLoading();
+    expect(bm.isLoadCancelled(d), isFalse);
+    expect(bm.isLoading, isTrue);
+    bm.endLoading(c); // the cancelled load's late finally
+    expect(bm.isLoading, isTrue, reason: 'd must remain in flight');
+    bm.endLoading(d);
+    expect(bm.isLoading, isFalse);
+
+    // 4. Cancelling with nothing in flight is a no-op (Back then falls through
+    //    to normal navigation).
+    expect(bm.cancelLoading(), isFalse);
+  });
+}

--- a/test/singletons/browser_load_test.dart
+++ b/test/singletons/browser_load_test.dart
@@ -49,5 +49,15 @@ void main() {
     // 4. Cancelling with nothing in flight is a no-op (Back then falls through
     //    to normal navigation).
     expect(bm.cancelLoading(), isFalse);
+
+    // 5. cancelable: false path — a load registered WITHOUT a canceler (a
+    //    mutation like playlist create/rename/delete) is not aborted by Back:
+    //    cancelLoading fires only registered cancelers, so the mutation's
+    //    request runs to completion.
+    var cancelerFires = 0;
+    bm.beginLoading(onCancel: () => cancelerFires++); // cancelable read/nav
+    bm.beginLoading(); // non-cancelable mutation — no canceler registered
+    expect(bm.cancelLoading(), isTrue);
+    expect(cancelerFires, 1, reason: 'only the cancelable load is aborted');
   });
 }


### PR DESCRIPTION
## The bug
Tapping a folder, then quickly tapping another while the first was still loading, kicked off two requests. Whichever HTTP response landed last won — so the browser could end up showing the wrong folder (or push both onto the stack in completion order).

## The fix
Built on the existing in-flight tracking that already drives the loading bar (`makeServerCall` is the chokepoint every browse fetch passes through).

**1. Block taps while loading.** `handleTap` ignores item taps while a browse fetch is in flight (`BrowserManager.isLoading`), so a second folder can't start a racing request. `addServer` stays actionable so the no-server screen is never locked.

**2. Back cancels a long load.** `makeServerCall` now runs on a per-call `http.Client` and registers it as a canceler. `BrowserManager.cancelLoading()` — wired into the Back handler ahead of the pop/navigate branches — closes the client so the pending request **actually aborts**, and marks the load's token cancelled so a response that still lands is dropped instead of navigated to.

In-flight loads are tracked as a **token Set** rather than a bare counter, so a cancelled call's late `endLoading()` can't zero out a newer load's state.

### Back-button precedence
`expanded player → collapse` · `album detail → close` · **`loading → cancel`** · `deeper stack → pop` · `else → exit`.

## Test plan
- New `test/singletons/browser_load_test.dart`: token lifecycle — independent tracking, cancellation fires cancelers + clears state + marks tokens cancelled, post-cancel loads aren't cancelled, and the late-`endLoading` safety property.
- `flutter analyze lib test` → clean · `flutter test` → **28/28** · `flutter build apk --debug` → built.
- ⚠️ On-device check pending: the wireless test device is offline right now. Manual repro once it's back: tap a folder then immediately tap another → second tap ignored; start a slow load → Back stops it and re-enables tapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)