### PR TITLE
Visualizer performance pass (ShaderEngine + shared infra)

### DIFF
--- a/android/app/src/main/cpp/shader_engine.cpp
+++ b/android/app/src/main/cpp/shader_engine.cpp
@@ -789,7 +789,7 @@ void ShaderEngine::renderFrame() {
         }
     }
 
-    // === Present pass: fboCurrent_ (with optional crossfade) → window ===
+    // === Present: fboCurrent_ → window, with optional crossfade ===
     float mixT = 1.0f;
     if (transitioning_) {
         const float t = std::chrono::duration<float>(now - transitionStart_).count()
@@ -797,23 +797,40 @@ void ShaderEngine::renderFrame() {
         if (t >= 1.0f) { transitioning_ = false; mixT = 1.0f; }
         else mixT = t * t * (3.0f - 2.0f * t);
     }
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glViewport(0, 0, width_, height_);
-    glUseProgram(presentProgram_);
-    if (locPresentCurrent_ >= 0) {
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, texCurrent_);
-        glUniform1i(locPresentCurrent_, 0);
+
+    if (!transitioning_) {
+        // Common case (no crossfade in flight): fboCurrent_ and the window
+        // are the same size, so a straight blit copies it to the screen.
+        // Cheaper than binding the present program + samplers and drawing a
+        // textured triangle just to sample one texture 1:1 every frame —
+        // and the old path bound *both* present textures + set uniforms even
+        // though the shader only sampled `current` when not transitioning.
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, fboCurrent_);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+        glBlitFramebuffer(0, 0, width_, height_, 0, 0, width_, height_,
+                          GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    } else {
+        // Crossfade in progress: blend the held previous frame (texOld_)
+        // with the new shader's current frame (texCurrent_).
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glViewport(0, 0, width_, height_);
+        glUseProgram(presentProgram_);
+        if (locPresentCurrent_ >= 0) {
+            glActiveTexture(GL_TEXTURE0);
+            glBindTexture(GL_TEXTURE_2D, texCurrent_);
+            glUniform1i(locPresentCurrent_, 0);
+        }
+        if (locPresentOld_ >= 0) {
+            glActiveTexture(GL_TEXTURE1);
+            glBindTexture(GL_TEXTURE_2D, texOld_);
+            glUniform1i(locPresentOld_, 1);
+        }
+        if (locPresentMixT_ >= 0) glUniform1f(locPresentMixT_, mixT);
+        glBindVertexArray(vao_);
+        glDrawArrays(GL_TRIANGLES, 0, 3);
+        glBindVertexArray(0);
     }
-    if (locPresentOld_ >= 0) {
-        glActiveTexture(GL_TEXTURE1);
-        glBindTexture(GL_TEXTURE_2D, texOld_);
-        glUniform1i(locPresentOld_, 1);
-    }
-    if (locPresentMixT_ >= 0) glUniform1f(locPresentMixT_, mixT);
-    glBindVertexArray(vao_);
-    glDrawArrays(GL_TRIANGLES, 0, 3);
-    glBindVertexArray(0);
 
     ++frameCount_;
 }

--- a/android/app/src/main/cpp/shader_engine.cpp
+++ b/android/app/src/main/cpp/shader_engine.cpp
@@ -657,6 +657,9 @@ void ShaderEngine::adoptPendingPassSetIfAny() {
         if (currentSet_->hasPass[i]) ensureBufferTarget(i);
     }
 
+    // Push the per-program constant uniforms once, now, instead of every frame.
+    primeConstantUniforms(currentSet_);
+
     transitionStart_ = std::chrono::steady_clock::now();
     transitioning_ = (fboOld_ != 0);
 
