### PR TITLE
perf: remaining #38 audit items (download coalesce, scratch reuse, async startup)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -80,8 +80,12 @@ Future<void> _startApp() async {
   // AndroidEqualizer to the player.
   await SettingsManager().load();
   await MediaManager().start();
-  await PlaylistManager().load();
-  await AutoDJManager().load();
+  // Saved playlists + AutoDJ config aren't needed for the first frame, and both
+  // are independent pure-disk reads — start them off the critical path so two
+  // sequential disk round-trips don't delay first paint. Both are stream-backed,
+  // so the Playlists / AutoDJ screens populate when the reads land.
+  unawaited(PlaylistManager().load());
+  unawaited(AutoDJManager().load());
   appLog('[app] mStream $kAppVersion started');
 
   // Wrap MaterialApp in a StreamBuilder bound to the theme + locale

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -387,6 +387,21 @@ class BrowserManager {
     _browserStream.sink.add(browserList);
   }
 
+  // Coalesced re-emit for the high-frequency download-progress path: a
+  // "Download all" fires progress ticks across many rows (one per 5% bucket per
+  // file), which can land dozens a second. Collapse them to <=1 emit / 100 ms so
+  // the whole list isn't rebuilt on every tick. Interactive callers (live search
+  // filtering, navigation) keep using updateStream() / the direct sink, so they
+  // stay immediate.
+  Timer? _downloadRefreshTimer;
+  void updateStreamCoalesced() {
+    if (_downloadRefreshTimer != null) return; // a flush is already scheduled
+    _downloadRefreshTimer = Timer(const Duration(milliseconds: 100), () {
+      _downloadRefreshTimer = null;
+      _browserStream.sink.add(browserList);
+    });
+  }
+
   /// Replaces the current (top) frame's list in place — no push/pop, so the
   /// back-stack is unchanged. Used to refresh a view (e.g. after a playlist
   /// create/rename) without adding a navigation entry.
@@ -511,6 +526,7 @@ class BrowserManager {
   void dispose() {
     _migrationSub?.cancel();
     _letterStripSub?.cancel();
+    _downloadRefreshTimer?.cancel();
     _browserStream.close();
     _browserLabel.close();
     _albumDetail.close();

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -92,7 +92,7 @@ class DownloadManager {
       final int pct = ((dt.progress.clamp(0.0, 1.0) * 100).round() ~/ 5) * 5;
       if (row.downloadProgress != pct) {
         row.downloadProgress = pct;
-        BrowserManager().updateStream();
+        BrowserManager().updateStreamCoalesced();
       }
     }
 

--- a/lib/singletons/visualizer_audio.dart
+++ b/lib/singletons/visualizer_audio.dart
@@ -102,9 +102,14 @@ class VisualizerAudio {
   // playback state — louder when something's playing, quiet (but
   // not silent) when paused so the screen never goes dead.
   final _rng = Random();
+  // Reused across ticks instead of allocating a fresh 4 KB buffer ~30x/s on the
+  // UI isolate (and the GC churn that brings): addPcm() serialises the samples
+  // into its platform-channel message synchronously — before its first await —
+  // so the bytes are copied out before the next tick can overwrite this.
+  late final Float32List _scratch = Float32List(_samplesPerTick * 2);
   Float32List _generate() {
     final amp = _playing ? 0.65 : 0.18;
-    final out = Float32List(_samplesPerTick * 2);
+    final out = _scratch;
     const beatHz = 2.0;
 
     for (var i = 0; i < _samplesPerTick; i++) {


### PR DESCRIPTION
The last three salvageable items from the stale perf-audit PR #38 — small, independent, and verified against current master. (The higher-value items already landed in #67/#68/#70.)

## 1. Coalesce the download-progress re-emit — `browser_list.dart` + `downloads.dart`

A "Download all" fires `updateStream()` from `downloads.dart` on every 5% progress bucket, across every downloading row — dozens of full-list re-emits a second under concurrency. Added a debounced **`updateStreamCoalesced()`** (≤1 emit / 100 ms) and pointed the download-progress tick at it.

**Adapted from #38, deliberately:** on current master `updateStream()` is *also* the **live search-filter** path (`openSearch` / `setSearchQuery` / `closeSearch`), so #38's blanket coalescing would have throttled typing. This keeps `updateStream()` immediate for search + navigation and debounces **only** the download path. The timer is cancelled in `dispose()`.

## 2. Reuse the visualizer PCM scratch buffer — `visualizer_audio.dart`

`_generate()` allocated a fresh `Float32List` (~4 KB) every tick (~30×/s) on the UI isolate. Now reuses one `_scratch` buffer. **Safe:** `VisualizerBridge.addPcm` does `invokeMethod('addPcm', {'samples': …})`, and the platform codec serialises the buffer into the channel message **synchronously, before the first `await`** — so the bytes are copied out before the next tick overwrites the scratch.

## 3. Move startup disk reads off the critical path — `main.dart`

`PlaylistManager().load()` and `AutoDJManager().load()` were `await`ed during startup. Neither is needed for the first frame and both are independent, stream-backed disk reads, so they're now `unawaited()` — their screens populate when the reads land instead of delaying first paint.

## Verification

- `flutter analyze` — **No issues found** (all four files).
- Smoke: a "Download all" still shows progress (now ≤10 list rebuilds/sec); live search filtering + folder navigation stay instant; the visualizer's audio-reactivity is unchanged; the Playlists + AutoDJ screens still populate.

With this, **#38's salvageable set is empty** — it can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
