### PR TITLE
fix: restore the navigation bar when leaving the visualizer

### DIFF
--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -95,7 +95,15 @@ class _VisualizerScreenState extends State<VisualizerScreen>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    // Restore the app chrome before the parent route reappears.
+    // Restore the app chrome before the parent route reappears. initState used
+    // immersiveSticky, which HIDES the status + navigation bars; edgeToEdge only
+    // sets the edge-to-edge *layout* — it does not re-show bars that were
+    // explicitly hidden, so on its own the nav bar stays gone after leaving the
+    // visualizer (the app shows it everywhere else). Force the overlays back on
+    // first (manual + all overlays = show), then return to the app-wide
+    // edge-to-edge layout.
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
+        overlays: SystemUiOverlay.values);
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,


### PR DESCRIPTION
## Bug

The Android **navigation bar (back / home) stayed hidden after exiting the Visualizer** — even though the app shows it everywhere else.

## Cause

`VisualizerScreen.initState` enters `SystemUiMode.immersiveSticky`, which **hides** the status + navigation bars for the fullscreen shader. On exit, `dispose()` set `SystemUiMode.edgeToEdge` to restore the chrome — but `edgeToEdge` only sets the edge-to-edge **layout** (content draws behind transparent bars); it does **not re-show** bars that were explicitly hidden. So the nav bar stayed gone after leaving the visualizer.

(It's the same reason `main.dart` already re-asserts `edgeToEdge` at startup — to recover when the app was killed while the visualizer had the bars hidden.)

## Fix

In `dispose()`, force the overlays back on before restoring the layout:

```dart
// show the bars …
SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: SystemUiOverlay.values);
// … then return to the app-wide edge-to-edge layout
SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
```

`manual` + all overlays explicitly **shows** the bars; the follow-up `edgeToEdge` returns to the transparent edge-to-edge layout the rest of the app uses. This covers every exit path (back button, long-press, system back, and the `detached` auto-pop) — they all funnel through `dispose()`.

## Verification

- `flutter analyze` — no new issues (one pre-existing baseline info at `visualizer_screen.dart:22`, untouched).
- Smoke: open the Visualizer → exit via the back button **and** the system back gesture → the bottom navigation bar is back and portrait is restored; repeat a few times to be sure it's reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
