### PR TITLE
perf: reuse a shared http.Client for one-shot API calls

### DIFF
--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -5,7 +5,7 @@ import 'package:audio_service/audio_service.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:mstream_music/main.dart';
 import 'package:rxdart/rxdart.dart';
-import 'package:http/http.dart' as http;
+import '../util/http_client.dart';
 import 'playback_backend.dart';
 import 'local_playback_backend.dart';
 import 'dlna_playback_backend.dart';
@@ -728,7 +728,7 @@ class AudioPlayerHandler extends BaseAudioHandler
 
       Map<String, dynamic> decoded;
       try {
-        final res = await http.post(
+        final res = await appHttpClient.post(
           Uri.parse(autoDJServer!.url).resolve('/api/v1/db/random-songs'),
           headers: {
             'Content-Type': 'application/json',

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -7,6 +7,7 @@ import '../objects/display_item.dart';
 import '../objects/metadata.dart';
 import 'media.dart';
 import '../util/stream_url.dart';
+import '../util/http_client.dart';
 import '../theme/velvet_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as path;
@@ -39,7 +40,7 @@ class ApiManager {
       body['ignoreVPaths'] = ignoreVPaths;
     }
 
-    final response = await http.post(
+    final response = await appHttpClient.post(
       Uri.parse(server.url).resolve('/api/v1/db/genres'),
       body: jsonEncode(body),
       headers: {
@@ -66,7 +67,7 @@ class ApiManager {
     final body = <String, dynamic>{'playlist': filepaths};
     if (expiresInDays != null) body['time'] = expiresInDays;
 
-    final response = await http.post(
+    final response = await appHttpClient.post(
       uri,
       body: json.encode(body),
       headers: {

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -13,7 +13,7 @@ import '../util/insecure_tls_channel.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as path;
 import 'package:rxdart/rxdart.dart';
-import 'package:http/http.dart' as http;
+import '../util/http_client.dart';
 
 class ServerManager {
   final List<Server> serverList = [];
@@ -180,7 +180,7 @@ class ServerManager {
       return;
     }
     try {
-      var response = await http
+      var response = await appHttpClient
           .get(Uri.parse(server.url).resolve('/api/v1/ping'), headers: {
         'Content-Type': 'application/json',
         'x-access-token': server.jwt ?? ''

--- a/lib/util/http_client.dart
+++ b/lib/util/http_client.dart
@@ -1,0 +1,16 @@
+import 'package:http/http.dart' as http;
+
+/// App-wide [http.Client] reused for one-shot API calls — the genre list, share
+/// links, the server-path / ping probe, and AutoDJ top-ups. The package:http
+/// convenience helpers (`http.get` / `http.post`) open AND tear down a fresh
+/// connection per call, paying a full TLS handshake every time; reusing a single
+/// Client lets those requests share pooled keep-alive connections.
+///
+/// Respects `HttpOverrides.global` (the self-signed-cert override installed in
+/// main's _startApp): the underlying HttpClient is created lazily on first use,
+/// which is always after startup. Lives for the app's lifetime — like the
+/// manager singletons — so it is never closed.
+///
+/// NOT used by `ApiManager.makeServerCall`: that deliberately creates a per-call
+/// Client so closing it aborts an in-flight browse (Back-to-cancel).
+final http.Client appHttpClient = http.Client();


### PR DESCRIPTION
## Problem

The `package:http` convenience helpers (`http.get` / `http.post`) open **and tear down a fresh connection per call** — a full TLS handshake every time, with no keep-alive. Four call sites used them, two of which fire on hot paths:

- `ApiManager.getGenres` / `sharePlaylist`
- `ServerManager.getServerPaths` — the per-server **ping, fired in parallel at startup** for every configured server
- `AudioPlayerHandler.autoDJ` — the random-songs top-up, **during playback** (up to several calls per top-up)

## Fix

New `util/http_client.dart` exposes a single app-wide `appHttpClient`; the four call sites route through it so they share **pooled keep-alive connections** instead of reconnecting each time.

- Respects `HttpOverrides.global` (the self-signed-cert override) — the underlying `HttpClient` is created lazily on first use, always after startup installs the override.
- App-lifetime singleton, never closed (like the manager singletons).
- In `audio_stuff.dart` / `server_list.dart` the now-unused `package:http` import is replaced by the new one; `api.dart` keeps its `http` import because `makeServerCall` still needs `http.Client`/`http.Response`.

### Deliberately NOT changed
- **`ApiManager.makeServerCall`** keeps its per-call `http.Client` on purpose — closing that client is how Back cancels an in-flight browse, so it can't share a long-lived one.
- **`util/server_compat.dart`** already supports client injection — left as-is.

## Scope note — `compute()` JSON decode deferred

Issue 5 also nominally covered offloading browse-response `jsonDecode` to a `compute()` isolate. I assessed it and **deferred it deliberately**:

1. It only moves the *decode* half off the UI isolate — the `DisplayItem`/widget-build loop that follows (with `Icon` widgets) **must** stay on the UI isolate, so a large-list navigation still janks during the build.
2. The decoded object graph is copied back across the isolate boundary, which tempers the gain.
3. The real fix for large-list jank is incremental/paginated list building — a separate, larger effort.

So this PR ships the clean, complete, low-risk half (connection reuse). Happy to follow up on incremental building if wanted.

## Verification

`flutter analyze` — 0 errors project-wide; no new issues.

Modernization-audit follow-up (issue 5, networking half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)