### PR TITLE
perf: bound Image.network art decode with cacheWidth

### DIFF
--- a/lib/objects/display_item.dart
+++ b/lib/objects/display_item.dart
@@ -8,6 +8,7 @@ import '../singletons/browser_list.dart';
 import '../singletons/file_explorer.dart';
 import '../theme/velvet_theme.dart';
 import '../util/stream_url.dart';
+import '../util/image_cache.dart';
 import '../l10n/app_localizations.dart';
 import '../l10n/enum_labels.dart';
 
@@ -55,6 +56,7 @@ class DisplayItem {
           width: size,
           height: size,
           fit: BoxFit.cover,
+          cacheWidth: artCacheSize(size),
           errorBuilder: (_, _, _) => _albumThumbPlaceholder(size, radius),
         ),
       );

--- a/lib/screens/album_detail_view.dart
+++ b/lib/screens/album_detail_view.dart
@@ -24,6 +24,7 @@ import '../util/ambient_color.dart';
 import '../util/media_format.dart';
 import '../util/queue_actions.dart';
 import '../util/stream_url.dart';
+import '../util/image_cache.dart';
 import '../widgets/player_panel.dart';
 
 /// Ink on top of the accent-filled Play button: dark espresso on bright accents,
@@ -323,6 +324,7 @@ class _AlbumDetailViewState extends State<AlbumDetailView> {
                     child: artUrl != null
                         ? Image.network(artUrl,
                             fit: BoxFit.cover,
+                            cacheWidth: artCacheSize(86),
                             errorBuilder: (_, _, _) =>
                                 albumArtFallback(iconSize: 30))
                         : albumArtFallback(iconSize: 30),

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import '../l10n/app_localizations.dart';
 import '../theme/velvet_theme.dart';
 import '../util/media_format.dart';
+import '../util/image_cache.dart';
 
 /// Song-info screen shown from the queue row's Info action: a blurred album-art
 /// backdrop, a hero cover, the title / artist / album·year, a track/disc line,
@@ -88,6 +89,10 @@ class MetadataScreen extends StatelessWidget {
                     art,
                     fit: BoxFit.cover,
                     alignment: Alignment.topCenter,
+                    // Heavily blurred (sigma 48), so a small decode is visually
+                    // indistinguishable from full-res and avoids holding a
+                    // screen-sized bitmap just to smear it.
+                    cacheWidth: 256,
                     errorBuilder: (_, _, _) => const SizedBox.shrink(),
                   ),
                 ),
