### PR TITLE
Plumb new server metadata through to the Song Info screen

### DIFF
--- a/lib/objects/metadata.dart
+++ b/lib/objects/metadata.dart
@@ -21,8 +21,16 @@ class MusicMetadata {
   // FLAC · kbps · kHz readout. durationSeconds is exposed as a [Duration] via
   // the [duration] getter.
   double? durationSeconds;
-  int? bitrate; // kbps
+  int? bitrate; // bits/second (server sends raw bps; divide by 1000 for kbps)
   int? sampleRate; // Hz
+  // Container/codec label (server `format`, e.g. "FLAC"); total track/disc
+  // counts (`track-total`/`disc-total`, V45) so the UI can show "track N of M";
+  // and this user's per-track play count (`play-count`, joined server-side on
+  // every track query). All null/absent on older API builds → treat as optional.
+  String? format;
+  int? trackTotal;
+  int? discTotal;
+  int? playCount;
   // Genre names for this track. Velvet servers emit `metadata.genres` as a
   // string list (many-to-many via track_genres); empty when untagged or on
   // servers that don't surface genres.
@@ -35,7 +43,11 @@ class MusicMetadata {
       this.genres = const [],
       this.durationSeconds,
       this.bitrate,
-      this.sampleRate});
+      this.sampleRate,
+      this.format,
+      this.trackTotal,
+      this.discTotal,
+      this.playCount});
 
   MusicMetadata.fromJson(Map<String, dynamic> json)
       : artist = json['artist'],
@@ -52,6 +64,10 @@ class MusicMetadata {
         durationSeconds = (json['durationSeconds'] as num?)?.toDouble(),
         bitrate = json['bitrate'],
         sampleRate = json['sampleRate'],
+        format = json['format'],
+        trackTotal = json['trackTotal'],
+        discTotal = json['discTotal'],
+        playCount = json['playCount'],
         genres = parseGenres(json['genres']);
 
   Map<String, dynamic> toJson() => {
@@ -69,6 +85,10 @@ class MusicMetadata {
         'durationSeconds': durationSeconds,
         'bitrate': bitrate,
         'sampleRate': sampleRate,
+        'format': format,
+        'trackTotal': trackTotal,
+        'discTotal': discTotal,
+        'playCount': playCount,
         'genres': genres,
       };
 
@@ -97,6 +117,10 @@ class MusicMetadata {
             m['sampleRate'] ??
             m['samplerate'] ??
             m['sample_rate']),
+        format: _asString(m['format']),
+        trackTotal: _asInt(m['track-total'] ?? m['trackTotal']),
+        discTotal: _asInt(m['disc-total'] ?? m['discTotal']),
+        playCount: _asInt(m['play-count'] ?? m['playCount']),
       );
 
   /// Parses the server's `genres` value (normally a string list) into a
@@ -134,6 +158,15 @@ class MusicMetadata {
     if (v is int) return v;
     if (v is num) return v.toInt();
     if (v is String) return int.tryParse(v);
+    return null;
+  }
+
+  /// Trims a string value; null for null / empty / non-string.
+  static String? _asString(dynamic v) {
+    if (v is String) {
+      final t = v.trim();
+      return t.isEmpty ? null : t;
+    }
     return null;
   }
 }

--- a/lib/screens/album_detail_view.dart
+++ b/lib/screens/album_detail_view.dart
@@ -173,13 +173,6 @@ class _AlbumDetailViewState extends State<AlbumDetailView> {
     return null;
   }
 
