### PR TITLE
feat(cast): cast iroh servers to Chromecast/DLNA via a LAN reverse-proxy

### DIFF
--- a/lib/media/cast_origin.dart
+++ b/lib/media/cast_origin.dart
@@ -1,0 +1,54 @@
+import 'package:audio_service/audio_service.dart' show MediaItem;
+
+import '../objects/server.dart';
+import '../singletons/server_list.dart';
+import 'cast_art.dart';
+import 'local_media_server.dart';
+
+/// Casting helpers for iroh servers.
+///
+/// A cast renderer (DLNA / Chromecast) fetches media by URL itself, but an iroh
+/// server's stream + art URLs point at `http://127.0.0.1:<tunnelPort>` — the
+/// phone's loopback tunnel, which a device across the LAN can't reach. These
+/// helpers detect such a track and re-origin its URLs through [LocalMediaServer],
+/// which relays the bytes to the renderer from the phone's LAN address over the
+/// tunnel (Range forwarded, so seeking still works).
+
+/// The iroh [Server] a queued [item] belongs to, or null when the item isn't
+/// from an iroh server (a plain HTTP server's URLs are already routable).
+Server? irohServerFor(MediaItem item) {
+  final s = ServerManager().byLocalname(item.extras?['server'] as String?);
+  return (s != null && s.isIroh) ? s : null;
+}
+
+/// Re-origin a loopback iroh URL through the LAN proxy so a renderer can reach
+/// it. [loopback] is a stored `http://127.0.0.1:<port>/...` URL; its path/query
+/// are rebound to [server]'s LIVE tunnel — current port + `__lt` token — so a
+/// port/token that went stale since the URL was built self-heals, and the
+/// loopback token never appears in the LAN-facing URL. The caller must have
+/// started [LocalMediaServer] first ([LocalMediaServer.ensureStarted]).
+Uri irohProxyUri(Server server, String loopback) {
+  final u = Uri.parse(loopback);
+  final base = Uri.parse(server.effectiveBaseUrl); // http://127.0.0.1:<livePort>
+  final q = Map<String, String>.from(u.queryParameters);
+  if (server.tunnelToken != null) q['__lt'] = server.tunnelToken!;
+  final upstream = u.replace(
+    scheme: base.scheme,
+    host: base.host,
+    port: base.port,
+    queryParameters: q.isEmpty ? null : q,
+  );
+  return LocalMediaServer().registerProxy(upstream);
+}
+
+/// The album-art URL to hand a renderer: full-resolution [castArtUrl], re-
+/// originated through the LAN proxy when the track is from an iroh server.
+/// Returns null when the item has no art. For the iroh case [LocalMediaServer]
+/// must already be running — the load path starts it when resolving the stream
+/// URL, which always happens before the art is read.
+String? castArtUriFor(MediaItem item) {
+  final art = castArtUrl(item);
+  if (art == null) return null;
+  final server = irohServerFor(item);
+  return server == null ? art : irohProxyUri(server, art).toString();
+}

--- a/lib/media/cast_origin.dart
+++ b/lib/media/cast_origin.dart
@@ -21,25 +21,33 @@ Server? irohServerFor(MediaItem item) {
   return (s != null && s.isIroh) ? s : null;
 }
 
