### PR TITLE
Diagnostics screen: in-app logs users can view, copy & share

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -411,5 +411,13 @@
   "accentThemeDefault": "Theme-Standard",
   "accentCustom": "Benutzerdefiniert",
   "settingsResumeQueue": "Warteschlange beim Start fortsetzen",
-  "settingsResumeQueueSubtitle": "Speichert die Wiedergabeliste und deine Position und stellt sie beim erneuten Öffnen der App wieder her."
+  "settingsResumeQueueSubtitle": "Speichert die Wiedergabeliste und deine Position und stellt sie beim erneuten Öffnen der App wieder her.",
+  "diagnosticsTitle": "Diagnose",
+  "diagnosticsEnable": "Protokollierung aktivieren",
+  "diagnosticsHint": "Protokolle bleiben auf deinem Gerät. Tokens werden vor dem Kopieren oder Teilen ausgeblendet.",
+  "diagnosticsCopy": "Kopieren",
+  "diagnosticsShare": "Teilen",
+  "diagnosticsClear": "Löschen",
+  "diagnosticsCopied": "Protokolle in die Zwischenablage kopiert",
+  "diagnosticsEmpty": "Noch keine Protokolle"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -638,5 +638,13 @@
   "accentThemeDefault": "Theme default",
   "accentCustom": "Custom",
   "settingsResumeQueue": "Resume queue on launch",
-  "settingsResumeQueueSubtitle": "Save the play queue and your place, and restore them when you reopen the app."
+  "settingsResumeQueueSubtitle": "Save the play queue and your place, and restore them when you reopen the app.",
+  "diagnosticsTitle": "Diagnostics",
+  "diagnosticsEnable": "Enable logging",
+  "diagnosticsHint": "Logs stay on your device. Tokens are hidden before copying or sharing.",
+  "diagnosticsCopy": "Copy",
+  "diagnosticsShare": "Share",
+  "diagnosticsClear": "Clear",
+  "diagnosticsCopied": "Logs copied to clipboard",
+  "diagnosticsEmpty": "No logs yet"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -353,5 +353,13 @@
   "accentThemeDefault": "Predeterminado del tema",
   "accentCustom": "Personalizado",
   "settingsResumeQueue": "Reanudar la cola al iniciar",
-  "settingsResumeQueueSubtitle": "Guarda la cola de reproducción y tu posición y las restaura al volver a abrir la app."
+  "settingsResumeQueueSubtitle": "Guarda la cola de reproducción y tu posición y las restaura al volver a abrir la app.",
+  "diagnosticsTitle": "Diagnóstico",
+  "diagnosticsEnable": "Activar registro",
+  "diagnosticsHint": "Los registros se quedan en tu dispositivo. Los tokens se ocultan antes de copiar o compartir.",
+  "diagnosticsCopy": "Copiar",
+  "diagnosticsShare": "Compartir",
+  "diagnosticsClear": "Borrar",
+  "diagnosticsCopied": "Registros copiados al portapapeles",
+  "diagnosticsEmpty": "Aún no hay registros"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -346,5 +346,13 @@
   "accentThemeDefault": "Par défaut du thème",
   "accentCustom": "Personnalisé",
   "settingsResumeQueue": "Reprendre la file au démarrage",
-  "settingsResumeQueueSubtitle": "Enregistre la file de lecture et votre position, puis les restaure à la réouverture de l'application."
+  "settingsResumeQueueSubtitle": "Enregistre la file de lecture et votre position, puis les restaure à la réouverture de l'application.",
+  "diagnosticsTitle": "Diagnostics",
+  "diagnosticsEnable": "Activer la journalisation",
+  "diagnosticsHint": "Les journaux restent sur votre appareil. Les jetons sont masqués avant copie ou partage.",
+  "diagnosticsCopy": "Copier",
+  "diagnosticsShare": "Partager",
+  "diagnosticsClear": "Effacer",
+  "diagnosticsCopied": "Journaux copiés dans le presse-papiers",
+  "diagnosticsEmpty": "Aucun journal pour l'instant"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -346,5 +346,13 @@
   "accentThemeDefault": "Predefinito del tema",
   "accentCustom": "Personalizzato",
   "settingsResumeQueue": "Riprendi la coda all'avvio",
-  "settingsResumeQueueSubtitle": "Salva la coda di riproduzione e la tua posizione e le ripristina alla riapertura dell'app."
+  "settingsResumeQueueSubtitle": "Salva la coda di riproduzione e la tua posizione e le ripristina alla riapertura dell'app.",
+  "diagnosticsTitle": "Diagnostica",
+  "diagnosticsEnable": "Abilita registrazione",
+  "diagnosticsHint": "I log restano sul tuo dispositivo. I token vengono nascosti prima di copiare o condividere.",
+  "diagnosticsCopy": "Copia",
+  "diagnosticsShare": "Condividi",
+  "diagnosticsClear": "Cancella",
+  "diagnosticsCopied": "Log copiati negli appunti",
+  "diagnosticsEmpty": "Nessun log ancora"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -346,5 +346,13 @@
   "accentThemeDefault": "テーマの既定",
   "accentCustom": "カスタム",
   "settingsResumeQueue": "起動時にキューを復元",
