### PR TITLE
perf: throttle now-playing position stream + reuse waveform Paints

### DIFF
--- a/lib/widgets/player_panel.dart
+++ b/lib/widgets/player_panel.dart
@@ -1417,18 +1417,16 @@ final BehaviorSubject<_MediaPos> _mediaPos = BehaviorSubject<_MediaPos>()
     MediaManager().audioHandler.positionStream,
     (item, pos) => _MediaPos(item, pos),
   ).distinct((a, b) =>
-      // positionStream ticks several times a second, but the now-playing
-      // consumers render only whole-second time text and a bar-quantised
-      // waveform (its played/unplayed boundary moves at most once per
-      // duration/64 s), so collapse to ~1 emit/sec. Without this the title
-      // row, both waveforms, and the scrubber rebuild — and each waveform
-      // re-rasters its 64 bars — on every sub-second tick. _MediaPos has no
-      // value equality, so compare the displayed fields explicitly; duration
-      // is included so the ratio refreshes when it lands after the track
-      // first appears.
+      // positionStream ticks several times a second; collapse it to ~2 emits/
+      // sec (500 ms buckets) so the title row, both waveforms, and the scrubber
+      // stop rebuilding — and the waveforms stop re-rastering their 64 bars — on
+      // every sub-frame tick, while the seek-bar fill / elapsed time stay
+      // visibly smooth. _MediaPos has no value equality, so compare the
+      // displayed fields explicitly; duration is included so the ratio
+      // refreshes when it lands after the track first appears.
       a.item?.id == b.item?.id &&
       a.item?.duration == b.item?.duration &&
-      a.position.inSeconds == b.position.inSeconds));
+      a.position.inMilliseconds ~/ 500 == b.position.inMilliseconds ~/ 500));
 
 String _fmt(Duration d) => formatDuration(d);
 

--- a/lib/widgets/player_panel.dart
+++ b/lib/widgets/player_panel.dart
@@ -1416,7 +1416,19 @@ final BehaviorSubject<_MediaPos> _mediaPos = BehaviorSubject<_MediaPos>()
     MediaManager().audioHandler.mediaItem,
     MediaManager().audioHandler.positionStream,
     (item, pos) => _MediaPos(item, pos),
-  ));
+  ).distinct((a, b) =>
+      // positionStream ticks several times a second, but the now-playing
+      // consumers render only whole-second time text and a bar-quantised
+      // waveform (its played/unplayed boundary moves at most once per
+      // duration/64 s), so collapse to ~1 emit/sec. Without this the title
+      // row, both waveforms, and the scrubber rebuild — and each waveform
+      // re-rasters its 64 bars — on every sub-second tick. _MediaPos has no
+      // value equality, so compare the displayed fields explicitly; duration
+      // is included so the ratio refreshes when it lands after the track
+      // first appears.
+      a.item?.id == b.item?.id &&
+      a.item?.duration == b.item?.duration &&
+      a.position.inSeconds == b.position.inSeconds));
 
 String _fmt(Duration d) => formatDuration(d);
 

--- a/lib/widgets/waveform_progress.dart
+++ b/lib/widgets/waveform_progress.dart
@@ -118,11 +118,15 @@ class _WaveformPainter extends CustomPainter {
     final gap = 1.5;
     final barWidth = (size.width - gap * (n - 1)) / n;
     final progressX = size.width * progress;
+    final centerY = size.height / 2;
+    // Two Paints reused for every bar instead of allocating one per bar on each
+    // repaint (×64 bars, on every position tick).
+    final playedPaint = Paint()..color = playedColor;
+    final unplayedPaint = Paint()..color = unplayedColor;
 
     for (int i = 0; i < n; i++) {
       final h = heights[i] * size.height;
       final left = i * (barWidth + gap);
-      final centerY = size.height / 2;
       final rect = RRect.fromLTRBR(
         left,
         centerY - h / 2,
@@ -131,10 +135,7 @@ class _WaveformPainter extends CustomPainter {
         Radius.circular(barWidth / 2),
       );
       final isPlayed = (left + barWidth / 2) <= progressX;
-      canvas.drawRRect(
-        rect,
-        Paint()..color = isPlayed ? playedColor : unplayedColor,
-      );
+      canvas.drawRRect(rect, isPlayed ? playedPaint : unplayedPaint);
     }
   }
 


### PR DESCRIPTION
Two paired micro-optimizations for the now-playing position UI (both carried forward from the stale perf-audit PR #38, whose other items have since landed independently on `master`).

## 1. Throttle the position stream to ~2 emits/sec

`_mediaPos` (the shared now-playing `mediaItem` + `position` stream) emits on every `positionStream` tick — several times a second. Its three `StreamBuilder` consumers — the **title/time row**, the **expanded scrubber**, and the **bottom-bar waveform** — therefore rebuilt on every sub-frame tick, and each `WaveformProgress` re-rastered its 64 bars.

Added a `.distinct()` on the combined stream that collapses it to **~2 emits/sec (500 ms buckets)**, keyed on `item.id` + `item.duration` + `position.inMilliseconds ~/ 500`.

**Cheap for what's drawn:** the position/duration text is whole-second (`_fmt`), and the waveform's played/unplayed boundary is **bar-quantised** (moves at most once per `duration / 64` s). 500 ms keeps the slim `_SeekBar` fill / elapsed time visibly smooth while still dropping from ~5 → ~2 emits/sec; the waveform scrubber (the default) is visually unchanged.

## 2. Reuse two Paints in the waveform painter

`_WaveformPainter.paint` allocated a fresh `Paint` per bar (×64) on every repaint. Now it hoists two reusable `Paint`s (played / unplayed) and `centerY` out of the loop — **2 allocations per repaint instead of 64**. Pairs with #1: the waveform now repaints ~2×/s, each repaint allocating 2 Paints rather than 64.

## Verification

- `flutter analyze` — **No issues found** (both files).
- Smoke: play a track → elapsed time + waveform advance smoothly; seeking works; switching tracks updates immediately; a duration that lands after the track first appears still refreshes the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
