### PR TITLE
perf: fix alphabet-scroller scroll lag on large lists (known item extents)

### DIFF
--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -235,6 +235,20 @@ class _BrowserState extends State<Browser> {
     }
   }
 
+  // Per-row extent for the browser list, shared by the ListView's
+  // itemExtentBuilder AND the letter-strip jump math so a jump lands exactly on
+  // the target row — no estimation, no multi-frame settle on long lists.
+  // 1-line rows (directories / artists) vs 2-line (albums / files with
+  // metadata), mirroring getText/getSubText. max(base, scaled) tracks the text
+  // scaler upward so larger accessibility text never clips, while staying at the
+  // tuned base at the default (and smaller) text scales.
+  static double _rowExtent(DisplayItem it, TextScaler ts) {
+    final base =
+        (it.metadata?.artist != null || it.subtext != null) ? 74.0 : 58.0;
+    final scaled = ts.scale(base);
+    return scaled > base ? scaled : base;
+  }
+
   Widget makePlaylistWidget(List<DisplayItem> b, int i, BuildContext c) {
     final l = AppLocalizations.of(c);
     return Material(
@@ -910,6 +924,7 @@ class _BrowserState extends State<Browser> {
                       initialData: SettingsManager().albumGrid,
                       builder: (context, gridSnap) {
                         final useGrid = (gridSnap.data ?? true) && allAlbums;
+                        final ts = MediaQuery.textScalerOf(context);
                         final Widget content = useGrid
                             ? AlbumGrid(
                                 items: browserList,
@@ -945,17 +960,20 @@ class _BrowserState extends State<Browser> {
                                         minLeadingWidth: 32,
                                       ),
                                 ),
-                                child: ListView.separated(
+                                child: ListView.builder(
                                     controller: BrowserManager().sc,
                                     physics:
                                         const AlwaysScrollableScrollPhysics(),
-                                    separatorBuilder:
-                                        (BuildContext context, int index) =>
-                                            Divider(
-                                                height: 1,
-                                                color:
-                                                    VelvetColors.border),
                                     itemCount: browserList.length,
+                                    // Known per-row extents give the sliver O(1)
+                                    // seek, so the letter-strip jumpTo lands
+                                    // instantly instead of estimating + settling
+                                    // over frames on long lists (the scrub lag).
+                                    // Rows already draw their own bottom border,
+                                    // so the old Divider separator is dropped.
+                                    // See _rowExtent.
+                                    itemExtentBuilder: (index, _) =>
+                                        _rowExtent(browserList[index], ts),
                                     itemBuilder:
                                         (BuildContext context, int index) {
                                       if (browserList.isEmpty) {
@@ -998,33 +1016,17 @@ class _BrowserState extends State<Browser> {
                                     offset = AlbumGrid.padTop +
                                         row * (rowH + AlbumGrid.spacing);
                                   } else {
-                                    // ListTile heights vary per-row by
-                                    // whether a subtitle is present:
-                                    //   1-line (Artists, dirs): ~56dp
-                                    //     + 1 border + 1 separator = 58
-                                    //   2-line (Albums, files w/ meta):
-                                    //     ~72dp + 1 border + 1 sep = 74
-                                    // File Explorer mixes both inside
-                                    // a single list (directories first,
-                                    // then metadata-bearing files), so
-                                    // we have to walk and SUM rather
-                                    // than multiply by a single height.
-                                    // O(i), microseconds even at 10k+
-                                    // items. Tune these constants if
-                                    // taps land too high or too low.
-                                    const oneLineRow = 58.0;
-                                    const twoLineRow = 74.0;
+                                    // Sum the SAME per-row extents the ListView
+                                    // lays out with (see _rowExtent) so the jump
+                                    // lands exactly on the target row. File
+                                    // Explorer mixes 1- and 2-line rows, hence
+                                    // the walk-and-sum. O(i), microseconds even
+                                    // at 10k+ items.
                                     double sum = 0;
                                     final stop =
                                         i.clamp(0, browserList.length);
                                     for (var k = 0; k < stop; k++) {
-                                      final it = browserList[k];
-                                      final twoLine = it.metadata?.artist !=
-                                              null ||
-                                          it.subtext != null;
-                                      sum += twoLine
-                                          ? twoLineRow
-                                          : oneLineRow;
+                                      sum += _rowExtent(browserList[k], ts);
                                     }
                                     offset = sum;
                                   }


### PR DESCRIPTION
## Symptom

The browser's A–Z scrubber felt laggy on long lists: the **first** scrub of an engagement took a beat to land on the right letter, then tracked fine — and the lag **returned after letting go and re-engaging**.

## Root cause

The browser list is a lazy, **variable-extent** `ListView.separated` (no `itemExtent`). `RenderSliverList` can't random-access a far scroll offset, so the letter-strip's `sc.jumpTo()` lands on an **estimate** and then *corrects over several frames* as it builds/measures rows — worse the longer the list. `maxScrollExtent` (used in the jump's clamp) is also only an estimate until enough rows are built, so the first jump can land short. Once the built rows recycle after you stop, the estimate resets — so re-engaging repeats the settle.

The album **grid** path doesn't have this: a fixed-aspect grid already has known extents and seeks in O(1). That's the tell — same `jumpTo`, but the grid is smooth.

## Fix

Give the list **known per-row extents** via `ListView.builder` + `itemExtentBuilder`, so the sliver seeks in O(1) and `maxScrollExtent` is exact immediately — the jump lands in one frame, no settle, no first-touch / after-idle recurrence.

- **`_rowExtent(item, textScaler)`** — one source of truth for row height, used by **both** `itemExtentBuilder` and the `onJump` offset sum, so the jump lands *exactly* on the target row (previously `onJump` summed its own `58/74` constants that only approximated the real layout).
- 1-line (directories/artists) vs 2-line (albums/files), as before. Extent is `max(base, textScaler.scale(base))` so larger accessibility text never clips, while the default scale stays at the tuned base.
- All six alphabetical row types already draw their own bottom border, so the redundant `Divider` separator is dropped (rows were previously double-lined: own border + separator). Base extents preserve the row pitch.

## Verification

`flutter analyze` clean (0 errors); `browser_load_test` passes. **Please give it an on-device pass** to confirm the scrub now feels instant and row spacing/dividers look right across text-scale settings — that's the part I can't validate from here.

If any residual lag remains after this, it'd be album-art decode as rows appear (a separate concern, already bounded by the `cacheWidth` work in #55) rather than the scroll-positioning settle this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)