-  "settingsResumeQueueSubtitle": "再生キューと再生位置を保存し、アプリを再び開いたときに復元します。"
+  "settingsResumeQueueSubtitle": "再生キューと再生位置を保存し、アプリを再び開いたときに復元します。",
+  "diagnosticsTitle": "診断",
+  "diagnosticsEnable": "ログ記録を有効にする",
+  "diagnosticsHint": "ログは端末内にのみ保存されます。コピーや共有の前にトークンは隠されます。",
+  "diagnosticsCopy": "コピー",
+  "diagnosticsShare": "共有",
+  "diagnosticsClear": "クリア",
+  "diagnosticsCopied": "ログをクリップボードにコピーしました",
+  "diagnosticsEmpty": "まだログがありません"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2195,6 +2195,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Save the play queue and your place, and restore them when you reopen the app.'**
   String get settingsResumeQueueSubtitle;
+
+  /// No description provided for @diagnosticsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Diagnostics'**
+  String get diagnosticsTitle;
+
+  /// No description provided for @diagnosticsEnable.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable logging'**
+  String get diagnosticsEnable;
+
+  /// No description provided for @diagnosticsHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Logs stay on your device. Tokens are hidden before copying or sharing.'**
+  String get diagnosticsHint;
+
+  /// No description provided for @diagnosticsCopy.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy'**
+  String get diagnosticsCopy;
+
+  /// No description provided for @diagnosticsShare.
+  ///
+  /// In en, this message translates to:
+  /// **'Share'**
+  String get diagnosticsShare;
+
+  /// No description provided for @diagnosticsClear.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear'**
+  String get diagnosticsClear;
+
+  /// No description provided for @diagnosticsCopied.
+  ///
+  /// In en, this message translates to:
+  /// **'Logs copied to clipboard'**
+  String get diagnosticsCopied;
+
+  /// No description provided for @diagnosticsEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No logs yet'**
+  String get diagnosticsEmpty;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1269,4 +1269,29 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get settingsResumeQueueSubtitle =>
       'Speichert die Wiedergabeliste und deine Position und stellt sie beim erneuten Öffnen der App wieder her.';
+
+  @override
+  String get diagnosticsTitle => 'Diagnose';
+
+  @override
+  String get diagnosticsEnable => 'Protokollierung aktivieren';
+
+  @override
+  String get diagnosticsHint =>
+      'Protokolle bleiben auf deinem Gerät. Tokens werden vor dem Kopieren oder Teilen ausgeblendet.';
+
+  @override
+  String get diagnosticsCopy => 'Kopieren';
+
+  @override
+  String get diagnosticsShare => 'Teilen';
+
+  @override
+  String get diagnosticsClear => 'Löschen';
+
+  @override
+  String get diagnosticsCopied => 'Protokolle in die Zwischenablage kopiert';
+
+  @override
+  String get diagnosticsEmpty => 'Noch keine Protokolle';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1252,4 +1252,29 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get settingsResumeQueueSubtitle =>
       'Save the play queue and your place, and restore them when you reopen the app.';
+
+  @override
+  String get diagnosticsTitle => 'Diagnostics';
+
+  @override
+  String get diagnosticsEnable => 'Enable logging';
+
+  @override
+  String get diagnosticsHint =>
+      'Logs stay on your device. Tokens are hidden before copying or sharing.';
+
+  @override
+  String get diagnosticsCopy => 'Copy';
+
+  @override
+  String get diagnosticsShare => 'Share';
+
+  @override
+  String get diagnosticsClear => 'Clear';
+
+  @override
+  String get diagnosticsCopied => 'Logs copied to clipboard';
+
+  @override
+  String get diagnosticsEmpty => 'No logs yet';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1268,4 +1268,29 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get settingsResumeQueueSubtitle =>
       'Guarda la cola de reproducción y tu posición y las restaura al volver a abrir la app.';
+
+  @override
+  String get diagnosticsTitle => 'Diagnóstico';
+
+  @override
+  String get diagnosticsEnable => 'Activar registro';
+
+  @override
+  String get diagnosticsHint =>
+      'Los registros se quedan en tu dispositivo. Los tokens se ocultan antes de copiar o compartir.';
+
+  @override
+  String get diagnosticsCopy => 'Copiar';
+
+  @override
+  String get diagnosticsShare => 'Compartir';
+
+  @override
+  String get diagnosticsClear => 'Borrar';
+
+  @override
+  String get diagnosticsCopied => 'Registros copiados al portapapeles';
+
+  @override
+  String get diagnosticsEmpty => 'Aún no hay registros';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1266,4 +1266,29 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get settingsResumeQueueSubtitle =>
       'Enregistre la file de lecture et votre position, puis les restaure à la réouverture de l\'application.';
+
+  @override
+  String get diagnosticsTitle => 'Diagnostics';
+
+  @override
+  String get diagnosticsEnable => 'Activer la journalisation';
+
+  @override
+  String get diagnosticsHint =>
+      'Les journaux restent sur votre appareil. Les jetons sont masqués avant copie ou partage.';
+
+  @override
+  String get diagnosticsCopy => 'Copier';
+
+  @override
+  String get diagnosticsShare => 'Partager';
+
+  @override
+  String get diagnosticsClear => 'Effacer';
+
+  @override
+  String get diagnosticsCopied => 'Journaux copiés dans le presse-papiers';
+
+  @override
+  String get diagnosticsEmpty => 'Aucun journal pour l\'instant';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1268,4 +1268,29 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get settingsResumeQueueSubtitle =>
       'Salva la coda di riproduzione e la tua posizione e le ripristina alla riapertura dell\'app.';
