### PR TITLE
fix: guard BuildContext across awaits (the 8 deferred lints)

### DIFF
--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -16,6 +16,7 @@ import '../objects/server.dart';
 import '../singletons/file_explorer.dart';
 import '../singletons/server_list.dart';
 import '../singletons/log_manager.dart';
+import '../singletons/app_messenger.dart';
 import '../singletons/browser_list.dart';
 import '../singletons/migration_manager.dart';
 import '../singletons/downloads.dart';
@@ -458,11 +459,10 @@ class MyCustomFormState extends State<MyCustomForm> {
           .timeout(Duration(seconds: 5));
 
       if (response.statusCode == 200) {
-        // setState(() {
-        //   submitPending = false;
-        // });
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text(l.connectionSuccessful)));
+        // App-wide messenger (not ScaffoldMessenger.of(context)): this runs
+        // after an await and saveServer pops the form, so a context-bound
+        // SnackBar would be lost / unsafe.
+        showGlobalSnack(l.connectionSuccessful);
         saveServer(lol);
         return;
       }
@@ -511,8 +511,7 @@ class MyCustomFormState extends State<MyCustomForm> {
         // Widget already disposed — nothing to update.
       }
 
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text(l.failedToLogin)));
+      showGlobalSnack(l.failedToLogin);
       return;
     }
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -6,6 +6,7 @@ import '../l10n/enum_labels.dart';
 import '../objects/player_layout.dart';
 import '../singletons/queue_store.dart';
 import '../singletons/settings.dart';
+import '../singletons/app_messenger.dart';
 import '../theme/velvet_theme.dart';
 import '../widgets/accent_color_sheet.dart';
 import 'eq_screen.dart';
@@ -430,12 +431,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
             onTap: () async {
               await SettingsManager().resetAll();
-              setState(() {});
-              if (mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text(l.settingsResetDone)),
-                );
-              }
+              if (mounted) setState(() {});
+              // App-wide messenger so the toast doesn't depend on this screen's
+              // context surviving the await.
+              showGlobalSnack(l.settingsResetDone);
             },
           ),
         ],

--- a/lib/screens/share_playlist_dialog.dart
+++ b/lib/screens/share_playlist_dialog.dart
@@ -14,6 +14,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../l10n/app_localizations.dart';
+import '../singletons/app_messenger.dart';
 import '../objects/server.dart';
 import '../singletons/api.dart';
 import '../singletons/media.dart';
@@ -226,11 +227,7 @@ class _ShareDialogState extends State<_ShareDialog> {
         TextButton(
           onPressed: () async {
             await Clipboard.setData(ClipboardData(text: _shareUrl!));
-            if (context.mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text(l.copiedToClipboard)),
-              );
-            }
+            showGlobalSnack(l.copiedToClipboard);
           },
           child: Text(l.copy),
         ),

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -192,7 +192,7 @@ class DownloadManager {
       // Storage location unavailable (e.g. SD card removed / chosen folder
       // deleted). Tell the user instead of silently doing nothing.
       final ctx = rootMessengerKey.currentContext;
-      showGlobalSnack(ctx != null
+      showGlobalSnack(ctx != null && ctx.mounted
           ? AppLocalizations.of(ctx).dlStorageUnavailable
           : 'Storage location unavailable — reconnect the SD card or change '
               "this server's storage location in Edit Server.");
@@ -250,7 +250,7 @@ class DownloadManager {
       // The volume could vanish between the null-check and the write.
       _inFlight.remove(downloadDirectory);
       final ctx = rootMessengerKey.currentContext;
-      showGlobalSnack(ctx != null
+      showGlobalSnack(ctx != null && ctx.mounted
           ? AppLocalizations.of(ctx).dlCouldNotStart
           : 'Could not start download — storage unavailable.');
     }

--- a/lib/singletons/file_explorer.dart
+++ b/lib/singletons/file_explorer.dart
@@ -23,7 +23,7 @@ class FileExplorer {
     Directory? woo = await getDownloadDir(s.storageMode, s.storageBasePath);
     if (woo == null) {
       final ctx = rootMessengerKey.currentContext;
-      return ctx != null
+      return ctx != null && ctx.mounted
           ? AppLocalizations.of(ctx).dlLocationUnavailable
           : 'Download location unavailable';
     }
@@ -44,7 +44,7 @@ class FileExplorer {
       if (woo == null) {
         // permanent/sdCard location is gone (card removed / folder deleted).
         final ctx = rootMessengerKey.currentContext;
-        showGlobalSnack(ctx != null
+        showGlobalSnack(ctx != null && ctx.mounted
             ? AppLocalizations.of(ctx).dlLocationUnavailableServer
             : 'Download location unavailable for this server.');
         BrowserManager().addListToStack(newList); // show an empty list


### PR DESCRIPTION
## Summary

Resolves the **8 `use_build_context_synchronously`** warnings deferred from the lint sweep (#59) — each a genuine "use a `BuildContext` after an `await`" case (the same caliber as #56). Two patterns:

### Screen toasts → `showGlobalSnack` (add_server ×2, settings_screen, share_playlist_dialog)

These showed a `SnackBar` via `ScaffoldMessenger.of(context)` after an `await`. Some were unguarded; the settings/share ones were guarded by a `mounted` check the analyzer flagged as **unrelated to the context being used** (`State.mounted` guarding a non-State context, or vice-versa). Switched them to the app-wide **`showGlobalSnack()`** — the `rootMessengerKey` messenger already used by the context-less singletons — which removes the `BuildContext` use entirely and is more robust:

- `add_server`'s "connection successful" / "failed to login" toasts now show on the root messenger, so the success toast survives `saveServer()` popping the form.
- `settings_screen`'s post-`await` `setState` is now also `mounted`-guarded (it wasn't before — a latent bug).

### Singletons → add `ctx.mounted` (file_explorer ×2, downloads ×2)

Each did, after an `await`:
```dart
final ctx = rootMessengerKey.currentContext;
... ctx != null ? AppLocalizations.of(ctx).<key> : '<english fallback>'
```
Added `ctx.mounted` to the guard (`ctx != null && ctx.mounted`) so a stale context falls back to the English literal instead of being used across the gap.

## Behaviour

No change in the normal (mounted) path. The guards only affect the rare unmounted case, which now degrades cleanly (root-messenger toast / English fallback) instead of risking a throw.

## Verification

`flutter analyze` — **0 errors, 0 `use_build_context_synchronously`** remaining. `browser_load_test` passes. (Other lints visible on this branch are the separate #59 sweep, not yet merged.)

Independent of #57 / #59; will rebase if they land first. Completes the audit's issue 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)