-  // 44100 → "44.1 kHz", 48000 → "48 kHz".
-  String _khzLabel(int hz) {
-    final k = hz / 1000.0;
-    final s = k == k.roundToDouble() ? k.toStringAsFixed(0) : k.toStringAsFixed(1);
-    return '$s kHz';
-  }
-
   // ── actions ──
   void _playFrom(int index, {bool shuffle = false}) {
     final songs = _songs;
@@ -295,9 +288,9 @@ class _AlbumDetailViewState extends State<AlbumDetailView> {
       final fmt = _formatLabel(songs);
       if (fmt != null) metaParts.add(fmt);
       final br = _bitrate(songs);
-      if (br != null) metaParts.add('$br kbps');
+      if (br != null) metaParts.add(formatBitrate(br));
       final sr = _sampleRate(songs);
-      if (sr != null) metaParts.add(_khzLabel(sr));
+      if (sr != null) metaParts.add(formatSampleRate(sr));
     }
 
     return Container(

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -36,23 +36,41 @@ class MetadataScreen extends StatelessWidget {
       if (year != null && '$year'.isNotEmpty && '$year' != '0') '$year',
     ].join('   ·   ');
 
-    // Track / disc as a plain line under the album.
+    // Track / disc as a plain line under the album — "track N of M" when the
+    // server reports the totals (track-total / disc-total).
     final trackDisc = <String>[
-      if (extras['track'] != null) 'track: ${_v(extras['track'])}',
-      if (extras['disc'] != null) 'disc: ${_v(extras['disc'])}',
+      if (extras['track'] != null)
+        _numOf('track', extras['track'], extras['trackTotal']),
+      if (extras['disc'] != null)
+        _numOf('disc', extras['disc'], extras['discTotal']),
     ].join(', ');
+
+    // Fidelity readout — "FLAC · 320 kbps · 44.1 kHz" — from the format / bitrate
+    // / sampleRate the queue now carries (server emits bitrate in bits/second,
+    // hence formatBitrate divides by 1000).
+    final fmt = extras['format'];
+    final bitrate = extras['bitrate'];
+    final sampleRate = extras['sampleRate'];
+    final fidelity = <String>[
+      if (fmt is String && fmt.trim().isNotEmpty) fmt.trim().toUpperCase(),
+      if (bitrate is num && bitrate > 0) formatBitrate(bitrate.toInt()),
+      if (sampleRate is num && sampleRate > 0) formatSampleRate(sampleRate.toInt()),
+    ].join('  ·  ');
 
     // Self-labelling chips (icon + value) — no extra translated strings, shown
     // only when the field is present.
     final chips = <Widget>[
       if (item.duration != null)
         _chip(Icons.schedule_rounded, formatDuration(item.duration!)),
+      if (fidelity.isNotEmpty) _chip(Icons.high_quality_rounded, fidelity),
       if (extras['bpm'] != null)
         _chip(Icons.speed_rounded, '${_v(extras['bpm'])} BPM'),
       if (key != null && key.trim().isNotEmpty)
         _chip(Icons.music_note_rounded, key.trim()),
       if (genre != null && genre.trim().isNotEmpty)
         _chip(Icons.category_rounded, genre.trim()),
+      if (extras['playCount'] is num && (extras['playCount'] as num) > 0)
+        _chip(Icons.repeat_rounded, '${_v(extras['playCount'])} plays'),
     ];
 
     return Scaffold(
@@ -221,6 +239,10 @@ class MetadataScreen extends StatelessWidget {
   // double); pass strings through unchanged.
   static String _v(dynamic value) =>
       value is num ? value.round().toString() : '$value';
+
+  // "track: 4 of 12" when a total is present, else "track: 4".
+  static String _numOf(String label, dynamic n, dynamic total) =>
+      total != null ? '$label: ${_v(n)} of ${_v(total)}' : '$label: ${_v(n)}';
 
   Widget _chip(IconData icon, String text) {
     return Container(

--- a/lib/util/media_format.dart
+++ b/lib/util/media_format.dart
@@ -18,6 +18,19 @@ String formatDuration(Duration d, {bool padMinutes = true}) {
   return '${padMinutes ? m.toString().padLeft(2, '0') : m}:$s';
 }
 
+/// Formats an audio bitrate as `"320 kbps"`. The mStream server reports bitrate
+/// in bits/second (raw `format.bitrate`), so divide by 1000 — rendering the raw
+/// value straight would read as e.g. "320000 kbps".
+String formatBitrate(int bitsPerSecond) => '${(bitsPerSecond / 1000).round()} kbps';
+
+/// Formats a sample rate in Hz as `"44.1 kHz"` / `"48 kHz"` (drops the decimal
+/// when it's a whole number of kHz).
+String formatSampleRate(int hz) {
+  final k = hz / 1000.0;
+  final s = k == k.roundToDouble() ? k.toStringAsFixed(0) : k.toStringAsFixed(1);
+  return '$s kHz';
+}
+
 /// The shared album-art placeholder (a raised tile + music-note glyph) shown
 /// while artwork loads, on a decode error, or when a track has no art.
 /// [iconSize] scales the glyph to the tile it fills.

--- a/lib/util/queue_actions.dart
+++ b/lib/util/queue_actions.dart
@@ -69,6 +69,13 @@ Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
       // bpm + musicalKey power AutoDJ's BPM-continuity / harmonic-mixing modes.
       'bpm': i.metadata?.bpm,
       'musicalKey': i.metadata?.musicalKey,
+      // Fidelity + counts for the Song Info screen (it reads only from extras).
+      'bitrate': i.metadata?.bitrate,
+      'sampleRate': i.metadata?.sampleRate,
+      'format': i.metadata?.format,
+      'trackTotal': i.metadata?.trackTotal,
+      'discTotal': i.metadata?.discTotal,
+      'playCount': i.metadata?.playCount,
     },
   );
 }


### PR DESCRIPTION
## What

The mStream server's `renderMetadataObj` now returns ~30 per-track metadata fields; the app was consuming ~15. This carries the **fidelity + count** fields through the app's existing `fromServerMap` → `MediaItem.extras` → display pipeline.

## Changes

- **Parse** `format`, `track-total`, `disc-total`, `play-count` in `MusicMetadata.fromServerMap` (with model + `fromJson`/`toJson` round-trip).
- **Carry** `bitrate`, `sampleRate`, `format`, track/disc totals and `play-count` into `MediaItem.extras` in `buildServerFileMediaItem`. The Song Info screen reads **only** from `extras`, so `bitrate`/`sampleRate` were already parsed into the model but never reached it.
- **Display** in Song Info (`metadata_screen.dart`): a fidelity chip (e.g. `FLAC · 320 kbps · 44.1 kHz`), `track: N of M` / `disc: N of M` when totals are present, and a `N plays` chip.
- **Bug fix:** the server reports bitrate in **bits/second**, but the album-detail banner rendered the raw value as "kbps" (e.g. `320000 kbps`). Added shared `formatBitrate` / `formatSampleRate` helpers in `media_format.dart` and routed both the banner and Song Info through them.

All fields are optional — older servers omit them and the UI degrades gracefully to current behavior.

## Test plan

- [x] `flutter analyze` on all changed files — **No issues found**.
- [ ] Not yet exercised against a live server; the new chips render only when the server actually populates the fields. Worth a visual confirm of the bitrate readout on a real album (the unit-bug fix).

## Notes

- This PR is the metadata-plumbing slice only; it does **not** include the separate admin-panel work in progress on `claude/stupefied-panini-bff12b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