+
+  @override
+  String get diagnosticsTitle => 'Diagnostica';
+
+  @override
+  String get diagnosticsEnable => 'Abilita registrazione';
+
+  @override
+  String get diagnosticsHint =>
+      'I log restano sul tuo dispositivo. I token vengono nascosti prima di copiare o condividere.';
+
+  @override
+  String get diagnosticsCopy => 'Copia';
+
+  @override
+  String get diagnosticsShare => 'Condividi';
+
+  @override
+  String get diagnosticsClear => 'Cancella';
+
+  @override
+  String get diagnosticsCopied => 'Log copiati negli appunti';
+
+  @override
+  String get diagnosticsEmpty => 'Nessun log ancora';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1209,4 +1209,28 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get settingsResumeQueueSubtitle => '再生キューと再生位置を保存し、アプリを再び開いたときに復元します。';
+
+  @override
+  String get diagnosticsTitle => '診断';
+
+  @override
+  String get diagnosticsEnable => 'ログ記録を有効にする';
+
+  @override
+  String get diagnosticsHint => 'ログは端末内にのみ保存されます。コピーや共有の前にトークンは隠されます。';
+
+  @override
+  String get diagnosticsCopy => 'コピー';
+
+  @override
+  String get diagnosticsShare => '共有';
+
+  @override
+  String get diagnosticsClear => 'クリア';
+
+  @override
+  String get diagnosticsCopied => 'ログをクリップボードにコピーしました';
+
+  @override
+  String get diagnosticsEmpty => 'まだログがありません';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1286,4 +1286,29 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get settingsResumeQueueSubtitle =>
       'Zapisuje kolejkę odtwarzania i pozycję oraz przywraca je po ponownym otwarciu aplikacji.';
+
+  @override
+  String get diagnosticsTitle => 'Diagnostyka';
+
+  @override
+  String get diagnosticsEnable => 'Włącz rejestrowanie';
+
+  @override
+  String get diagnosticsHint =>
+      'Dzienniki pozostają na Twoim urządzeniu. Tokeny są ukrywane przed skopiowaniem lub udostępnieniem.';
+
+  @override
+  String get diagnosticsCopy => 'Kopiuj';
+
+  @override
+  String get diagnosticsShare => 'Udostępnij';
+
+  @override
+  String get diagnosticsClear => 'Wyczyść';
+
+  @override
+  String get diagnosticsCopied => 'Skopiowano dzienniki do schowka';
+
+  @override
+  String get diagnosticsEmpty => 'Brak dzienników';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1264,4 +1264,30 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get settingsResumeQueueSubtitle =>
       'Salva a fila de reprodução e sua posição e as restaura ao reabrir o app.';
+
+  @override
+  String get diagnosticsTitle => 'Diagnóstico';
+
+  @override
+  String get diagnosticsEnable => 'Ativar registro';
+
+  @override
+  String get diagnosticsHint =>
+      'Os registros ficam no seu dispositivo. Os tokens são ocultados antes de copiar ou compartilhar.';
+
+  @override
+  String get diagnosticsCopy => 'Copiar';
+
+  @override
+  String get diagnosticsShare => 'Compartilhar';
+
+  @override
+  String get diagnosticsClear => 'Limpar';
+
+  @override
+  String get diagnosticsCopied =>
+      'Registros copiados para a área de transferência';
+
+  @override
+  String get diagnosticsEmpty => 'Ainda não há registros';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1290,4 +1290,29 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get settingsResumeQueueSubtitle =>
       'Сохраняет очередь воспроизведения и позицию и восстанавливает их при повторном открытии приложения.';
+
+  @override
+  String get diagnosticsTitle => 'Диагностика';
+
+  @override
+  String get diagnosticsEnable => 'Включить журналирование';
+
+  @override
+  String get diagnosticsHint =>
+      'Журналы хранятся на вашем устройстве. Токены скрываются перед копированием или отправкой.';
+
+  @override
+  String get diagnosticsCopy => 'Копировать';
+
+  @override
+  String get diagnosticsShare => 'Поделиться';
+
+  @override
+  String get diagnosticsClear => 'Очистить';
+
+  @override
+  String get diagnosticsCopied => 'Журналы скопированы в буфер обмена';
+
+  @override
+  String get diagnosticsEmpty => 'Журналов пока нет';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1185,4 +1185,28 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settingsResumeQueueSubtitle => '保存播放队列和当前播放位置，并在重新打开应用时恢复。';
+
+  @override
+  String get diagnosticsTitle => '诊断';
+
+  @override
+  String get diagnosticsEnable => '启用日志记录';
+
+  @override
+  String get diagnosticsHint => '日志仅保存在您的设备上。复制或分享前会隐藏令牌。';
+
+  @override
+  String get diagnosticsCopy => '复制';
+
+  @override
+  String get diagnosticsShare => '分享';
+
+  @override
+  String get diagnosticsClear => '清除';
+
+  @override
+  String get diagnosticsCopied => '日志已复制到剪贴板';
+
+  @override
+  String get diagnosticsEmpty => '暂无日志';
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -346,5 +346,13 @@
   "accentThemeDefault": "Domyślny motywu",
   "accentCustom": "Niestandardowy",
   "settingsResumeQueue": "Wznów kolejkę po uruchomieniu",