@@ -704,6 +707,10 @@ void ShaderEngine::renderPass(int idx, const Pass& p, GLuint targetFbo,
     glViewport(0, 0, targetW, targetH);
     glUseProgram(p.program);
 
+    // Per-frame uniforms only. iMouse, iDate, iSampleRate, iChannelResolution,
+    // the iChannel sampler-unit bindings, and iParams are constant for the
+    // program's lifetime (or change only on setTuning) and are uploaded once
+    // in primeConstantUniforms()/applyParamsToCurrentSet().
     if (p.locs.time       >= 0) glUniform1f(p.locs.time, elapsed);
     if (p.locs.timeDelta  >= 0) glUniform1f(p.locs.timeDelta, delta);
     if (p.locs.frame      >= 0) glUniform1i(p.locs.frame, frameCount_);
@@ -711,28 +718,16 @@ void ShaderEngine::renderPass(int idx, const Pass& p, GLuint targetFbo,
         static_cast<float>(targetW),
         static_cast<float>(targetH),
         static_cast<float>(targetW) / static_cast<float>(targetH));
-    if (p.locs.mouse      >= 0) glUniform4f(p.locs.mouse, 0,0,0,0);
-    if (p.locs.date       >= 0) glUniform4f(p.locs.date, 0,0,0,0);
-    if (p.locs.sampleRate >= 0) glUniform1f(p.locs.sampleRate, 44100.0f);
-    if (p.locs.params     >= 0) glUniform1fv(p.locs.params, NUM_PARAMS, params_);
     if (p.locs.channelTime >= 0) {
         const float t[4] = {elapsed,elapsed,elapsed,elapsed};
         glUniform1fv(p.locs.channelTime, 4, t);
     }
-    if (p.locs.channelResolution >= 0) {
-        const float r[12] = {
-            static_cast<float>(width_), static_cast<float>(height_), 1,
-            static_cast<float>(width_), static_cast<float>(height_), 1,
-            static_cast<float>(width_), static_cast<float>(height_), 1,
-            static_cast<float>(width_), static_cast<float>(height_), 1,
-        };
-        glUniform3fv(p.locs.channelResolution, 4, r);
-    }
 
-    // Bind iChannel0..3 textures + sampler uniforms.
+    // Bind iChannel0..3 textures. The sampler→unit mapping (sampler = unit c)
+    // was set once at prime time, so we only rebind the texture each frame
+    // (it changes as buffers ping-pong).
     for (int c = 0; c < 4; ++c) {
         if (p.locs.channel[c] < 0) continue;
-        // Audio channel resolution differs from buffer; override if needed.
         GLuint tex;
         if (p.channelSrc[c] == CHAN_AUDIO) {
             tex = audioTex;
@@ -741,12 +736,50 @@ void ShaderEngine::renderPass(int idx, const Pass& p, GLuint targetFbo,
         }
         glActiveTexture(GL_TEXTURE0 + c);
         glBindTexture(GL_TEXTURE_2D, tex);
-        glUniform1i(p.locs.channel[c], c);
     }
 
     glBindVertexArray(vao_);
     glDrawArrays(GL_TRIANGLES, 0, 3);
     glBindVertexArray(0);
+}
+
+void ShaderEngine::primeConstantUniforms(PassSet* set) {
+    if (!set) return;
+    // All four input channels report the engine's render size, matching the
+    // previous per-frame behavior. (Constant-size analysis buffers don't read
+    // iChannelResolution, so the approximation is harmless.)
+    const float chRes[12] = {
+        static_cast<float>(width_), static_cast<float>(height_), 1,
+        static_cast<float>(width_), static_cast<float>(height_), 1,
+        static_cast<float>(width_), static_cast<float>(height_), 1,
+        static_cast<float>(width_), static_cast<float>(height_), 1,
+    };
+    for (int i = 0; i < PASS_COUNT; ++i) {
+        if (!set->hasPass[i]) continue;
+        const Pass& p = set->passes[i];
+        glUseProgram(p.program);
+        if (p.locs.sampleRate >= 0) glUniform1f(p.locs.sampleRate, 44100.0f);
+        if (p.locs.mouse >= 0) glUniform4f(p.locs.mouse, 0, 0, 0, 0);
+        if (p.locs.date  >= 0) glUniform4f(p.locs.date, 0, 0, 0, 0);
+        if (p.locs.channelResolution >= 0)
+            glUniform3fv(p.locs.channelResolution, 4, chRes);
+        for (int c = 0; c < 4; ++c) {
+            if (p.locs.channel[c] >= 0) glUniform1i(p.locs.channel[c], c);
+        }
+        if (p.locs.params >= 0) glUniform1fv(p.locs.params, NUM_PARAMS, params_);
+    }
+    paramsDirty_ = false;
+}
+
+void ShaderEngine::applyParamsToCurrentSet() {
+    if (!currentSet_) return;
+    for (int i = 0; i < PASS_COUNT; ++i) {
+        if (!currentSet_->hasPass[i]) continue;
+        const Pass& p = currentSet_->passes[i];
+        if (p.locs.params < 0) continue;
+        glUseProgram(p.program);
+        glUniform1fv(p.locs.params, NUM_PARAMS, params_);
+    }
 }
 
 void ShaderEngine::renderFrame() {
@@ -762,6 +795,13 @@ void ShaderEngine::renderFrame() {
         glBindFramebuffer(GL_FRAMEBUFFER, fboCurrent_);
         glClearColor(0,0,0,1); glClear(GL_COLOR_BUFFER_BIT);
     } else {
+        // Tuning changed since last frame? Re-push iParams to the programs
+        // once, here, rather than re-uploading it in every renderPass.
+        if (paramsDirty_) {
+            applyParamsToCurrentSet();
+            paramsDirty_ = false;
+        }
+
         const GLuint audioTex = audio_.upload();
 
         // Render every buffer pass that exists, in fixed order A..D.
@@ -849,6 +889,9 @@ void ShaderEngine::setTuning(const float* values, std::size_t count) {
         const std::size_t idx = static_cast<std::size_t>(i) + 3;
         params_[i] = (idx < count) ? values[idx] : 0.0f;
     }
+    // Pushed to the programs by the next renderFrame (not here — this may run
+    // before the current set exists, and we want a single GL touch point).
+    paramsDirty_ = true;
 }
 
 void ShaderEngine::loadPreset(const char* data, bool /*smoothTransition*/) {
@@ -871,6 +914,7 @@ void ShaderEngine::loadPreset(const char* data, bool /*smoothTransition*/) {
         for (int i = 0; i < 4; ++i) {
             if (currentSet_->hasPass[i]) ensureBufferTarget(i);
         }
+        primeConstantUniforms(currentSet_);
         transitionStart_ = std::chrono::steady_clock::now();
         transitioning_ = (fboOld_ != 0);
         return;

--- a/android/app/src/main/cpp/shader_engine.cpp
+++ b/android/app/src/main/cpp/shader_engine.cpp
@@ -167,6 +167,9 @@ struct ParsedShader {
     bool hasCommon = false;
     // [passIdx][channel] = ChannelSource enum int
     int channelSrc[ShaderEngine::PASS_COUNT][4] = {{0}};
+    // Requested render size per pass; 0 = full window resolution.
+    int passW[ShaderEngine::PASS_COUNT] = {0};
+    int passH[ShaderEngine::PASS_COUNT] = {0};
 };
 
 int passIndexFromName(const std::string& nameLower) {
@@ -238,6 +241,11 @@ ParsedShader parseShader(const std::string& source) {
     std::regex passMarker(R"(^\s*//\s*===\s*pass\s*:\s*([a-zA-Z]+)\s*===)");
     std::regex channelMarker(
         R"(^\s*//\s*===\s*channel\s+([a-zA-Z]+)\s*\.\s*(\d+)\s*=\s*([a-zA-Z]+))");
+    // Optional per-pass render size: `// === size bufferc = 1x1`. Lets a
+    // pass that writes a single constant value render at e.g. 1x1 instead
+    // of a full-screen pass. Honored for buffer passes only.
+    std::regex sizeMarker(
+        R"(^\s*//\s*===\s*size\s+([a-zA-Z]+)\s*=\s*(\d+)\s*[xX]\s*(\d+))");
 
     while (std::getline(stream, line)) {
         std::smatch m;
@@ -255,7 +263,7 @@ ParsedShader parseShader(const std::string& source) {
             continue;
         }
         if (curPass == -1) {
-            // Pre-marker zone: look for routing lines
+            // Pre-marker zone: look for routing + size lines
             std::smatch cm;
             if (std::regex_search(line, cm, channelMarker)) {
                 std::string target = lowerAlnum(cm[1].str());
@@ -265,6 +273,14 @@ ParsedShader parseShader(const std::string& source) {
                 int srcEnum = channelSourceFromString(srcName);
                 if (tgtIdx >= 0 && ch >= 0 && ch < 4) {
                     out.channelSrc[tgtIdx][ch] = srcEnum;
+                }
+            } else if (std::regex_search(line, cm, sizeMarker)) {
+                int tgtIdx = passIndexFromName(lowerAlnum(cm[1].str()));
+                int w = std::stoi(cm[2].str());
+                int h = std::stoi(cm[3].str());
+                if (tgtIdx >= 0 && w > 0 && h > 0) {
+                    out.passW[tgtIdx] = w;
+                    out.passH[tgtIdx] = h;
                 }
             }
             // Other pre-marker lines are ignored (comments, etc.)
@@ -412,9 +428,24 @@ void ShaderEngine::teardownOffscreenTargets() {
 
 bool ShaderEngine::ensureBufferTarget(int idx) {
     BufferTarget& bt = bufferTargets_[idx];
-    if (bt.allocated) return true;
+
+    // Render size for this buffer: the pass's declared size (e.g. a 1x1
+    // audio-analysis buffer), or full window resolution by default.
+    int rw = width_, rh = height_;
+    if (currentSet_ && currentSet_->hasPass[idx]) {
+        const Pass& p = currentSet_->passes[idx];
+        if (p.renderW > 0 && p.renderH > 0) { rw = p.renderW; rh = p.renderH; }
+    }
+
+    if (bt.allocated) {
+        if (bt.w == rw && bt.h == rh) return true;
+        // A preset swap re-requested this slot at a different size; free
+        // the old textures and reallocate to match.
+        releaseBufferTarget(idx);
+    }
+
     for (int p = 0; p < 2; ++p) {
-        if (!createColorFbo(width_, height_, &bt.fbo[p], &bt.tex[p])) {
+        if (!createColorFbo(rw, rh, &bt.fbo[p], &bt.tex[p])) {
             // free anything created
             for (int q = 0; q < p; ++q) {
                 glDeleteFramebuffers(1, &bt.fbo[q]);
@@ -429,22 +460,26 @@ bool ShaderEngine::ensureBufferTarget(int idx) {
     }
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     bt.writeIdx = 0;
+    bt.w = rw; bt.h = rh;
     bt.allocated = true;
     return true;
 }
 
-void ShaderEngine::releaseAllBufferTargets() {
-    for (int i = 0; i < 4; ++i) {
-        BufferTarget& bt = bufferTargets_[i];
-        if (!bt.allocated) continue;
-        for (int p = 0; p < 2; ++p) {
-            if (bt.fbo[p]) glDeleteFramebuffers(1, &bt.fbo[p]);
-            if (bt.tex[p]) glDeleteTextures(1, &bt.tex[p]);
-            bt.fbo[p] = 0; bt.tex[p] = 0;
-        }
-        bt.allocated = false;
-        bt.writeIdx = 0;
+void ShaderEngine::releaseBufferTarget(int idx) {
+    BufferTarget& bt = bufferTargets_[idx];
+    if (!bt.allocated) return;
+    for (int p = 0; p < 2; ++p) {
+        if (bt.fbo[p]) glDeleteFramebuffers(1, &bt.fbo[p]);
+        if (bt.tex[p]) glDeleteTextures(1, &bt.tex[p]);
+        bt.fbo[p] = 0; bt.tex[p] = 0;
     }
+    bt.allocated = false;
+    bt.writeIdx = 0;
+    bt.w = 0; bt.h = 0;
+}
+
+void ShaderEngine::releaseAllBufferTargets() {
+    for (int i = 0; i < 4; ++i) releaseBufferTarget(i);
 }
 
 bool ShaderEngine::setupSharedContext() {
@@ -541,6 +576,12 @@ ShaderEngine::PassSet* ShaderEngine::compilePassSet(const std::string& source) {
         pp.locs = queryUniformLocations(prog);
         for (int c = 0; c < 4; ++c) {
             pp.channelSrc[c] = static_cast<ChannelSource>(parsed.channelSrc[i][c]);
+        }
+        // Image always renders full res (the present pass samples it 1:1);
+        // only buffer passes honor a declared size.
+        if (i != PASS_IMAGE) {
+            pp.renderW = parsed.passW[i];
+            pp.renderH = parsed.passH[i];
         }
         set->hasPass[i] = true;
         ++totalCompiled;
@@ -657,18 +698,19 @@ GLuint ShaderEngine::channelTextureFor(ChannelSource src, int currentPassIdx,
 }
 
 void ShaderEngine::renderPass(int idx, const Pass& p, GLuint targetFbo,
+                                int targetW, int targetH,
                                 float elapsed, float delta, GLuint audioTex) {
     glBindFramebuffer(GL_FRAMEBUFFER, targetFbo);
-    glViewport(0, 0, width_, height_);
+    glViewport(0, 0, targetW, targetH);
     glUseProgram(p.program);
 
     if (p.locs.time       >= 0) glUniform1f(p.locs.time, elapsed);
     if (p.locs.timeDelta  >= 0) glUniform1f(p.locs.timeDelta, delta);
     if (p.locs.frame      >= 0) glUniform1i(p.locs.frame, frameCount_);
     if (p.locs.resolution >= 0) glUniform3f(p.locs.resolution,
-        static_cast<float>(width_),
-        static_cast<float>(height_),
-        static_cast<float>(width_) / static_cast<float>(height_));
+        static_cast<float>(targetW),
+        static_cast<float>(targetH),
+        static_cast<float>(targetW) / static_cast<float>(targetH));
     if (p.locs.mouse      >= 0) glUniform4f(p.locs.mouse, 0,0,0,0);
     if (p.locs.date       >= 0) glUniform4f(p.locs.date, 0,0,0,0);
     if (p.locs.sampleRate >= 0) glUniform1f(p.locs.sampleRate, 44100.0f);
@@ -728,13 +770,13 @@ void ShaderEngine::renderFrame() {
             BufferTarget& bt = bufferTargets_[i];
             if (!bt.allocated) continue;
             renderPass(i, currentSet_->passes[i], bt.fbo[bt.writeIdx],
-                       elapsed, delta, audioTex);
+                       bt.w, bt.h, elapsed, delta, audioTex);
         }
 
-        // Image pass renders into fboCurrent_.
+        // Image pass renders into fboCurrent_ (always full window res).
         if (currentSet_->hasPass[PASS_IMAGE]) {
             renderPass(PASS_IMAGE, currentSet_->passes[PASS_IMAGE], fboCurrent_,
-                       elapsed, delta, audioTex);
+                       width_, height_, elapsed, delta, audioTex);
         }
 
         // After all passes done this frame, swap each buffer's

--- a/android/app/src/main/cpp/shader_engine.h
+++ b/android/app/src/main/cpp/shader_engine.h
@@ -112,6 +112,14 @@ private:
         UniformLocs locs{};
         // Source for each of the 4 iChannel uniforms in this pass.
         ChannelSource channelSrc[4] = {CHAN_NONE, CHAN_NONE, CHAN_NONE, CHAN_NONE};
+        // Requested render size for this pass's target, 0 = full window res.
+        // Only honored for buffer passes (A..D); the image pass always
+        // renders at full res so the present pass can sample it 1:1. Lets a
+        // shader declare e.g. an audio-analysis buffer that writes one
+        // constant value as `1x1`, instead of paying a full-screen pass to
+        // produce a single texel. See the `// === size <pass> = WxH` marker.
+        int renderW = 0;
+        int renderH = 0;
     };
 
     // A complete set of compiled passes for one shader preset.
@@ -126,15 +134,21 @@ private:
         GLuint tex[2] = {0, 0};
         int writeIdx = 0;
         bool allocated = false;
+        // Size the textures were allocated at, so a preset swap that
+        // re-requests this buffer slot at a different size reallocates.
+        int w = 0;
+        int h = 0;
     };
 
     // === Render-thread methods ===
     void adoptPendingPassSetIfAny();
     void renderPass(int idx, const Pass& p, GLuint targetFbo,
+                     int targetW, int targetH,
                      float elapsed, float delta, GLuint audioTex);
     GLuint channelTextureFor(ChannelSource src, int currentPassIdx,
                               GLuint audioTex) const;
     bool ensureBufferTarget(int idx);
+    void releaseBufferTarget(int idx);
     void releaseAllBufferTargets();
     void clearCurrentSet();
 

--- a/android/app/src/main/cpp/shader_engine.h
+++ b/android/app/src/main/cpp/shader_engine.h
@@ -151,6 +151,15 @@ private:
     void releaseBufferTarget(int idx);
     void releaseAllBufferTargets();
     void clearCurrentSet();
+    // Upload the uniforms that are constant for a program's lifetime (or
+    // change only on setTuning): iChannelResolution, iSampleRate, iMouse,
+    // iDate, the iChannel sampler-unit bindings, and iParams. Called once
+    // when a PassSet is adopted, instead of re-uploading them every frame in
+    // renderPass. Uniform values live in the program object, so they persist
+    // across the glUseProgram switches between passes.
+    void primeConstantUniforms(PassSet* set);
+    // Re-upload just iParams to the current set's programs (after setTuning).
+    void applyParamsToCurrentSet();
 
     // === Worker-thread methods ===
     void workerLoop();
@@ -211,6 +220,10 @@ private:
     // declared defaults on load, so shaders that read iParams[i] always
     // see a sensible value.
     float params_[NUM_PARAMS] = {0.0f};
+    // Set by setTuning(), cleared once the new params_ have been pushed to the
+    // current set's programs. Lets renderFrame skip the per-frame iParams
+    // re-upload when tuning hasn't changed.
+    bool paramsDirty_ = false;
 
     // --- Worker thread state ---
     std::thread worker_;

--- a/android/app/src/main/cpp/visualizer_bridge.cpp
+++ b/android/app/src/main/cpp/visualizer_bridge.cpp
@@ -95,6 +95,16 @@ bool setupEgl(BridgeContext* ctx) {
         LOGE("eglMakeCurrent failed: 0x%x", eglGetError());
         return false;
     }
+
+    // Decouple buffer swap from display vsync. The on-screen render thread
+    // already paces itself to ~60fps with Thread.sleep, and the transcode
+    // path paces to the audio clock — so the default swap interval of 1
+    // (which blocks each swap on vsync) double-throttles. Worse, on a
+    // 90/120Hz panel a 60fps sleep target beats against vsync and delivers
+    // uneven frames. Interval 0 makes the manual pacing the single clock.
+    // Best-effort: a driver may clamp/ignore it, in which case the sleep
+    // still caps the rate.
+    eglSwapInterval(ctx->display, 0);
     return true;
 }
 

--- a/android/app/src/main/cpp/visualizer_bridge.cpp
+++ b/android/app/src/main/cpp/visualizer_bridge.cpp
@@ -220,10 +220,11 @@ Java_com_example_mstream_1music_VisualizerBridge_nativeRenderFrame(
         JNIEnv* /*env*/, jobject /*thiz*/, jlong ctxPtr) {
     auto* ctx = reinterpret_cast<BridgeContext*>(ctxPtr);
     if (!ctx || !ctx->engine) return;
-    // Context should already be current on this thread (set up at
-    // init), but re-make-current cheaply guards against any other
-    // GL caller stealing it.
-    eglMakeCurrent(ctx->display, ctx->surface, ctx->surface, ctx->context);
+    // The context was made current on this dedicated render thread at
+    // nativeInit and nothing else steals it: the shader-compile worker runs
+    // on its own thread with its own context, and loadPreset/dispose run on
+    // this same thread. So no per-frame eglMakeCurrent is needed — the
+    // encoder render path (nativeRenderFrameAt) already relies on this.
     ctx->engine->renderFrame();
     eglSwapBuffers(ctx->display, ctx->surface);
 }

--- a/assets/shaders/04-cyber-fuji.glsl
+++ b/assets/shaders/04-cyber-fuji.glsl
@@ -63,6 +63,10 @@
 // === channel image.1 = buffera
 // === channel buffera.0 = music
 // === channel buffera.1 = buffera
+// buffera writes one constant vec4 (the 4 band amplitudes) to every pixel
+// and the image pass samples a single texel, so render it at 1x1 instead of
+// paying a full-screen pass with 24 texture fetches per pixel.
+// === size buffera = 1x1
 
 // === pass: image ===
 

--- a/assets/shaders/05-hex-marching.glsl
+++ b/assets/shaders/05-hex-marching.glsl
@@ -31,6 +31,10 @@
 // === channel bufferb.1 = bufferb
 // === channel bufferc.0 = music
 // === channel bufferc.1 = bufferc
+// bufferc is the bass-onset detector: it writes one value to every pixel and
+// the image pass samples a single texel, so render it at 1x1 rather than a
+// full-screen pass. (bufferA/bufferB are the full-res visual passes.)
+// === size bufferc = 1x1
 //
 // === pass: image ===
 // License CC0: Hex Marching

--- a/lib/singletons/visualizer_audio.dart
+++ b/lib/singletons/visualizer_audio.dart
@@ -39,6 +39,7 @@ class VisualizerAudio {
     if (_active) return;
     _active = true;
     _frame = 0;
+    _phaseBass = _phaseMid = _phaseTreble = 0.0;
 
     final initial = MediaManager().audioHandler.playbackState.value;
     _playing = initial.playing;
@@ -107,28 +108,47 @@ class VisualizerAudio {
   // into its platform-channel message synchronously — before its first await —
   // so the bytes are copied out before the next tick can overwrite this.
   late final Float32List _scratch = Float32List(_samplesPerTick * 2);
+  // Running phase of each carrier, advanced sample-by-sample. Persisting it
+  // across ticks keeps the oscillators continuous even though their centre
+  // frequencies are refreshed only once per tick (see below).
+  double _phaseBass = 0.0;
+  double _phaseMid = 0.0;
+  double _phaseTreble = 0.0;
+
   Float32List _generate() {
     final amp = _playing ? 0.65 : 0.18;
     final out = _scratch;
     const beatHz = 2.0;
 
+    // The sweep LFOs are all < 1 Hz, so their value barely moves across one
+    // ~12 ms tick. Evaluate them once per tick (at the tick midpoint) instead
+    // of per sample — that drops three sin() calls per sample to three per
+    // tick. The carriers then advance by a fixed phase step for the tick,
+    // accumulated into _phase* so they stay continuous tick-to-tick.
+    //   bass:   60–120 Hz, sweeping at 0.31 Hz
+    //   mid:   440–970 Hz, sweeping at 0.47 Hz
+    //   treble: 2 kHz–5 kHz, sweeping at 0.71 Hz
+    final tMid = (_frame * _samplesPerTick + _samplesPerTick / 2) / _sampleRate;
+    final bassF   =   60 +   60 * (0.5 + 0.5 * sin(2 * pi * 0.31 * tMid));
+    final midF    =  440 +  530 * (0.5 + 0.5 * sin(2 * pi * 0.47 * tMid));
+    final trebleF = 2000 + 3000 * (0.5 + 0.5 * sin(2 * pi * 0.71 * tMid));
+    final dBass   = 2 * pi * bassF   / _sampleRate;
+    final dMid    = 2 * pi * midF    / _sampleRate;
+    final dTreble = 2 * pi * trebleF / _sampleRate;
+
     for (var i = 0; i < _samplesPerTick; i++) {
       final t = (_frame * _samplesPerTick + i) / _sampleRate;
 
-      // Beat envelope — same shape as a low-frequency tremolo.
+      // Beat envelope — fixed 2 Hz, so a plain sin on absolute time is
+      // already continuous tick-to-tick.
       final beat = 0.5 + 0.5 * sin(2 * pi * beatHz * t);
 
-      // Three slow LFO-modulated sweeps spanning the spectrum:
-      //   bass:   60–180 Hz, sweeping at 0.31 Hz
-      //   mid:   440–1500 Hz, sweeping at 0.47 Hz
-      //   treble: 2 kHz–8 kHz, sweeping at 0.71 Hz
-      final bassF   =   60 +   60 * (0.5 + 0.5 * sin(2 * pi * 0.31 * t));
-      final midF    =  440 +  530 * (0.5 + 0.5 * sin(2 * pi * 0.47 * t));
-      final trebleF = 2000 + 3000 * (0.5 + 0.5 * sin(2 * pi * 0.71 * t));
-
-      final bass   = sin(2 * pi * bassF   * t) * 0.55;
-      final mid    = sin(2 * pi * midF    * t) * 0.30;
-      final treble = sin(2 * pi * trebleF * t) * 0.18;
+      _phaseBass += dBass;
+      _phaseMid += dMid;
+      _phaseTreble += dTreble;
+      final bass   = sin(_phaseBass)   * 0.55;
+      final mid    = sin(_phaseMid)    * 0.30;
+      final treble = sin(_phaseTreble) * 0.18;
 
       // Light broadband noise so every FFT bin gets some energy —
       // otherwise the spectrum-bar shader looks too quantised.
@@ -146,6 +166,10 @@ class VisualizerAudio {
       out[2 * i] = sample;
       out[2 * i + 1] = r;
     }
+    // Wrap phases so they don't lose float precision over a long session.
+    _phaseBass %= 2 * pi;
+    _phaseMid %= 2 * pi;
+    _phaseTreble %= 2 * pi;
     _frame++;
     return out;
   }


### PR DESCRIPTION
Performance audit of the visualizer stack (both engines + shared infrastructure), implemented as six focused commits. Each addresses a distinct hot-path cost; the ProjectM path is a thin passthrough to `libprojectM-4.so`, so the wins are concentrated in the custom **ShaderEngine** and the shared audio/present/pacing code.

## Commits (one per finding)

1. **Render constant-output buffer passes at a declared size.** The audio-analysis buffer passes (cyber-fuji `bufferA`, hex-marching `bufferC`) compute one `vec4` of state and write it identically to every pixel; the image pass then samples a single texel. They were running full-screen passes — at ~2400×1080 that's ~2.6M invocations each doing up to 24 `texture()` fetches to produce 4 floats, plus two full-res RGBA8 ping-pong textures (~20 MB). Added a `// === size <pass> = WxH` marker so those buffers render at `1x1`. Biggest GPU + memory win.
2. **Blit instead of a textured present pass when not crossfading.** The present pass ran a full-screen textured draw every frame even though the crossfade is only live for 0.6 s after a swap. When idle, copy `fboCurrent_` → window with `glBlitFramebuffer` and skip the program/sampler/draw setup.
3. **`eglSwapInterval(0)`.** The render thread paces to ~60 fps with `Thread.sleep` and the transcode path paces to the audio clock, but swap blocked on vsync (default interval 1) — double-throttling, and beating against 90/120 Hz panels. Make the manual pacing the single clock.
4. **Drop the per-frame defensive `eglMakeCurrent`** on the on-screen render path. The context never leaves the dedicated render thread (the encoder path already relies on this).
5. **Hoist constant uniforms out of `renderPass`.** `iChannelResolution`, `iSampleRate`, `iMouse`, `iDate`, the `iChannel` sampler-unit bindings, and `iParams` were re-uploaded every pass every frame though they never change frame-to-frame. Push them once at adopt (`primeConstantUniforms`); re-push `iParams` only when `setTuning` dirties it.
6. **Cut per-sample trig in the synthesized PCM generator.** `_generate()` runs on the UI isolate and did 7 `sin()`/sample. The sweep LFOs (<1 Hz) are hoisted to once-per-tick and the carriers use phase accumulators → 4 `sin()`/sample (~43% fewer).

## Verification
- All native translation units compile clean with the project's pinned NDK (28.2, arm64, `-Wall`).
- `flutter analyze` clean on the changed Dart.
- **Not** yet built into an APK or run on-device — compile/analyze only.

## Behavioral note
Commit 6 slightly changes the *character* of the synthesized idle signal (cleaner swept tones vs the old buzzy texture). It only affects the default synthesized-audio mode (real-audio capture is unaffected) and is purely cosmetic.

## Deliberately out of scope
- **Render-scale dial** (render offscreen at a fraction of window res, upscale in the present pass) — a real lever but a quality-changing feature, not a fix. Easy follow-up.
- ProjectM mesh size (48×36 is a sensible default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)