-/// Re-origin a loopback iroh URL through the LAN proxy so a renderer can reach
-/// it. [loopback] is a stored `http://127.0.0.1:<port>/...` URL; its path/query
-/// are rebound to [server]'s LIVE tunnel — current port + `__lt` token — so a
-/// port/token that went stale since the URL was built self-heals, and the
-/// loopback token never appears in the LAN-facing URL. The caller must have
-/// started [LocalMediaServer] first ([LocalMediaServer.ensureStarted]).
-Uri irohProxyUri(Server server, String loopback) {
-  final u = Uri.parse(loopback);
+/// Rebind a stored loopback iroh URL to [server]'s LIVE tunnel — current port +
+/// `__lt` token — so a port/token that went stale since the URL was built
+/// self-heals. [stored] is a `http://127.0.0.1:<port>/...` URL. Returns the live
+/// loopback URL; the caller decides whether to relay it through the LAN proxy
+/// ([irohProxyUri], for a renderer that can't reach loopback) or hand it to an
+/// on-device consumer that can (the visualizer transcoder).
+Uri irohLoopbackUri(Server server, String stored) {
+  final u = Uri.parse(stored);
   final base = Uri.parse(server.effectiveBaseUrl); // http://127.0.0.1:<livePort>
   final q = Map<String, String>.from(u.queryParameters);
   if (server.tunnelToken != null) q['__lt'] = server.tunnelToken!;
-  final upstream = u.replace(
+  return u.replace(
     scheme: base.scheme,
     host: base.host,
     port: base.port,
     queryParameters: q.isEmpty ? null : q,
   );
-  return LocalMediaServer().registerProxy(upstream);
 }
+
+/// Re-origin a loopback iroh URL through the LAN proxy so a renderer can reach
+/// it. [loopback] is a stored `http://127.0.0.1:<port>/...` URL, rebound to the
+/// LIVE tunnel ([irohLoopbackUri]) so a stale port/token self-heals; the loopback
+/// `__lt` token rides only the inward leg and never appears in the LAN-facing
+/// URL. The caller must have started [LocalMediaServer] first
+/// ([LocalMediaServer.ensureStarted]).
+Uri irohProxyUri(Server server, String loopback) =>
+    LocalMediaServer().registerProxy(irohLoopbackUri(server, loopback));
 
 /// The album-art URL to hand a renderer: full-resolution [castArtUrl], re-
 /// originated through the LAN proxy when the track is from an iroh server.

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -180,11 +180,15 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       await LocalMediaServer().ensureStarted();
       return LocalMediaServer().registerFile(localPath);
     }
-    // (A downloaded iroh track carries a localPath and was served as a local file
-    // above — faster, and it skips the tunnel.)
     final iroh = irohServerFor(item);
     if (iroh != null) {
       await LocalMediaServer().ensureStarted();
+      // A downloaded iroh track is already on disk — serve it from there (faster,
+      // and it skips the tunnel relay). Its id is a 127.0.0.1 loopback URL, so
+      // isNetwork is true and the disk branch above is bypassed; handle it here.
+      if (localPath != null && File(localPath).existsSync()) {
+        return LocalMediaServer().registerFile(localPath);
+      }
       return irohProxyUri(iroh, item.id);
     }
     return Uri.parse(item.id);

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -307,7 +307,20 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     final dir = '$parent/$_loadCounter';
     _currentVizDir = dir;
 
-    final source = (item.extras?['localPath'] as String?) ?? item.id;
+    // The transcoder reads this source on-device. A downloaded track is read
+    // straight from disk; otherwise, for an iroh server, item.id is a stored
+    // loopback URL whose port/token may have gone stale — re-origin to the live
+    // tunnel (loopback IS reachable on the phone, so no LAN proxy is needed for
+    // the transcoder's own input, only for the renderer's HLS pull).
+    final localPath = item.extras?['localPath'] as String?;
+    final String source;
+    if (localPath != null && File(localPath).existsSync()) {
+      source = localPath;
+    } else {
+      final iroh = irohServerFor(item);
+      source =
+          iroh != null ? irohLoopbackUri(iroh, item.id).toString() : item.id;
+    }
     final cfg = await resolveVisualizerCastConfig();
     if (gen != _loadGen) throw StateError('superseded');
     final quality = SettingsManager().castVisualizerQuality;

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -11,6 +11,7 @@ import '../singletons/cast_manager.dart';
 import '../singletons/settings.dart';
 import 'cast_art.dart';
 import 'cast_log.dart';
+import 'cast_origin.dart';
 import 'emulated_playlist_backend.dart';
 import 'local_media_server.dart';
 import 'playback_backend.dart';
@@ -167,9 +168,10 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   }
 
   // ── Media construction ──
-  // A network id (server URL) is sent as-is; a local-only item (file-explorer
-  // track — id is a UUID) is served from the phone's LocalMediaServer so the
-  // receiver can reach it.
+  // A plain HTTP server id is sent as-is; a local-only item (file-explorer track
+  // — id is a UUID) is served from the phone's LocalMediaServer; an iroh server's
+  // id is the phone-loopback tunnel URL the receiver can't reach, so it's relayed
+  // through the LocalMediaServer proxy (re-bound to the live tunnel).
   Future<Uri> _resolveUri(MediaItem item) async {
     final localPath = item.extras?['localPath'] as String?;
     final isNetwork =
@@ -178,12 +180,21 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       await LocalMediaServer().ensureStarted();
       return LocalMediaServer().registerFile(localPath);
     }