-  "settingsResumeQueueSubtitle": "Zapisuje kolejkę odtwarzania i pozycję oraz przywraca je po ponownym otwarciu aplikacji."
+  "settingsResumeQueueSubtitle": "Zapisuje kolejkę odtwarzania i pozycję oraz przywraca je po ponownym otwarciu aplikacji.",
+  "diagnosticsTitle": "Diagnostyka",
+  "diagnosticsEnable": "Włącz rejestrowanie",
+  "diagnosticsHint": "Dzienniki pozostają na Twoim urządzeniu. Tokeny są ukrywane przed skopiowaniem lub udostępnieniem.",
+  "diagnosticsCopy": "Kopiuj",
+  "diagnosticsShare": "Udostępnij",
+  "diagnosticsClear": "Wyczyść",
+  "diagnosticsCopied": "Skopiowano dzienniki do schowka",
+  "diagnosticsEmpty": "Brak dzienników"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -411,5 +411,13 @@
   "accentThemeDefault": "Padrão do tema",
   "accentCustom": "Personalizado",
   "settingsResumeQueue": "Retomar a fila ao iniciar",
-  "settingsResumeQueueSubtitle": "Salva a fila de reprodução e sua posição e as restaura ao reabrir o app."
+  "settingsResumeQueueSubtitle": "Salva a fila de reprodução e sua posição e as restaura ao reabrir o app.",
+  "diagnosticsTitle": "Diagnóstico",
+  "diagnosticsEnable": "Ativar registro",
+  "diagnosticsHint": "Os registros ficam no seu dispositivo. Os tokens são ocultados antes de copiar ou compartilhar.",
+  "diagnosticsCopy": "Copiar",
+  "diagnosticsShare": "Compartilhar",
+  "diagnosticsClear": "Limpar",
+  "diagnosticsCopied": "Registros copiados para a área de transferência",
+  "diagnosticsEmpty": "Ainda não há registros"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -346,5 +346,13 @@
   "accentThemeDefault": "Из темы",
   "accentCustom": "Свой",
   "settingsResumeQueue": "Восстанавливать очередь при запуске",
-  "settingsResumeQueueSubtitle": "Сохраняет очередь воспроизведения и позицию и восстанавливает их при повторном открытии приложения."
+  "settingsResumeQueueSubtitle": "Сохраняет очередь воспроизведения и позицию и восстанавливает их при повторном открытии приложения.",
+  "diagnosticsTitle": "Диагностика",
+  "diagnosticsEnable": "Включить журналирование",
+  "diagnosticsHint": "Журналы хранятся на вашем устройстве. Токены скрываются перед копированием или отправкой.",
+  "diagnosticsCopy": "Копировать",
+  "diagnosticsShare": "Поделиться",
+  "diagnosticsClear": "Очистить",
+  "diagnosticsCopied": "Журналы скопированы в буфер обмена",
+  "diagnosticsEmpty": "Журналов пока нет"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -346,5 +346,13 @@
   "accentThemeDefault": "主题默认",
   "accentCustom": "自定义",
   "settingsResumeQueue": "启动时恢复播放队列",
-  "settingsResumeQueueSubtitle": "保存播放队列和当前播放位置，并在重新打开应用时恢复。"
+  "settingsResumeQueueSubtitle": "保存播放队列和当前播放位置，并在重新打开应用时恢复。",
+  "diagnosticsTitle": "诊断",
+  "diagnosticsEnable": "启用日志记录",
+  "diagnosticsHint": "日志仅保存在您的设备上。复制或分享前会隐藏令牌。",
+  "diagnosticsCopy": "复制",
+  "diagnosticsShare": "分享",
+  "diagnosticsClear": "清除",
+  "diagnosticsCopied": "日志已复制到剪贴板",
+  "diagnosticsEmpty": "暂无日志"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,10 +20,12 @@ import 'singletons/migration_manager.dart';
 import 'screens/add_server.dart';
 import 'screens/manage_server.dart';
 import 'screens/settings_screen.dart';
+import 'screens/diagnostics_screen.dart';
 import 'screens/share_playlist_dialog.dart';
 import 'singletons/auto_dj_manager.dart';
 import 'singletons/media.dart';
 import 'singletons/queue_store.dart';
+import 'singletons/log_manager.dart';
 import 'singletons/playlists.dart';
 import 'singletons/settings.dart';
 import 'theme/velvet_theme.dart';
@@ -34,7 +36,23 @@ import 'l10n/app_localizations.dart';
 import 'widgets/player_panel.dart';
 import 'widgets/browser_toolbar.dart';
 
