### PR TITLE
Improve DB search: multi-select category dropdown + context subheaders

### DIFF
--- a/integration_test/search_categories_test.dart
+++ b/integration_test/search_categories_test.dart
@@ -1,0 +1,77 @@
+// Search-category dropdown.
+//
+// Beside the home search field sits a dropdown that picks which categories the
+// DB search queries. It uses CHECKBOXES (multi-select) rather than single-pick,
+// so the user can search, say, just Artists + Albums. The two things that make
+// that work — a checkbox per category, and the menu staying OPEN while you
+// toggle (so several can be picked in one go) — are verified here.
+//
+// Lives in its own file because each integration test mounts a fresh
+// MStreamApp, and mounting it twice in one process re-subscribes a
+// single-subscription singleton stream (DownloadManager) — so one mount,
+// one scenario, per file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mstream_music/l10n/app_localizations.dart';
+import 'package:mstream_music/main.dart';
+import 'package:mstream_music/singletons/media.dart';
+
+import 'helpers/test_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  MockServer? mockServer;
+
+  setUpAll(() async {
+    await MediaManager().start();
+  });
+
+  setUp(resetAppState);
+
+  tearDown(() async {
+    await mockServer?.close();
+    mockServer = null;
+  });
+
+  testWidgets(
+    'category dropdown shows a checkbox per category and stays open on toggle',
+    (WidgetTester tester) async {
+      // Only the home screen is needed — the default ping route from
+      // MockServer.start is enough to seed a server and land on the browser.
+      mockServer = await MockServer.start({});
+      await seedServer(mockServer!.url);
+
+      // Localization delegates mirror the real MaterialApp in main.dart — see
+      // search_test.dart for why a bare MaterialApp crashes MStreamApp.build.
+      await tester.pumpWidget(MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: MStreamApp(),
+      ));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      // Open the category dropdown beside the search field.
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+
+      // One checkbox per category. 'Songs' and 'Files' are unique to the menu
+      // (the home grid has Albums/Artists cards too, so assert on the
+      // menu-only labels to avoid matching those).
+      expect(find.byType(CheckboxListTile), findsNWidgets(4));
+      expect(find.text('Songs'), findsOneWidget);
+      expect(find.text('Files'), findsOneWidget);
+
+      // Toggling a box must NOT close the menu — the whole point of checkboxes
+      // is picking several without reopening. Tap 'Files'; the menu stays up.
+      await tester.tap(find.text('Files'));
+      await tester.pumpAndSettle();
+      expect(find.byType(CheckboxListTile), findsNWidgets(4),
+          reason: 'menu stayed open after toggling a checkbox');
+      expect(find.text('Songs'), findsOneWidget);
+    },
+  );
+}

--- a/integration_test/search_categories_test.dart
+++ b/integration_test/search_categories_test.dart
@@ -1,10 +1,12 @@
-// Search-category dropdown.
+// Search-category dropdown + focus preview.
 //
 // Beside the home search field sits a dropdown that picks which categories the
 // DB search queries. It uses CHECKBOXES (multi-select) rather than single-pick,
-// so the user can search, say, just Artists + Albums. The two things that make
-// that work — a checkbox per category, and the menu staying OPEN while you
-// toggle (so several can be picked in one go) — are verified here.
+// so the user can search, say, just Artists + Albums. This verifies:
+//   • touching the field shows a subheader previewing which categories a search
+//     will cover (so stale defaults from a past session are visible up front);
+//   • the dropdown shows a checkbox per category and stays OPEN while toggling
+//     (so several can be picked in one go).
 //
 // Lives in its own file because each integration test mounts a fresh
 // MStreamApp, and mounting it twice in one process re-subscribes a
@@ -38,7 +40,7 @@ void main() {
   });
 
   testWidgets(
-    'category dropdown shows a checkbox per category and stays open on toggle',
+    'category dropdown: focus preview + a checkbox per category, stays open',
     (WidgetTester tester) async {
       // Only the home screen is needed — the default ping route from
       // MockServer.start is enough to seed a server and land on the browser.
@@ -53,6 +55,13 @@ void main() {
         home: MStreamApp(),
       ));
       await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      // Touching the search field previews which categories a search will
+      // cover, so a stale selection from a past session is visible before
+      // typing. (Default selection → "Searching ...".)
+      await tester.tap(find.byType(TextField));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Searching'), findsOneWidget);
 
       // Open the category dropdown beside the search field.
       await tester.tap(find.byIcon(Icons.tune));

--- a/integration_test/search_test.dart
+++ b/integration_test/search_test.dart
@@ -20,6 +20,7 @@ import 'package:integration_test/integration_test.dart';
 
 import 'package:mstream_music/l10n/app_localizations.dart';
 import 'package:mstream_music/main.dart';
+import 'package:mstream_music/singletons/browser_list.dart';
 import 'package:mstream_music/singletons/media.dart';
 
 import 'helpers/test_helpers.dart';
@@ -97,6 +98,11 @@ void main() {
 
       // The results page shows a subheader echoing the query that produced it.
       expect(find.textContaining('Results for'), findsOneWidget);
+
+      // Submitting navigated off the home menu, so the search field's focus
+      // (which drives the scope-preview overlay) must have cleared — guards the
+      // regression where the preview stayed stuck after leaving home.
+      expect(BrowserManager().searchFocused, isFalse);
     },
   );
 }

--- a/integration_test/search_test.dart
+++ b/integration_test/search_test.dart
@@ -9,6 +9,10 @@
 // Catches regressions in the most complex parsing path in
 // lib/singletons/api.dart.searchServer — three different DisplayItem
 // shapes share one response.
+//
+// The search-category dropdown beside the field is covered separately in
+// search_categories_test.dart (mounting MStreamApp twice in one process
+// re-subscribes a singleton stream, so each scenario gets its own file).
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/integration_test/search_test.dart
+++ b/integration_test/search_test.dart
@@ -94,6 +94,9 @@ void main() {
       expect(find.text('Pink Floyd'), findsOneWidget);
       expect(find.text('Wish You Were Here'), findsOneWidget);
       expect(find.text('Have-a-Cigar.mp3'), findsOneWidget);
+
+      // The results page shows a subheader echoing the query that produced it.
+      expect(find.textContaining('Results for'), findsOneWidget);
     },
   );
 }

--- a/integration_test/search_test.dart
+++ b/integration_test/search_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'package:mstream_music/l10n/app_localizations.dart';
 import 'package:mstream_music/main.dart';
 import 'package:mstream_music/singletons/media.dart';
 
@@ -66,7 +67,15 @@ void main() {
 
       await seedServer(mockServer!.url);
 
-      await tester.pumpWidget(MaterialApp(home: MStreamApp()));
+      // MStreamApp.build calls AppLocalizations.of(context), so the host
+      // MaterialApp must carry the app's localization delegates (mirrors the
+      // real MaterialApp in main.dart). Without them AppLocalizations.of
+      // returns null and the app crashes before the search field renders.
+      await tester.pumpWidget(MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: MStreamApp(),
+      ));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
       // Search TextField is in the top row when on the root browse menu.

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -466,6 +466,21 @@
   "browserConfirmDeleteFolder": "Confirm Delete Folder",
   "browserSearchHint": "Search Database",
   "@browserConfirmDeletePlaylist": { "description": "Browser delete-confirmation dialog titles + search hint." },