+    // (A downloaded iroh track carries a localPath and was served as a local file
+    // above — faster, and it skips the tunnel.)
+    final iroh = irohServerFor(item);
+    if (iroh != null) {
+      await LocalMediaServer().ensureStarted();
+      return irohProxyUri(iroh, item.id);
+    }
     return Uri.parse(item.id);
   }
 
   GoogleCastMediaInformation _mediaInfo(MediaItem item, String url) {
-    // Full-res art (drop the compress= size param) — looks sharp on a TV.
-    final art = castArtUrl(item);
+    // Full-res art (drop the compress= size param) — looks sharp on a TV; for an
+    // iroh server it's relayed through the LAN proxy (LocalMediaServer already
+    // started by _resolveUri above) so the receiver can fetch it.
+    final art = castArtUriFor(item);
     return GoogleCastMediaInformation(
       contentId: url,
       contentUrl: Uri.parse(url),

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 
 import 'cast_art.dart';
 import 'cast_log.dart';
+import 'cast_origin.dart';
 import 'emulated_playlist_backend.dart';
 import 'local_media_server.dart';
 import 'playback_backend.dart';
@@ -50,9 +51,11 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
   static const int _kMaxPollFailures = 4;
 
   // ── Transport ──
-  // DLNA renderers fetch the URL themselves. A network id (server URL) is
-  // handed over as-is; a local-only item (file-explorer track — id is a UUID)
-  // is served from the phone's LocalMediaServer so the renderer can reach it.
+  // DLNA renderers fetch the URL themselves. A plain HTTP server id is handed
+  // over as-is; a local-only item (file-explorer track — id is a UUID) is served
+  // from the phone's LocalMediaServer; an iroh server's id is the phone-loopback
+  // tunnel URL the renderer can't reach, so it's relayed through the
+  // LocalMediaServer proxy (re-bound to the live tunnel).
   Future<Uri> _resolveUri(MediaItem item) async {
     final localPath = item.extras?['localPath'] as String?;
     final isNetwork =
@@ -61,12 +64,21 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
       await LocalMediaServer().ensureStarted();
       return LocalMediaServer().registerFile(localPath);
     }
+    // (A downloaded iroh track carries a localPath and was served as a local file
+    // above — faster, and it skips the tunnel.)
+    final iroh = irohServerFor(item);
+    if (iroh != null) {
+      await LocalMediaServer().ensureStarted();
+      return irohProxyUri(iroh, item.id);
+    }
     return Uri.parse(item.id);
   }
 
   AudioMetadata _metaFor(MediaItem item) {
-    // Full-res art (drop the compress= size param) — looks sharp on a TV.
-    final art = castArtUrl(item);
+    // Full-res art (drop the compress= size param) — looks sharp on a TV; for an
+    // iroh server it's relayed through the LAN proxy (LocalMediaServer already
+    // started by _resolveUri above) so the renderer can fetch it.
+    final art = castArtUriFor(item);
     return AudioMetadata(
       title: item.title,
       artist: item.artist,

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -64,11 +64,15 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
       await LocalMediaServer().ensureStarted();
       return LocalMediaServer().registerFile(localPath);
     }
-    // (A downloaded iroh track carries a localPath and was served as a local file
-    // above — faster, and it skips the tunnel.)
     final iroh = irohServerFor(item);
     if (iroh != null) {
       await LocalMediaServer().ensureStarted();
+      // A downloaded iroh track is already on disk — serve it from there (faster,
+      // and it skips the tunnel relay). Its id is a 127.0.0.1 loopback URL, so
+      // isNetwork is true and the disk branch above is bypassed; handle it here.
+      if (localPath != null && File(localPath).existsSync()) {
+        return LocalMediaServer().registerFile(localPath);
+      }
       return irohProxyUri(iroh, item.id);
     }
     return Uri.parse(item.id);

--- a/lib/media/local_media_server.dart
+++ b/lib/media/local_media_server.dart
@@ -349,7 +349,7 @@ class LocalMediaServer {
       res.headers.set(
           HttpHeaders.contentTypeHeader,
           upRes.headers.value(HttpHeaders.contentTypeHeader) ??
-              mimeForPath(_basename(upstream.path)));
+              _proxyFallbackType(upstream.path));
       final cr = upRes.headers.value(HttpHeaders.contentRangeHeader);
       if (cr != null) res.headers.set(HttpHeaders.contentRangeHeader, cr);
       res.headers.set(HttpHeaders.acceptRangesHeader, 'bytes');
@@ -383,6 +383,20 @@ class LocalMediaServer {
         await res.close();
       } catch (_) {}
     }
+  }
+
+  // Content-Type fallback for a proxied upstream that omits the header. Unlike
+  // the file-serving branch (always audio), the proxy relays BOTH the iroh audio
+  // stream and the iroh album-art image, so the audio-only mimeForPath would
+  // mislabel a header-less art relay as audio/mpeg. Recognize image extensions
+  // here, then defer to the audio sniff for the stream case.
+  String _proxyFallbackType(String path) {
+    final name = _basename(path).toLowerCase();
+    if (name.endsWith('.jpg') || name.endsWith('.jpeg')) return 'image/jpeg';
+    if (name.endsWith('.png')) return 'image/png';
+    if (name.endsWith('.webp')) return 'image/webp';
+    if (name.endsWith('.gif')) return 'image/gif';
+    return mimeForPath(path);
   }
 
   // Body length from a `Content-Range: bytes <start>-<end>/<total>` header.

--- a/lib/media/local_media_server.dart
+++ b/lib/media/local_media_server.dart
@@ -29,6 +29,8 @@ class LocalMediaServer {
   final Map<String, String> _files = <String, String>{}; // token -> abs path
   final Map<String, String> _types = <String, String>{}; // token -> content type
   final Map<String, String> _dirs = <String, String>{}; // token -> directory
+  final Map<String, Uri> _proxies = <String, Uri>{}; // token -> upstream loopback URL
+  HttpClient? _proxyClient; // reused for the iroh relay leg (keep-alive to loopback)
 
   bool get isRunning => _server != null;
 
@@ -91,6 +93,43 @@ class LocalMediaServer {
         pathSegments: [token, playlist]);
   }
 