-Future<void> main() async {
+void main() {
+  // Run the app inside a Zone whose print() handler tees every log line into
+  // the in-app diagnostic buffer (LogManager) — so users can view / copy /
+  // share logs from the Diagnostics screen — while still forwarding to the
+  // console / logcat. Uncaught async errors are captured here too; Flutter
+  // framework errors reach the buffer via their default debugPrint path.
+  runZonedGuarded(_startApp, (Object error, StackTrace stack) {
+    LogManager().add('Uncaught: $error\n$stack');
+  }, zoneSpecification: ZoneSpecification(
+    print: (self, parent, zone, String line) {
+      LogManager().add(line);
+      parent.print(zone, line);
+    },
+  ));
+}
+
+Future<void> _startApp() async {
   WidgetsFlutterBinding.ensureInitialized();
   // Show the system bars edge-to-edge from the first frame, so a launch that
   // inherits a leftover immersive mode (e.g. the app was killed while the
@@ -505,6 +523,17 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
                   Navigator.push(
                     context,
                     MaterialPageRoute(builder: (context) => SettingsScreen()),
+                  );
+                },
+              ),
+              ListTile(
+                leading: Icon(Icons.bug_report_outlined),
+                title: Text(l.diagnosticsTitle),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => DiagnosticsScreen()),
                   );
                 },
               ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,7 @@ import 'singletons/auto_dj_manager.dart';
 import 'singletons/media.dart';
 import 'singletons/queue_store.dart';
 import 'singletons/log_manager.dart';
+import 'app_version.dart';
 import 'singletons/playlists.dart';
 import 'singletons/settings.dart';
 import 'theme/velvet_theme.dart';
@@ -70,6 +71,7 @@ Future<void> _startApp() async {
   await MediaManager().start();
   await PlaylistManager().load();
   await AutoDJManager().load();
+  appLog('[app] mStream $kAppVersion started');
 
   // Wrap MaterialApp in a StreamBuilder bound to the theme + locale
   // settings so switching either triggers a full rebuild. setActive runs

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -18,6 +18,7 @@ import '../objects/server.dart';
 import '../objects/metadata.dart';
 import '../singletons/auto_dj_manager.dart';
 import '../singletons/cast_manager.dart';
+import '../singletons/log_manager.dart';
 import '../singletons/settings.dart';
 import '../util/camelot.dart';
 
@@ -105,6 +106,14 @@ class AudioPlayerHandler extends BaseAudioHandler
       if (_reordering) return;
       if (index == queue.value.length - 1) {
         autoDJ();
+      }
+      if (index != null && index >= 0 && index < queue.value.length) {
+        final item = queue.value[index];
+        if (item.id != _lastPlayLoggedId) {
+          _lastPlayLoggedId = item.id;
+          appLog('[play] track ${index + 1}/${queue.value.length}: '
+              '${item.title}');
+        }
       }
       _emitCurrentMediaItem();
     });
@@ -324,6 +333,10 @@ class AudioPlayerHandler extends BaseAudioHandler
   // MediaItem instead.
   bool _reordering = false;
 
+  // Last item id logged by the [play] track-change diagnostic, so repeated
+  // currentIndex emits for the same track don't spam the log.
+  String? _lastPlayLoggedId;
+
   @override
   Future<void> skipToQueueItem(int index) async {
     // Then default implementations of skipToNext and skipToPrevious provided by
@@ -359,13 +372,20 @@ class AudioPlayerHandler extends BaseAudioHandler
     // (File.existsSync + Uri.file) from the server-download-folder PR now lives
     // in LocalPlaybackBackend._uriFor.
     await _backend.addSource(item);
+    appLog('[queue] add: ${item.title} (now ${queue.value.length})');
   }
 
   @override
-  Future<void> play() => _backend.play();
+  Future<void> play() {
+    appLog('[play] play');
+    return _backend.play();
+  }
 
   @override
