### PR TITLE
Fix visualizer startup crash on ABIs without the native bridge (+ parallel builds)

### DIFF
--- a/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/VisualizerBridge.kt
@@ -32,7 +32,18 @@ private const val TRANSCODE_JOIN_TIMEOUT_MS = 1_000L
 class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
 
     companion object {
-        init { System.loadLibrary("visualizer_bridge") }
+        // The native lib isn't built for every ABI — armeabi-v7a (32-bit ARM)
+        // ships without the visualizer bridge + projectM. Guard the load so a
+        // missing .so degrades to "visualizer unavailable" instead of crashing at
+        // startup (this plugin is registered eagerly in MainActivity, so the
+        // companion initializer runs on launch).
+        private val nativeAvailable: Boolean = try {
+            System.loadLibrary("visualizer_bridge")
+            true
+        } catch (e: Throwable) {
+            Log.w(TAG, "visualizer_bridge native lib unavailable for this ABI", e)
+            false
+        }
     }
 
     // JNI methods — implemented in visualizer_bridge.cpp.
@@ -98,6 +109,14 @@ class VisualizerBridge : FlutterPlugin, MethodChannel.MethodCallHandler {
     }
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        if (!nativeAvailable) {
+            // No visualizer native lib for this ABI (e.g. 32-bit ARM). Return null
+            // so "create" yields a null texture id → Dart shows the "visualizer
+            // unavailable" state; every other call no-ops, so nothing reaches an
+            // unlinked native symbol.
+            result.success(null)
+            return
+        }
         when (call.method) {
             "create" -> handleCreate(call, result)
             "addPcm" -> handleAddPcm(call, result)

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,8 @@
 org.gradle.jvmargs=-Xmx4096M
+# Run independent module tasks in parallel. Deliberately NO build cache
+# (org.gradle.caching): release builds stay cache-free/cold for deterministic CI
+# releases — preferred over build speed here.
+org.gradle.parallel=true
 android.useAndroidX=true
 android.enableJetifier=false
 # This builtInKotlin flag was added automatically by Flutter migrator


### PR DESCRIPTION
The architecture-minimization work (arm64-only → arm64+armeabi-v7a restrictions, `jniLibs` excludes, `--target-platform`, the Gradle build cache + CI cache) has been **rolled back**. Release builds target **all ABIs again**, identical to master.

What remains are the two non-arch pieces worth keeping:

## 1. Fix: visualizer can crash the app at startup (pre-existing bug)
`VisualizerBridge` is registered eagerly at startup and its companion initializer calls `System.loadLibrary("visualizer_bridge")`. That `.so` is only built for arm64-v8a + x86_64, so on any ABI shipping without it — notably **armeabi-v7a (32-bit ARM)**, which the all-ABI release includes — the load throws `UnsatisfiedLinkError` during plugin registration and **crashes the app on launch**. This exists on master today.

The fix wraps the load in try/catch and no-ops native calls when the lib is absent → the existing "visualizer unavailable" UI shows instead of crashing.

## 2. `org.gradle.parallel` (minor)
Independent module tasks run concurrently. Not a cache; no staleness risk.

## Verified
- Guard compiles and runs on a physical **arm64** device (bridge loads, visualizer works — guard is a no-op when the lib is present).
- 32-bit graceful path verified by construction + ABI layout, **not** runtime-tested (no 32-bit hardware on hand).

Based on current master (v0.25.1).
