### PR TITLE
chore: lint sweep — route print() to appLog + clear manual-fix lints

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -128,7 +128,7 @@ class MStreamApp extends StatefulWidget {
   const MStreamApp({super.key});
 
   @override
-  _MStreamAppState createState() => _MStreamAppState();
+  State<MStreamApp> createState() => _MStreamAppState();
 }
 
 class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -67,7 +67,7 @@ class AudioPlayerHandler extends BaseAudioHandler
 
   Server? autoDJServer;
 
-  var jsonAutoDJIgnoreList;
+  dynamic jsonAutoDJIgnoreList;
 
   // Session-only: the Camelot anchor for harmonic mixing. Locked on
   // the first DJ-picked song with a recognised key (after that, every
@@ -165,7 +165,7 @@ class AudioPlayerHandler extends BaseAudioHandler
         await params.bands[i].setGain(saved[i]);
       }
     } catch (e) {
-      print("EQ apply error: $e");
+      appLog('[eq] apply error: $e');
     }
   }
 
@@ -322,7 +322,10 @@ class AudioPlayerHandler extends BaseAudioHandler
     });
   }
 
+  // Re-seed the inherited customState with a typed CustomEvent default (it
+  // carries the AutoDJ server). Deliberately shadows BaseAudioHandler.customState.
   @override
+  // ignore: overridden_fields
   BehaviorSubject<dynamic> customState =
       BehaviorSubject<dynamic>.seeded(CustomEvent(null));
 
@@ -366,14 +369,14 @@ class AudioPlayerHandler extends BaseAudioHandler
   }
 
   @override
-  Future<void> addQueueItem(MediaItem item) async {
-    queue.add(queue.value..add(item));
+  Future<void> addQueueItem(MediaItem mediaItem) async {
+    queue.add(queue.value..add(mediaItem));
     // The backend extracts the playable URI (local backend) or builds renderer
     // metadata (cast backend) from the item itself. The offline-file detection
     // (File.existsSync + Uri.file) from the server-download-folder PR now lives
     // in LocalPlaybackBackend._uriFor.
-    await _backend.addSource(item);
-    appLog('[queue] add: ${item.title} (now ${queue.value.length})');
+    await _backend.addSource(mediaItem);
+    appLog('[queue] add: ${mediaItem.title} (now ${queue.value.length})');
   }
 
   @override
@@ -409,7 +412,7 @@ class AudioPlayerHandler extends BaseAudioHandler
   }
 
   @override
