### PR TITLE
Fix grey band + scrubber overflow when the search keyboard opens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -356,6 +356,14 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
         },
         child: Stack(children: [
           Scaffold(
+            // The only text input over this Scaffold is the search field in the
+            // toolbar (always at the top, never under the keyboard), so don't
+            // resize the body when the keyboard opens. Resizing shrank the body
+            // and turned the reserved mini-player strip into a grey band above
+            // the keyboard — and squeezed the 27-letter scrubber into a RenderFlex
+            // overflow. Leaving the body full-height keeps the list under the
+            // keyboard (scrollable) with no grey gap.
+            resizeToAvoidBottomInset: false,
             onDrawerChanged: (open) => _drawerOpen.value = open,
             appBar: AppBar(
               title: Column(


### PR DESCRIPTION
## Problem
Opening the browser's local-search keyboard left a grey rectangle over the lower half of the list, and squeezed the A–Z letter scrubber into a `RenderFlex` overflow ("BOTTOM OVERFLOWED").

## Cause
The root `Scaffold` used the default `resizeToAvoidBottomInset: true`, so the body shrank when the keyboard appeared. That:
1. pushed the body's reserved mini-player strip up into view as an empty grey band above the keyboard, and
2. left the 27-letter scrubber too little height to lay out.

## Fix
The only text input over this `Scaffold` is the search field in the toolbar (always at the top, never under the keyboard), so the body never needs to resize. Setting `resizeToAvoidBottomInset: false` keeps the body full-height — the list runs under the keyboard (scrollable) with no grey gap and the scrubber has room.

## Testing
- `flutter analyze`: clean.
- Verified on-device (Galaxy S25): local search open + keyboard up, on both a short folder and a long alphabetical list — no grey band, no overflow, the list fills cleanly down to the keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
