### PR TITLE
perf: batch DisplayItem download-badge checks (drop constructor disk I/O)

### DIFF
--- a/lib/objects/display_item.dart
+++ b/lib/objects/display_item.dart
@@ -4,8 +4,6 @@ import 'package:flutter/material.dart';
 
 import 'server.dart';
 import 'metadata.dart';
-import '../singletons/browser_list.dart';
-import '../singletons/file_explorer.dart';
 import '../theme/velvet_theme.dart';
 import '../util/stream_url.dart';
 import '../l10n/app_localizations.dart';
@@ -174,41 +172,31 @@ class DisplayItem {
         hit(data?.split('/').last);
   }
 
+  // Plain data constructor. The on-device "downloaded" badge is no longer
+  // resolved here: this used to fire a per-item getDownloadDir() + File.exists()
+  // straight from the constructor, so building a folder of N file rows kicked
+  // off N disk probes AND up to N full browser re-emits (each present file
+  // called BrowserManager().updateStream()). BrowserManager now resolves the
+  // badge for a whole list in one batched pass — see [recheckDownloadedIn] and
+  // BrowserManager._resolveDownloadBadges.
   DisplayItem(
-      this.server, this.name, this.type, this.data, this.icon, this.subtext) {
-    // Check if file is saved on device
-    if (type == 'file') {
-      String downloadDirectory = server!.localname + data!;
-      FileExplorer()
-          .getDownloadDir(server!.storageMode, server!.storageBasePath)
-          .then((dir) {
-        if (dir == null) {
-          return;
-        }
-        String finalString = '${dir.path}/media/$downloadDirectory';
+      this.server, this.name, this.type, this.data, this.icon, this.subtext);
 
-        File(finalString).exists().then((ex) {
-          if (ex == true) {
-            downloadProgress = 100;
-            BrowserManager().updateStream();
-          }
-        });
-      });
-    }
-  }
-
-  // Re-evaluates whether this file exists at the server's CURRENT storage
-  // location and updates [downloadProgress] (100 = present, 0 = not). Unlike
-  // the constructor's one-shot check (which only ever sets 100), this also
-  // CLEARS a stale badge — so after a server's download location changes, a row
-  // that no longer has a local copy stops claiming it's downloaded. A row
-  // that's mid-download (1–99%) is left alone. The caller refreshes the
-  // browser stream once after a batch.
-  Future<void> recheckDownloaded() async {
+  // Re-evaluates whether this file exists under [dir] — the server's already-
+  // resolved download base, so the full path is <dir>/media/<localname>/... —
+  // and updates [downloadProgress] (100 = present, 0 = not). [dir] null means
+  // the location is currently unavailable (SD card out / folder deleted) and is
+  // treated as "no local copy". Also CLEARS a stale badge, so after a server's
+  // download location changes a row that no longer has a copy stops claiming
+  // one. A row that's mid-download (1–99%) is left alone.
+  //
+  // Takes a pre-resolved [dir] so a caller can resolve getDownloadDir() ONCE
+  // for a whole list (it's a platform-channel / stat call) and refresh the
+  // browser stream once after the batch, instead of paying that cost per row.
+  // See BrowserManager._resolveDownloadBadges.
+  Future<void> recheckDownloadedIn(Directory? dir) async {
     if (type != 'file' || server == null || data == null) return;
     if (downloadProgress > 0 && downloadProgress < 100) return;
-    final dir = await FileExplorer()
-        .getDownloadDir(server!.storageMode, server!.storageBasePath);
     bool present = false;
     if (dir != null) {
       present =

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -7,6 +7,7 @@ import '../singletons/server_list.dart';
 import '../singletons/settings.dart';
 import '../singletons/migration_manager.dart';
 import '../singletons/file_explorer.dart';
+import '../singletons/downloads.dart';
 import '../objects/display_item.dart';
 import '../objects/server.dart';
 import '../theme/velvet_theme.dart';
@@ -362,6 +363,11 @@ class BrowserManager {
       ..clear()
       ..addAll(newList);
 
+    // Re-attach any in-flight download to its new row instance (seed progress +
+    // re-point the tracker) BEFORE emitting, so re-opening a folder mid-download
+    // shows the progress bar immediately instead of a blank row.
+    DownloadManager().rebindActiveDownloads(newList);
+
     // Reset to top synchronously BEFORE emitting so the upcoming
     // rebuild lays out at offset 0 in a single frame. Doing this
     // via addPostFrameCallback paints the new list at the inherited
@@ -391,6 +397,7 @@ class BrowserManager {
     browserList
       ..clear()
       ..addAll(newList);
+    DownloadManager().rebindActiveDownloads(newList);
     _browserStream.sink.add(browserList);
     unawaited(_resolveDownloadBadges(newList));
   }

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -6,6 +6,7 @@ import 'package:rxdart/rxdart.dart';
 import '../singletons/server_list.dart';
 import '../singletons/settings.dart';
 import '../singletons/migration_manager.dart';
+import '../singletons/file_explorer.dart';
 import '../objects/display_item.dart';
 import '../objects/server.dart';
 import '../theme/velvet_theme.dart';
@@ -368,6 +369,12 @@ class BrowserManager {
     if (sc.hasClients) sc.jumpTo(0);
 
     _browserStream.sink.add(browserList);
+
+    // Resolve the on-device download badges for this list's file rows in one
+    // batched pass (replaces the per-item probe the DisplayItem constructor
+    // used to fire). Fire-and-forget: the list is already on screen and the
+    // badges flip in with a single re-emit once the disk checks finish.
+    unawaited(_resolveDownloadBadges(newList));
   }
 
   void updateStream() {
@@ -385,6 +392,7 @@ class BrowserManager {
       ..clear()
       ..addAll(newList);
     _browserStream.sink.add(browserList);
+    unawaited(_resolveDownloadBadges(newList));
   }
 
   // Re-check the on-device download badge for cached file rows against their
@@ -408,9 +416,39 @@ class BrowserManager {
     for (final item in browserList) {
       if (item.type == 'file' && match(item)) items.add(item);
     }
-    if (items.isEmpty) return;
-    await Future.wait(items.map((i) => i.recheckDownloaded()));
-    updateStream();
+    await _resolveDownloadBadges(items);
+  }
+
+  // Resolve the on-device "downloaded" badge for the file rows in [items],
+  // then re-emit the browser once — but only if a badge actually changed, so a
+  // list with no local copies doesn't trigger a redundant full-list rebuild.
+  //
+  // Groups rows by their server's storage location so getDownloadDir() (a
+  // platform-channel / stat call) runs ONCE per distinct location instead of
+  // once per row — the per-item cost the DisplayItem constructor used to pay.
+  // Within a location the File.exists() probes run in parallel. No-ops when
+  // there are no file rows.
+  Future<void> _resolveDownloadBadges(Iterable<DisplayItem> items) async {
+    final byLocation = <(String, String?), List<DisplayItem>>{};
+    for (final i in items) {
+      if (i.type != 'file' || i.server == null || i.data == null) continue;
+      final key = (i.server!.storageMode, i.server!.storageBasePath);
+      (byLocation[key] ??= <DisplayItem>[]).add(i);
+    }
+    if (byLocation.isEmpty) return;
+
+    var changed = false;
+    for (final entry in byLocation.entries) {
+      final (mode, base) = entry.key;
+      final dir = await FileExplorer().getDownloadDir(mode, base);
+      final rows = entry.value;
+      final before = [for (final i in rows) i.downloadProgress];
+      await Future.wait(rows.map((i) => i.recheckDownloadedIn(dir)));
+      for (var k = 0; k < rows.length; k++) {
+        if (rows[k].downloadProgress != before[k]) changed = true;
+      }
+    }
+    if (changed) updateStream();
   }
 
   void popBrowser() {

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -145,6 +145,29 @@ class DownloadManager {
     }
   }
 
+  /// Re-attach in-flight downloads to a freshly-built list of browser rows.
+  ///
+  /// When a directory is re-fetched (e.g. navigating out and back in), its
+  /// DisplayItems are NEW instances starting at 0 progress, while the active
+  /// download still points at the discarded original row — so its inline bar
+  /// vanishes. For each row matching an in-flight tracker (by serverName +
+  /// filepath), seed the row's progress and re-point the tracker at it so
+  /// subsequent ticks drive the row the user is actually looking at. Cheap
+  /// no-op when nothing is downloading. (Same 5% quantization as _onUpdate.)
+  void rebindActiveDownloads(Iterable<DisplayItem> rows) {
+    if (downloadMap.isEmpty) return;
+    final byPath = <String, DownloadTracker>{
+      for (final t in downloadMap.values) t.filePath: t,
+    };
+    for (final r in rows) {
+      if (r.type != 'file' || r.server == null || r.data == null) continue;
+      final t = byPath[r.server!.localname + r.data!];
+      if (t == null) continue;
+      r.downloadProgress = ((t.progress.clamp(0.0, 1.0) * 100).round() ~/ 5) * 5;
+      t.referenceDisplayItem = r;
+    }
+  }
+
   Future<void> downloadOneFile(String downloadUrl, String serverName,
       String filepath,
       {DisplayItem? referenceItem}) async {


### PR DESCRIPTION
## Problem

The `DisplayItem` constructor fired a per-item `getDownloadDir()` + `File.exists()` for every `type == 'file'` row, and **each present file called `BrowserManager().updateStream()`**:

```dart
DisplayItem(...) {
  if (this.type == 'file') {
    FileExplorer().getDownloadDir(...).then((dir) {
      File('${dir.path}/media/...').exists().then((ex) {
        if (ex == true) { downloadProgress = 100; BrowserManager().updateStream(); }
      });
    });
  }
}
```

Opening a folder of **N** tracks therefore kicked off **N concurrent disk probes** — each re-resolving the *same* download directory through a platform channel — plus **up to N full browser re-emits** (each re-emit rebuilds the whole list). This is the biggest perceived-jank source when opening large file lists, and doing async work in a constructor is an anti-pattern.

## Fix

Replace the constructor side-effect with a single batched pass at the points where a list actually loads.

- **`DisplayItem`** — constructor is now pure data. `recheckDownloaded()` → **`recheckDownloadedIn(Directory? dir)`**, taking an already-resolved download base so the dir is resolved once for a whole list rather than once per row. Badge semantics are unchanged (sets 100/0, clears a stale badge, leaves a mid-download 1–99 row alone).
- **`BrowserManager._resolveDownloadBadges(items)`** — groups file rows by storage location, resolves `getDownloadDir()` **once per location**, runs the `File.exists()` probes in **parallel**, and re-emits the browser **once — and only if a badge actually changed** (so a list with no local copies skips a redundant full-list rebuild).
- Wired into the two list-load chokepoints (`addListToStack`, `replaceTop`). The existing `_refreshDownloadStatus` (server-edit / migration-done refresh) now routes through the same helper, so it gets the once-per-location optimization too instead of N `getDownloadDir()` calls.
- Removing the `display_item → browser_list / file_explorer` imports also breaks an import cycle.

**Net for an N-file folder:** `getDownloadDir()` N → 1 (per location), and browser re-emits up to N → at most 1.

## Why it's behaviour-preserving

`downloadProgress` is only *rendered* in the browser list (the green left-edge bar) and the Downloads screen (fed by active-download ticks, not the constructor). Album-detail song rows are file items but never read `downloadProgress`, and every browser file list flows through `addListToStack` / `replaceTop`.

## Verification

- `flutter analyze` — 0 errors project-wide; the two changed files report no issues.
- `flutter test test/singletons/browser_load_test.dart` — passes.

Part of the modernization audit follow-ups (issue 2). Independent of #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)