### PR TITLE
perf: scope visualizer slider drags to their own row (not the Texture)

### DIFF
--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -470,33 +470,50 @@ class _VisualizerScreenState extends State<VisualizerScreen>
 
   Widget _globalSlider(int i) {
     final range = _globalRanges[i];
-    final v = _globalValues[i].clamp(range[0], range[1]).toDouble();
-    return _sliderRow(
-      label: _globalLabels[i],
-      value: v,
-      min: range[0],
-      max: range[1],
-      onChanged: (nv) {
-        setState(() => _globalValues[i] = nv);
-        _pushTuning();
+    // Each slider drives a local StatefulBuilder so a drag rebuilds only its own
+    // row — not the whole screen subtree (which hosts the Texture widget and the
+    // full slider list). The drag mutates the shared model in place; _pushTuning()
+    // pushes it to the renderer and _persistGlobal() saves it on release.
+    return StatefulBuilder(
+      builder: (context, setLocal) {
+        final v = _globalValues[i].clamp(range[0], range[1]).toDouble();
+        return _sliderRow(
+          label: _globalLabels[i],
+          value: v,
+          min: range[0],
+          max: range[1],
+          onChanged: (nv) {
+            _globalValues[i] = nv;
+            setLocal(() {});
+            _pushTuning();
+          },
+          onChangeEnd: (_) => _persistGlobal(),
+        );
       },
-      onChangeEnd: (_) => _persistGlobal(),
     );
   }
 
   Widget _shaderSlider(int i) {
     final p = _shaderParams[i];
-    final v = _paramValues[i].clamp(p.min, p.max).toDouble();
-    return _sliderRow(
-      label: p.name,
-      value: v,
-      min: p.min,
-      max: p.max,
-      onChanged: (nv) {
-        setState(() => _paramValues[i] = nv);
-        _pushTuning();
+    // Local StatefulBuilder: dragging rebuilds only this row, not the Texture +
+    // whole slider list. Mutates the shared model in place; _pushTuning() pushes
+    // it to the renderer and _persistShader() saves it on release.
+    return StatefulBuilder(
+      builder: (context, setLocal) {
+        final v = _paramValues[i].clamp(p.min, p.max).toDouble();
+        return _sliderRow(
+          label: p.name,
+          value: v,
+          min: p.min,
+          max: p.max,
+          onChanged: (nv) {
+            _paramValues[i] = nv;
+            setLocal(() {});
+            _pushTuning();
+          },
+          onChangeEnd: (_) => _persistShader(),
+        );
       },
-      onChangeEnd: (_) => _persistShader(),
     );
   }
 


### PR DESCRIPTION
## What

Dragging a tuning slider in the Visualizer rebuilt the **entire** `VisualizerScreen` on every `onChanged` — `_globalSlider` / `_shaderSlider` each called `setState`. That subtree hosts the `Texture` widget (the live render surface) and the full slider list, so a single drag fired many full-screen rebuilds per second.

## Fix

Wrap each slider in a `StatefulBuilder`. On drag the handler mutates the shared params list in place and calls the **local** `setLocal(() {})` — rebuilding only that one row — while `_pushTuning()` still pushes the live value to the renderer (`VisualizerBridge.setTuning`). `onChangeEnd` still persists on release.

Reset (`_resetTuning`) keeps its whole-screen `setState`, so after a reset the rows re-read and show their defaults.

## Context

Carried forward from the stale perf-audit PR #38 — its higher-value items (the now-playing position-stream throttle + waveform `Paint` reuse) already landed in #67.

## Verification

- `flutter analyze` — no new issues from this change. (It reports one pre-existing baseline info, `use_key_in_widget_constructors` at `visualizer_screen.dart:22` — the `VisualizerScreen` constructor, untouched here.)
- Smoke: open the Visualizer tuning panel → drag a global slider and a shader slider; the value readout + handle track smoothly and the effect updates live; tap **Reset** → all sliders snap back to defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