+  /// Register an upstream loopback URL ([upstream], an iroh
+  /// `http://127.0.0.1:<port>/...` tunnel URL a renderer can't reach) and return
+  /// a LAN URL that reverse-proxies to it. Used to cast an iroh server's stream /
+  /// art: the renderer fetches from the phone's LAN address and this server relays
+  /// the bytes over the tunnel (forwarding Range so seeking works). The upstream's
+  /// `__lt` loopback token rides only the inward leg — it's never in the LAN-facing
+  /// URL. Reuses the token for an already-registered upstream. Requires
+  /// [ensureStarted].
+  Uri registerProxy(Uri upstream) {
+    final server = _server;
+    final host = _host;
+    if (server == null || host == null) {
+      throw StateError('registerProxy called before ensureStarted');
+    }
+    // Dedup on the URL minus the `__lt` token: the same track reloaded (seek /
+    // replay / a tunnel reconnect that rotated the token) reuses its slot rather
+    // than leaking a new entry — so the map stays bounded by distinct tracks, not
+    // by loads. The stored upstream is refreshed to the current token for relays.
+    final key = _proxyKey(upstream);
+    for (final e in _proxies.entries) {
+      if (_proxyKey(e.value) == key) {
+        _proxies[e.key] = upstream;
+        return _proxyUrlFor(host, server.port, e.key, upstream);
+      }
+    }
+    final token = _newToken();
+    _proxies[token] = upstream;
+    return _proxyUrlFor(host, server.port, token, upstream);
+  }
+
+  // Dedup key for a proxied upstream: the URL without the rotating `__lt` token.
+  String _proxyKey(Uri upstream) {
+    if (!upstream.queryParameters.containsKey('__lt')) return upstream.toString();
+    final q = Map<String, String>.from(upstream.queryParameters)..remove('__lt');
+    return upstream.replace(queryParameters: q.isEmpty ? null : q).toString();
+  }
+
   /// Close the server and forget all registered files. Called when casting ends.
   Future<void> stop() async {
     final s = _server;
@@ -99,6 +138,10 @@ class LocalMediaServer {
     _files.clear();
     _types.clear();
     _dirs.clear();
+    _proxies.clear();
+    final pc = _proxyClient;
+    _proxyClient = null;
+    pc?.close(force: true);
     if (s != null) {
       try {
         await s.close(force: true);
@@ -115,14 +158,33 @@ class LocalMediaServer {
         pathSegments: [token, _basename(absPath)],
       );
 
+  // The LAN URL a renderer fetches for a proxied upstream. Keep the upstream's
+  // basename as the last segment so a content-type-by-extension sniff (and the
+  // Chromecast contentType) matches what a direct stream would yield.
+  Uri _proxyUrlFor(String host, int port, String token, Uri upstream) {
+    final name = _basename(upstream.path);
+    return Uri(
+      scheme: 'http',
+      host: host,
+      port: port,
+      pathSegments: name.isEmpty ? [token] : [token, name],
+    );
+  }
+
   String _newToken() {
+    // 32 hex chars = 128-bit, matching the Rust loopback token — an unguessable
+    // path segment is the only thing gating a LAN peer from a registered resource.
     const chars = '0123456789abcdef';
     final sb = StringBuffer();
-    for (var i = 0; i < 16; i++) {
+    for (var i = 0; i < 32; i++) {
       sb.write(chars[_rng.nextInt(chars.length)]);
     }
     final t = sb.toString();
-    return (_files.containsKey(t) || _dirs.containsKey(t)) ? _newToken() : t;
+    return (_files.containsKey(t) ||
+            _dirs.containsKey(t) ||
+            _proxies.containsKey(t))
+        ? _newToken()
+        : t;
   }
 
   String? _hlsType(String name) {
@@ -191,6 +253,9 @@ class LocalMediaServer {
     try {
       final seg = req.uri.pathSegments;
       final token = seg.isEmpty ? null : seg.first;
+      if (token != null && _proxies.containsKey(token)) {
+        return _proxyRequest(req, _proxies[token]!);
+      }
       String? path;
       String? contentType;
       if (token != null) {
@@ -256,6 +321,75 @@ class LocalMediaServer {
         await res.close();
       } catch (_) {}
     }
+  }
+
+  // Relay a renderer's GET/HEAD to the [upstream] loopback URL, forwarding Range
+  // so the renderer can seek and copying back status + content headers verbatim.
+  // The upstream is the iroh tunnel's loopback listener; bytes stream through
+  // without buffering the whole track. A failed inner leg surfaces as 502 so the
+  // renderer (and the cast-failure fallback) treats it as a load error.
+  Future<void> _proxyRequest(HttpRequest req, Uri upstream) async {
+    final res = req.response;
+    HttpClientResponse? upRes; // tracked so a failed relay can release the socket
+    try {
+      final client = _proxyClient ??=
+          (HttpClient()..connectionTimeout = const Duration(seconds: 15));
+      final method = req.method == 'HEAD' ? 'HEAD' : 'GET';
+      final up = await client.openUrl(method, upstream);
+      // Forward the byte range; ask for identity so Content-Length / Content-Range
+      // stay exact (audio isn't gzipped, but be explicit rather than rely on it).
+      final range = req.headers.value(HttpHeaders.rangeHeader);
+      if (range != null) up.headers.set(HttpHeaders.rangeHeader, range);
+      up.headers.set(HttpHeaders.acceptEncodingHeader, 'identity');
+      upRes = await up.close();
+
+      res.statusCode = upRes.statusCode;
+      // Fall back to a basename sniff when the upstream omits Content-Type: a DLNA
+      // renderer has no separate content-type field and relies on this header.
+      res.headers.set(
+          HttpHeaders.contentTypeHeader,
+          upRes.headers.value(HttpHeaders.contentTypeHeader) ??
+              mimeForPath(_basename(upstream.path)));
+      final cr = upRes.headers.value(HttpHeaders.contentRangeHeader);
+      if (cr != null) res.headers.set(HttpHeaders.contentRangeHeader, cr);
+      res.headers.set(HttpHeaders.acceptRangesHeader, 'bytes');
+      // A 206 may omit Content-Length (only Content-Range is required); derive it
+      // from the range so the renderer always knows the body size for seeking.
+      var len = upRes.headers.contentLength;
+      if (len < 0 && cr != null) len = _lenFromContentRange(cr);
+      if (method == 'HEAD') {
+        // Raw header (not res.contentLength, which would make close() enforce a
+        // matching body on this empty response).
+        if (len >= 0) res.headers.set(HttpHeaders.contentLengthHeader, '$len');
+        await upRes.drain<void>();
+        await res.close();
+        return;
+      }
+      if (len >= 0) res.contentLength = len; // else leave -1 → chunked
+      await res.addStream(upRes);
+      upRes = null; // body fully relayed — nothing to release
+      await res.close();
+    } catch (e) {
+      castLog('LocalMediaServer proxy relay failed', error: e);
+      // Drain the half-read upstream so the reused keep-alive client doesn't pool
+      // a dirty socket (e.g. the renderer aborted mid-stream on a seek).
+      if (upRes != null) {
+        try {
+          await upRes.drain<void>();
+        } catch (_) {}
+      }
+      try {
+        res.statusCode = HttpStatus.badGateway;
+        await res.close();
+      } catch (_) {}
+    }
+  }
+
+  // Body length from a `Content-Range: bytes <start>-<end>/<total>` header.
+  int _lenFromContentRange(String cr) {
+    final m = RegExp(r'bytes\s+(\d+)-(\d+)').firstMatch(cr);
+    if (m == null) return -1;
+    return int.parse(m.group(2)!) - int.parse(m.group(1)!) + 1;
   }
 
   Future<void> _notFound(HttpResponse res) async {

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -319,11 +319,16 @@ class ServerManager {
     if (!IrohTunnel.isSupported) return;
     final s = currentServer;
     if (s != null && s.isIroh && s.irohPairingCode != null) {
-      // A remote renderer (Chromecast/DLNA) can't reach the phone-local tunnel,
-      // so fall back to on-device playback if we were casting.
-      if (CastManager().isCasting) {
-        unawaited(CastManager().selectTarget(CastTarget.local));
-      }
+      // NB: don't drop an active cast here at the top. A renderer reaches an iroh
+      // server through the LAN proxy (LocalMediaServer), so casting iroh is
+      // supported, and a no-op ensure (healthy tunnel → early return below) must
+      // leave the cast alone — otherwise every app-resume/network-change would
+      // kick playback back to the phone. A real same-server rebuild (new loopback
+      // port) is handled by rebuildTranscodeUrls below, which reloads the active
+      // backend (cast included) onto the fresh tunnel. The only case that DOES
+      // fall back to the phone — switching to a *different* iroh server, which
+      // tears the single tunnel out from under the current queue — is handled at
+      // the stop below.
       _startStatusPolling();
       if (_activeTunnelCode == s.irohPairingCode && s.tunnelPort != null) {
         // Already wired up. The supervisor handles transient drops itself; only
@@ -336,6 +341,14 @@ class ServerManager {
       // The shim holds one tunnel; switching servers (or rebuilding a dead one)
       // requires dropping the old one first (start() returns the stale port otherwise).
       if (_activeTunnelCode != null) {
+        // Switching to a DIFFERENT iroh server tears down the only tunnel, so the
+        // current queue (which belongs to the outgoing server) can no longer be
+        // reached by a renderer — fall back to on-device playback. A same-server
+        // rebuild keeps the queue valid (the cast reloads via rebuildTranscodeUrls
+        // below), so it must NOT drop.
+        if (_activeTunnelCode != s.irohPairingCode && CastManager().isCasting) {
+          unawaited(CastManager().selectTarget(CastTarget.local));
+        }
         IrohTunnel.instance.stop();
         _activeTunnelCode = null;
       }
@@ -351,7 +364,13 @@ class ServerManager {
         // loopback port + token, so any queued iroh stream URLs are stale. Rebuild
         // them off the current effectiveBaseUrl (idempotent — no-op if unchanged)
         // so resume / play doesn't load a dead port.
-        if (oldPort != null && oldPort != port) {
+        //
+        // Also rebuild on a fresh bind from null (oldPort == null) *while casting*:
+        // if a previous resume's start() failed it nulled tunnelPort, so this
+        // recovered bind would otherwise skip the rebuild and leave the renderer
+        // stranded on the dead old port. (When not casting, a null→port bind is a
+        // cold start with no live stream to reload, so leave that path unchanged.)
+        if (oldPort != port && (oldPort != null || CastManager().isCasting)) {
           unawaited(MediaManager().audioHandler.customAction(
               'rebuildTranscodeUrls', const {'upcomingOnly': false}));
         }

--- a/lib/widgets/cast_picker_sheet.dart
+++ b/lib/widgets/cast_picker_sheet.dart
@@ -29,21 +29,21 @@ class _CastPickerSheetState extends State<CastPickerSheet> {
   bool _searchSettled = false;
   Timer? _searchTimer;
 
-  // External (DLNA/Chromecast) renderers can't reach an iroh server's loopback
-  // tunnel, so for an iroh server only "This device" is offered.
+  // An iroh server's stream is a phone-loopback tunnel URL a renderer can't reach
+  // directly; casting relays it through the on-device LAN proxy (LocalMediaServer).
+  // That works for audio, but the visualizer cast transcodes the source on-device
+  // and can't yet read an iroh loopback source — so the visualizer toggle (only)
+  // stays hidden for iroh.
   final bool _irohActive = ServerManager().currentServer?.isIroh == true;
 
   @override
   void initState() {
     super.initState();
-    // Scan only while the picker is visible — and not at all for an iroh server
-    // (no external target can play its loopback stream).
-    if (!_irohActive) {
-      CastManager().startDiscovery();
-      _searchTimer = Timer(const Duration(seconds: 10), () {
-        if (mounted) setState(() => _searchSettled = true);
-      });
-    }
+    // Scan only while the picker is visible (battery-friendly).
+    CastManager().startDiscovery();
+    _searchTimer = Timer(const Duration(seconds: 10), () {
+      if (mounted) setState(() => _searchSettled = true);
+    });
   }
 
   @override
@@ -104,35 +104,23 @@ class _CastPickerSheetState extends State<CastPickerSheet> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     for (final t in targets)
-                      if (!_irohActive || t.kind == CastTargetKind.local)
-                        _TargetRow(
-                          target: t,
-                          selected: t == active,
-                          icon: _iconFor(t.kind),
-                          onTap: () {
-                            CastManager()
-                                .selectTarget(t, visualizer: _visualizer);
-                            Navigator.of(context).pop();
-                          },
-                        ),
+                      _TargetRow(
+                        target: t,
+                        selected: t == active,
+                        icon: _iconFor(t.kind),
+                        onTap: () {
+                          CastManager()
+                              .selectTarget(t, visualizer: _visualizer);
+                          Navigator.of(context).pop();
+                        },
+                      ),
                   ],
                 );
               },
             ),
-            // iroh: only "This device" works; external renderers can't reach the
-            // phone-local tunnel.
-            if (_irohActive)
-              Padding(
-                padding: const EdgeInsets.only(top: 12),
-                child: Text(
-                  l.irohCastUnavailable,
-                  style:
-                      TextStyle(fontSize: 12, color: VelvetColors.textSecondary),
-                ),
-              ),
             // The "searching…" hint only appears once discovery backends are
             // registered (Phase 3+). Until then the list is just this device.
-            if (!_irohActive && CastManager().hasDiscoverers) ...[
+            if (CastManager().hasDiscoverers) ...[
               const SizedBox(height: 12),
               if (!_searchSettled)
                 Row(
@@ -165,8 +153,9 @@ class _CastPickerSheetState extends State<CastPickerSheet> {
                   ),
                 ),
             ],
-            // Cast-the-visualizer is Chromecast-only, so it's irrelevant for an
-            // iroh server (no external target).
+            // Cast-the-visualizer transcodes the source on-device; that path
+            // can't yet read an iroh server's loopback source, so it's hidden for
+            // iroh (audio casting above still works). Chromecast-only.
             if (!_irohActive) ...[
               const Divider(height: 24),
               // Stream the app's own visualizer (rendered + encoded on-device) to

--- a/lib/widgets/cast_picker_sheet.dart
+++ b/lib/widgets/cast_picker_sheet.dart
@@ -20,21 +20,26 @@ class CastPickerSheet extends StatefulWidget {
 }
 
 class _CastPickerSheetState extends State<CastPickerSheet> {
-  // Sticky choice: when checked, picking a Chromecast streams the visualizer.
-  late bool _visualizer = SettingsManager().castVisualizerEnabled;
-
-  // After an initial window the "searching…" spinner settles to a quiet hint so
-  // it doesn't imply an endless scan — discovery keeps running underneath while
-  // the sheet is open, so a device that wakes up later still appears.
-  bool _searchSettled = false;
-  Timer? _searchTimer;
-
   // An iroh server's stream is a phone-loopback tunnel URL a renderer can't reach
   // directly; casting relays it through the on-device LAN proxy (LocalMediaServer).
   // That works for audio, but the visualizer cast transcodes the source on-device
   // and can't yet read an iroh loopback source — so the visualizer toggle (only)
   // stays hidden for iroh.
   final bool _irohActive = ServerManager().currentServer?.isIroh == true;
+
+  // Sticky choice: when checked, picking a Chromecast streams the visualizer.
+  // Forced off for iroh — the persisted setting must not leak in, since the
+  // toggle that could clear it is hidden for iroh (otherwise a user who enabled
+  // it on a normal server would feed a 127.0.0.1 loopback source to the on-device
+  // transcoder, the exact path the hidden toggle exists to prevent).
+  late bool _visualizer =
+      !_irohActive && SettingsManager().castVisualizerEnabled;
+
+  // After an initial window the "searching…" spinner settles to a quiet hint so
+  // it doesn't imply an endless scan — discovery keeps running underneath while
+  // the sheet is open, so a device that wakes up later still appears.
+  bool _searchSettled = false;
+  Timer? _searchTimer;
 
   @override
   void initState() {
@@ -109,8 +114,11 @@ class _CastPickerSheetState extends State<CastPickerSheet> {
                         selected: t == active,
                         icon: _iconFor(t.kind),
                         onTap: () {
-                          CastManager()
-                              .selectTarget(t, visualizer: _visualizer);
+                          // Belt-and-suspenders: never hand the visualizer path
+                          // an iroh loopback source (the flag is already forced
+                          // off for iroh above; this guards future refactors).
+                          CastManager().selectTarget(t,
+                              visualizer: _irohActive ? false : _visualizer);
                           Navigator.of(context).pop();
                         },
                       ),

--- a/lib/widgets/cast_picker_sheet.dart
+++ b/lib/widgets/cast_picker_sheet.dart
@@ -6,7 +6,6 @@ import 'package:rxdart/rxdart.dart';
 import '../media/cast_target.dart';
 import '../singletons/cast_manager.dart';
 import '../singletons/settings.dart';
-import '../singletons/server_list.dart';
 import '../theme/velvet_theme.dart';
 import '../l10n/app_localizations.dart';
 
@@ -20,20 +19,10 @@ class CastPickerSheet extends StatefulWidget {
 }
 
 class _CastPickerSheetState extends State<CastPickerSheet> {
-  // An iroh server's stream is a phone-loopback tunnel URL a renderer can't reach
-  // directly; casting relays it through the on-device LAN proxy (LocalMediaServer).
-  // That works for audio, but the visualizer cast transcodes the source on-device
-  // and can't yet read an iroh loopback source — so the visualizer toggle (only)
-  // stays hidden for iroh.
-  final bool _irohActive = ServerManager().currentServer?.isIroh == true;
-
   // Sticky choice: when checked, picking a Chromecast streams the visualizer.
-  // Forced off for iroh — the persisted setting must not leak in, since the
-  // toggle that could clear it is hidden for iroh (otherwise a user who enabled
-  // it on a normal server would feed a 127.0.0.1 loopback source to the on-device
-  // transcoder, the exact path the hidden toggle exists to prevent).
-  late bool _visualizer =
-      !_irohActive && SettingsManager().castVisualizerEnabled;
+  // Works for iroh too: the transcoder reads the iroh loopback source on-device
+  // (re-origined to the live tunnel — see ChromecastPlaybackBackend).
+  late bool _visualizer = SettingsManager().castVisualizerEnabled;
 
   // After an initial window the "searching…" spinner settles to a quiet hint so
   // it doesn't imply an endless scan — discovery keeps running underneath while
@@ -114,11 +103,8 @@ class _CastPickerSheetState extends State<CastPickerSheet> {
                         selected: t == active,
                         icon: _iconFor(t.kind),
                         onTap: () {
-                          // Belt-and-suspenders: never hand the visualizer path
-                          // an iroh loopback source (the flag is already forced
-                          // off for iroh above; this guards future refactors).
-                          CastManager().selectTarget(t,
-                              visualizer: _irohActive ? false : _visualizer);
+                          CastManager()
+                              .selectTarget(t, visualizer: _visualizer);
                           Navigator.of(context).pop();
                         },
                       ),
@@ -161,37 +147,34 @@ class _CastPickerSheetState extends State<CastPickerSheet> {
                   ),
                 ),
             ],
-            // Cast-the-visualizer transcodes the source on-device; that path
-            // can't yet read an iroh server's loopback source, so it's hidden for
-            // iroh (audio casting above still works). Chromecast-only.
-            if (!_irohActive) ...[
-              const Divider(height: 24),
-              // Stream the app's own visualizer (rendered + encoded on-device) to
-              // the TV instead of plain audio. Chromecast only; the choice is
-              // sticky (persisted) and applied when a device is picked above.
-              CheckboxListTile(
-                contentPadding: EdgeInsets.zero,
-                controlAffinity: ListTileControlAffinity.leading,
-                dense: true,
-                activeColor: VelvetColors.primary,
-                value: _visualizer,
-                onChanged: (v) {
-                  setState(() => _visualizer = v ?? false);
-                  SettingsManager().setCastVisualizerEnabled(_visualizer);
-                },
-                title: Text(
-                  l.castVisualizer,
-                  style: TextStyle(color: VelvetColors.textPrimary),
-                ),
-                subtitle: Text(
-                  l.castVisualizerSubtitle,
-                  style: TextStyle(
-                    fontSize: 12,
-                    color: VelvetColors.textSecondary,
-                  ),
+            // Stream the app's own visualizer (rendered + encoded on-device) to
+            // the TV instead of plain audio. Chromecast only; the choice is
+            // sticky (persisted) and applied when a device is picked above. Works
+            // for an iroh server too — the transcoder reads its loopback source
+            // directly on-device (re-origined to the live tunnel).
+            const Divider(height: 24),
+            CheckboxListTile(
+              contentPadding: EdgeInsets.zero,
+              controlAffinity: ListTileControlAffinity.leading,
+              dense: true,
+              activeColor: VelvetColors.primary,
+              value: _visualizer,
+              onChanged: (v) {
+                setState(() => _visualizer = v ?? false);
+                SettingsManager().setCastVisualizerEnabled(_visualizer);
+              },
+              title: Text(
+                l.castVisualizer,
+                style: TextStyle(color: VelvetColors.textPrimary),
+              ),
+              subtitle: Text(
+                l.castVisualizerSubtitle,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: VelvetColors.textSecondary,
                 ),
               ),
-            ],
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## What

Enables casting an **iroh** server's media to a Chromecast / DLNA renderer. Previously casting was hard-disabled for iroh servers because a renderer fetches media by URL itself, and an iroh server is only reachable through the phone's loopback tunnel (`http://127.0.0.1:<tunnelPort>`) — which a device across the LAN can't reach.

## How

Relaying through the phone is the only option (the renderer has no iroh client and can't reach the private server), so this extends the existing `LocalMediaServer` — already used to cast phone-local files — into a **LAN → loopback reverse proxy**:

```
Chromecast ──GET http://<phone-LAN-ip>:<port>/<token>/track.flac (Range)
   └──▶ HttpClient ──▶ http://127.0.0.1:<tunnelPort>/media/…&__lt=<token> (Range)
            └──▶ iroh QUIC tunnel ──▶ real mStream server
```

- **`cast_origin.dart`** (new): `irohServerFor`, `irohProxyUri` (re-origins a stored loopback URL, rebinding to the **live** tunnel port + `__lt` token so a stale stored URL self-heals), `castArtUriFor`.
- **`LocalMediaServer`**: `registerProxy()` + a reverse-proxy branch that relays GET/HEAD, forwards `Range`, and copies back status / `Content-Range` so seeking works. The loopback `__lt` token rides only the inward leg — never in the LAN-facing URL.
- **Both cast backends**: `_resolveUri` routes iroh items through the proxy; album art re-originated the same way.
- **Cast picker**: external targets now offered for iroh servers. The *visualizer-cast* toggle stays hidden for iroh — its on-device transcode can't read a loopback source yet (follow-up).

The phone stays in the data path for the whole cast session, but the existing `audio_service` foreground service already keeps the process awake + the tunnel scheduled, so no sleep-stall and no new wakelock needed.

## Hardening (from an adversarial review of the diff)

- Drain the upstream on a relay error so the reused keep-alive client doesn't pool a half-read socket (renderer aborts on seek).
- Derive `Content-Length` from `Content-Range` when a 206 omits it.
- Sniff `Content-Type` from the basename when the upstream omits it (DLNA has no separate content-type field).
- 128-bit resource tokens (was 64-bit), matching the loopback token.
- Dedup proxy registrations on the `__lt`-stripped URL so a token refresh reuses the slot (map stays bounded by distinct tracks, cleared on cast-end).

Not changed (deliberate, v1): the pre-existing wildcard CORS (token-in-path is the access control; entropy bumped to mitigate), and HLS-transcoded **visualizer** cast over iroh.

## Scope notes

- mStream `/transcode` is a single stream (not HLS), so both `/media` and `/transcode` proxy identically; the only HLS is the on-device visualizer.
- Plain HTTP servers and local file-explorer tracks are unaffected (the iroh branch only triggers when the item's server `isIroh`).

## Test plan

- [ ] Cast to Chromecast → play, **seek**, skip, album art on the TV
- [ ] DLNA target (separate metadata route, same proxy path)
- [ ] Wi-Fi blip mid-cast → falls back to phone cleanly
- [ ] Plain HTTP-server casting still works (no regression)

`flutter analyze` clean (16-issue pre-existing baseline, zero new). Verified on-device install; functional smoke test in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)