### PR TITLE
fix: don't use BuildContext across an await in the server-switch handler

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -450,7 +450,12 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
                                       throwErr: true);
                                   await ServerManager().callAfterEditServer();
                                 } catch (err) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
+                                  // Use the app-wide messenger key, not
+                                  // ScaffoldMessenger.of(context): this runs
+                                  // after two awaits, by which point the
+                                  // captured context may be unmounted (the
+                                  // StreamBuilder rebuilt / the menu closed).
+                                  rootMessengerKey.currentState?.showSnackBar(
                                       SnackBar(
                                           content: Text(
                                               l.mainFailedToConnect)));


### PR DESCRIPTION
## Problem

The server-switcher `PopupMenuButton`'s `onSelected` showed its failure toast with `ScaffoldMessenger.of(context)` from the `catch` block — but that runs **after two awaits** (`getServerPaths` + `callAfterEditServer`):

```dart
onSelected: (int selectedServerIndex) async {
  if (selectedServerIndex > -1) {
    ServerManager().changeCurrentServer(selectedServerIndex);
    try {
      await ServerManager().getServerPaths(..., throwErr: true);
      await ServerManager().callAfterEditServer();
    } catch (err) {
      ScaffoldMessenger.of(context).showSnackBar(...);  // ← stale context
    }
  }
  ...
}
```

By the time the `catch` runs, the captured `StreamBuilder` context may be unmounted (the menu closed / the builder rebuilt on the server-list stream). Looking the messenger up from that stale context can throw instead of showing the toast — the `use_build_context_synchronously` the analyzer flags here. This is the one genuine latent bug surfaced by the modernization audit.

## Fix

Use the app-wide `rootMessengerKey` (the `MaterialApp`'s `scaffoldMessengerKey`, already used a few lines up for the cast-error toast) instead of resolving the messenger from the stale context. `l` (`AppLocalizations`) is captured before the await, so it's unaffected.

One-line change + an explaining comment.

## Verification

`flutter analyze lib/main.dart` no longer reports `use_build_context_synchronously` at the call site; 0 errors. (The unrelated `library_private_types_in_public_api` on `createState` is left for the broader lint-cleanup follow-up to keep this PR scoped to the bug.)

Modernization-audit follow-up (issue 4). Independent of #53 / #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)