@@ -138,6 +143,7 @@ class MetadataScreen extends StatelessWidget {
                         ? Image.network(
                             art,
                             fit: BoxFit.cover,
+                            cacheWidth: artCacheSize(224),
                             errorBuilder: (_, _, _) =>
                                 albumArtFallback(iconSize: 60),
                           )

--- a/lib/util/image_cache.dart
+++ b/lib/util/image_cache.dart
@@ -1,0 +1,18 @@
+import 'dart:ui' as ui;
+
+/// Physical-pixel decode dimension for showing album art at [logicalSize]
+/// logical pixels. Pass it as `Image.network(..., cacheWidth: artCacheSize(n))`
+/// so the engine decodes the art at display resolution instead of holding the
+/// full-resolution source bitmap in the image cache — cutting memory use and
+/// decode jank on art-heavy scrolling lists (the album grid, the queue, browser
+/// thumbnails).
+///
+/// Scales by the device pixel ratio so the decode stays crisp on high-density
+/// screens. Reads the implicit view's DPR rather than a MediaQuery so it also
+/// works from the context-free render helpers (DisplayItem.getAlbumThumb, the
+/// player panel's shared _albumArt). Falls back to the logical size when no view
+/// is attached yet — the decode is still bounded, just potentially a touch soft.
+int artCacheSize(double logicalSize) {
+  final dpr = ui.PlatformDispatcher.instance.implicitView?.devicePixelRatio ?? 1.0;
+  return (logicalSize * dpr).round();
+}

--- a/lib/widgets/album_grid.dart
+++ b/lib/widgets/album_grid.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import '../objects/display_item.dart';
 import '../theme/velvet_theme.dart';
 import '../util/stream_url.dart';
+import '../util/image_cache.dart';
 
 class AlbumGrid extends StatelessWidget {
   final List<DisplayItem> items;
@@ -38,16 +39,20 @@ class AlbumGrid extends StatelessWidget {
   static int columnsFor(double width) =>
       width > 600 ? 4 : (width > 400 ? 3 : 2);
 
-  static double rowHeightFor(double width) {
+  static double itemWidthFor(double width) {
     final cols = columnsFor(width);
-    final itemWidth = (width - padHorizontal * 2 - spacing * (cols - 1)) / cols;
-    return itemWidth / aspectRatio;
+    return (width - padHorizontal * 2 - spacing * (cols - 1)) / cols;
   }
+
+  static double rowHeightFor(double width) => itemWidthFor(width) / aspectRatio;
 
   @override
   Widget build(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
     final crossAxisCount = columnsFor(width);
+    // Decode cover art at the card's pixel width (computed once for the grid),
+    // not the full source resolution — see artCacheSize.
+    final cacheW = artCacheSize(itemWidthFor(width));
 
     return Container(
       color: VelvetColors.bg,
@@ -66,6 +71,7 @@ class AlbumGrid extends StatelessWidget {
           return _AlbumCard(
             item: item,
             onTap: () => onTap(i),
+            cacheWidth: cacheW,
           );
         },
       ),
@@ -76,8 +82,10 @@ class AlbumGrid extends StatelessWidget {
 class _AlbumCard extends StatelessWidget {
   final DisplayItem item;
   final VoidCallback onTap;
+  final int cacheWidth;
 
-  const _AlbumCard({required this.item, required this.onTap});
+  const _AlbumCard(
+      {required this.item, required this.onTap, required this.cacheWidth});
 
   @override
   Widget build(BuildContext context) {
@@ -153,6 +161,7 @@ class _AlbumCard extends StatelessWidget {
       return Image.network(
         url,
         fit: BoxFit.cover,
+        cacheWidth: cacheWidth,
         errorBuilder: (_, _, _) => _NoArtPlaceholder(),
         loadingBuilder: (_, child, prog) => prog == null
             ? child

--- a/lib/widgets/player_panel.dart
+++ b/lib/widgets/player_panel.dart
@@ -15,6 +15,7 @@ import '../singletons/settings.dart';
 import '../theme/velvet_theme.dart';
 import '../util/ambient_color.dart';
 import '../util/media_format.dart';
+import '../util/image_cache.dart';
 import 'cast_picker_sheet.dart';
 import 'more_actions_sheet.dart';
 import 'queue_list.dart';
@@ -713,6 +714,7 @@ class _TopSmall extends StatelessWidget {
                         child: url != null
                             ? Image.network(url,
                                 fit: BoxFit.cover,
+                                cacheWidth: artCacheSize(44),
                                 errorBuilder: (_, _, _) => _fallback(20))
                             : _fallback(20)),
                   ),
@@ -1375,7 +1377,9 @@ Widget _albumArt(String? url,
       borderRadius: BorderRadius.circular(radius),
       child: url != null
           ? Image.network(url,
-              fit: BoxFit.cover, errorBuilder: (_, _, _) => fallback())
+              fit: BoxFit.cover,
+              cacheWidth: artCacheSize(size),
+              errorBuilder: (_, _, _) => fallback())
           : fallback(),
     ),
   );

--- a/lib/widgets/queue_list.dart
+++ b/lib/widgets/queue_list.dart
@@ -10,6 +10,7 @@ import '../singletons/downloads.dart';
 import '../singletons/media.dart';
 import '../theme/velvet_theme.dart';
 import '../util/media_format.dart';
+import '../util/image_cache.dart';
 
 /// Active-row state — which queue slot is playing, and whether it's playing —
 /// pushed down to each row (see [QueueList.build]) so a track advancing rebuilds
@@ -263,6 +264,7 @@ class _QueueRow extends StatelessWidget {
                       child: url != null
                           ? Image.network(url,
                               fit: BoxFit.cover,
+                              cacheWidth: artCacheSize(40),
                               errorBuilder: (_, _, _) => _artFallback())
                           : _artFallback(),
                     ),


### PR DESCRIPTION
## Problem

Album art was decoded at **full source resolution** into the image cache regardless of the box it's displayed in: a 40px queue thumbnail or a 48px browser row held a full-size bitmap, and the album grid decoded every cell's cover at native size. On art-heavy scrolling lists this means avoidable image-cache memory pressure and decode jank.

## Fix

New `util/image_cache.dart` exposes `artCacheSize(logicalSize)` → the display size × device pixel ratio (read from the implicit view's DPR, so it works from the context-free render helpers `DisplayItem.getAlbumThumb` and the player's shared `_albumArt`). It's passed as `Image.network(cacheWidth: …)` at each art site so the engine decodes at display resolution instead of source resolution:

| Site | Box | 
|---|---|
| browser row thumbnail (`getAlbumThumb`) | 48px |
| album grid cell | per-card width (computed once per grid via new `itemWidthFor`) |
| queue row | 40px |
| mini-player | 44px |
| large now-playing art (`_albumArt`) | its `size` |
| album-detail banner | 86px |
| metadata hero | 224px |
| metadata backdrop | fixed `cacheWidth: 256` — heavily blurred (sigma 48), so a small decode is visually identical and avoids a screen-sized bitmap |

## Notes / safety

- **Display size is unchanged everywhere.** Every touched `Image.network` has an explicit box and `BoxFit.cover`; `cacheWidth` only caps decode resolution. `cacheWidth` alone (not `cacheHeight`) preserves the square source aspect ratio.
- **`DisplayItem.getImage()` is deliberately left untouched** — it's the unsized `ListTile` leading on file rows, so adding `cacheWidth` would change its intrinsic size and shift layout, and it only ever loads already-small `compress=s` art.
- `AlbumGrid.rowHeightFor` was refactored to delegate to the new `itemWidthFor` (identical math; the letter-strip offset calc that calls it is unaffected).

## Verification

`flutter analyze` — 0 errors project-wide (the 7 changed files report no issues).

Modernization-audit follow-up (issue 3). Independent of #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)