+
+  "searchScopeHint": "Search {scope}",
+  "@searchScopeHint": {
+    "description": "Database search field hint when a specific (non-default) search scope is active, e.g. \"Search Artists\".",
+    "placeholders": {
+      "scope": { "type": "String" }
+    }
+  },
+  "searchScopeTooltip": "What to search",
+  "searchScopeEverything": "Everything",
+  "searchScopeArtists": "Artists",
+  "searchScopeAlbums": "Albums",
+  "searchScopeSongs": "Songs",
+  "searchScopeFiles": "Files",
+  "@searchScopeTooltip": { "description": "SearchScope dropdown: tooltip on the icon button + the five scope option labels (which categories the DB search queries)." },
   "browserDownloadsStarted": "{count, plural, =1{1 download started} other{{count} downloads started}}",
   "@browserDownloadsStarted": {
     "description": "Snackbar after queueing downloads from the browser.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -467,20 +467,13 @@
   "browserSearchHint": "Search Database",
   "@browserConfirmDeletePlaylist": { "description": "Browser delete-confirmation dialog titles + search hint." },
 
-  "searchScopeHint": "Search {scope}",
-  "@searchScopeHint": {
-    "description": "Database search field hint when a specific (non-default) search scope is active, e.g. \"Search Artists\".",
-    "placeholders": {
-      "scope": { "type": "String" }
-    }
-  },
-  "searchScopeTooltip": "What to search",
-  "searchScopeEverything": "Everything",
-  "searchScopeArtists": "Artists",
-  "searchScopeAlbums": "Albums",
-  "searchScopeSongs": "Songs",
-  "searchScopeFiles": "Files",
-  "@searchScopeTooltip": { "description": "SearchScope dropdown: tooltip on the icon button + the five scope option labels (which categories the DB search queries)." },
+  "searchCategoriesTooltip": "What to search",
+  "searchCategoriesHeader": "Search in",
+  "searchCategoryArtists": "Artists",
+  "searchCategoryAlbums": "Albums",
+  "searchCategorySongs": "Songs",
+  "searchCategoryFiles": "Files",
+  "@searchCategoriesTooltip": { "description": "Search-category checkbox dropdown: tooltip on the icon button, the menu header, and the four category labels (which categories the DB search queries — the user ticks any combination)." },
   "browserDownloadsStarted": "{count, plural, =1{1 download started} other{{count} downloads started}}",
   "@browserDownloadsStarted": {
     "description": "Snackbar after queueing downloads from the browser.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -474,6 +474,21 @@
   "searchCategorySongs": "Songs",
   "searchCategoryFiles": "Files",
   "@searchCategoriesTooltip": { "description": "Search-category checkbox dropdown: tooltip on the icon button, the menu header, and the four category labels (which categories the DB search queries — the user ticks any combination)." },
+
+  "searchSubheaderResults": "Results for “{term}”",
+  "@searchSubheaderResults": {
+    "description": "Thin subheader on the search-results page echoing the submitted query.",
+    "placeholders": {
+      "term": { "type": "String" }
+    }
+  },
+  "searchSubheaderCategories": "Searching {categories}",
+  "@searchSubheaderCategories": {
+    "description": "Thin subheader shown while the server-search field is focused, previewing which categories (e.g. \"Artists · Albums\") a search will cover.",
+    "placeholders": {
+      "categories": { "type": "String" }
+    }
+  },
   "browserDownloadsStarted": "{count, plural, =1{1 download started} other{{count} downloads started}}",
   "@browserDownloadsStarted": {
     "description": "Snackbar after queueing downloads from the browser.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -482,7 +482,7 @@
       "term": { "type": "String" }
     }
   },
-  "searchSubheaderCategories": "Searching {categories}",
+  "searchSubheaderCategories": "Searching: {categories}",
   "@searchSubheaderCategories": {
     "description": "Thin subheader shown while the server-search field is focused, previewing which categories (e.g. \"Artists · Albums\") a search will cover.",
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1488,6 +1488,48 @@ abstract class AppLocalizations {
   /// **'Search Database'**
   String get browserSearchHint;
 
+  /// Database search field hint when a specific (non-default) search scope is active, e.g. "Search Artists".
+  ///
+  /// In en, this message translates to:
+  /// **'Search {scope}'**
+  String searchScopeHint(String scope);
+
+  /// SearchScope dropdown: tooltip on the icon button + the five scope option labels (which categories the DB search queries).
+  ///
+  /// In en, this message translates to:
+  /// **'What to search'**
+  String get searchScopeTooltip;
+
+  /// No description provided for @searchScopeEverything.
+  ///
+  /// In en, this message translates to:
+  /// **'Everything'**
+  String get searchScopeEverything;
+
+  /// No description provided for @searchScopeArtists.
+  ///
+  /// In en, this message translates to:
+  /// **'Artists'**
+  String get searchScopeArtists;
+
+  /// No description provided for @searchScopeAlbums.
+  ///
+  /// In en, this message translates to:
+  /// **'Albums'**
+  String get searchScopeAlbums;
+
+  /// No description provided for @searchScopeSongs.
+  ///
+  /// In en, this message translates to:
+  /// **'Songs'**
+  String get searchScopeSongs;
+
+  /// No description provided for @searchScopeFiles.
+  ///
+  /// In en, this message translates to:
+  /// **'Files'**
+  String get searchScopeFiles;
+
   /// Snackbar after queueing downloads from the browser.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1488,47 +1488,41 @@ abstract class AppLocalizations {
   /// **'Search Database'**
   String get browserSearchHint;
 
-  /// Database search field hint when a specific (non-default) search scope is active, e.g. "Search Artists".
-  ///
-  /// In en, this message translates to:
-  /// **'Search {scope}'**
-  String searchScopeHint(String scope);
-
-  /// SearchScope dropdown: tooltip on the icon button + the five scope option labels (which categories the DB search queries).
+  /// Search-category checkbox dropdown: tooltip on the icon button, the menu header, and the four category labels (which categories the DB search queries — the user ticks any combination).
   ///
   /// In en, this message translates to:
   /// **'What to search'**
-  String get searchScopeTooltip;
+  String get searchCategoriesTooltip;
 
-  /// No description provided for @searchScopeEverything.
+  /// No description provided for @searchCategoriesHeader.
   ///
   /// In en, this message translates to:
-  /// **'Everything'**
-  String get searchScopeEverything;
+  /// **'Search in'**
+  String get searchCategoriesHeader;
 
-  /// No description provided for @searchScopeArtists.
+  /// No description provided for @searchCategoryArtists.
   ///
   /// In en, this message translates to:
   /// **'Artists'**
-  String get searchScopeArtists;
+  String get searchCategoryArtists;
 
-  /// No description provided for @searchScopeAlbums.
+  /// No description provided for @searchCategoryAlbums.
   ///
   /// In en, this message translates to:
   /// **'Albums'**
-  String get searchScopeAlbums;
+  String get searchCategoryAlbums;
 
-  /// No description provided for @searchScopeSongs.
+  /// No description provided for @searchCategorySongs.
   ///
   /// In en, this message translates to:
   /// **'Songs'**
-  String get searchScopeSongs;
+  String get searchCategorySongs;
 
-  /// No description provided for @searchScopeFiles.
+  /// No description provided for @searchCategoryFiles.
   ///
   /// In en, this message translates to:
   /// **'Files'**
-  String get searchScopeFiles;
+  String get searchCategoryFiles;
 
   /// Snackbar after queueing downloads from the browser.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1524,6 +1524,18 @@ abstract class AppLocalizations {
   /// **'Files'**
   String get searchCategoryFiles;
 
+  /// Thin subheader on the search-results page echoing the submitted query.
+  ///
+  /// In en, this message translates to:
+  /// **'Results for “{term}”'**
+  String searchSubheaderResults(String term);
+
+  /// Thin subheader shown while the server-search field is focused, previewing which categories (e.g. "Artists · Albums") a search will cover.
+  ///
+  /// In en, this message translates to:
+  /// **'Searching {categories}'**
+  String searchSubheaderCategories(String categories);
+
   /// Snackbar after queueing downloads from the browser.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1533,7 +1533,7 @@ abstract class AppLocalizations {
   /// Thin subheader shown while the server-search field is focused, previewing which categories (e.g. "Artists · Albums") a search will cover.
   ///
   /// In en, this message translates to:
-  /// **'Searching {categories}'**
+  /// **'Searching: {categories}'**
   String searchSubheaderCategories(String categories);
 
   /// Snackbar after queueing downloads from the browser.

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -824,6 +824,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String searchSubheaderResults(String term) {
+    return 'Results for “$term”';
+  }
+
+  @override
+  String searchSubheaderCategories(String categories) {
+    return 'Searching $categories';
+  }
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -806,6 +806,29 @@ class AppLocalizationsDe extends AppLocalizations {
   String get browserSearchHint => 'Datenbank durchsuchen';
 
   @override
+  String searchScopeHint(String scope) {
+    return 'Search $scope';
+  }
+
+  @override
+  String get searchScopeTooltip => 'What to search';
+
+  @override
+  String get searchScopeEverything => 'Everything';
+
+  @override
+  String get searchScopeArtists => 'Artists';
+
+  @override
+  String get searchScopeAlbums => 'Albums';
+
+  @override
+  String get searchScopeSongs => 'Songs';
+
+  @override
+  String get searchScopeFiles => 'Files';
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -830,7 +830,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String searchSubheaderCategories(String categories) {
-    return 'Searching $categories';
+    return 'Searching: $categories';
   }
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -806,27 +806,22 @@ class AppLocalizationsDe extends AppLocalizations {
   String get browserSearchHint => 'Datenbank durchsuchen';
 
   @override
-  String searchScopeHint(String scope) {
-    return 'Search $scope';
-  }
+  String get searchCategoriesTooltip => 'What to search';
 
   @override
-  String get searchScopeTooltip => 'What to search';
+  String get searchCategoriesHeader => 'Search in';
 
   @override
-  String get searchScopeEverything => 'Everything';
+  String get searchCategoryArtists => 'Artists';
 
   @override
-  String get searchScopeArtists => 'Artists';
+  String get searchCategoryAlbums => 'Albums';
 
   @override
-  String get searchScopeAlbums => 'Albums';
+  String get searchCategorySongs => 'Songs';
 
   @override
-  String get searchScopeSongs => 'Songs';
-
-  @override
-  String get searchScopeFiles => 'Files';
+  String get searchCategoryFiles => 'Files';
 
   @override
   String browserDownloadsStarted(int count) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -820,7 +820,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String searchSubheaderCategories(String categories) {
-    return 'Searching $categories';
+    return 'Searching: $categories';
   }
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -796,27 +796,22 @@ class AppLocalizationsEn extends AppLocalizations {
   String get browserSearchHint => 'Search Database';
 
   @override
-  String searchScopeHint(String scope) {
-    return 'Search $scope';
-  }
+  String get searchCategoriesTooltip => 'What to search';
 
   @override
-  String get searchScopeTooltip => 'What to search';
+  String get searchCategoriesHeader => 'Search in';
 
   @override
-  String get searchScopeEverything => 'Everything';
+  String get searchCategoryArtists => 'Artists';
 
   @override
-  String get searchScopeArtists => 'Artists';
+  String get searchCategoryAlbums => 'Albums';
 
   @override
-  String get searchScopeAlbums => 'Albums';
+  String get searchCategorySongs => 'Songs';
 
   @override
-  String get searchScopeSongs => 'Songs';
-
-  @override
-  String get searchScopeFiles => 'Files';
+  String get searchCategoryFiles => 'Files';
 
   @override
   String browserDownloadsStarted(int count) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -814,6 +814,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String searchSubheaderResults(String term) {
+    return 'Results for “$term”';
+  }
+
+  @override
+  String searchSubheaderCategories(String categories) {
+    return 'Searching $categories';
+  }
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -796,6 +796,29 @@ class AppLocalizationsEn extends AppLocalizations {
   String get browserSearchHint => 'Search Database';
 
   @override
+  String searchScopeHint(String scope) {
+    return 'Search $scope';
+  }
+
+  @override
+  String get searchScopeTooltip => 'What to search';
+
+  @override
+  String get searchScopeEverything => 'Everything';
+
+  @override
+  String get searchScopeArtists => 'Artists';
+
+  @override
+  String get searchScopeAlbums => 'Albums';
+
+  @override
+  String get searchScopeSongs => 'Songs';
+
+  @override
+  String get searchScopeFiles => 'Files';
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -805,27 +805,22 @@ class AppLocalizationsEs extends AppLocalizations {
   String get browserSearchHint => 'Buscar en la base de datos';
 
   @override
-  String searchScopeHint(String scope) {
-    return 'Search $scope';
-  }
+  String get searchCategoriesTooltip => 'What to search';
 
   @override
-  String get searchScopeTooltip => 'What to search';
+  String get searchCategoriesHeader => 'Search in';
 
   @override
-  String get searchScopeEverything => 'Everything';
+  String get searchCategoryArtists => 'Artists';
 
   @override
-  String get searchScopeArtists => 'Artists';
+  String get searchCategoryAlbums => 'Albums';
 
   @override
-  String get searchScopeAlbums => 'Albums';
+  String get searchCategorySongs => 'Songs';
 
   @override
-  String get searchScopeSongs => 'Songs';
-
-  @override
-  String get searchScopeFiles => 'Files';
+  String get searchCategoryFiles => 'Files';
 
   @override
   String browserDownloadsStarted(int count) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -829,7 +829,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String searchSubheaderCategories(String categories) {
-    return 'Searching $categories';
+    return 'Searching: $categories';
   }
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -823,6 +823,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String searchSubheaderResults(String term) {
+    return 'Results for “$term”';
+  }
+
+  @override
+  String searchSubheaderCategories(String categories) {
+    return 'Searching $categories';
+  }
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -805,6 +805,29 @@ class AppLocalizationsEs extends AppLocalizations {
   String get browserSearchHint => 'Buscar en la base de datos';
 
   @override
+  String searchScopeHint(String scope) {
+    return 'Search $scope';
+  }
+
+  @override
+  String get searchScopeTooltip => 'What to search';
+
+  @override
+  String get searchScopeEverything => 'Everything';
+
+  @override
+  String get searchScopeArtists => 'Artists';
+
+  @override
+  String get searchScopeAlbums => 'Albums';
+
+  @override
+  String get searchScopeSongs => 'Songs';
+
+  @override
+  String get searchScopeFiles => 'Files';
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -804,6 +804,29 @@ class AppLocalizationsFr extends AppLocalizations {
   String get browserSearchHint => 'Rechercher dans la base de données';
 
   @override
+  String searchScopeHint(String scope) {
+    return 'Search $scope';
+  }
+
+  @override
+  String get searchScopeTooltip => 'What to search';
+
+  @override
+  String get searchScopeEverything => 'Everything';
+
+  @override
+  String get searchScopeArtists => 'Artists';
+
+  @override
+  String get searchScopeAlbums => 'Albums';
+
+  @override
+  String get searchScopeSongs => 'Songs';
+
+  @override
+  String get searchScopeFiles => 'Files';
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -828,7 +828,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String searchSubheaderCategories(String categories) {
-    return 'Searching $categories';
+    return 'Searching: $categories';
   }
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -804,27 +804,22 @@ class AppLocalizationsFr extends AppLocalizations {
   String get browserSearchHint => 'Rechercher dans la base de données';
 
   @override
-  String searchScopeHint(String scope) {
-    return 'Search $scope';
-  }
+  String get searchCategoriesTooltip => 'What to search';
 
   @override
-  String get searchScopeTooltip => 'What to search';
+  String get searchCategoriesHeader => 'Search in';
 
   @override
-  String get searchScopeEverything => 'Everything';
+  String get searchCategoryArtists => 'Artists';
 
   @override
-  String get searchScopeArtists => 'Artists';
+  String get searchCategoryAlbums => 'Albums';
 
   @override
-  String get searchScopeAlbums => 'Albums';
+  String get searchCategorySongs => 'Songs';
 
   @override
-  String get searchScopeSongs => 'Songs';
-
-  @override
-  String get searchScopeFiles => 'Files';
+  String get searchCategoryFiles => 'Files';
 
   @override
   String browserDownloadsStarted(int count) {

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -822,6 +822,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String searchSubheaderResults(String term) {
+    return 'Results for “$term”';
+  }
+
+  @override
+  String searchSubheaderCategories(String categories) {
+    return 'Searching $categories';
+  }
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -827,7 +827,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String searchSubheaderCategories(String categories) {
-    return 'Searching $categories';
+    return 'Searching: $categories';
   }
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -803,27 +803,22 @@ class AppLocalizationsIt extends AppLocalizations {
   String get browserSearchHint => 'Cerca nel database';
 
   @override
-  String searchScopeHint(String scope) {
-    return 'Search $scope';
-  }
+  String get searchCategoriesTooltip => 'What to search';
 
   @override
-  String get searchScopeTooltip => 'What to search';
+  String get searchCategoriesHeader => 'Search in';
 
   @override
-  String get searchScopeEverything => 'Everything';
+  String get searchCategoryArtists => 'Artists';
 
   @override
-  String get searchScopeArtists => 'Artists';
+  String get searchCategoryAlbums => 'Albums';
 
   @override
-  String get searchScopeAlbums => 'Albums';
+  String get searchCategorySongs => 'Songs';
 
   @override
-  String get searchScopeSongs => 'Songs';
-
-  @override
-  String get searchScopeFiles => 'Files';
+  String get searchCategoryFiles => 'Files';
 
   @override
   String browserDownloadsStarted(int count) {

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -821,6 +821,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String searchSubheaderResults(String term) {
+    return 'Results for “$term”';
+  }
+
+  @override
+  String searchSubheaderCategories(String categories) {
+    return 'Searching $categories';
+  }
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -803,6 +803,29 @@ class AppLocalizationsIt extends AppLocalizations {
   String get browserSearchHint => 'Cerca nel database';
 
   @override
+  String searchScopeHint(String scope) {
+    return 'Search $scope';
+  }
+
+  @override
+  String get searchScopeTooltip => 'What to search';
+
+  @override
+  String get searchScopeEverything => 'Everything';
+
+  @override
+  String get searchScopeArtists => 'Artists';
+
+  @override
+  String get searchScopeAlbums => 'Albums';
+
+  @override
+  String get searchScopeSongs => 'Songs';
+
+  @override
+  String get searchScopeFiles => 'Files';
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -794,6 +794,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String searchSubheaderResults(String term) {
+    return 'Results for “$term”';
+  }
+
+  @override
+  String searchSubheaderCategories(String categories) {
+    return 'Searching $categories';
+  }
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -776,27 +776,22 @@ class AppLocalizationsJa extends AppLocalizations {
   String get browserSearchHint => 'データベースを検索';
 
   @override
-  String searchScopeHint(String scope) {
-    return 'Search $scope';
-  }
+  String get searchCategoriesTooltip => 'What to search';
 
   @override
-  String get searchScopeTooltip => 'What to search';
+  String get searchCategoriesHeader => 'Search in';
 
   @override
-  String get searchScopeEverything => 'Everything';
+  String get searchCategoryArtists => 'Artists';
 
   @override
-  String get searchScopeArtists => 'Artists';
+  String get searchCategoryAlbums => 'Albums';
 
   @override
-  String get searchScopeAlbums => 'Albums';
+  String get searchCategorySongs => 'Songs';
 
   @override
-  String get searchScopeSongs => 'Songs';
-
-  @override
-  String get searchScopeFiles => 'Files';
+  String get searchCategoryFiles => 'Files';
 
   @override
   String browserDownloadsStarted(int count) {

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -776,6 +776,29 @@ class AppLocalizationsJa extends AppLocalizations {
   String get browserSearchHint => 'データベースを検索';
 
   @override
+  String searchScopeHint(String scope) {
+    return 'Search $scope';
+  }
+
+  @override
+  String get searchScopeTooltip => 'What to search';
+
+  @override
+  String get searchScopeEverything => 'Everything';
+
+  @override
+  String get searchScopeArtists => 'Artists';
+
+  @override
+  String get searchScopeAlbums => 'Albums';
+
+  @override
+  String get searchScopeSongs => 'Songs';
+
+  @override
+  String get searchScopeFiles => 'Files';
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -800,7 +800,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String searchSubheaderCategories(String categories) {
-    return 'Searching $categories';
+    return 'Searching: $categories';
   }
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -807,27 +807,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get browserSearchHint => 'Szukaj w bazie danych';
 
   @override
-  String searchScopeHint(String scope) {
-    return 'Search $scope';
-  }
+  String get searchCategoriesTooltip => 'What to search';
 
   @override
-  String get searchScopeTooltip => 'What to search';
+  String get searchCategoriesHeader => 'Search in';
 
   @override
-  String get searchScopeEverything => 'Everything';
+  String get searchCategoryArtists => 'Artists';
 
   @override
-  String get searchScopeArtists => 'Artists';
+  String get searchCategoryAlbums => 'Albums';
 
   @override
-  String get searchScopeAlbums => 'Albums';
+  String get searchCategorySongs => 'Songs';
 
   @override
-  String get searchScopeSongs => 'Songs';
-
-  @override
-  String get searchScopeFiles => 'Files';
+  String get searchCategoryFiles => 'Files';
 
   @override
   String browserDownloadsStarted(int count) {

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -807,6 +807,29 @@ class AppLocalizationsPl extends AppLocalizations {
   String get browserSearchHint => 'Szukaj w bazie danych';
 
   @override
+  String searchScopeHint(String scope) {
+    return 'Search $scope';
+  }
+
+  @override
+  String get searchScopeTooltip => 'What to search';
+
+  @override
+  String get searchScopeEverything => 'Everything';
+
+  @override
+  String get searchScopeArtists => 'Artists';
+
+  @override
+  String get searchScopeAlbums => 'Albums';
+
+  @override
+  String get searchScopeSongs => 'Songs';
+
+  @override
+  String get searchScopeFiles => 'Files';
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -825,6 +825,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String searchSubheaderResults(String term) {
+    return 'Results for “$term”';
+  }
+
+  @override
+  String searchSubheaderCategories(String categories) {
+    return 'Searching $categories';
+  }
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -831,7 +831,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String searchSubheaderCategories(String categories) {
-    return 'Searching $categories';
+    return 'Searching: $categories';
   }
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -803,27 +803,22 @@ class AppLocalizationsPt extends AppLocalizations {
   String get browserSearchHint => 'Pesquisar no banco de dados';
 
   @override
-  String searchScopeHint(String scope) {
-    return 'Search $scope';
-  }
+  String get searchCategoriesTooltip => 'What to search';
 
   @override
-  String get searchScopeTooltip => 'What to search';
+  String get searchCategoriesHeader => 'Search in';
 
   @override
-  String get searchScopeEverything => 'Everything';
+  String get searchCategoryArtists => 'Artists';
 
   @override
-  String get searchScopeArtists => 'Artists';
+  String get searchCategoryAlbums => 'Albums';
 
   @override
-  String get searchScopeAlbums => 'Albums';
+  String get searchCategorySongs => 'Songs';
 
   @override
-  String get searchScopeSongs => 'Songs';
-
-  @override
-  String get searchScopeFiles => 'Files';
+  String get searchCategoryFiles => 'Files';
 
   @override
   String browserDownloadsStarted(int count) {

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -803,6 +803,29 @@ class AppLocalizationsPt extends AppLocalizations {
   String get browserSearchHint => 'Pesquisar no banco de dados';
 
   @override
+  String searchScopeHint(String scope) {
+    return 'Search $scope';
+  }
+
+  @override
+  String get searchScopeTooltip => 'What to search';
+
+  @override
+  String get searchScopeEverything => 'Everything';
+
+  @override
+  String get searchScopeArtists => 'Artists';
+
+  @override
+  String get searchScopeAlbums => 'Albums';
+
+  @override
+  String get searchScopeSongs => 'Songs';
+
+  @override
+  String get searchScopeFiles => 'Files';
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -827,7 +827,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String searchSubheaderCategories(String categories) {
-    return 'Searching $categories';
+    return 'Searching: $categories';
   }
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -821,6 +821,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String searchSubheaderResults(String term) {
+    return 'Results for “$term”';
+  }
+
+  @override
+  String searchSubheaderCategories(String categories) {
+    return 'Searching $categories';
+  }
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -811,27 +811,22 @@ class AppLocalizationsRu extends AppLocalizations {
   String get browserSearchHint => 'Поиск в базе данных';
 
   @override
-  String searchScopeHint(String scope) {
-    return 'Search $scope';
-  }
+  String get searchCategoriesTooltip => 'What to search';
 
   @override
-  String get searchScopeTooltip => 'What to search';
+  String get searchCategoriesHeader => 'Search in';
 
   @override
-  String get searchScopeEverything => 'Everything';
+  String get searchCategoryArtists => 'Artists';
 
   @override
-  String get searchScopeArtists => 'Artists';
+  String get searchCategoryAlbums => 'Albums';
 
   @override
-  String get searchScopeAlbums => 'Albums';
+  String get searchCategorySongs => 'Songs';
 
   @override
-  String get searchScopeSongs => 'Songs';
-
-  @override
-  String get searchScopeFiles => 'Files';
+  String get searchCategoryFiles => 'Files';
 
   @override
   String browserDownloadsStarted(int count) {

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -811,6 +811,29 @@ class AppLocalizationsRu extends AppLocalizations {
   String get browserSearchHint => 'Поиск в базе данных';
 
   @override
+  String searchScopeHint(String scope) {
+    return 'Search $scope';
+  }
+
+  @override
+  String get searchScopeTooltip => 'What to search';
+
+  @override
+  String get searchScopeEverything => 'Everything';
+
+  @override
+  String get searchScopeArtists => 'Artists';
+
+  @override
+  String get searchScopeAlbums => 'Albums';
+
+  @override
+  String get searchScopeSongs => 'Songs';
+
+  @override
+  String get searchScopeFiles => 'Files';
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -829,6 +829,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String searchSubheaderResults(String term) {
+    return 'Results for “$term”';
+  }
+
+  @override
+  String searchSubheaderCategories(String categories) {
+    return 'Searching $categories';
+  }
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -835,7 +835,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String searchSubheaderCategories(String categories) {
-    return 'Searching $categories';
+    return 'Searching: $categories';
   }
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -779,6 +779,16 @@ class AppLocalizationsZh extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String searchSubheaderResults(String term) {
+    return 'Results for “$term”';
+  }
+
+  @override
+  String searchSubheaderCategories(String categories) {
+    return 'Searching $categories';
+  }
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -761,27 +761,22 @@ class AppLocalizationsZh extends AppLocalizations {
   String get browserSearchHint => '搜索数据库';
 
   @override
-  String searchScopeHint(String scope) {
-    return 'Search $scope';
-  }
+  String get searchCategoriesTooltip => 'What to search';
 
   @override
-  String get searchScopeTooltip => 'What to search';
+  String get searchCategoriesHeader => 'Search in';
 
   @override
-  String get searchScopeEverything => 'Everything';
+  String get searchCategoryArtists => 'Artists';
 
   @override
-  String get searchScopeArtists => 'Artists';
+  String get searchCategoryAlbums => 'Albums';
 
   @override
-  String get searchScopeAlbums => 'Albums';
+  String get searchCategorySongs => 'Songs';
 
   @override
-  String get searchScopeSongs => 'Songs';
-
-  @override
-  String get searchScopeFiles => 'Files';
+  String get searchCategoryFiles => 'Files';
 
   @override
   String browserDownloadsStarted(int count) {

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -785,7 +785,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String searchSubheaderCategories(String categories) {
-    return 'Searching $categories';
+    return 'Searching: $categories';
   }
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -761,6 +761,29 @@ class AppLocalizationsZh extends AppLocalizations {
   String get browserSearchHint => '搜索数据库';
 
   @override
+  String searchScopeHint(String scope) {
+    return 'Search $scope';
+  }
+
+  @override
+  String get searchScopeTooltip => 'What to search';
+
+  @override
+  String get searchScopeEverything => 'Everything';
+
+  @override
+  String get searchScopeArtists => 'Artists';
+
+  @override
+  String get searchScopeAlbums => 'Albums';
+
+  @override
+  String get searchScopeSongs => 'Songs';
+
+  @override
+  String get searchScopeFiles => 'Files';
+
+  @override
   String browserDownloadsStarted(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/enum_labels.dart
+++ b/lib/l10n/enum_labels.dart
@@ -82,19 +82,17 @@ extension VisualizerAudioSourceLabel on VisualizerAudioSource {
   }
 }
 
-extension SearchScopeLabel on SearchScope {
+extension SearchCategoryLabel on SearchCategory {
   String label(AppLocalizations l) {
     switch (this) {
-      case SearchScope.everything:
-        return l.searchScopeEverything;
-      case SearchScope.artists:
-        return l.searchScopeArtists;
-      case SearchScope.albums:
-        return l.searchScopeAlbums;
-      case SearchScope.songs:
-        return l.searchScopeSongs;
-      case SearchScope.files:
-        return l.searchScopeFiles;
+      case SearchCategory.artists:
+        return l.searchCategoryArtists;
+      case SearchCategory.albums:
+        return l.searchCategoryAlbums;
+      case SearchCategory.songs:
+        return l.searchCategorySongs;
+      case SearchCategory.files:
+        return l.searchCategoryFiles;
     }
   }
 }

--- a/lib/l10n/enum_labels.dart
+++ b/lib/l10n/enum_labels.dart
@@ -82,6 +82,23 @@ extension VisualizerAudioSourceLabel on VisualizerAudioSource {
   }
 }
 
+extension SearchScopeLabel on SearchScope {
+  String label(AppLocalizations l) {
+    switch (this) {
+      case SearchScope.everything:
+        return l.searchScopeEverything;
+      case SearchScope.artists:
+        return l.searchScopeArtists;
+      case SearchScope.albums:
+        return l.searchScopeAlbums;
+      case SearchScope.songs:
+        return l.searchScopeSongs;
+      case SearchScope.files:
+        return l.searchScopeFiles;
+    }
+  }
+}
+
 /// Localized label for a built-in browser node, breadcrumb, or tab.
 ///
 /// The browser's section nodes (File Explorer, Albums, …) and the

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -348,6 +348,11 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
             // A browse fetch is in flight — Back stops it (and re-enables taps)
             // instead of navigating away.
             BrowserManager().cancelLoading();
+          } else if (BrowserManager().searchFocused) {
+            // The home search field has focus (e.g. Back just dismissed the
+            // keyboard) — drop focus so the search-scope preview slides away,
+            // rather than popping/exiting on the same press.
+            FocusManager.instance.primaryFocus?.unfocus();
           } else if (BrowserManager().browserCache.length > 1) {
             BrowserManager().popBrowser();
           } else {

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -735,26 +735,48 @@ class _BrowserState extends State<Browser> {
                     ])))));
   }
 
-  // The thin context strip under the toolbar. Shows, in priority order:
-  //   • search field focused on the home menu → which categories a search will
-  //     cover (so stale defaults from a past session are visible up front);
-  //   • a search-results list → the query it was run for;
-  //   • the file explorer → the current directory path.
-  // The term/path are tracked per stack frame (BrowserManager.currentSearchTerm
-  // / currentPath), so each reverts on back-nav. Mutually exclusive in practice:
-  // the focus preview only shows on the home menu, where term and path are null.
+  // In-flow context strip under the toolbar: the query on a search-results list,
+  // or the current directory in the file explorer. Both are persistent context
+  // for their view (tracked per stack frame, so they revert on back-nav). The
+  // transient search-scope preview is a separate slide-over overlay so it
+  // doesn't shove the list down — see _searchScopePreview.
   Widget _browserSubheader(BuildContext context, AppLocalizations l) {
-    return StreamBuilder<bool>(
-      stream: BrowserManager().searchFocusedStream,
-      initialData: BrowserManager().searchFocused,
-      builder: (context, focusSnap) {
-        return StreamBuilder<List<DisplayItem>>(
-          stream: BrowserManager().browserListStream,
-          builder: (context, _) {
-            final term = BrowserManager().currentSearchTerm;
-            final path = BrowserManager().currentPath;
-            if ((focusSnap.data ?? false) && term == null && path == null) {
-              return StreamBuilder<Set<SearchCategory>>(
+    return StreamBuilder<List<DisplayItem>>(
+      stream: BrowserManager().browserListStream,
+      builder: (context, _) {
+        final term = BrowserManager().currentSearchTerm;
+        if (term != null) {
+          return _subheaderStrip(Icons.search, l.searchSubheaderResults(term));
+        }
+        final path = BrowserManager().currentPath;
+        if (path != null) {
+          return _subheaderStrip(
+              Icons.folder_outlined, path.isEmpty ? '/' : path,
+              mono: true);
+        }
+        return const SizedBox.shrink();
+      },
+    );
+  }
+
+  // Transient search-scope preview that SLIDES OVER the list (rather than
+  // pushing it down) while the home search field is focused, so the user can
+  // see — and fix — a stale category selection before typing. Driven by
+  // BrowserManager.searchFocused; wrapped in IgnorePointer so it never blocks
+  // taps on the list beneath it.
+  Widget _searchScopePreview(BuildContext context, AppLocalizations l) {
+    return IgnorePointer(
+      child: StreamBuilder<bool>(
+        stream: BrowserManager().searchFocusedStream,
+        initialData: BrowserManager().searchFocused,
+        builder: (context, focusSnap) {
+          return ClipRect(
+            child: AnimatedSlide(
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeOutCubic,
+              offset:
+                  (focusSnap.data ?? false) ? Offset.zero : const Offset(0, -1),
+              child: StreamBuilder<Set<SearchCategory>>(
                 stream: SettingsManager().searchCategoriesStream,
                 initialData: SettingsManager().searchCategories,
                 builder: (context, catSnap) {
@@ -767,21 +789,11 @@ class _BrowserState extends State<Browser> {
                   return _subheaderStrip(
                       Icons.manage_search, l.searchSubheaderCategories(names));
                 },
-              );
-            }
-            if (term != null) {
-              return _subheaderStrip(
-                  Icons.search, l.searchSubheaderResults(term));
-            }
-            if (path != null) {
-              return _subheaderStrip(
-                  Icons.folder_outlined, path.isEmpty ? '/' : path,
-                  mono: true);
-            }
-            return const SizedBox.shrink();
-          },
-        );
-      },
+              ),
+            ),
+          );
+        },
+      ),
     );
   }
 
@@ -816,9 +828,10 @@ class _BrowserState extends State<Browser> {
 
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    return Column(children: <Widget>[
-      // Context strip under the toolbar (search categories / search term /
-      // file path) — see _browserSubheader.
+    return Stack(children: <Widget>[
+      Column(children: <Widget>[
+      // In-flow context strip under the toolbar (search term / file path) —
+      // see _browserSubheader.
       _browserSubheader(context, l),
       // Thin indeterminate bar while any browser server call is in
       // flight (all go through ApiManager.makeServerCall). Fixed 3px
@@ -1047,6 +1060,14 @@ class _BrowserState extends State<Browser> {
                       },
                     );
                   })))
+      ]),
+      // Slide-over search-scope preview over the top of the list (focus-driven).
+      Positioned(
+        top: 0,
+        left: 0,
+        right: 0,
+        child: _searchScopePreview(context, l),
+      ),
     ]);
   }
 }

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -735,46 +735,91 @@ class _BrowserState extends State<Browser> {
                     ])))));
   }
 
+  // The thin context strip under the toolbar. Shows, in priority order:
+  //   • search field focused on the home menu → which categories a search will
+  //     cover (so stale defaults from a past session are visible up front);
+  //   • a search-results list → the query it was run for;
+  //   • the file explorer → the current directory path.
+  // The term/path are tracked per stack frame (BrowserManager.currentSearchTerm
+  // / currentPath), so each reverts on back-nav. Mutually exclusive in practice:
+  // the focus preview only shows on the home menu, where term and path are null.
+  Widget _browserSubheader(BuildContext context, AppLocalizations l) {
+    return StreamBuilder<bool>(
+      stream: BrowserManager().searchFocusedStream,
+      initialData: BrowserManager().searchFocused,
+      builder: (context, focusSnap) {
+        return StreamBuilder<List<DisplayItem>>(
+          stream: BrowserManager().browserListStream,
+          builder: (context, _) {
+            final term = BrowserManager().currentSearchTerm;
+            final path = BrowserManager().currentPath;
+            if ((focusSnap.data ?? false) && term == null && path == null) {
+              return StreamBuilder<Set<SearchCategory>>(
+                stream: SettingsManager().searchCategoriesStream,
+                initialData: SettingsManager().searchCategories,
+                builder: (context, catSnap) {
+                  final cats =
+                      catSnap.data ?? SettingsManager().searchCategories;
+                  final names = SearchCategory.values
+                      .where(cats.contains)
+                      .map((c) => c.label(l))
+                      .join(' · ');
+                  return _subheaderStrip(
+                      Icons.manage_search, l.searchSubheaderCategories(names));
+                },
+              );
+            }
+            if (term != null) {
+              return _subheaderStrip(
+                  Icons.search, l.searchSubheaderResults(term));
+            }
+            if (path != null) {
+              return _subheaderStrip(
+                  Icons.folder_outlined, path.isEmpty ? '/' : path,
+                  mono: true);
+            }
+            return const SizedBox.shrink();
+          },
+        );
+      },
+    );
+  }
+
+  Widget _subheaderStrip(IconData icon, String text, {bool mono = false}) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(14, 4, 12, 5),
+      decoration: BoxDecoration(
+        color: VelvetColors.raised,
+        border: Border(bottom: BorderSide(color: VelvetColors.border)),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 13, color: VelvetColors.textTertiary),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              text,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontFamily: mono ? 'monospace' : null,
+                fontSize: 11.5,
+                color: VelvetColors.textSecondary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return Column(children: <Widget>[
-      // Current File Explorer path — a thin strip under the toolbar/back button.
-      // Only shown in the file explorer (BrowserManager.currentPath is null
-      // elsewhere); rebuilds on each navigation via browserListStream.
-      StreamBuilder<List<DisplayItem>>(
-        stream: BrowserManager().browserListStream,
-        builder: (context, _) {
-          final path = BrowserManager().currentPath;
-          if (path == null) return const SizedBox.shrink();
-          return Container(
-            width: double.infinity,
-            padding: const EdgeInsets.fromLTRB(14, 4, 12, 5),
-            decoration: BoxDecoration(
-              color: VelvetColors.raised,
-              border: Border(bottom: BorderSide(color: VelvetColors.border)),
-            ),
-            child: Row(
-              children: [
-                Icon(Icons.folder_outlined,
-                    size: 13, color: VelvetColors.textTertiary),
-                const SizedBox(width: 6),
-                Expanded(
-                  child: Text(
-                    path.isEmpty ? '/' : path,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontFamily: 'monospace',
-                      fontSize: 11.5,
-                      color: VelvetColors.textSecondary,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          );
-        },
-      ),
+      // Context strip under the toolbar (search categories / search term /
+      // file path) — see _browserSubheader.
+      _browserSubheader(context, l),
       // Thin indeterminate bar while any browser server call is in
       // flight (all go through ApiManager.makeServerCall). Fixed 3px
       // slot — empty when idle — so the list never jumps.

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -242,8 +242,18 @@ class ApiManager {
 
   Future<void> searchServer(String search) async {
     try {
-      var res = await makeServerCall(null, '/api/v1/db/search',
-          {'noFiles': true, 'search': search}, 'POST');
+      // The user's search-scope setting decides which of the endpoint's four
+      // categories to query. `everything` (the default) reproduces mStream's
+      // classic artists+albums+songs search; a single-category scope sends the
+      // other three `no*` flags so the server only does the work that's asked.
+      final scope = SettingsManager().searchScope;
+      var res = await makeServerCall(null, '/api/v1/db/search', {
+        'search': search,
+        'noArtists': !scope.includeArtists,
+        'noAlbums': !scope.includeAlbums,
+        'noTitles': !scope.includeSongs,
+        'noFiles': !scope.includeFiles,
+      }, 'POST');
 
       BrowserManager().setBrowserLabel('Search');
       List<DisplayItem> newList = [];
@@ -279,6 +289,24 @@ class ApiManager {
             '/' + e['filepath'],
             Icon(Icons.music_note, color: VelvetColors.accent),
             'song');
+        newItem.altAlbumArt = e['album_art_file'];
+        newList.add(newItem);
+      });
+
+      // Files (filepath matches) — only populated when the scope is `files`.
+      // Same shape as titles (name + filepath); guarded with `?.` because
+      // older servers may omit the key entirely. The row renders as a file:
+      // getText shows the filename, so we surface the folder as the subtitle.
+      res['files']?.forEach((e) {
+        final String fp = e['filepath'];
+        final int slash = fp.lastIndexOf('/');
+        DisplayItem newItem = new DisplayItem(
+            ServerManager().currentServer,
+            e['name'],
+            'file',
+            '/' + fp,
+            Icon(Icons.insert_drive_file, color: VelvetColors.accent),
+            slash > 0 ? fp.substring(0, slash) : null);
         newItem.altAlbumArt = e['album_art_file'];
         newList.add(newItem);
       });

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -242,17 +242,16 @@ class ApiManager {
 
   Future<void> searchServer(String search) async {
     try {
-      // The user's search-scope setting decides which of the endpoint's four
-      // categories to query. `everything` (the default) reproduces mStream's
-      // classic artists+albums+songs search; a single-category scope sends the
-      // other three `no*` flags so the server only does the work that's asked.
-      final scope = SettingsManager().searchScope;
+      // The user's ticked search categories map 1:1 onto the endpoint's four
+      // `no*` flags — the server only does the work that's asked. The default
+      // set (artists+albums+songs) reproduces mStream's classic search.
+      final cats = SettingsManager().searchCategories;
       var res = await makeServerCall(null, '/api/v1/db/search', {
         'search': search,
-        'noArtists': !scope.includeArtists,
-        'noAlbums': !scope.includeAlbums,
-        'noTitles': !scope.includeSongs,
-        'noFiles': !scope.includeFiles,
+        'noArtists': !cats.contains(SearchCategory.artists),
+        'noAlbums': !cats.contains(SearchCategory.albums),
+        'noTitles': !cats.contains(SearchCategory.songs),
+        'noFiles': !cats.contains(SearchCategory.files),
       }, 'POST');
 
       BrowserManager().setBrowserLabel('Search');

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -310,7 +310,9 @@ class ApiManager {
         newList.add(newItem);
       });
 
-      BrowserManager().addListToStack(newList);
+      // Stash the query on the frame so the results view shows a "Results for
+      // …" subheader (and it reverts on back-nav, like the file-explorer path).
+      BrowserManager().addListToStack(newList, searchTerm: search);
     } catch (err) {
       print(err);
     }

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -21,6 +21,10 @@ class BrowserManager {
   // (null for non-file-explorer frames), so the path row shows the right folder
   // and reverts on back-nav. Display-only — no navigation logic reads it.
   final List<String?> pathCache = [];
+  // 1:1 with browserCache. The DB-search query per frame (null for non-search
+  // frames), so the search-results subheader shows the term and reverts on
+  // back-nav, mirroring pathCache. Display-only.
+  final List<String?> searchTermCache = [];
 
   final List<DisplayItem> browserList = [];
 
@@ -37,6 +41,11 @@ class BrowserManager {
   /// Current File Explorer directory path for the top frame, or null when the
   /// current view isn't the file explorer.
   String? get currentPath => pathCache.isNotEmpty ? pathCache.last : null;
+
+  /// The DB-search query for the top frame, or null when the current view
+  /// isn't a search-results list.
+  String? get currentSearchTerm =>
+      searchTermCache.isNotEmpty ? searchTermCache.last : null;
 
   String listName = 'Welcome';
 
@@ -120,6 +129,13 @@ class BrowserManager {
       BehaviorSubject<({bool open, String query})>.seeded(
           (open: false, query: ''));
 
+  // Whether the home "search the whole server" field is focused. The toolbar
+  // owns the field and reports focus here; the body shows a subheader previewing
+  // which categories a search will cover, so stale defaults are visible before
+  // the user types.
+  late final BehaviorSubject<bool> _searchFocused =
+      BehaviorSubject<bool>.seeded(false);
+
   StreamSubscription<int>? _letterStripSub;
   StreamSubscription<MigrationProgress?>? _migrationSub;
 
@@ -191,10 +207,18 @@ class BrowserManager {
     return true;
   }
 
+  /// Report whether the home server-search field is focused (called by the
+  /// toolbar). Drives the search-category preview subheader in the body.
+  void setSearchFocused(bool focused) {
+    if (_searchFocused.value != focused) _searchFocused.add(focused);
+  }
+
   void clear() {
     List<DisplayItem> hold = browserCache[0];
     bool holdAlpha = alphabeticalCache.isNotEmpty ? alphabeticalCache[0] : false;
     String? holdPath = pathCache.isNotEmpty ? pathCache[0] : null;
+    String? holdTerm =
+        searchTermCache.isNotEmpty ? searchTermCache[0] : null;
 
     browserCache.clear();
     browserList.clear();
@@ -208,6 +232,9 @@ class BrowserManager {
     pathCache
       ..clear()
       ..add(holdPath);
+    searchTermCache
+      ..clear()
+      ..add(holdTerm);
   }
 
   void goToNavScreen() {
@@ -219,6 +246,7 @@ class BrowserManager {
     scrollCache.clear();
     alphabeticalCache.clear();
     pathCache.clear();
+    searchTermCache.clear();
 
     if (ServerManager().currentServer == null) {
       return;
@@ -285,6 +313,7 @@ class BrowserManager {
     // Nav screen isn't alphabetical content — just the section list.
     alphabeticalCache.add(false);
     pathCache.add(null); // home nav isn't the file explorer — no path row
+    searchTermCache.add(null); // home nav isn't a search result — no term row
     browserList.add(newItem1);
     browserList.add(newItem2);
     browserList.add(newItem3);
@@ -304,6 +333,7 @@ class BrowserManager {
     scrollCache.clear();
     alphabeticalCache.clear();
     pathCache.clear();
+    searchTermCache.clear();
 
     browserList.add(new DisplayItem(null, 'Welcome To mStream', 'addServer', '',
         Icon(Icons.add, color: VelvetColors.textSecondary), 'Click here to add server'));
@@ -312,7 +342,7 @@ class BrowserManager {
   }
 
   void addListToStack(List<DisplayItem> newList,
-      {bool alphabetical = false, String? path}) {
+      {bool alphabetical = false, String? path, String? searchTerm}) {
     // Capture the current screen's scroll position before navigating
     // forward. sc.hasClients is false when navigation is triggered
     // from a non-Browser context (e.g. tapping File Explorer in the
@@ -325,6 +355,7 @@ class BrowserManager {
     browserCache.add(newList);
     alphabeticalCache.add(alphabetical);
     pathCache.add(path);
+    searchTermCache.add(searchTerm);
 
     browserList.clear();
     newList.forEach((element) {
@@ -391,6 +422,7 @@ class BrowserManager {
     browserCache.removeLast();
     if (alphabeticalCache.isNotEmpty) alphabeticalCache.removeLast();
     if (pathCache.isNotEmpty) pathCache.removeLast();
+    if (searchTermCache.isNotEmpty) searchTermCache.removeLast();
     browserList.clear();
     browserCache[browserCache.length - 1].forEach((el) {
       browserList.add(el);
@@ -440,6 +472,7 @@ class BrowserManager {
     _browserLabel.close();
     _albumDetail.close();
     _search.close();
+    _searchFocused.close();
     _loading.close();
   }
 
@@ -449,4 +482,6 @@ class BrowserManager {
   DisplayItem? get albumDetail => _albumDetail.value;
   Stream<({bool open, String query})> get searchStream => _search.stream;
   ({bool open, String query}) get search => _search.value;
+  Stream<bool> get searchFocusedStream => _searchFocused.stream;
+  bool get searchFocused => _searchFocused.value;
 }

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -211,6 +211,8 @@ class SettingsManager {
       BehaviorSubject<int?>.seeded(accentColor);
   late final BehaviorSubject<Locale?> _localeStream =
       BehaviorSubject<Locale?>.seeded(localeOverride);
+  late final BehaviorSubject<Set<SearchCategory>> _searchCategoriesStream =
+      BehaviorSubject<Set<SearchCategory>>.seeded(searchCategories);
 
   /// The forced locale, or `null` to follow the device. Fed straight to
   /// `MaterialApp.locale`. Parses BCP-47-ish codes so script- and
@@ -300,6 +302,7 @@ class SettingsManager {
       _playerLayoutStream.add(playerLayout);
       _accentColorStream.add(accentColor);
       _localeStream.add(localeOverride);
+      _searchCategoriesStream.add(searchCategories);
     } catch (_) {
       // Corrupt or missing file: fall back to defaults.
     }
@@ -512,6 +515,7 @@ class SettingsManager {
     final next = applyToggle(searchCategories, c);
     if (identical(next, searchCategories)) return; // unchanged (last one)
     searchCategories = next;
+    _searchCategoriesStream.add(next);
     await _save();
   }
 
@@ -635,6 +639,7 @@ class SettingsManager {
     _themeStream.add(appTheme);
     _accentColorStream.add(accentColor);
     _localeStream.add(localeOverride);
+    _searchCategoriesStream.add(searchCategories);
     await _save();
   }
 
@@ -644,6 +649,8 @@ class SettingsManager {
   Stream<PlayerLayout> get playerLayoutStream => _playerLayoutStream.stream;
   Stream<int?> get accentColorStream => _accentColorStream.stream;
   Stream<Locale?> get localeStream => _localeStream.stream;
+  Stream<Set<SearchCategory>> get searchCategoriesStream =>
+      _searchCategoriesStream.stream;
 
   void dispose() {
     _albumGridStream.close();
@@ -652,5 +659,6 @@ class SettingsManager {
     _playerLayoutStream.close();
     _accentColorStream.close();
     _localeStream.close();
+    _searchCategoriesStream.close();
   }
 }

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -101,30 +101,18 @@ enum VisualizerAudioSource {
   // lib/l10n/enum_labels.dart.
 }
 
-/// Which categories the whole-server DB search (POST /api/v1/db/search)
-/// queries. That endpoint exposes four independent categories through its
-/// `noArtists` / `noAlbums` / `noTitles` / `noFiles` flags; each scope below
-/// maps to one combination of them. `everything` is the default and
-/// reproduces mStream's classic search (artists + albums + songs, with files
-/// excluded — bare filepath matches are noisy next to song titles). `files`
-/// is the only scope that searches filepaths, so it stands alone. Persisted
-/// as the JSON 'searchScope' key.
-enum SearchScope {
-  everything,
+/// A category the whole-server DB search (POST /api/v1/db/search) can query.
+/// The endpoint exposes these four independently through its `noArtists` /
+/// `noAlbums` / `noTitles` / `noFiles` flags, so the search dropdown lets the
+/// user tick any combination (see [SettingsManager.searchCategories]).
+/// Persisted as a list of names under the JSON 'searchCategories' key.
+enum SearchCategory {
   artists,
   albums,
   songs,
   files;
 
-  // Localized labels: SearchScopeLabel extension in lib/l10n/enum_labels.dart.
-
-  bool get includeArtists =>
-      this == SearchScope.everything || this == SearchScope.artists;
-  bool get includeAlbums =>
-      this == SearchScope.everything || this == SearchScope.albums;
-  bool get includeSongs =>
-      this == SearchScope.everything || this == SearchScope.songs;
-  bool get includeFiles => this == SearchScope.files;
+  // Localized labels: SearchCategoryLabel extension in lib/l10n/enum_labels.dart.
 }
 
 /// User-tweakable settings persisted to disk as a JSON blob next to
@@ -145,10 +133,17 @@ class SettingsManager {
   int letterStripThreshold = 25;
   TapBehavior tapBehavior = TapBehavior.addToQueue;
   StartupView startupView = StartupView.browser;
-  // Which categories the whole-server search queries (see SearchScope). The
-  // default `everything` reproduces mStream's classic artists+albums+songs
-  // search; the browser toolbar's search-scope dropdown writes this.
-  SearchScope searchScope = SearchScope.everything;
+  // Which categories the whole-server search queries. The default
+  // (artists + albums + songs, files off) reproduces mStream's classic search;
+  // files is opt-in because bare filepath matches are noisy next to titles.
+  // The browser toolbar's checkbox dropdown writes this; at least one category
+  // is always kept selected (see [toggleSearchCategory]).
+  static const Set<SearchCategory> defaultSearchCategories = {
+    SearchCategory.artists,
+    SearchCategory.albums,
+    SearchCategory.songs,
+  };
+  Set<SearchCategory> searchCategories = defaultSearchCategories;
   AppTheme appTheme = AppTheme.dark;
   // Which Now Playing layout the expanded player uses (Small/Medium/Large/XL).
   PlayerLayout playerLayout = PlayerLayout.medium;
@@ -216,8 +211,6 @@ class SettingsManager {
       BehaviorSubject<int?>.seeded(accentColor);
   late final BehaviorSubject<Locale?> _localeStream =
       BehaviorSubject<Locale?>.seeded(localeOverride);
-  late final BehaviorSubject<SearchScope> _searchScopeStream =
-      BehaviorSubject<SearchScope>.seeded(searchScope);
 
   /// The forced locale, or `null` to follow the device. Fed straight to
   /// `MaterialApp.locale`. Parses BCP-47-ish codes so script- and
@@ -268,7 +261,7 @@ class SettingsManager {
       letterStripThreshold = m['letterStripThreshold'] ?? 25;
       tapBehavior = _readTapBehavior(m);
       startupView = _readStartupView(m);
-      searchScope = _readSearchScope(m);
+      searchCategories = _readSearchCategories(m);
       appTheme = _readTheme(m);
       playerLayout = _readPlayerLayout(m);
       final accent = m['accentColor'];
@@ -307,7 +300,6 @@ class SettingsManager {
       _playerLayoutStream.add(playerLayout);
       _accentColorStream.add(accentColor);
       _localeStream.add(localeOverride);
-      _searchScopeStream.add(searchScope);
     } catch (_) {
       // Corrupt or missing file: fall back to defaults.
     }
@@ -388,14 +380,52 @@ class SettingsManager {
     return StartupView.browser;
   }
 
-  SearchScope _readSearchScope(Map<String, dynamic> m) {
-    final str = m['searchScope'];
-    if (str is String) {
-      for (final v in SearchScope.values) {
-        if (v.name == str) return v;
+  Set<SearchCategory> _readSearchCategories(Map<String, dynamic> m) {
+    final raw = m['searchCategories'];
+    if (raw is List) {
+      final set = <SearchCategory>{};
+      for (final item in raw) {
+        for (final c in SearchCategory.values) {
+          if (c.name == item) set.add(c);
+        }
       }
+      // Empty/garbage shouldn't leave the user unable to search anything.
+      if (set.isNotEmpty) return set;
     }
-    return SearchScope.everything;
+    // Migrate the pre-multiselect single 'searchScope' enum, if present, so an
+    // existing install keeps a sensible selection after upgrading.
+    final legacy = m['searchScope'];
+    if (legacy is String) return _migrateLegacyScope(legacy);
+    return {...defaultSearchCategories};
+  }
+
+  /// Maps the old single-select scope name to the equivalent category set.
+  static Set<SearchCategory> _migrateLegacyScope(String scope) {
+    switch (scope) {
+      case 'artists':
+        return {SearchCategory.artists};
+      case 'albums':
+        return {SearchCategory.albums};
+      case 'songs':
+        return {SearchCategory.songs};
+      case 'files':
+        return {SearchCategory.files};
+      case 'everything':
+      default:
+        return {...defaultSearchCategories};
+    }
+  }
+
+  /// Pure toggle used by the checkbox dropdown: flips [c] within [current]
+  /// but never empties the set — unchecking the last remaining category is a
+  /// no-op (returns [current] unchanged), so a search always has a target.
+  static Set<SearchCategory> applyToggle(
+      Set<SearchCategory> current, SearchCategory c) {
+    if (current.contains(c)) {
+      if (current.length == 1) return current;
+      return {...current}..remove(c);
+    }
+    return {...current, c};
   }
 
   Future<void> _save() async {
@@ -410,7 +440,7 @@ class SettingsManager {
       'letterStripThreshold': letterStripThreshold,
       'tapBehavior': tapBehavior.name,
       'startupView': startupView.name,
-      'searchScope': searchScope.name,
+      'searchCategories': searchCategories.map((c) => c.name).toList(),
       'theme': appTheme.name,
       'playerLayout': playerLayout.name,
       'accentColor': accentColor,
@@ -476,9 +506,12 @@ class SettingsManager {
     await _save();
   }
 
-  Future<void> setSearchScope(SearchScope v) async {
-    searchScope = v;
-    _searchScopeStream.add(v);
+  /// Toggle whether [c] is one of the searched categories. Keeps at least one
+  /// category selected (see [applyToggle]); persists only when it changed.
+  Future<void> toggleSearchCategory(SearchCategory c) async {
+    final next = applyToggle(searchCategories, c);
+    if (identical(next, searchCategories)) return; // unchanged (last one)
+    searchCategories = next;
     await _save();
   }
 
@@ -583,7 +616,7 @@ class SettingsManager {
     letterStripThreshold = 25;
     tapBehavior = TapBehavior.addToQueue;
     startupView = StartupView.browser;
-    searchScope = SearchScope.everything;
+    searchCategories = {...defaultSearchCategories};
     appTheme = AppTheme.dark;
     playerLayout = PlayerLayout.medium;
     accentColor = null;
@@ -602,7 +635,6 @@ class SettingsManager {
     _themeStream.add(appTheme);
     _accentColorStream.add(accentColor);
     _localeStream.add(localeOverride);
-    _searchScopeStream.add(searchScope);
     await _save();
   }
 
@@ -612,7 +644,6 @@ class SettingsManager {
   Stream<PlayerLayout> get playerLayoutStream => _playerLayoutStream.stream;
   Stream<int?> get accentColorStream => _accentColorStream.stream;
   Stream<Locale?> get localeStream => _localeStream.stream;
-  Stream<SearchScope> get searchScopeStream => _searchScopeStream.stream;
 
   void dispose() {
     _albumGridStream.close();
@@ -621,6 +652,5 @@ class SettingsManager {
     _playerLayoutStream.close();
     _accentColorStream.close();
     _localeStream.close();
-    _searchScopeStream.close();
   }
 }

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -101,6 +101,32 @@ enum VisualizerAudioSource {
   // lib/l10n/enum_labels.dart.
 }
 
+/// Which categories the whole-server DB search (POST /api/v1/db/search)
+/// queries. That endpoint exposes four independent categories through its
+/// `noArtists` / `noAlbums` / `noTitles` / `noFiles` flags; each scope below
+/// maps to one combination of them. `everything` is the default and
+/// reproduces mStream's classic search (artists + albums + songs, with files
+/// excluded — bare filepath matches are noisy next to song titles). `files`
+/// is the only scope that searches filepaths, so it stands alone. Persisted
+/// as the JSON 'searchScope' key.
+enum SearchScope {
+  everything,
+  artists,
+  albums,
+  songs,
+  files;
+
+  // Localized labels: SearchScopeLabel extension in lib/l10n/enum_labels.dart.
+
+  bool get includeArtists =>
+      this == SearchScope.everything || this == SearchScope.artists;
+  bool get includeAlbums =>
+      this == SearchScope.everything || this == SearchScope.albums;
+  bool get includeSongs =>
+      this == SearchScope.everything || this == SearchScope.songs;
+  bool get includeFiles => this == SearchScope.files;
+}
+
 /// User-tweakable settings persisted to disk as a JSON blob next to
 /// servers.json. Uses path_provider — same dependency the rest of the
 /// app already pulls in — so no SharedPreferences plugin required.
@@ -119,6 +145,10 @@ class SettingsManager {
   int letterStripThreshold = 25;
   TapBehavior tapBehavior = TapBehavior.addToQueue;
   StartupView startupView = StartupView.browser;
+  // Which categories the whole-server search queries (see SearchScope). The
+  // default `everything` reproduces mStream's classic artists+albums+songs
+  // search; the browser toolbar's search-scope dropdown writes this.
+  SearchScope searchScope = SearchScope.everything;
   AppTheme appTheme = AppTheme.dark;
   // Which Now Playing layout the expanded player uses (Small/Medium/Large/XL).
   PlayerLayout playerLayout = PlayerLayout.medium;
@@ -186,6 +216,8 @@ class SettingsManager {
       BehaviorSubject<int?>.seeded(accentColor);
   late final BehaviorSubject<Locale?> _localeStream =
       BehaviorSubject<Locale?>.seeded(localeOverride);
+  late final BehaviorSubject<SearchScope> _searchScopeStream =
+      BehaviorSubject<SearchScope>.seeded(searchScope);
 
   /// The forced locale, or `null` to follow the device. Fed straight to
   /// `MaterialApp.locale`. Parses BCP-47-ish codes so script- and
@@ -236,6 +268,7 @@ class SettingsManager {
       letterStripThreshold = m['letterStripThreshold'] ?? 25;
       tapBehavior = _readTapBehavior(m);
       startupView = _readStartupView(m);
+      searchScope = _readSearchScope(m);
       appTheme = _readTheme(m);
       playerLayout = _readPlayerLayout(m);
       final accent = m['accentColor'];
@@ -274,6 +307,7 @@ class SettingsManager {
       _playerLayoutStream.add(playerLayout);
       _accentColorStream.add(accentColor);
       _localeStream.add(localeOverride);
+      _searchScopeStream.add(searchScope);
     } catch (_) {
       // Corrupt or missing file: fall back to defaults.
     }
@@ -354,6 +388,16 @@ class SettingsManager {
     return StartupView.browser;
   }
 
+  SearchScope _readSearchScope(Map<String, dynamic> m) {
+    final str = m['searchScope'];
+    if (str is String) {
+      for (final v in SearchScope.values) {
+        if (v.name == str) return v;
+      }
+    }
+    return SearchScope.everything;
+  }
+
   Future<void> _save() async {
     final f = await _file;
     await f.writeAsString(jsonEncode({
@@ -366,6 +410,7 @@ class SettingsManager {
       'letterStripThreshold': letterStripThreshold,
       'tapBehavior': tapBehavior.name,
       'startupView': startupView.name,
+      'searchScope': searchScope.name,
       'theme': appTheme.name,
       'playerLayout': playerLayout.name,
       'accentColor': accentColor,
@@ -428,6 +473,12 @@ class SettingsManager {
 
   Future<void> setStartupView(StartupView v) async {
     startupView = v;
+    await _save();
+  }
+
+  Future<void> setSearchScope(SearchScope v) async {
+    searchScope = v;
+    _searchScopeStream.add(v);
     await _save();
   }
 
@@ -532,6 +583,7 @@ class SettingsManager {
     letterStripThreshold = 25;
     tapBehavior = TapBehavior.addToQueue;
     startupView = StartupView.browser;
+    searchScope = SearchScope.everything;
     appTheme = AppTheme.dark;
     playerLayout = PlayerLayout.medium;
     accentColor = null;
@@ -550,6 +602,7 @@ class SettingsManager {
     _themeStream.add(appTheme);
     _accentColorStream.add(accentColor);
     _localeStream.add(localeOverride);
+    _searchScopeStream.add(searchScope);
     await _save();
   }
 
@@ -559,6 +612,7 @@ class SettingsManager {
   Stream<PlayerLayout> get playerLayoutStream => _playerLayoutStream.stream;
   Stream<int?> get accentColorStream => _accentColorStream.stream;
   Stream<Locale?> get localeStream => _localeStream.stream;
+  Stream<SearchScope> get searchScopeStream => _searchScopeStream.stream;
 
   void dispose() {
     _albumGridStream.close();
@@ -567,5 +621,6 @@ class SettingsManager {
     _playerLayoutStream.close();
     _accentColorStream.close();
     _localeStream.close();
+    _searchScopeStream.close();
   }
 }

--- a/lib/widgets/browser_toolbar.dart
+++ b/lib/widgets/browser_toolbar.dart
@@ -13,6 +13,8 @@
 // download / add-all actions operate on the current list — the album's loaded
 // songs when the detail view is up, otherwise the browser list.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -61,19 +63,28 @@ class _BrowserToolbarState extends State<BrowserToolbar> {
   );
 
   // The home "search the whole server" field's focus drives the body's
-  // category-preview subheader (so the user sees the current scope before
+  // category-preview overlay (so the user sees the current scope before
   // typing). Owned here so it survives the toolbar's stream-driven rebuilds.
   final FocusNode _homeSearchFocus = FocusNode();
+  StreamSubscription<List<DisplayItem>>? _navSub;
 
   @override
   void initState() {
     super.initState();
     _homeSearchFocus.addListener(
         () => BrowserManager().setSearchFocused(_homeSearchFocus.hasFocus));
+    // Drop focus the moment we navigate off the home menu. The field otherwise
+    // keeps logical focus through back/keyboard-dismiss and navigation (Flutter
+    // even restores it on return to home), which left the preview stuck on.
+    _navSub = BrowserManager().browserListStream.listen((list) {
+      final isHome = list.isNotEmpty && list[0].type == 'execAction';
+      if (!isHome && _homeSearchFocus.hasFocus) _homeSearchFocus.unfocus();
+    });
   }
 
   @override
   void dispose() {
+    _navSub?.cancel();
     BrowserManager().setSearchFocused(false);
     _homeSearchFocus.dispose();
     super.dispose();

--- a/lib/widgets/browser_toolbar.dart
+++ b/lib/widgets/browser_toolbar.dart
@@ -157,42 +157,64 @@ class _BrowserToolbarState extends State<BrowserToolbar> {
         ),
       );
 
-  // Scope dropdown for the home search field: a single-select menu that picks
-  // which of /api/v1/db/search's categories the query hits. itemBuilder reads
-  // the current scope on open so the active row is always checked; selecting
-  // one persists it (SettingsManager.setSearchScope → settings.json).
-  Widget _searchScopeMenu(BuildContext context, AppLocalizations l) {
-    return PopupMenuButton<SearchScope>(
+  // Multi-select checkbox dropdown for the home search field: the user ticks
+  // any combination of the four /api/v1/db/search categories. A single
+  // disabled PopupMenuItem hosts a StatefulBuilder so ticking a box updates the
+  // checks AND persists (toggleSearchCategory) WITHOUT closing the menu — the
+  // disabled item swallows no taps of its own, so the inner CheckboxListTiles
+  // keep the route open for picking several. At least one stays checked.
+  Widget _searchCategoryMenu(BuildContext context, AppLocalizations l) {
+    return PopupMenuButton<void>(
       icon: Icon(Icons.tune, color: VelvetColors.appBarTextSecondary, size: 22),
-      tooltip: l.searchScopeTooltip,
+      tooltip: l.searchCategoriesTooltip,
       color: VelvetColors.surface,
-      onSelected: (v) => SettingsManager().setSearchScope(v),
-      itemBuilder: (_) {
-        final current = SettingsManager().searchScope;
-        return SearchScope.values.map((scope) {
-          final selected = scope == current;
-          return PopupMenuItem<SearchScope>(
-            value: scope,
-            child: Row(children: [
-              SizedBox(
-                width: 26,
-                child: selected
-                    ? Icon(Icons.check,
-                        size: 18, color: VelvetColors.primary)
-                    : null,
-              ),
-              Text(
-                scope.label(l),
-                style: TextStyle(
-                  color: VelvetColors.textPrimary,
-                  fontWeight:
-                      selected ? FontWeight.w600 : FontWeight.normal,
-                ),
-              ),
-            ]),
-          );
-        }).toList();
-      },
+      itemBuilder: (_) => [
+        PopupMenuItem<void>(
+          enabled: false,
+          padding: EdgeInsets.zero,
+          child: StatefulBuilder(
+            builder: (context, setMenuState) {
+              final selected = SettingsManager().searchCategories;
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 10, 16, 2),
+                    child: Text(
+                      l.searchCategoriesHeader,
+                      style: TextStyle(
+                        color: VelvetColors.textSecondary,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: 0.4,
+                      ),
+                    ),
+                  ),
+                  for (final c in SearchCategory.values)
+                    CheckboxListTile(
+                      value: selected.contains(c),
+                      dense: true,
+                      controlAffinity: ListTileControlAffinity.leading,
+                      contentPadding:
+                          const EdgeInsets.symmetric(horizontal: 8),
+                      activeColor: VelvetColors.primary,
+                      title: Text(
+                        c.label(l),
+                        style: TextStyle(
+                            color: VelvetColors.textPrimary, fontSize: 14),
+                      ),
+                      onChanged: (_) {
+                        SettingsManager().toggleSearchCategory(c);
+                        setMenuState(() {});
+                      },
+                    ),
+                ],
+              );
+            },
+          ),
+        ),
+      ],
     );
   }
 
@@ -251,42 +273,29 @@ class _BrowserToolbarState extends State<BrowserToolbar> {
       ]);
     }
 
-    // Home section list: the "search the whole server" field, plus a scope
+    // Home section list: the "search the whole server" field, plus a checkbox
     // dropdown that picks which categories the search queries (persisted).
     final isHome = s.list.isNotEmpty && s.list[0].type == 'execAction';
     if (isHome) {
       return Row(children: [
         const SizedBox(width: 8),
         Expanded(
-          // Rebuild only the field as the scope changes so its hint reflects
-          // the active scope ("Search Artists" etc.). The menu reads the scope
-          // fresh when it opens, so it stays outside this builder.
-          child: StreamBuilder<SearchScope>(
-            stream: SettingsManager().searchScopeStream,
-            initialData: SettingsManager().searchScope,
-            builder: (context, scopeSnap) {
-              final scope = scopeSnap.data ?? SearchScope.everything;
-              return TextField(
-                textInputAction: TextInputAction.search,
-                onSubmitted: (text) => ApiManager().searchServer(text),
-                style: TextStyle(color: VelvetColors.appBarText, fontSize: 15),
-                cursorColor: VelvetColors.primary,
-                decoration: InputDecoration(
-                  isDense: true,
-                  border: InputBorder.none,
-                  prefixIcon: Icon(Icons.search,
-                      color: VelvetColors.appBarTextSecondary),
-                  hintText: scope == SearchScope.everything
-                      ? l.browserSearchHint
-                      : l.searchScopeHint(scope.label(l)),
-                  hintStyle:
-                      TextStyle(color: VelvetColors.appBarTextSecondary),
-                ),
-              );
-            },
+          child: TextField(
+            textInputAction: TextInputAction.search,
+            onSubmitted: (text) => ApiManager().searchServer(text),
+            style: TextStyle(color: VelvetColors.appBarText, fontSize: 15),
+            cursorColor: VelvetColors.primary,
+            decoration: InputDecoration(
+              isDense: true,
+              border: InputBorder.none,
+              prefixIcon:
+                  Icon(Icons.search, color: VelvetColors.appBarTextSecondary),
+              hintText: l.browserSearchHint,
+              hintStyle: TextStyle(color: VelvetColors.appBarTextSecondary),
+            ),
           ),
         ),
-        _searchScopeMenu(context, l),
+        _searchCategoryMenu(context, l),
       ]);
     }
 

--- a/lib/widgets/browser_toolbar.dart
+++ b/lib/widgets/browser_toolbar.dart
@@ -60,6 +60,25 @@ class _BrowserToolbarState extends State<BrowserToolbar> {
         (album: album, search: search, label: label, list: list),
   );
 
+  // The home "search the whole server" field's focus drives the body's
+  // category-preview subheader (so the user sees the current scope before
+  // typing). Owned here so it survives the toolbar's stream-driven rebuilds.
+  final FocusNode _homeSearchFocus = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _homeSearchFocus.addListener(
+        () => BrowserManager().setSearchFocused(_homeSearchFocus.hasFocus));
+  }
+
+  @override
+  void dispose() {
+    BrowserManager().setSearchFocused(false);
+    _homeSearchFocus.dispose();
+    super.dispose();
+  }
+
   // Files in [all] that can be downloaded (server files only), de-noised of
   // playlists. Album songs and browse rows both flow through here.
   List<DisplayItem> _downloadable(List<DisplayItem> all) => all
@@ -281,6 +300,7 @@ class _BrowserToolbarState extends State<BrowserToolbar> {
         const SizedBox(width: 8),
         Expanded(
           child: TextField(
+            focusNode: _homeSearchFocus,
             textInputAction: TextInputAction.search,
             onSubmitted: (text) => ApiManager().searchServer(text),
             style: TextStyle(color: VelvetColors.appBarText, fontSize: 15),

--- a/lib/widgets/browser_toolbar.dart
+++ b/lib/widgets/browser_toolbar.dart
@@ -22,6 +22,7 @@ import '../objects/display_item.dart';
 import '../singletons/api.dart';
 import '../singletons/browser_list.dart';
 import '../singletons/downloads.dart';
+import '../singletons/settings.dart';
 import '../theme/velvet_theme.dart';
 import '../util/queue_actions.dart';
 import 'local_search_bar.dart';
@@ -156,6 +157,45 @@ class _BrowserToolbarState extends State<BrowserToolbar> {
         ),
       );
 
+  // Scope dropdown for the home search field: a single-select menu that picks
+  // which of /api/v1/db/search's categories the query hits. itemBuilder reads
+  // the current scope on open so the active row is always checked; selecting
+  // one persists it (SettingsManager.setSearchScope → settings.json).
+  Widget _searchScopeMenu(BuildContext context, AppLocalizations l) {
+    return PopupMenuButton<SearchScope>(
+      icon: Icon(Icons.tune, color: VelvetColors.appBarTextSecondary, size: 22),
+      tooltip: l.searchScopeTooltip,
+      color: VelvetColors.surface,
+      onSelected: (v) => SettingsManager().setSearchScope(v),
+      itemBuilder: (_) {
+        final current = SettingsManager().searchScope;
+        return SearchScope.values.map((scope) {
+          final selected = scope == current;
+          return PopupMenuItem<SearchScope>(
+            value: scope,
+            child: Row(children: [
+              SizedBox(
+                width: 26,
+                child: selected
+                    ? Icon(Icons.check,
+                        size: 18, color: VelvetColors.primary)
+                    : null,
+              ),
+              Text(
+                scope.label(l),
+                style: TextStyle(
+                  color: VelvetColors.textPrimary,
+                  fontWeight:
+                      selected ? FontWeight.w600 : FontWeight.normal,
+                ),
+              ),
+            ]),
+          );
+        }).toList();
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
@@ -211,27 +251,42 @@ class _BrowserToolbarState extends State<BrowserToolbar> {
       ]);
     }
 
-    // Home section list: the "search the whole server" field.
+    // Home section list: the "search the whole server" field, plus a scope
+    // dropdown that picks which categories the search queries (persisted).
     final isHome = s.list.isNotEmpty && s.list[0].type == 'execAction';
     if (isHome) {
       return Row(children: [
         const SizedBox(width: 8),
         Expanded(
-          child: TextField(
-            textInputAction: TextInputAction.search,
-            onSubmitted: (text) => ApiManager().searchServer(text),
-            style: TextStyle(color: VelvetColors.appBarText, fontSize: 15),
-            cursorColor: VelvetColors.primary,
-            decoration: InputDecoration(
-              isDense: true,
-              border: InputBorder.none,
-              prefixIcon:
-                  Icon(Icons.search, color: VelvetColors.appBarTextSecondary),
-              hintText: l.browserSearchHint,
-              hintStyle: TextStyle(color: VelvetColors.appBarTextSecondary),
-            ),
+          // Rebuild only the field as the scope changes so its hint reflects
+          // the active scope ("Search Artists" etc.). The menu reads the scope
+          // fresh when it opens, so it stays outside this builder.
+          child: StreamBuilder<SearchScope>(
+            stream: SettingsManager().searchScopeStream,
+            initialData: SettingsManager().searchScope,
+            builder: (context, scopeSnap) {
+              final scope = scopeSnap.data ?? SearchScope.everything;
+              return TextField(
+                textInputAction: TextInputAction.search,
+                onSubmitted: (text) => ApiManager().searchServer(text),
+                style: TextStyle(color: VelvetColors.appBarText, fontSize: 15),
+                cursorColor: VelvetColors.primary,
+                decoration: InputDecoration(
+                  isDense: true,
+                  border: InputBorder.none,
+                  prefixIcon: Icon(Icons.search,
+                      color: VelvetColors.appBarTextSecondary),
+                  hintText: scope == SearchScope.everything
+                      ? l.browserSearchHint
+                      : l.searchScopeHint(scope.label(l)),
+                  hintStyle:
+                      TextStyle(color: VelvetColors.appBarTextSecondary),
+                ),
+              );
+            },
           ),
         ),
+        _searchScopeMenu(context, l),
       ]);
     }
 

--- a/test/singletons/search_scope_test.dart
+++ b/test/singletons/search_scope_test.dart
@@ -1,54 +1,53 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mstream_music/singletons/settings.dart';
 
-// SearchScope is the contract behind the DB-search scope dropdown: each scope
-// maps to a combination of the /api/v1/db/search `no*` flags. ApiManager
-// .searchServer sends `noArtists: !scope.includeArtists` (etc.), so these
-// getters decide which categories the server actually queries. The default
-// `everything` must reproduce mStream's legacy artists+albums+songs search
-// (i.e. files excluded → noFiles:true), so that's pinned explicitly.
+// The search dropdown stores a Set<SearchCategory>; ApiManager.searchServer
+// maps it 1:1 onto /api/v1/db/search's no* flags (noArtists = !contains(...)).
+// Two invariants are pinned here:
+//   1. The default set reproduces mStream's legacy search — artists + albums +
+//      songs, files OFF (the old hard-coded noFiles:true).
+//   2. applyToggle never empties the set, so a search always has a target.
 void main() {
-  group('SearchScope category flags', () {
-    test('everything = artists + albums + songs, files excluded (legacy)', () {
-      const s = SearchScope.everything;
-      expect(s.includeArtists, isTrue);
-      expect(s.includeAlbums, isTrue);
-      expect(s.includeSongs, isTrue);
-      expect(s.includeFiles, isFalse);
-      // The flags the API actually sends — legacy behaviour was noFiles:true.
-      expect(!s.includeFiles, isTrue);
+  group('default search categories', () {
+    test('is artists + albums + songs, files off (legacy parity)', () {
+      const d = SettingsManager.defaultSearchCategories;
+      expect(d, {
+        SearchCategory.artists,
+        SearchCategory.albums,
+        SearchCategory.songs,
+      });
+      // The flag the API derives from this — legacy behaviour was noFiles:true.
+      expect(d.contains(SearchCategory.files), isFalse);
+    });
+  });
+
+  group('SettingsManager.applyToggle', () {
+    test('adds an unselected category', () {
+      final r = SettingsManager.applyToggle(
+          {SearchCategory.artists}, SearchCategory.files);
+      expect(r, {SearchCategory.artists, SearchCategory.files});
     });
 
-    test('single-category scopes query exactly one category', () {
-      void only(SearchScope s,
-          {required bool artists,
-          required bool albums,
-          required bool songs,
-          required bool files}) {
-        expect(s.includeArtists, artists, reason: '$s artists');
-        expect(s.includeAlbums, albums, reason: '$s albums');
-        expect(s.includeSongs, songs, reason: '$s songs');
-        expect(s.includeFiles, files, reason: '$s files');
-      }
-
-      only(SearchScope.artists,
-          artists: true, albums: false, songs: false, files: false);
-      only(SearchScope.albums,
-          artists: false, albums: true, songs: false, files: false);
-      only(SearchScope.songs,
-          artists: false, albums: false, songs: true, files: false);
-      only(SearchScope.files,
-          artists: false, albums: false, songs: false, files: true);
+    test('removes a selected category when others remain', () {
+      final r = SettingsManager.applyToggle(
+          {SearchCategory.artists, SearchCategory.albums},
+          SearchCategory.albums);
+      expect(r, {SearchCategory.artists});
     });
 
-    test('every scope queries at least one category (no empty search)', () {
-      for (final s in SearchScope.values) {
-        final any = s.includeArtists ||
-            s.includeAlbums ||
-            s.includeSongs ||
-            s.includeFiles;
-        expect(any, isTrue, reason: '$s would send all no* flags true');
-      }
+    test('unchecking the last category is a no-op (keeps at least one)', () {
+      final current = {SearchCategory.songs};
+      final r = SettingsManager.applyToggle(current, SearchCategory.songs);
+      expect(r, {SearchCategory.songs});
+      expect(identical(r, current), isTrue,
+          reason: 'returns the input unchanged so callers skip persisting');
+    });
+
+    test('does not mutate the input set', () {
+      final current = {SearchCategory.artists};
+      SettingsManager.applyToggle(current, SearchCategory.albums);
+      expect(current, {SearchCategory.artists},
+          reason: 'input set must be left untouched');
     });
   });
 }

--- a/test/singletons/search_scope_test.dart
+++ b/test/singletons/search_scope_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/singletons/settings.dart';
+
+// SearchScope is the contract behind the DB-search scope dropdown: each scope
+// maps to a combination of the /api/v1/db/search `no*` flags. ApiManager
+// .searchServer sends `noArtists: !scope.includeArtists` (etc.), so these
+// getters decide which categories the server actually queries. The default
+// `everything` must reproduce mStream's legacy artists+albums+songs search
+// (i.e. files excluded → noFiles:true), so that's pinned explicitly.
+void main() {
+  group('SearchScope category flags', () {
+    test('everything = artists + albums + songs, files excluded (legacy)', () {
+      const s = SearchScope.everything;
+      expect(s.includeArtists, isTrue);
+      expect(s.includeAlbums, isTrue);
+      expect(s.includeSongs, isTrue);
+      expect(s.includeFiles, isFalse);
+      // The flags the API actually sends — legacy behaviour was noFiles:true.
+      expect(!s.includeFiles, isTrue);
+    });
+
+    test('single-category scopes query exactly one category', () {
+      void only(SearchScope s,
+          {required bool artists,
+          required bool albums,
+          required bool songs,
+          required bool files}) {
+        expect(s.includeArtists, artists, reason: '$s artists');
+        expect(s.includeAlbums, albums, reason: '$s albums');
+        expect(s.includeSongs, songs, reason: '$s songs');
+        expect(s.includeFiles, files, reason: '$s files');
+      }
+
+      only(SearchScope.artists,
+          artists: true, albums: false, songs: false, files: false);
+      only(SearchScope.albums,
+          artists: false, albums: true, songs: false, files: false);
+      only(SearchScope.songs,
+          artists: false, albums: false, songs: true, files: false);
+      only(SearchScope.files,
+          artists: false, albums: false, songs: false, files: true);
+    });
+
+    test('every scope queries at least one category (no empty search)', () {
+      for (final s in SearchScope.values) {
+        final any = s.includeArtists ||
+            s.includeAlbums ||
+            s.includeSongs ||
+            s.includeFiles;
+        expect(any, isTrue, reason: '$s would send all no* flags true');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Improves the whole-server search (the "Search Database" field on the browser home):

1. **Pick exactly what to search.** A checkbox dropdown beside the field lets the user tick any combination of **Artists / Albums / Songs / Files** — a direct match to `/api/v1/db/search`'s four independent `no*` flags (the field previously hard-coded artists+albums+songs). Persisted across sessions.
2. **Context subheaders** (thin strip under the toolbar, like the file-explorer path row):
   - on a results list, the query it was run for — *Results for "…"* (in-flow);
   - while the field is focused, a preview of which categories the search will cover — *Searching Artists · Albums · Songs* — so a stale selection from a past session is obvious before you type. This one **slides over** the list (doesn't push it down) and slides back up on blur.

## Changes

- **Settings** — `SearchCategory` enum + persisted `Set<SearchCategory>`; `applyToggle` keeps ≥1 category selected; migrates the old single `searchScope` key. `searchCategoriesStream` so the preview reacts live.
- **API** — `searchServer` maps the set 1:1 onto the `no*` flags, renders the `files` category when ticked, and stashes the query on the nav frame.
- **BrowserManager** — per-frame `searchTermCache` (mirrors `pathCache`, reverts on back-nav) + a `searchFocused` stream.
- **UI** — `browser_toolbar.dart`: checkbox dropdown that stays open while toggling; a `FocusNode` reports focus and is dropped the moment the browser leaves the home menu (fixes a stuck preview — the field otherwise keeps focus through back/navigation and even gets focus-restored on return). `browser.dart`: in-flow `_browserSubheader` (term/path) + a separate `_searchScopePreview` slide-over overlay (`AnimatedSlide` + `IgnorePointer`, so it never blocks the list).
- **l10n** — `searchCategory*`, `searchSubheaderResults`, `searchSubheaderCategories`.

## Behaviour notes

- **Default = legacy behaviour** (artists+albums+songs, `noFiles:true`); pinned by a unit test.
- **At least one category** stays selected; **`files`** is opt-in (filepath matches are noisy next to titles).
- Subheaders are mutually exclusive in practice (the focus preview only shows on the home menu); the album-detail `IndexedStack` swaps out the body, so nothing peeks through.

## Verification

- `flutter analyze lib` → **No issues found**.
- `flutter test test/singletons/search_scope_test.dart` → **5/5** (default-set legacy parity + `applyToggle` "keep at least one").
- `flutter test integration_test/search_test.dart` (emulator) → renders results, shows the *Results for …* subheader, and **focus clears after navigating** (regression guard for the stuck-preview bug).
- `flutter test integration_test/search_categories_test.dart` (emulator) → focus shows the category preview; dropdown shows a checkbox per category and **stays open** on toggle.
- Built + installed to a physical Galaxy S25 over Wi-Fi for manual testing.

### Incidental test fix (pre-existing breakage)

The integration tests mount the app as a bare `MaterialApp(home: MStreamApp())`, but since `730cf0d` (June 3) `MStreamApp.build` calls `AppLocalizations.of(context)` — with no delegate that returns null and crashes at startup, so these tests have been failing on `master` independent of this branch. I wired the real `localizationsDelegates`/`supportedLocales` into the two search test files; the other 8 share the breakage (follow-up). Each test mounts `MStreamApp` once per process (a second mount re-subscribes a single-subscription singleton stream), which is why the category scenario is its own file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