-  Future<void> pause() => _backend.pause();
+  Future<void> pause() {
+    appLog('[play] pause');
+    return _backend.pause();
+  }
 
   @override
   Future<void> skipToNext() async {
@@ -382,6 +402,7 @@ class AudioPlayerHandler extends BaseAudioHandler
 
   @override
   Future<void> stop() async {
+    appLog('[play] stop');
     await _backend.stop();
     await super.stop();
   }
@@ -434,6 +455,7 @@ class AudioPlayerHandler extends BaseAudioHandler
   customAction(String name, [Map<String, dynamic>? extras]) async {
     switch (name) {
       case 'clearPlaylist':
+        appLog('[queue] cleared');
         await _backend.stop();
         await super.stop();
         await _backend.clearSources();

--- a/lib/media/cast_log.dart
+++ b/lib/media/cast_log.dart
@@ -1,5 +1,7 @@
 import 'dart:developer' as developer;
 
+import '../singletons/log_manager.dart';
+
 /// Structured logging for the casting subsystem (the DLNA + Chromecast
 /// backends and their discoverers).
 ///
@@ -18,4 +20,7 @@ import 'dart:developer' as developer;
 /// it.)
 void castLog(String message, {Object? error, StackTrace? stackTrace}) {
   developer.log(message, name: 'cast', error: error, stackTrace: stackTrace);
+  // Mirror into the in-app diagnostic buffer (developer.log doesn't go through
+  // the print Zone) so the cast diagnostics show up on the Diagnostics screen.
+  LogManager().add(error == null ? '[cast] $message' : '[cast] $message: $error');
 }

--- a/lib/screens/diagnostics_screen.dart
+++ b/lib/screens/diagnostics_screen.dart
@@ -1,0 +1,149 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../l10n/app_localizations.dart';
+import '../singletons/log_manager.dart';
+import '../singletons/settings.dart';
+import '../theme/velvet_theme.dart';
+
+/// User-facing log viewer: shows the in-app diagnostic buffer ([LogManager]) so
+/// users can read recent logs and Copy / Share them when reporting an issue.
+/// Reached from the drawer. Logging is on by default; the toggle here turns
+/// capture off. Secrets are already redacted in the buffer, so copy/share are
+/// safe to hand to a maintainer.
+class DiagnosticsScreen extends StatefulWidget {
+  @override
+  State<DiagnosticsScreen> createState() => _DiagnosticsScreenState();
+}
+
+class _DiagnosticsScreenState extends State<DiagnosticsScreen> {
+  Future<void> _copy() async {
+    final l = AppLocalizations.of(context);
+    await Clipboard.setData(ClipboardData(text: LogManager().dump()));
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(l.diagnosticsCopied)));
+  }
+
+  Future<void> _share() async {
+    final text = LogManager().dump();
+    final body = text.isEmpty ? '(no logs)' : text;
+    try {
+      // Share a .txt file so a long log isn't truncated the way a text share
+      // can be; fall back to a plain-text share if the file write fails.
+      final dir = await getTemporaryDirectory();
+      final file = File(
+          '${dir.path}/mstream-log-${DateTime.now().millisecondsSinceEpoch}.txt');
+      await file.writeAsString(body);
+      await Share.shareXFiles([XFile(file.path, mimeType: 'text/plain')],
+          subject: 'mStream logs');
+    } catch (_) {
+      await Share.share(body, subject: 'mStream logs');
+    }
+  }
+
+  void _clear() {
+    LogManager().clear();
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(l.diagnosticsTitle)),
+      body: SafeArea(
+        top: false,
+        child: Column(
+          children: [
+            SwitchListTile(
+              title: Text(l.diagnosticsEnable),
+              subtitle: Text(
+                l.diagnosticsHint,
+                style:
+                    TextStyle(color: VelvetColors.textSecondary, fontSize: 12),
+              ),
+              value: SettingsManager().diagnosticsLogging,
+              onChanged: (v) async {
+                await SettingsManager().setDiagnosticsLogging(v);
+                if (mounted) setState(() {});
+              },
+              activeThumbColor: VelvetColors.primary,
+            ),
+            Divider(height: 1, color: VelvetColors.border),
+            Expanded(
+              child: StreamBuilder<List<String>>(
+                stream: LogManager().stream,
+                initialData: LogManager().lines,
+                builder: (context, snap) {
+                  final lines = snap.data ?? const <String>[];
+                  if (lines.isEmpty) {
+                    return Center(
+                      child: Text(l.diagnosticsEmpty,
+                          style:
+                              TextStyle(color: VelvetColors.textSecondary)),
+                    );
+                  }
+                  // Newest first so the latest entries are visible immediately.
+                  final display = lines.reversed.toList();
+                  return ListView.builder(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 8),
+                    itemCount: display.length,
+                    itemBuilder: (context, i) => Padding(
+                      padding: const EdgeInsets.only(bottom: 2),
+                      child: Text(
+                        display[i],
+                        style: TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 11,
+                          height: 1.3,
+                          color: VelvetColors.textPrimary,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            Divider(height: 1, color: VelvetColors.border),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
+              child: Row(
+                children: [
+                  Expanded(child: _action(Icons.copy, l.diagnosticsCopy, _copy)),
+                  const SizedBox(width: 8),
+                  Expanded(
+                      child: _action(Icons.share, l.diagnosticsShare, _share)),
+                  const SizedBox(width: 8),
+                  Expanded(
+                      child: _action(
+                          Icons.delete_outline, l.diagnosticsClear, _clear)),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _action(IconData icon, String label, VoidCallback onTap) {
+    return OutlinedButton.icon(
+      onPressed: onTap,
+      icon: Icon(icon, size: 18),
+      label: Text(label, overflow: TextOverflow.ellipsis),
+      style: OutlinedButton.styleFrom(
+        foregroundColor: VelvetColors.primary,
+        side: BorderSide(color: VelvetColors.primary.withValues(alpha: 0.5)),
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(VelvetColors.radiusSmall)),
+      ),
+    );
+  }
+}

--- a/lib/screens/diagnostics_screen.dart
+++ b/lib/screens/diagnostics_screen.dart
@@ -88,9 +88,13 @@ class _DiagnosticsScreenState extends State<DiagnosticsScreen> {
                               TextStyle(color: VelvetColors.textSecondary)),
                     );
                   }
-                  // Newest first so the latest entries are visible immediately.
+                  // Terminal-style: oldest at the top, newest at the bottom,
+                  // pinned to the latest line. reverse:true lays the
+                  // newest-first list out from the bottom up and keeps the view
+                  // following new entries as they arrive.
                   final display = lines.reversed.toList();
                   return ListView.builder(
+                    reverse: true,
                     padding: const EdgeInsets.symmetric(
                         horizontal: 12, vertical: 8),
                     itemCount: display.length,

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -1,5 +1,6 @@
 import './server_list.dart';
 import './browser_list.dart';
+import './log_manager.dart';
 import './settings.dart';
 import '../objects/server.dart';
 import '../objects/display_item.dart';
@@ -105,18 +106,27 @@ class ApiManager {
 
       Uri currentUri = Uri.parse(server.url).resolve(location);
 
+      final sw = Stopwatch()..start();
       var response;
-      if (getOrPost == 'GET') {
-        response = await client
-            .get(currentUri, headers: {'x-access-token': server.jwt ?? ''});
-      } else {
-        response = await client.post(currentUri,
-            body: json.encode(payload),
-            headers: {
-              'Content-Type': 'application/json',
-              'x-access-token': server.jwt ?? ''
-            });
+      try {
+        if (getOrPost == 'GET') {
+          response = await client
+              .get(currentUri, headers: {'x-access-token': server.jwt ?? ''});
+        } else {
+          response = await client.post(currentUri,
+              body: json.encode(payload),
+              headers: {
+                'Content-Type': 'application/json',
+                'x-access-token': server.jwt ?? ''
+              });
+        }
+      } catch (e) {
+        appLog('[api] $getOrPost $location → error: $e '
+            '(${sw.elapsedMilliseconds}ms)');
+        rethrow;
       }
+      appLog('[api] $getOrPost $location → ${response.statusCode} '
+          '(${sw.elapsedMilliseconds}ms)');
 
       if (response.statusCode > 299) {
         throw Exception('Server Call Failed');

--- a/lib/singletons/log_manager.dart
+++ b/lib/singletons/log_manager.dart
@@ -4,6 +4,17 @@ import 'package:rxdart/rxdart.dart';
 
 import 'settings.dart';
 
+/// App-wide informational logging for non-cast subsystems. Routed through
+/// `print()` so the main() print-Zone tees it into the in-app buffer (redacted,
+/// gated by the logging toggle) AND forwards it to the console / logcat — one
+/// path, no double entry. Use for happy-path activity (server calls, playback,
+/// startup) so the Diagnostics screen shows a real trail, not just errors.
+void appLog(String message) {
+  // ignore: avoid_print — deliberate: the print Zone in main() captures this
+  // into the diagnostic buffer; this is the app's info-logging entry point.
+  print(message);
+}
+
 /// In-app diagnostic log buffer. Captures `print()` output (via a custom print
 /// Zone installed in main()), the cast subsystem's `castLog()`, and uncaught
 /// errors into a bounded ring buffer that the user can view, copy and share from

--- a/lib/singletons/log_manager.dart
+++ b/lib/singletons/log_manager.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+
+import 'settings.dart';
+
+/// In-app diagnostic log buffer. Captures `print()` output (via a custom print
+/// Zone installed in main()), the cast subsystem's `castLog()`, and uncaught
+/// errors into a bounded ring buffer that the user can view, copy and share from
+/// the Diagnostics screen.
+///
+/// Secrets are redacted AT CAPTURE TIME (tokens / jwt / passwords masked), so
+/// the buffer — and therefore anything the user copies or shares — never
+/// contains credentials, even though stream URLs and servers.json carry them.
+/// (The raw line still goes to the console / `adb logcat` for developers; only
+/// the user-facing in-app copy is scrubbed.)
+class LogManager {
+  LogManager._();
+  static final LogManager _instance = LogManager._();
+  factory LogManager() => _instance;
+
+  // Ring buffer cap — enough to cover a repro session without unbounded growth.
+  static const int _maxLines = 2000;
+  final List<String> _lines = <String>[];
+
+  // Emits the capped line list on every change so the Diagnostics screen
+  // refreshes live while it's open.
+  late final BehaviorSubject<List<String>> _stream =
+      BehaviorSubject<List<String>>.seeded(const <String>[]);
+  Stream<List<String>> get stream => _stream.stream;
+  List<String> get lines => List.unmodifiable(_lines);
+  bool get isEmpty => _lines.isEmpty;
+
+  bool get _enabled => SettingsManager().diagnosticsLogging;
+
+  /// Append a log entry: split into lines, timestamp + redact each, append, and
+  /// trim to the cap. No-op while logging is disabled. MUST NOT call print()
+  /// itself — it's fed from the print Zone and would recurse.
+  void add(String message) {
+    if (!_enabled) return;
+    final stamp = _stamp();
+    for (final raw in message.split('\n')) {
+      if (raw.isEmpty) continue;
+      _lines.add('$stamp ${_redactSecrets(raw)}');
+    }
+    if (_lines.length > _maxLines) {
+      _lines.removeRange(0, _lines.length - _maxLines);
+    }
+    if (!_stream.isClosed) _stream.add(List.unmodifiable(_lines));
+  }
+
+  void clear() {
+    _lines.clear();
+    if (!_stream.isClosed) _stream.add(const <String>[]);
+  }
+
+  /// The whole buffer as text (chronological), for copy / share.
+  String dump() => _lines.join('\n');
+
+  String _stamp() {
+    final t = DateTime.now();
+    String p2(int n) => n.toString().padLeft(2, '0');
+    String p3(int n) => n.toString().padLeft(3, '0');
+    return '${p2(t.hour)}:${p2(t.minute)}:${p2(t.second)}.${p3(t.millisecond)}';
+  }
+
+  /// Mask credentials that legitimately appear in URLs / JSON we log: the
+  /// `token=` query param on stream/art URLs, and `jwt` / `password` /
+  /// `x-access-token` values in bodies or headers.
+  static String _redactSecrets(String s) {
+    var out = s;
+    out = out.replaceAllMapped(
+        RegExp(r'(token=)[^&\s"\)\]]+', caseSensitive: false),
+        (m) => '${m[1]}***');
+    out = out.replaceAllMapped(
+        RegExp(
+            r'("?(?:jwt|password|x-access-token)"?\s*[:=]\s*"?)([^",}\s&]+)',
+            caseSensitive: false),
+        (m) => '${m[1]}***');
+    return out;
+  }
+}

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -121,6 +121,9 @@ class SettingsManager {
   // Whether the play queue + position are persisted and restored on the next
   // launch (see QueueStore). On by default.
   bool resumeQueue = true;
+  // Whether in-app diagnostic logging is captured (see LogManager) so users can
+  // view / copy / share logs from the Diagnostics screen. On by default.
+  bool diagnosticsLogging = true;
   // Visualizer audio source — synthesized is the default so the
   // visualizer Just Works without prompting for RECORD_AUDIO. Users
   // can opt into real audio in Settings; the toggle there walks them
@@ -212,6 +215,7 @@ class SettingsManager {
       accentColor = accent is int ? accent : null;
       eqEnabled = m['eqEnabled'] ?? false;
       resumeQueue = m['resumeQueue'] ?? true;
+      diagnosticsLogging = m['diagnosticsLogging'] ?? true;
       final rawGains = m['eqBandGains'];
       eqBandGains = rawGains is List
           ? rawGains.whereType<num>().map((n) => n.toDouble()).toList()
@@ -326,6 +330,7 @@ class SettingsManager {
       'accentColor': accentColor,
       'eqEnabled': eqEnabled,
       'resumeQueue': resumeQueue,
+      'diagnosticsLogging': diagnosticsLogging,
       'eqBandGains': eqBandGains,
       'visualizerAudioSource': visualizerAudioSource.name,
       'visualizerEngine': visualizerEngine.name,
@@ -402,6 +407,11 @@ class SettingsManager {
     await _save();
   }
 
+  Future<void> setDiagnosticsLogging(bool v) async {
+    diagnosticsLogging = v;
+    await _save();
+  }
+
   Future<void> setEqBandGains(List<double> v) async {
     eqBandGains = v;
     await _save();
@@ -462,6 +472,7 @@ class SettingsManager {
     accentColor = null;
     eqEnabled = false;
     resumeQueue = true;
+    diagnosticsLogging = true;
     eqBandGains = const [];
     visualizerAudioSource = VisualizerAudioSource.synthesized;
     visualizerEngine = VisualizerEngine.milkdrop;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -612,6 +620,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -833,6 +857,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,8 @@ dependencies:
   ffi: ^2.1.4
   media_cast_dlna: ^0.3.1
   flutter_chrome_cast: ^1.4.6
+  # Native share sheet for exporting diagnostic logs (Diagnostics screen).
+  share_plus: ^10.1.4
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Users couldn't see app logs without `adb`, which makes remote bug reports (like the current DLNA break-up) hard to diagnose. This adds an on-device log viewer reachable from the drawer.

## What's in it
- **`LogManager`** — a bounded 2000-line ring buffer. Captured via a custom **print Zone** in `main()` (tees every `print` line into the buffer while still forwarding to logcat), plus a **`castLog()` funnel** and the Zone's uncaught-error handler. Existing log calls are captured without rewriting them.
- **Secret redaction at capture time** — `token=` query params and `jwt` / `password` / `x-access-token` values are masked, so a copied/shared log never leaks credentials (stream URLs and `servers.json` carry them).
- **Diagnostics screen** (drawer entry, bug-report icon): live log view (newest first), an **Enable logging** toggle, and **Copy / Share / Clear**. Copy → clipboard; Share → writes a redacted `mstream-log-<ts>.txt` and opens the native share sheet.
- **Default ON** — `SettingsManager.diagnosticsLogging` (persisted), per request.
- New dep: **`share_plus` 10.1.4** (builds cleanly under AGP 9).
- **l10n**: 8 new keys translated across all 10 locales; `app_localizations` regenerated.

## Privacy
Logs stay on the device; nothing is sent anywhere unless the user taps Share. The redaction means even a shared log won't contain auth tokens. The screen shows a one-line note to that effect.

## Test plan
- `flutter analyze lib` clean · `flutter test` **34/34** · `flutter build apk --debug` builds (share_plus OK under AGP 9)
- Installed + launched on device — clean startup (the zone-wrapped `main` / LogManager / share_plus init are the startup-risk areas)
- ⚠️ The in-app view/copy/share interactions are visual — the Flutter surface is opaque to `screencap`/`uiautomator`, so those want a quick manual check on-device.

Directly useful for the DLNA issue: the reporter can open **Diagnostics → Share** after reproducing, and the `[cast]` poll-failure / renderer-lost lines will be right there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)