-  Future<void> setShuffleMode(AudioServiceShuffleMode doesntMatter) async {
+  Future<void> setShuffleMode(AudioServiceShuffleMode shuffleMode) async {
     if (_backend.shuffleEnabled == true) {
       await _backend.setShuffleEnabled(false);
       await super.setShuffleMode(AudioServiceShuffleMode.none);
@@ -422,7 +425,7 @@ class AudioPlayerHandler extends BaseAudioHandler
   }
 
   @override
-  Future<void> setRepeatMode(AudioServiceRepeatMode doesntMatter) async {
+  Future<void> setRepeatMode(AudioServiceRepeatMode repeatMode) async {
     if (_backend.repeatAll == true) {
       await _backend.setRepeatAll(false);
       await super.setRepeatMode(AudioServiceRepeatMode.none);
@@ -435,22 +438,22 @@ class AudioPlayerHandler extends BaseAudioHandler
   }
 
   @override
-  Future<void> removeQueueItem(MediaItem i) async {
-    await super.removeQueueItem(i);
+  Future<void> removeQueueItem(MediaItem mediaItem) async {
+    await super.removeQueueItem(mediaItem);
     // TODO: See removeQueueItemAt
   }
 
   @override
-  Future<void> removeQueueItemAt(int i) async {
-    await super.removeQueueItemAt(i);
+  Future<void> removeQueueItemAt(int index) async {
+    await super.removeQueueItemAt(index);
     // Update the queue BEFORE the backend. removeSourceAt makes the backend emit
     // its new currentIndex, and the currentIndexStream listener re-derives the
     // now-playing item as queue.value[index]. If the queue still held the
     // removed item, the wrong row would briefly render as the active/playing row
     // (a flash in the accent colour) before correcting — same root cause as the
     // reorder flash. Reordering keeps the queue and the emitted index in sync.
-    queue.add(queue.value..removeAt(i));
-    await _backend.removeSourceAt(i);
+    queue.add(queue.value..removeAt(index));
+    await _backend.removeSourceAt(index);
   }
 
   @override

--- a/lib/media/common.dart
+++ b/lib/media/common.dart
@@ -1,4 +1,6 @@
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, avoid_print
+// Dev-only LoggingAudioHandler decorator (not in the production handler chain);
+// its _log() prints by design.
 import 'package:audio_service/audio_service.dart';
 import 'package:rxdart/rxdart.dart';
 

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -15,6 +15,7 @@ import '../l10n/app_localizations.dart';
 import '../objects/server.dart';
 import '../singletons/file_explorer.dart';
 import '../singletons/server_list.dart';
+import '../singletons/log_manager.dart';
 import '../singletons/browser_list.dart';
 import '../singletons/migration_manager.dart';
 import '../singletons/downloads.dart';
@@ -53,9 +54,7 @@ class MyCustomForm extends StatefulWidget {
   const MyCustomForm({super.key, this.editThisServer});
 
   @override
-  MyCustomFormState createState() {
-    return MyCustomFormState(editThisServer: editThisServer);
-  }
+  MyCustomFormState createState() => MyCustomFormState();
 }
 
 // Create a corresponding State class. This class will hold the data related to
@@ -107,9 +106,6 @@ class MyCustomFormState extends State<MyCustomForm> {
   String? _testResult;
   bool? _testSuccess;
 
-  final int? editThisServer;
-  MyCustomFormState({this.editThisServer}) : super();
-
   @override
   @protected
   @mustCallSuper
@@ -118,7 +114,7 @@ class MyCustomFormState extends State<MyCustomForm> {
 
     bool isEdit = false;
     try {
-      Server s = ServerManager().serverList[editThisServer ?? -1];
+      Server s = ServerManager().serverList[widget.editThisServer ?? -1];
       _urlCtrl.text = s.url;
       _usernameCtrl.text = s.username ?? '';
       _passwordCtrl.text = s.password ?? '';
@@ -132,7 +128,10 @@ class MyCustomFormState extends State<MyCustomForm> {
       if ((s.username ?? '').isEmpty && (s.password ?? '').isEmpty) {
         _publicAccess = true;
       }
-    } catch (err) {}
+    } catch (err) {
+      // No server at that index (e.g. the "add server" flow) — leave the form
+      // blank.
+    }
 
     // Existing server: keep its folder as-is (it maps to already-downloaded
     // files). New server: auto-derive the folder from the URL as the user
@@ -213,7 +212,9 @@ class MyCustomFormState extends State<MyCustomForm> {
   bool _localNameTaken(String name) {
     final list = ServerManager().serverList;
     for (int i = 0; i < list.length; i++) {
-      if (i == editThisServer) continue; // ignore the server being edited
+      if (i == widget.editThisServer) {
+        continue; // ignore the server being edited
+      }
       if (list[i].localname == name) return true;
     }
     return false;
@@ -465,7 +466,10 @@ class MyCustomFormState extends State<MyCustomForm> {
         saveServer(lol);
         return;
       }
-    } catch (err) {}
+    } catch (err) {
+      // Ping probe failed (unreachable / non-200) — fall through to the login
+      // attempt below.
+    }
 
     // Public access mode: no credentials to try, so surface the
     // failure clearly instead of falling through to a login attempt
@@ -498,12 +502,14 @@ class MyCustomFormState extends State<MyCustomForm> {
       // Save
       saveServer(lol, res['token']);
     } catch (err) {
-      print(err);
+      appLog('[add-server] login failed: $err');
       try {
         setState(() {
           submitPending = false;
         });
-      } catch (e) {}
+      } catch (e) {
+        // Widget already disposed — nothing to update.
+      }
 
       ScaffoldMessenger.of(context)
           .showSnackBar(SnackBar(content: Text(l.failedToLogin)));
@@ -740,9 +746,11 @@ class MyCustomFormState extends State<MyCustomForm> {
 
     bool shouldUpdate = false;
     try {
-      ServerManager().serverList[editThisServer ?? -1];
+      ServerManager().serverList[widget.editThisServer ?? -1];
       shouldUpdate = true;
-    } catch (err) {}
+    } catch (err) {
+      // No existing entry at that index → treat as a new server.
+    }
 
     // Don't persist credentials that the user wasn't allowed to edit:
     // when the public-access toggle is on, the username/password
@@ -764,7 +772,7 @@ class MyCustomFormState extends State<MyCustomForm> {
         : null;
 
     if (shouldUpdate) {
-      final s = ServerManager().serverList[editThisServer!];
+      final s = ServerManager().serverList[widget.editThisServer!];
       // If the storage target is changing, cancel in-flight downloads first so
       // none land at the old location after the switch (they'd be stranded).
       if (s.storageMode != _storageMode ||
@@ -794,7 +802,7 @@ class MyCustomFormState extends State<MyCustomForm> {
       s.allowSelfSigned = _allowSelfSigned;
       s.storageBasePath = basePath;
       ServerManager()
-          .editServer(editThisServer!, _urlCtrl.text, username, password);
+          .editServer(widget.editThisServer!, _urlCtrl.text, username, password);
       await ServerManager().getServerPaths(s);
       await ServerManager().callAfterEditServer();
       // The browser may be showing this server's files with download badges

--- a/lib/screens/manage_server.dart
+++ b/lib/screens/manage_server.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import '../l10n/app_localizations.dart';
 import '../objects/server.dart';
 import '../singletons/server_list.dart';
+import '../singletons/log_manager.dart';
 import '../theme/velvet_theme.dart';
 import 'add_server.dart';
 
@@ -229,7 +230,7 @@ class DeleteServerDialog extends StatefulWidget {
   DeleteServerDialog({super.key, required this.cServer});
 
   @override
-  _DeleteServerDialogState createState() => _DeleteServerDialogState();
+  State<DeleteServerDialog> createState() => _DeleteServerDialogState();
 }
 
 class _DeleteServerDialogState extends State<DeleteServerDialog> {
@@ -267,7 +268,9 @@ class _DeleteServerDialogState extends State<DeleteServerDialog> {
             try {
               ServerManager().removeServer(
                   widget.cServer, isRemoveFilesOnServerDeleteSelected);
-            } catch (err) {}
+            } catch (err) {
+              appLog('[server] remove failed: $err');
+            }
             Navigator.of(context).pop();
           },
         ),

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -148,13 +148,13 @@ class ApiManager {
 
   Future<void> getRecursiveFiles(String directory,
       {Server? useThisServer}) async {
-    var res;
+    dynamic res;
     try {
       res = await makeServerCall(useThisServer,
           '/api/v1/file-explorer/recursive', {"directory": directory}, 'POST');
     } catch (err) {
       // TODO: Handle Errors
-      print(err);
+      appLog('[api] getRecursiveFiles failed: $err');
       return;
     }
 
@@ -182,13 +182,13 @@ class ApiManager {
   }
 
   Future<void> getPlaylists({Server? useThisServer}) async {
-    var res;
+    dynamic res;
     try {
       res = await makeServerCall(
           useThisServer, '/api/v1/playlist/getall', {}, 'GET');
     } catch (err) {
       // TODO: Handle Errors
-      print(err);
+      appLog('[api] getPlaylists failed: $err');
       return;
     }
 
@@ -200,11 +200,11 @@ class ApiManager {
   /// back-stack frame) — used after a create / rename so the list updates
   /// without pushing a navigation entry.
   Future<void> refreshPlaylists() async {
-    var res;
+    dynamic res;
     try {
       res = await makeServerCall(null, '/api/v1/playlist/getall', {}, 'GET');
     } catch (err) {
-      print(err);
+      appLog('[api] refreshPlaylists failed: $err');
       return;
     }
     BrowserManager()
@@ -233,7 +233,7 @@ class ApiManager {
           {'playlistname': playlistId}, 'POST', cancelable: false);
     } catch (err) {
       // TODO: Handle Errors
-      print(err);
+      appLog('[api] removePlaylist failed: $err');
       return;
     }
 
@@ -285,7 +285,7 @@ class ApiManager {
             ServerManager().currentServer,
             e['name'],
             'file',
-            '/' + e['filepath'],
+            '/${e['filepath']}',
             Icon(Icons.music_note, color: VelvetColors.accent),
             'song');
         newItem.altAlbumArt = e['album_art_file'];
@@ -314,17 +314,17 @@ class ApiManager {
       // …" subheader (and it reverts on back-nav, like the file-explorer path).
       BrowserManager().addListToStack(newList, searchTerm: search);
     } catch (err) {
-      print(err);
+      appLog('[api] searchServer failed: $err');
     }
   }
 
   Future<void> getAlbums({Server? useThisServer}) async {
-    var res;
+    dynamic res;
     try {
       res = await makeServerCall(useThisServer, '/api/v1/db/albums', {}, 'GET');
     } catch (err) {
       // TODO: Handle Errors
-      print(err);
+      appLog('[api] getAlbums failed: $err');
       return;
     }
 
@@ -373,7 +373,7 @@ class ApiManager {
           useThisServer,
           e['filepath'],
           'file',
-          '/' + e['filepath'],
+          '/${e['filepath']}',
           Icon(Icons.music_note, color: VelvetColors.accent),
           null);
 
@@ -390,7 +390,7 @@ class ApiManager {
       newList = await fetchAlbumSongs(album, useThisServer: useThisServer);
     } catch (err) {
       // TODO: Handle Errors
-      print(err);
+      appLog('[api] getAlbumSongs failed: $err');
       return;
     }
 
@@ -398,13 +398,13 @@ class ApiManager {
   }
 
   Future<void> getRecentlyAdded({Server? useThisServer}) async {
-    var res;
+    dynamic res;
     try {
       res = await makeServerCall(
           useThisServer, '/api/v1/db/recent/added', {'limit': 100}, 'POST');
     } catch (err) {
       // TODO: Handle Errors
-      print(err);
+      appLog('[api] getRecentlyAdded failed: $err');
       return;
     }
 
@@ -418,7 +418,7 @@ class ApiManager {
           useThisServer,
           e['filepath'],
           'file',
-          '/' + e['filepath'],
+          '/${e['filepath']}',
           Icon(Icons.music_note, color: VelvetColors.accent),
           null);
 
@@ -430,12 +430,12 @@ class ApiManager {
   }
 
   Future<void> getRated({Server? useThisServer}) async {
-    var res;
+    dynamic res;
     try {
       res = await makeServerCall(useThisServer, '/api/v1/db/rated', {}, 'GET');
     } catch (err) {
       // TODO: Handle Errors
-      print(err);
+      appLog('[api] getRated failed: $err');
       return;
     }
 
@@ -449,7 +449,7 @@ class ApiManager {
           useThisServer,
           e['filepath'],
           'file',
-          '/' + e['filepath'],
+          '/${e['filepath']}',
           Icon(Icons.music_note, color: VelvetColors.accent),
           m.artist);
 
@@ -462,13 +462,13 @@ class ApiManager {
   }
 
   Future<void> getArtists({Server? useThisServer}) async {
-    var res;
+    dynamic res;
     try {
       res =
           await makeServerCall(useThisServer, '/api/v1/db/artists', {}, 'GET');
     } catch (err) {
       // TODO: Handle Errors
-      print(err);
+      appLog('[api] getArtists failed: $err');
       return;
     }
 
@@ -484,13 +484,13 @@ class ApiManager {
   }
 
   Future<void> getArtistAlbums(String artist, {Server? useThisServer}) async {
-    var res;
+    dynamic res;
     try {
       res = await makeServerCall(useThisServer, '/api/v1/db/artists-albums',
           {'artist': artist}, 'POST');
     } catch (err) {
       // TODO: Handle Errors
-      print(err);
+      appLog('[api] getArtistAlbums failed: $err');
       return;
     }
 
@@ -516,13 +516,13 @@ class ApiManager {
 
   Future<void> getPlaylistContents(String playlistName,
       {Server? useThisServer}) async {
-    var res;
+    dynamic res;
     try {
       res = await makeServerCall(useThisServer, '/api/v1/playlist/load',
           {'playlistname': playlistName}, 'POST');
     } catch (err) {
       // TODO: Handle Errors
-      print(err);
+      appLog('[api] getPlaylistContents failed: $err');
       return;
     }
 
@@ -534,7 +534,7 @@ class ApiManager {
           useThisServer,
           e['filepath'],
           'file',
-          '/' + e['filepath'],
+          '/${e['filepath']}',
           Icon(Icons.music_note, color: VelvetColors.accent),
           null);
 
@@ -546,7 +546,7 @@ class ApiManager {
   }
 
   Future<void> getFileList(String directory, {Server? useThisServer}) async {
-    var res;
+    dynamic res;
     try {
       res = await makeServerCall(useThisServer, '/api/v1/file-explorer', {
         "directory": directory,
@@ -561,7 +561,7 @@ class ApiManager {
       }, 'POST');
     } catch (err) {
       // TODO: Handle Errors
-      print(err);
+      appLog('[api] getFileList failed: $err');
       return;
     }
 

--- a/lib/singletons/file_explorer.dart
+++ b/lib/singletons/file_explorer.dart
@@ -61,7 +61,6 @@ class FileExplorer {
     file
         .list(recursive: false, followLinks: false)
         .listen((FileSystemEntity entity) {
-      print(entity.path);
       Icon useIcon;
       String type;
       if (entity is File) {

--- a/lib/singletons/log_manager.dart
+++ b/lib/singletons/log_manager.dart
@@ -10,8 +10,10 @@ import 'settings.dart';
 /// path, no double entry. Use for happy-path activity (server calls, playback,
 /// startup) so the Diagnostics screen shows a real trail, not just errors.
 void appLog(String message) {
-  // ignore: avoid_print — deliberate: the print Zone in main() captures this
-  // into the diagnostic buffer; this is the app's info-logging entry point.
+  // The print Zone in main() tees this into the in-app diagnostic buffer
+  // (redacted, gated by the logging toggle) AND forwards it to the console.
+  // This is the app's info-logging entry point — print here is deliberate.
+  // ignore: avoid_print
   print(message);
 }
 

--- a/lib/singletons/queue_store.dart
+++ b/lib/singletons/queue_store.dart
@@ -10,6 +10,7 @@ import '../objects/server.dart';
 import '../util/stream_url.dart';
 import 'media.dart';
 import 'server_list.dart';
+import 'log_manager.dart';
 import 'settings.dart';
 
 /// Persists the play queue + current track/position so they survive the app
@@ -58,7 +59,7 @@ class QueueStore {
       await _restore();
     } catch (e) {
       // A corrupt / incompatible file must never block startup.
-      print('QueueStore restore failed: $e');
+      appLog('[queue] restore failed: $e');
     }
     _restoring = false;
     _attachListeners();
@@ -158,7 +159,7 @@ class QueueStore {
       };
       await file.writeAsString(jsonEncode(snapshot));
     } catch (e) {
-      print('QueueStore save failed: $e');
+      appLog('[queue] save failed: $e');
     }
   }
 


### PR DESCRIPTION
## Summary

Burns down the remaining **manual (non-autofixable) analyzer warnings** left after the lint baseline (#52): **73 → 22 issues, 0 errors**. No behaviour change except log routing (noted below). The 22 remaining are the 8 deferred context-guard warnings and 14 in visualizer/native code (out of scope).

## `print()` → `appLog` (avoid_print, 20)

- **`api.dart`** — 13 catch-block `print(err)` → `appLog('[api] <method> failed: $err')` (done via a scoped subagent, verified by analyze).
- **`audio_stuff.dart`** (EQ apply), **`add_server.dart`** (login), **`queue_store.dart`** (restore/save) → `appLog` with a tag, so failures show in the Diagnostics buffer (redacted) instead of only stdout.
- **`file_explorer.dart`** — removed the per-file `print` that logged a line per entry during a local-folder listing (log spam).
- **`log_manager.dart`** — `appLog()`'s own *deliberate* `print`: moved the `// ignore: avoid_print` directly above it so the suppression actually applies (it was separated by a comment line).
- **`common.dart`** — dev-only `LoggingAudioHandler` decorator (not in the production chain): added `avoid_print` to its `ignore_for_file`.

## Other lints

| Lint | Fix |
|---|---|
| `library_private_types_in_public_api` | `createState` → `State<T>` in `main.dart` (`MStreamApp`) + `manage_server.dart` (`DeleteServerDialog`) |
| `no_logic_in_create_state` | `add_server` `MyCustomForm.createState` no longer passes config into the State ctor; the State reads `widget.editThisServer` |
| `prefer_typing_uninitialized_variables` | `api.dart` `var res;` → `dynamic res;` (genuine type); `audio_stuff` `jsonAutoDJIgnoreList` |
| `prefer_interpolation_to_compose_strings` | `api.dart` string concatenations |
| `avoid_renaming_method_parameters` | `audio_stuff` handler overrides renamed to match `BaseAudioHandler` (`mediaItem`/`index`/`shuffleMode`/`repeatMode`) |
| `overridden_fields` | `audio_stuff` `customState` is a deliberate typed re-seed — documented + `// ignore` |
| `empty_catches` | documented each intentional swallow (add_server probe/edit fallthroughs) or logged it (manage_server delete failure → `appLog`) |

## Deferred (separate follow-up)

The **8 `use_build_context_synchronously`** warnings (`add_server`, `settings_screen`, `share_playlist_dialog`, `downloads`, `file_explorer`). These are behaviour-changing correctness guards — `mounted` checks / messenger-key swaps, the same caliber as the #56 fix — and each needs individual review. They don't belong in a mechanical sweep.

**Visualizer/native** lints (12 `library_private_types` in `projectm_bindings`, + `visualizer_screen` key, + `projectm_controller` doc comment) are out of scope — owned by the visualizer branches.

## Verification

`flutter analyze` — 0 errors, 73 → 22 issues (only the deferred 8 + visualizer 14 remain). `browser_load_test` passes. No visualizer/native files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)