### PR TITLE
perf: memoize accent ink + drop per-rebuild ThemeData in the browser list

### DIFF
--- a/lib/screens/album_detail_view.dart
+++ b/lib/screens/album_detail_view.dart
@@ -27,12 +27,6 @@ import '../util/stream_url.dart';
 import '../util/image_cache.dart';
 import '../widgets/player_panel.dart';
 
-/// Ink on top of the accent-filled Play button: dark espresso on bright accents,
-/// white on a dark custom accent (mirrors player_panel's `_kAmberInk`).
-Color get _accentInk => VelvetColors.primary.computeLuminance() > 0.42
-    ? const Color(0xFF1A1206)
-    : Colors.white;
-
 class AlbumDetailView extends StatefulWidget {
   /// The tapped album row — carries name, server, altAlbumArt (`album_art_file`)
   /// and subtext, from getAlbums().
@@ -377,7 +371,7 @@ class _AlbumDetailViewState extends State<AlbumDetailView> {
                     IconButton.filled(
                       onPressed: enabled ? () => _playFrom(0) : null,
                       tooltip: l.play,
-                      icon: Icon(Icons.play_arrow, color: _accentInk),
+                      icon: Icon(Icons.play_arrow, color: accentInk),
                       style: IconButton.styleFrom(
                         backgroundColor: VelvetColors.primary,
                         disabledBackgroundColor:

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -937,29 +937,25 @@ class _BrowserState extends State<Browser> {
                                 onTap: (i) =>
                                     handleTap(browserList, i, context),
                               )
-                            // Theme override so the browser's rows
+                            // ListTileTheme override so the browser's rows
                             // are denser than the global ListTile
                             // default — gains ~26px of horizontal
                             // space for the title (less truncation)
                             // without affecting Settings/About/etc.
+                            // (.merge, not a full Theme copyWith, so a
+                            // list rebuild doesn't allocate a whole
+                            // ThemeData — see the download-tick rebuilds.)
                             //   contentPadding: 16 -> 10 (saves 12)
                             //   horizontalTitleGap: 16 -> 10 (saves 6)
                             //   minLeadingWidth: 40 -> 32 (saves 8)
                             // Heights are unchanged by these knobs,
                             // so the letter-scrub cumulative math
                             // stays correct.
-                            : Theme(
-                                data: Theme.of(context).copyWith(
-                                  listTileTheme: Theme.of(context)
-                                      .listTileTheme
-                                      .copyWith(
-                                        contentPadding:
-                                            EdgeInsets.symmetric(
-                                                horizontal: 10),
-                                        horizontalTitleGap: 10,
-                                        minLeadingWidth: 32,
-                                      ),
-                                ),
+                            : ListTileTheme.merge(
+                                contentPadding:
+                                    const EdgeInsets.symmetric(horizontal: 10),
+                                horizontalTitleGap: 10,
+                                minLeadingWidth: 32,
                                 child: ListView.builder(
                                     controller: BrowserManager().sc,
                                     physics:

--- a/lib/theme/velvet_theme.dart
+++ b/lib/theme/velvet_theme.dart
@@ -141,6 +141,23 @@ class VelvetPalette {
 Color onAccent(Color c) =>
     c.computeLuminance() > 0.5 ? Colors.black : Colors.white;
 
+/// Ink for content on top of the accent-filled play button (e.g. the play/pause
+/// glyph): dark espresso on bright accents, white on a dark custom accent, so it
+/// stays legible whatever accent the user picks. Memoized — `computeLuminance()`
+/// is non-trivial and the accent only changes on a theme/accent switch, not per
+/// player-control rebuild (this is read on the hot player path).
+Color? _accentInkCache;
+Color? _accentInkForPrimary;
+Color get accentInk {
+  final p = VelvetColors.primary;
+  if (p != _accentInkForPrimary) {
+    _accentInkForPrimary = p;
+    _accentInkCache =
+        p.computeLuminance() > 0.42 ? const Color(0xFF1A1206) : Colors.white;
+  }
+  return _accentInkCache!;
+}
+
 // Original Velvet palette — navy bg, purple primary.
 const _velvetPalette = VelvetPalette(
   brightness: Brightness.dark,

--- a/lib/widgets/player_panel.dart
+++ b/lib/widgets/player_panel.dart
@@ -21,14 +21,6 @@ import 'more_actions_sheet.dart';
 import 'queue_list.dart';
 import 'waveform_progress.dart';
 
-/// Ink for content on top of the accent-filled play button. The dark espresso
-/// (`#1a1206`, from the design) reads on bright accents (amber/orange/yellow),
-/// but flips to white on a dark custom accent so the play/pause glyph stays
-/// visible whatever accent the user picks.
-Color get _kAmberInk => VelvetColors.primary.computeLuminance() > 0.42
-    ? const Color(0xFF1A1206)
-    : Colors.white;
-
 /// A Spotify/Apple-Music-style player panel pinned to the bottom of the
 /// screen. Collapsed it shows a mini-player (art + title + play/pause).
 /// Dragged up — or tapped — it expands into a full "Now Playing" view whose
@@ -768,7 +760,7 @@ class _TopSmall extends StatelessWidget {
                           iconSize: 22,
                           padding: EdgeInsets.zero,
                           icon: Icon(playing ? Icons.pause : Icons.play_arrow),
-                          color: _kAmberInk,
+                          color: accentInk,
                           onPressed: playing ? handler.pause : handler.play,
                         ),
                       );
@@ -852,7 +844,7 @@ class _TransportControls extends StatelessWidget {
                 iconSize: playSize * 0.5,
                 padding: EdgeInsets.zero,
                 icon: Icon(playing ? Icons.pause : Icons.play_arrow),
-                color: _kAmberInk,
+                color: accentInk,
                 onPressed: playing ? handler.pause : handler.play,
               ),
             );


### PR DESCRIPTION
Two small hot-path wins from the post-audit perf re-survey (items 2 and 3 of what was left).

## 1. Accent ink recomputed `computeLuminance()` on every read

`player_panel`'s `_kAmberInk` and `album_detail_view`'s `_accentInk` were **identical** getters running the (non-trivial) sRGB luminance calc on *every* player-control rebuild — but the result only changes when the accent/theme changes.

Consolidated both into a single **memoized `accentInk`** in `velvet_theme.dart` (cached per primary colour, recomputed only when the accent changes). Also removes the duplicated ink logic the two files carried (`album_detail` even noted it "mirrors player_panel's `_kAmberInk`").

## 2. Browser list allocated a full `ThemeData` per rebuild

The list wrapped its content in `Theme(data: Theme.of(context).copyWith(listTileTheme: …))`, which clones a whole `ThemeData` on **every `browserListStream` emit** — including the ~20 download-progress ticks per active download. It only ever overrode three `ListTile` properties (contentPadding / horizontalTitleGap / minLeadingWidth), so switched to **`ListTileTheme.merge(...)`**, which merges just those into the ambient `ListTileTheme` (a small `ListTileThemeData`) instead of cloning the entire theme.

Row density (the whole point of the override) is unchanged.

## Verification

`flutter analyze` clean (0 errors); `browser_load_test` passes. Net −1 line (the consolidation removes the duplicated getters).

The remaining perf item is the bigger structural one — large-library navigation jank (decode + DisplayItem build on the UI isolate), which deserves its own focused effort with on-device profiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)