### PR TITLE
fix: iroh saved-queue rebind + warn/skip a track that won't play

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -937,6 +937,10 @@
   "@irohConnectBody": {
     "description": "Explainer under the iroh tab header on the add-server form."
   },
+  "irohOneServerLimit": "Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.",
+  "@irohOneServerLimit": {
+    "description": "Shown on the iroh add-server tab when an iroh server already exists (only one is allowed)."
+  },
   "irohPairingCodeLabel": "Pairing code",
   "@irohPairingCodeLabel": {
     "description": "Text field label for the iroh pairing code (add-server iroh tab and the re-pair sheet)."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2490,6 +2490,12 @@ abstract class AppLocalizations {
   /// **'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.'**
   String get irohConnectBody;
 
+  /// Shown on the iroh add-server tab when an iroh server already exists (only one is allowed).
+  ///
+  /// In en, this message translates to:
+  /// **'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.'**
+  String get irohOneServerLimit;
+
   /// Text field label for the iroh pairing code (add-server iroh tab and the re-pair sheet).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1437,6 +1437,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
+  String get irohOneServerLimit =>
+      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
+
+  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1420,6 +1420,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
+  String get irohOneServerLimit =>
+      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
+
+  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1436,6 +1436,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
+  String get irohOneServerLimit =>
+      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
+
+  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1435,6 +1435,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
+  String get irohOneServerLimit =>
+      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
+
+  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1437,6 +1437,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
+  String get irohOneServerLimit =>
+      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
+
+  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1374,6 +1374,10 @@ class AppLocalizationsJa extends AppLocalizations {
       'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
+  String get irohOneServerLimit =>
+      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
+
+  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1454,6 +1454,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
+  String get irohOneServerLimit =>
+      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
+
+  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1433,6 +1433,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
+  String get irohOneServerLimit =>
+      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
+
+  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1458,6 +1458,10 @@ class AppLocalizationsRu extends AppLocalizations {
       'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
+  String get irohOneServerLimit =>
+      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
+
+  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1346,6 +1346,10 @@ class AppLocalizationsZh extends AppLocalizations {
       'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
+  String get irohOneServerLimit =>
+      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
+
+  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -292,7 +292,10 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
       initialData: ServerManager().tunnelStatus,
       builder: (context, snap) {
         final st = snap.data ?? IrohTunnelStatus.down;
-        if (ServerManager().currentServer?.isIroh != true) {
+        // Show whenever the tunnel has a server to serve — including a background
+        // playback server while a non-iroh default is the selected server (the
+        // tunnel "follows playback").
+        if (!ServerManager().tunnelActive) {
           return const SizedBox.shrink();
         }
         final l = AppLocalizations.of(context);

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -342,24 +342,46 @@ class AudioPlayerHandler extends BaseAudioHandler
 
   // just_audio surfaced a playback error (local stream path only — remote
   // backends report failures via rendererLostStream). Two cases:
-  //  • an iroh tunnel drop (the transport blipped, the source is fine) → recover
-  //    in place once the tunnel is back, rather than skipping;
-  //  • the source itself failed (missing/bad track, server 500, dead URL) → warn
-  //    and skip to the next track.
+  //  • the FAILED source is served through the current iroh tunnel and that
+  //    tunnel is down/reconnecting → a transport blip, not a bad source: recover
+  //    in place once it's back rather than skipping (it bails gracefully if the
+  //    tunnel can't come back — the reconnect / re-pair banner explains why);
+  //  • anything else (bad/missing track, server 500, dead URL, or a connected
+  //    tunnel) → warn and skip to the next track.
   void _onPlaybackError(Object error) {
     if (!identical(_backend, _localBackend)) return;
-    final server = ServerManager().currentServer;
-    // Any non-connected iroh state is a transport problem, not a bad source:
-    // recover (which bails gracefully if the tunnel can't come back — the
-    // reconnect / re-pair banner then explains why) instead of burning through
-    // the queue. A connected tunnel that still errored means the source is bad.
-    if (server != null &&
-        server.isIroh &&
+    // One error-handler at a time: while a recover or skip is in flight, ignore
+    // further errors (a burst for one failure, or the wrap-around after a skip).
+    // Whatever's playing when it finishes re-decides on its own fresh error.
+    if (_recoveringPlayback || _skipPending) return;
+    // Resolve the FAILED item's server (not just currentServer): only the current
+    // iroh server's items ride the single live tunnel, so a local file, an HTTP
+    // item, or an item from a different iroh server can't be recovered by waiting
+    // on this tunnel — those skip instead.
+    final idx = _localBackend.currentIndex;
+    final q = queue.value;
+    final failed = (idx != null && idx >= 0 && idx < q.length) ? q[idx] : null;
+    final itemServer = failed == null
+        ? null
+        : ServerManager().byLocalname(failed.extras?['server'] as String?);
+    final current = ServerManager().currentServer;
+    if (itemServer != null &&
+        current != null &&
+        itemServer.localname == current.localname &&
+        current.isIroh &&
         IrohTunnel.instance.status != IrohTunnelStatus.connected) {
       _recoverIrohPlayback();
       return;
     }
-    unawaited(_skipFailedTrack(error));
+    // Serialize the skip through _switchChain (shared with recovery + backend
+    // switches, so none run concurrently on the backend); _skipPending collapses
+    // a burst of error events into the single skip.
+    _skipPending = true;
+    _switchChain = _switchChain
+        .then((_) => _skipFailedTrack(error))
+        .catchError((Object e) =>
+            castLog('skip-to-next after playback error failed', error: e))
+        .whenComplete(() => _skipPending = false);
   }
 
   // Recover on an iroh mid-stream tunnel drop: the supervisor reconnects on the
@@ -375,6 +397,8 @@ class AudioPlayerHandler extends BaseAudioHandler
         now.difference(_lastPlaybackRecovery!) < const Duration(seconds: 10)) {
       return;
     }
+    // A transport drop isn't a bad source — don't let it eat the skip budget.
+    _failedSkips = 0;
     _recoveringPlayback = true;
     _lastPlaybackRecovery = now;
     _switchChain = _switchChain.then((_) async {
@@ -392,6 +416,9 @@ class AudioPlayerHandler extends BaseAudioHandler
 
   // Consecutive failed tracks since one last loaded (reset on a `ready` state).
   int _failedSkips = 0;
+  // True while a skip is chained/running — collapses an error burst into one skip
+  // and keeps the before/after index read uncontended.
+  bool _skipPending = false;
   DateTime? _lastErrorToast;
   // Collapse a run of failures into one toast (a long unplayable stretch
   // shouldn't fire a snackbar per track).
@@ -399,13 +426,14 @@ class AudioPlayerHandler extends BaseAudioHandler
 
   // A source failed to play — warn (debounced) and skip to the next track, bounded
   // so an entirely-unplayable queue stops instead of looping (notably under
-  // repeat-all). Local backend only; the iroh-recover case is handled above.
+  // repeat-all). Serialized via _switchChain by the caller; local backend only.
   Future<void> _skipFailedTrack(Object error) async {
+    if (!identical(_backend, _localBackend)) return; // switched to a renderer meanwhile
     final q = queue.value;
     if (q.isEmpty) return;
     castLog('playback error — skipping track', error: error);
     _failedSkips++;
-    if (_failedSkips > q.length) {
+    if (_failedSkips >= q.length) {
       // Tried every track once and none loaded — the whole queue is unplayable.
       _failedSkips = 0;
       _showPlaybackErrorToast(
@@ -414,20 +442,18 @@ class AudioPlayerHandler extends BaseAudioHandler
       return;
     }
     _showPlaybackErrorToast('Skipping a track that won’t play.', debounce: true);
-    try {
-      final before = _localBackend.currentIndex;
-      await _localBackend.seekToNext(); // shuffle/repeat-aware
-      if (_localBackend.currentIndex == before) {
-        // seekToNext was a no-op → end of the queue with no repeat; stop rather
-        // than replay the failed track.
-        _failedSkips = 0;
-        await _localBackend.stop();
-        return;
-      }
-      unawaited(_localBackend.play());
-    } catch (e) {
-      castLog('skip-to-next after playback error failed', error: e);
+    final before = _localBackend.currentIndex;
+    // seekToNext()'s Future completes only after _player.currentIndex is updated,
+    // so the post-await read reliably reflects the new position.
+    await _localBackend.seekToNext(); // shuffle/repeat-aware
+    if (_localBackend.currentIndex == before) {
+      // No-op → end of the queue with no repeat; stop rather than replay the
+      // failed track.
+      _failedSkips = 0;
+      await _localBackend.stop();
+      return;
     }
+    unawaited(_localBackend.play());
   }
 
   void _showPlaybackErrorToast(String message, {bool debounce = false}) {

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -18,9 +18,11 @@ import '../objects/server.dart';
 import '../objects/metadata.dart';
 import '../singletons/auto_dj_manager.dart';
 import '../singletons/cast_manager.dart';
+import '../singletons/app_messenger.dart';
 import '../singletons/log_manager.dart';
 import '../singletons/settings.dart';
 import '../singletons/server_list.dart';
+import '../native/iroh_tunnel.dart';
 import '../util/camelot.dart';
 import '../util/stream_url.dart';
 
@@ -143,6 +145,10 @@ class AudioPlayerHandler extends BaseAudioHandler
     // Stop the service when playback reaches the end of the queue.
     _backendSubject.switchMap((b) => b.processingStateStream).listen((state) {
       if (state == BackendProcessingState.completed) stop();
+      // A track that loads (vs. failing to load) clears the consecutive-failure
+      // count, so the skip-bad-track loop guard only trips on a genuine run of
+      // unplayable tracks.
+      if (state == BackendProcessingState.ready) _failedSkips = 0;
     });
     // A remote backend that loses its renderer mid-cast (TV off, Wi-Fi drop)
     // emits here; fall back to local playback at the same spot + a toast.
@@ -334,17 +340,36 @@ class AudioPlayerHandler extends BaseAudioHandler
     });
   }
 
-  // just_audio surfaced a playback error. On an iroh server a mid-stream tunnel
-  // drop lands here; the supervisor reconnects on the SAME loopback port, so once
-  // it's back we re-seed the current source and resume at its position. Debounced
-  // (and guarded) so a persistently-failing source can't spin.
+  // just_audio surfaced a playback error (local stream path only — remote
+  // backends report failures via rendererLostStream). Two cases:
+  //  • an iroh tunnel drop (the transport blipped, the source is fine) → recover
+  //    in place once the tunnel is back, rather than skipping;
+  //  • the source itself failed (missing/bad track, server 500, dead URL) → warn
+  //    and skip to the next track.
+  void _onPlaybackError(Object error) {
+    if (!identical(_backend, _localBackend)) return;
+    final server = ServerManager().currentServer;
+    // Any non-connected iroh state is a transport problem, not a bad source:
+    // recover (which bails gracefully if the tunnel can't come back — the
+    // reconnect / re-pair banner then explains why) instead of burning through
+    // the queue. A connected tunnel that still errored means the source is bad.
+    if (server != null &&
+        server.isIroh &&
+        IrohTunnel.instance.status != IrohTunnelStatus.connected) {
+      _recoverIrohPlayback();
+      return;
+    }
+    unawaited(_skipFailedTrack(error));
+  }
+
+  // Recover on an iroh mid-stream tunnel drop: the supervisor reconnects on the
+  // SAME loopback port, so once it's back we re-seed the current source and resume
+  // at its position. Debounced (and guarded) so a persistently-failing source
+  // can't spin.
   bool _recoveringPlayback = false;
   DateTime? _lastPlaybackRecovery;
-  void _onPlaybackError(Object error) {
+  void _recoverIrohPlayback() {
     if (_recoveringPlayback) return;
-    if (!identical(_backend, _localBackend)) return; // on-device stream path only
-    final server = ServerManager().currentServer;
-    if (server == null || !server.isIroh) return;
     final now = DateTime.now();
     if (_lastPlaybackRecovery != null &&
         now.difference(_lastPlaybackRecovery!) < const Duration(seconds: 10)) {
@@ -363,6 +388,58 @@ class AudioPlayerHandler extends BaseAudioHandler
     }).catchError((Object e) {
       castLog('iroh playback recovery failed', error: e);
     }).whenComplete(() => _recoveringPlayback = false);
+  }
+
+  // Consecutive failed tracks since one last loaded (reset on a `ready` state).
+  int _failedSkips = 0;
+  DateTime? _lastErrorToast;
+  // Collapse a run of failures into one toast (a long unplayable stretch
+  // shouldn't fire a snackbar per track).
+  static const Duration _kErrorToastGap = Duration(seconds: 4);
+
+  // A source failed to play — warn (debounced) and skip to the next track, bounded
+  // so an entirely-unplayable queue stops instead of looping (notably under
+  // repeat-all). Local backend only; the iroh-recover case is handled above.
+  Future<void> _skipFailedTrack(Object error) async {
+    final q = queue.value;
+    if (q.isEmpty) return;
+    castLog('playback error — skipping track', error: error);
+    _failedSkips++;
+    if (_failedSkips > q.length) {
+      // Tried every track once and none loaded — the whole queue is unplayable.
+      _failedSkips = 0;
+      _showPlaybackErrorToast(
+          "Can't play these tracks — check your connection or server.");
+      await _localBackend.stop();
+      return;
+    }
+    _showPlaybackErrorToast('Skipping a track that won’t play.', debounce: true);
+    try {
+      final before = _localBackend.currentIndex;
+      await _localBackend.seekToNext(); // shuffle/repeat-aware
+      if (_localBackend.currentIndex == before) {
+        // seekToNext was a no-op → end of the queue with no repeat; stop rather
+        // than replay the failed track.
+        _failedSkips = 0;
+        await _localBackend.stop();
+        return;
+      }
+      unawaited(_localBackend.play());
+    } catch (e) {
+      castLog('skip-to-next after playback error failed', error: e);
+    }
+  }
+
+  void _showPlaybackErrorToast(String message, {bool debounce = false}) {
+    if (debounce) {
+      final now = DateTime.now();
+      if (_lastErrorToast != null &&
+          now.difference(_lastErrorToast!) < _kErrorToastGap) {
+        return;
+      }
+      _lastErrorToast = now;
+    }
+    showGlobalSnack(message);
   }
 
   // Re-seed the inherited customState with a typed CustomEvent default (it

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -22,7 +22,6 @@ import '../singletons/app_messenger.dart';
 import '../singletons/log_manager.dart';
 import '../singletons/settings.dart';
 import '../singletons/server_list.dart';
-import '../native/iroh_tunnel.dart';
 import '../util/camelot.dart';
 import '../util/stream_url.dart';
 
@@ -120,11 +119,18 @@ class AudioPlayerHandler extends BaseAudioHandler
       }
       if (index != null && index >= 0 && index < queue.value.length) {
         final item = queue.value[index];
+        // The single iroh tunnel follows playback: point it at this track's iroh
+        // server so a queue from a non-default iroh server connects in the
+        // background (default stays selected) and a multi-server queue re-targets
+        // the tunnel as it advances. Null for a local/HTTP track (no tunnel).
+        ServerManager().setPlaybackServer(_serverFor(item));
         if (item.id != _lastPlayLoggedId) {
           _lastPlayLoggedId = item.id;
           appLog('[play] track ${index + 1}/${queue.value.length}: '
               '${item.title}');
         }
+      } else {
+        ServerManager().setPlaybackServer(null);
       }
       _emitCurrentMediaItem();
     });
@@ -341,36 +347,31 @@ class AudioPlayerHandler extends BaseAudioHandler
   }
 
   // just_audio surfaced a playback error (local stream path only — remote
-  // backends report failures via rendererLostStream). Two cases:
-  //  • the FAILED source is served through the current iroh tunnel and that
-  //    tunnel is down/reconnecting → a transport blip, not a bad source: recover
-  //    in place once it's back rather than skipping (it bails gracefully if the
-  //    tunnel can't come back — the reconnect / re-pair banner explains why);
-  //  • anything else (bad/missing track, server 500, dead URL, or a connected
-  //    tunnel) → warn and skip to the next track.
+  // backends report failures via rendererLostStream). The split, keyed on the
+  // FAILED track's iroh server (the tunnel "follows playback", so it may not be
+  // the browsed server):
+  //  • iroh source whose tunnel is NOT live for it yet — launch, a cross-server
+  //    queue advance that needs a tunnel switch, or a mid-stream drop → recover in
+  //    place (ensure that server's tunnel, then re-seed + resume), don't skip;
+  //  • anything else (local/HTTP source, or an iroh source whose tunnel IS up and
+  //    it still failed = bad source) → warn and skip to the next track.
   void _onPlaybackError(Object error) {
     if (!identical(_backend, _localBackend)) return;
     // One error-handler at a time: while a recover or skip is in flight, ignore
     // further errors (a burst for one failure, or the wrap-around after a skip).
     // Whatever's playing when it finishes re-decides on its own fresh error.
     if (_recoveringPlayback || _skipPending) return;
-    // Resolve the FAILED item's server (not just currentServer): only the current
-    // iroh server's items ride the single live tunnel, so a local file, an HTTP
-    // item, or an item from a different iroh server can't be recovered by waiting
-    // on this tunnel — those skip instead.
     final idx = _localBackend.currentIndex;
     final q = queue.value;
     final failed = (idx != null && idx >= 0 && idx < q.length) ? q[idx] : null;
-    final itemServer = failed == null
-        ? null
-        : ServerManager().byLocalname(failed.extras?['server'] as String?);
-    final current = ServerManager().currentServer;
+    final itemServer = failed == null ? null : _serverFor(failed);
     if (itemServer != null &&
-        current != null &&
-        itemServer.localname == current.localname &&
-        current.isIroh &&
-        IrohTunnel.instance.status != IrohTunnelStatus.connected) {
-      _recoverIrohPlayback();
+        itemServer.isIroh &&
+        !ServerManager().tunnelServes(itemServer)) {
+      // The tunnel isn't live for this track's iroh server — point it there and
+      // resume rather than skipping. (If it IS serving this server and the track
+      // still failed, that's a bad source → falls through to skip below.)
+      _recoverIrohPlayback(itemServer);
       return;
     }
     // Serialize the skip through _switchChain (shared with recovery + backend
@@ -384,31 +385,40 @@ class AudioPlayerHandler extends BaseAudioHandler
         .whenComplete(() => _skipPending = false);
   }
 
-  // Recover on an iroh mid-stream tunnel drop: the supervisor reconnects on the
-  // SAME loopback port, so once it's back we re-seed the current source and resume
-  // at its position. Debounced (and guarded) so a persistently-failing source
-  // can't spin.
+  // Bring the single tunnel to [server] (the failed track's iroh server) and
+  // resume in place: covers a mid-stream drop (supervisor reconnects the same
+  // loopback port), a launch with a not-yet-connected tunnel, and a cross-server
+  // queue advance that needs a tunnel switch. setPlaybackServer re-targets the
+  // tunnel; awaitTunnelReady(server:) waits for THAT server; then re-seed (live
+  // URLs, rebuilt on the (re)bind) + resume. Debounced + guarded so it can't spin.
   bool _recoveringPlayback = false;
-  DateTime? _lastPlaybackRecovery;
-  void _recoverIrohPlayback() {
+  // Per-server cooldown (keyed by localname): a persistently-failing server can't
+  // spin, but advancing across servers in a multi-iroh queue isn't blocked by one
+  // server's recent recovery.
+  final Map<String, DateTime> _lastRecoveryByServer = {};
+  void _recoverIrohPlayback(Server server) {
     if (_recoveringPlayback) return;
     final now = DateTime.now();
-    if (_lastPlaybackRecovery != null &&
-        now.difference(_lastPlaybackRecovery!) < const Duration(seconds: 10)) {
+    final last = _lastRecoveryByServer[server.localname];
+    if (last != null && now.difference(last) < const Duration(seconds: 10)) {
       return;
     }
     // A transport drop isn't a bad source — don't let it eat the skip budget.
     _failedSkips = 0;
     _recoveringPlayback = true;
-    _lastPlaybackRecovery = now;
+    _lastRecoveryByServer[server.localname] = now;
+    // Point the single tunnel at this track's server (no-op if already there).
+    ServerManager().setPlaybackServer(server);
     _switchChain = _switchChain.then((_) async {
       if (queue.value.isEmpty) return;
       final pos = _localBackend.position;
       final idx = _localBackend.currentIndex ?? 0;
-      final ready = await ServerManager().awaitTunnelReady();
-      if (!ready) return; // tunnel didn't recover; the banner shows why
+      final ready = await ServerManager().awaitTunnelReady(server: server);
+      if (!ready) return; // tunnel didn't come up; the banner shows why
       await _localBackend.setSources(queue.value);
-      await _localBackend.seek(pos, index: idx, play: true);
+      // Resume with the user's intent: a mid-stream drop while playing resumes
+      // playing; a launch-time recovery (never played) stays paused.
+      await _localBackend.seek(pos, index: idx, play: _playIntent);
     }).catchError((Object e) {
       castLog('iroh playback recovery failed', error: e);
     }).whenComplete(() => _recoveringPlayback = false);
@@ -527,15 +537,22 @@ class AudioPlayerHandler extends BaseAudioHandler
     appLog('[queue] add: ${mediaItem.title} (now ${queue.value.length})');
   }
 
+  // The user's intended play state, tracked across just_audio errors (which flip
+  // the backend's `playing` to false). A recovery uses this so a launch-time
+  // re-seed resumes PAUSED rather than autoplaying on open.
+  bool _playIntent = false;
+
   @override
   Future<void> play() {
     appLog('[play] play');
+    _playIntent = true;
     return _backend.play();
   }
 
   @override
   Future<void> pause() {
     appLog('[play] pause');
+    _playIntent = false;
     return _backend.pause();
   }
 
@@ -555,6 +572,10 @@ class AudioPlayerHandler extends BaseAudioHandler
   @override
   Future<void> stop() async {
     appLog('[play] stop');
+    _playIntent = false;
+    // Playback ended — release the tunnel claim so it reverts to the browsed
+    // server (or tears down) instead of lingering for a stopped queue.
+    ServerManager().setPlaybackServer(null);
     await _backend.stop();
     await super.stop();
   }

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -119,20 +119,29 @@ class AudioPlayerHandler extends BaseAudioHandler
       }
       if (index != null && index >= 0 && index < queue.value.length) {
         final item = queue.value[index];
-        // The single iroh tunnel follows playback: point it at this track's iroh
-        // server so a queue from a non-default iroh server connects in the
-        // background (default stays selected) and a multi-server queue re-targets
-        // the tunnel as it advances. Null for a local/HTTP track (no tunnel).
-        ServerManager().setPlaybackServer(_serverFor(item));
         if (item.id != _lastPlayLoggedId) {
           _lastPlayLoggedId = item.id;
           appLog('[play] track ${index + 1}/${queue.value.length}: '
               '${item.title}');
         }
-      } else {
-        ServerManager().setPlaybackServer(null);
       }
       _emitCurrentMediaItem();
+    });
+    // Tunnel-follows-queue (one-iroh-server cap): keep the iroh tunnel up whenever
+    // the queue holds a song from the iroh server, and let it go when none remain.
+    // Recomputed on every queue edit; with the cap, the first iroh match is THE
+    // iroh server. This is what makes a queue from the iroh server connect in the
+    // background while the default stays selected.
+    queue.listen((items) {
+      Server? iroh;
+      for (final it in items) {
+        final s = _serverFor(it);
+        if (s != null && s.isIroh) {
+          iroh = s;
+          break;
+        }
+      }
+      ServerManager().setQueueIrohServer(iroh);
     });
     // duration usually arrives via durationStream after the source
     // loads. Re-emit the current MediaItem with the duration filled in
@@ -385,16 +394,15 @@ class AudioPlayerHandler extends BaseAudioHandler
         .whenComplete(() => _skipPending = false);
   }
 
-  // Bring the single tunnel to [server] (the failed track's iroh server) and
-  // resume in place: covers a mid-stream drop (supervisor reconnects the same
-  // loopback port), a launch with a not-yet-connected tunnel, and a cross-server
-  // queue advance that needs a tunnel switch. setPlaybackServer re-targets the
-  // tunnel; awaitTunnelReady(server:) waits for THAT server; then re-seed (live
-  // URLs, rebuilt on the (re)bind) + resume. Debounced + guarded so it can't spin.
+  // Resume after an iroh playback error whose tunnel isn't live yet: a mid-stream
+  // drop (the supervisor reconnects the same loopback port) or a launch where the
+  // tunnel wasn't up when the queue was restored. The tunnel target is owned by
+  // the queue listener (this server's songs are queued); just await it for
+  // [server], then re-seed (URLs rebuilt on the (re)bind) + resume with the user's
+  // play intent. Per-server debounced + guarded so a failing source can't spin.
   bool _recoveringPlayback = false;
-  // Per-server cooldown (keyed by localname): a persistently-failing server can't
-  // spin, but advancing across servers in a multi-iroh queue isn't blocked by one
-  // server's recent recovery.
+  // Per-server cooldown (keyed by localname) so a persistently-failing server
+  // can't spin on recovery.
   final Map<String, DateTime> _lastRecoveryByServer = {};
   void _recoverIrohPlayback(Server server) {
     if (_recoveringPlayback) return;
@@ -407,15 +415,21 @@ class AudioPlayerHandler extends BaseAudioHandler
     _failedSkips = 0;
     _recoveringPlayback = true;
     _lastRecoveryByServer[server.localname] = now;
-    // Point the single tunnel at this track's server (no-op if already there).
-    ServerManager().setPlaybackServer(server);
+    // The tunnel target is owned by the queue listener (this server's songs are
+    // queued, so it's already the target); just wait for it and re-seed.
     _switchChain = _switchChain.then((_) async {
       if (queue.value.isEmpty) return;
       final pos = _localBackend.position;
       final idx = _localBackend.currentIndex ?? 0;
       final ready = await ServerManager().awaitTunnelReady(server: server);
       if (!ready) return; // tunnel didn't come up; the banner shows why
-      await _localBackend.setSources(queue.value);
+      // Rebuild URLs against the now-live tunnel ourselves rather than reusing
+      // queue.value: a hard restart may have changed the port/token, and the
+      // concurrent rebuild-on-(re)bind might not have refreshed queue.value yet —
+      // _withRebuiltUrl uses the current effectiveBaseUrl, so these are always live.
+      final fresh = queue.value.map(_withRebuiltUrl).toList();
+      queue.add(fresh);
+      await _localBackend.setSources(fresh);
       // Resume with the user's intent: a mid-stream drop while playing resumes
       // playing; a launch-time recovery (never played) stays paused.
       await _localBackend.seek(pos, index: idx, play: _playIntent);
@@ -573,9 +587,9 @@ class AudioPlayerHandler extends BaseAudioHandler
   Future<void> stop() async {
     appLog('[play] stop');
     _playIntent = false;
-    // Playback ended — release the tunnel claim so it reverts to the browsed
-    // server (or tears down) instead of lingering for a stopped queue.
-    ServerManager().setPlaybackServer(null);
+    // Don't touch the tunnel here: it follows the QUEUE, not the play/stop state,
+    // so a stopped-but-still-queued iroh song keeps its tunnel (the queue listener
+    // tears it down when the iroh songs are actually removed/cleared).
     await _backend.stop();
     await super.stop();
   }

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -1476,6 +1476,12 @@ class MyCustomFormState extends State<MyCustomForm> {
   // the live tunnel adopted as the active connection, then switch to it.
   Future<void> _saveIrohServer(
       {required String code, required int port, required String jwt}) async {
+    // Backstop the one-iroh-server cap (the tab UI normally blocks reaching here).
+    if (ServerManager().hasIrohServer) {
+      if (mounted) setState(() => _irohSaving = false);
+      _showIrohResult(false, AppLocalizations.of(context).irohOneServerLimit);
+      return;
+    }
     final id = code.hashCode.toUnsigned(32).toRadixString(16);
     final username = _irohPublic ? '' : _irohUserCtrl.text;
     final password = _irohPublic ? '' : _irohPassCtrl.text;
@@ -1497,6 +1503,29 @@ class MyCustomFormState extends State<MyCustomForm> {
 
   Widget _buildIrohTab(BuildContext context) {
     final l = AppLocalizations.of(context);
+    // One iroh server max (a single native tunnel). If one's already configured,
+    // show why instead of the pairing UI.
+    if (ServerManager().hasIrohServer) {
+      return SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(28, 40, 28, 28),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.hub_outlined,
+                  size: 40, color: VelvetColors.textSecondary),
+              const SizedBox(height: 16),
+              Text(
+                l.irohOneServerLimit,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                    color: VelvetColors.textSecondary, fontSize: 14, height: 1.4),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
     return SafeArea(
       child: SingleChildScrollView(
         padding: EdgeInsets.fromLTRB(20, 20, 20, 24),

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -125,7 +125,9 @@ class ApiManager {
         // self-healing tunnel a moment to recover, then retry once. (Skip on a
         // user cancel — closing the client throws too.)
         if (isIroh && !BrowserManager().isLoadCancelled(loadToken)) {
-          final ready = await ServerManager().awaitTunnelReady();
+          // Wait for THIS call's server (the tunnel may be serving a background
+          // playback server instead of the browsed one).
+          final ready = await ServerManager().awaitTunnelReady(server: server);
           if (!ready) {
             appLog('[api] iroh tunnel down; $getOrPost $location failed: $e');
             rethrow;

--- a/lib/singletons/queue_store.dart
+++ b/lib/singletons/queue_store.dart
@@ -83,10 +83,10 @@ class QueueStore {
 
   /// Localname of the server the saved queue would resume on — its current-index
   /// item's `extras['server']` — or null when there's no resumable queue or that
-  /// item is local. Lets startup bring up the right (iroh) tunnel and make that
-  /// server active BEFORE the queue is restored, so its items rebuild against a
-  /// live tunnel instead of a dead loopback port. Cheap: reads + parses the file
-  /// but builds no MediaItems.
+  /// item is local. Lets startup bring that (iroh) server's tunnel up in the
+  /// BACKGROUND before restoring, so the items rebuild against a live tunnel
+  /// instead of a dead loopback port (the default stays the selected server).
+  /// Cheap: reads + parses the file but builds no MediaItems.
   Future<String?> peekResumeServer() async {
     if (!SettingsManager().resumeQueue) return null;
     try {

--- a/lib/singletons/queue_store.dart
+++ b/lib/singletons/queue_store.dart
@@ -81,6 +81,32 @@ class QueueStore {
           ? AudioServiceRepeatMode.all
           : AudioServiceRepeatMode.none;
 
+  /// Localname of the server the saved queue would resume on — its current-index
+  /// item's `extras['server']` — or null when there's no resumable queue or that
+  /// item is local. Lets startup bring up the right (iroh) tunnel and make that
+  /// server active BEFORE the queue is restored, so its items rebuild against a
+  /// live tunnel instead of a dead loopback port. Cheap: reads + parses the file
+  /// but builds no MediaItems.
+  Future<String?> peekResumeServer() async {
+    if (!SettingsManager().resumeQueue) return null;
+    try {
+      final file = await _file;
+      if (!await file.exists()) return null;
+      final dynamic raw = jsonDecode(await file.readAsString());
+      if (raw is! Map || raw['version'] != _schemaVersion) return null;
+      final dynamic items = raw['items'];
+      if (items is! List || items.isEmpty) return null;
+      int index = (raw['index'] is int) ? raw['index'] as int : 0;
+      if (index < 0 || index >= items.length) index = 0;
+      final entry = items[index];
+      if (entry is! Map) return null;
+      final extras = entry['extras'];
+      return (extras is Map) ? extras['server'] as String? : null;
+    } catch (_) {
+      return null; // a corrupt/unreadable file must never block startup
+    }
+  }
+
   Future<void> _restore() async {
     if (!SettingsManager().resumeQueue) return; // feature disabled
     final file = await _file;

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -115,7 +115,7 @@ class ServerManager {
       if (resumeName != null && resumeName != currentServer?.localname) {
         final rs = byLocalname(resumeName);
         if (rs != null && rs.isIroh) {
-          setPlaybackServer(rs);
+          setQueueIrohServer(rs);
           await awaitTunnelReady(server: rs);
         }
       }
@@ -168,7 +168,17 @@ class ServerManager {
     }
   }
 
+  /// True when an iroh server is already configured. Only one is supported (a
+  /// single native tunnel), so the add-server flow gates a second one.
+  bool get hasIrohServer => serverList.any((s) => s.isIroh);
+
   Future<void> addServer(Server newServer) async {
+    // One iroh server max (single tunnel). The add-server UI blocks this; this is
+    // the code-level backstop so no other path can add a second.
+    if (newServer.isIroh && hasIrohServer) {
+      showGlobalSnack('Only one iroh server is supported.');
+      return;
+    }
     serverList.add(newServer);
 
     if (currentServer == null) {
@@ -318,32 +328,31 @@ class ServerManager {
   // can't race the single tunnel's start/stop (mirrors the cast _switchChain).
   Future<void> _tunnelChain = Future.value();
 
-  // The iroh server of the currently-playing/queued track, when it differs from
-  // (or equals) the browsed server. The single tunnel "follows playback": it
-  // serves this server so a queue from a non-default iroh server plays while the
-  // default stays selected. Pushed by the audio handler on every track change.
-  Server? _playbackServer;
+  // With the one-iroh-server cap, the tunnel "follows the queue": it's up when
+  // the iroh server is the browsed server OR its songs are in the play queue.
+  // This holds the iroh server the queue currently references (pushed by the
+  // audio handler on queue changes); null when no queued song is from it.
+  Server? _queueIrohServer;
 
-  /// Point the (single) tunnel at the iroh server backing the current track.
-  /// [s] is the playing track's server (or null for a local / HTTP / no track).
-  /// No-op when unchanged; otherwise re-evaluates the tunnel target.
-  void setPlaybackServer(Server? s) {
+  /// Record the iroh server the play queue references ([s]), or null when no
+  /// queued song is from an iroh server. No-op when unchanged; otherwise
+  /// re-evaluates the tunnel target. Called by the audio handler on queue changes.
+  void setQueueIrohServer(Server? s) {
     final next = (s != null && s.isIroh) ? s : null;
-    if (next?.localname == _playbackServer?.localname) return;
-    _playbackServer = next;
+    if (next?.localname == _queueIrohServer?.localname) return;
+    _queueIrohServer = next;
     unawaited(ensureActiveTunnel());
   }
 
-  // Which iroh server the single tunnel should currently serve. Playback wins:
-  // the playing track's iroh server (so a background queue plays under a non-iroh
-  // default); otherwise the browsed server when it's iroh. Null → no tunnel.
-  // (With one tunnel, browsing a *different* iroh server than the one playing
-  // can't load until playback stops — rare, since setups usually have one.)
+  // Which iroh server the single tunnel should serve: the browsed server when it
+  // IS the iroh server, OR the iroh server whose songs are queued. Null → no
+  // tunnel. (One-iroh-server cap, so these resolve to the same server when both
+  // apply — there's never a second iroh server to contend for the tunnel.)
   Server? _tunnelTargetServer() {
-    final p = _playbackServer;
-    if (p != null && p.isIroh) return p;
     final c = currentServer;
-    return (c != null && c.isIroh) ? c : null;
+    if (c != null && c.isIroh) return c;
+    final q = _queueIrohServer;
+    return (q != null && q.isIroh) ? q : null;
   }
 
   /// True when the tunnel currently has a server to serve (the browsed iroh server
@@ -594,6 +603,12 @@ class ServerManager {
       Server removeThisServer, bool removeSyncedFiles) async {
     serverList.remove(removeThisServer);
     _serverListStream.sink.add(serverList);
+    // Drop a stale queue-tunnel pointer to the removed server so ensureActiveTunnel
+    // below doesn't try to keep its tunnel up (the queue listener would clear it on
+    // the next edit, but do it now).
+    if (_queueIrohServer?.localname == removeThisServer.localname) {
+      _queueIrohServer = null;
+    }
 
     if (serverList.isEmpty) {
       // force the browser to rerender so it displays

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -352,7 +352,6 @@ class ServerManager {
         IrohTunnel.instance.stop();
         _activeTunnelCode = null;
       }
-      final oldPort = s.tunnelPort;
       _tunnelStarting = true;
       _refreshTunnelStatus(); // surface "Connecting…" while the dial runs
       try {
@@ -360,20 +359,19 @@ class ServerManager {
         s.tunnelPort = port;
         s.tunnelToken = IrohTunnel.instance.localToken;
         _activeTunnelCode = s.irohPairingCode;
-        // A hard rebuild (re-pair, verify-when-down, server switch) binds a NEW
-        // loopback port + token, so any queued iroh stream URLs are stale. Rebuild
-        // them off the current effectiveBaseUrl (idempotent — no-op if unchanged)
-        // so resume / play doesn't load a dead port.
-        //
-        // Also rebuild on a fresh bind from null (oldPort == null) *while casting*:
-        // if a previous resume's start() failed it nulled tunnelPort, so this
-        // recovered bind would otherwise skip the rebuild and leave the renderer
-        // stranded on the dead old port. (When not casting, a null→port bind is a
-        // cold start with no live stream to reload, so leave that path unchanged.)
-        if (oldPort != port && (oldPort != null || CastManager().isCasting)) {
-          unawaited(MediaManager().audioHandler.customAction(
-              'rebuildTranscodeUrls', const {'upcomingOnly': false}));
-        }
+        // This bind set a loopback port + token. Any queued iroh stream URL built
+        // before now is stale, so rebuild them off the live effectiveBaseUrl.
+        // Unconditional on purpose: besides a port that changed on a reconnect /
+        // re-pair / server switch, the queue can also be restored at launch
+        // BEFORE the tunnel is up (a slow or failed first connect bakes
+        // http://127.0.0.1:0 with no token), and the retry that finally connects
+        // has no prior port — so a "changed-only" guard would skip exactly the
+        // case that strands the saved queue. Only an actual (re)start reaches here
+        // (the already-wired-up fast path returned above), and the rebuild no-ops
+        // when no URL actually changed. (Also reloads an active cast onto the fresh
+        // tunnel — see the no-drop note above.)
+        unawaited(MediaManager().audioHandler.customAction(
+            'rebuildTranscodeUrls', const {'upcomingOnly': false}));
       } catch (e) {
         s.tunnelPort = null;
         s.tunnelToken = null;

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -14,6 +14,7 @@ import '../native/iroh_tunnel.dart';
 import '../media/cast_target.dart';
 import 'cast_manager.dart';
 import './media.dart';
+import './queue_store.dart';
 
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as path;
@@ -102,9 +103,22 @@ class ServerManager {
 
     if (serverList.isNotEmpty) {
       currentServer = serverList[0];
-      // Bring up the tunnel for an iroh default server BEFORE the browser queries
-      // it and before the queue is restored (main.dart gates QueueStore.init on
-      // loadServerList completing).
+      // If a saved queue would resume on a *different* iroh server, make that the
+      // active one. The shim holds a single tunnel, so a non-active iroh server's
+      // tunnel is down and its restored queue items would bake against a dead
+      // loopback port (fixed only by a later manual re-select). Activating it here
+      // — before QueueStore.init restores (main.dart gates that on loadServerList
+      // completing) — brings its tunnel up so the items resolve to a live URL.
+      // HTTP/local resume targets need no tunnel, so they leave the primary active.
+      final resumeServerName = await QueueStore().peekResumeServer();
+      if (resumeServerName != null) {
+        final resumeServer = byLocalname(resumeServerName);
+        if (resumeServer != null && resumeServer.isIroh) {
+          currentServer = resumeServer;
+        }
+      }
+      // Bring up the tunnel for an iroh active server BEFORE the browser queries
+      // it and before the queue is restored.
       await ensureActiveTunnel();
       BrowserManager().goToNavScreen();
       _currentServerStream.sink.add(currentServer);

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -103,23 +103,22 @@ class ServerManager {
 
     if (serverList.isNotEmpty) {
       currentServer = serverList[0];
-      // If a saved queue would resume on a *different* iroh server, make that the
-      // active one. The shim holds a single tunnel, so a non-active iroh server's
-      // tunnel is down and its restored queue items would bake against a dead
-      // loopback port (fixed only by a later manual re-select). Activating it here
-      // — before QueueStore.init restores (main.dart gates that on loadServerList
-      // completing) — brings its tunnel up so the items resolve to a live URL.
-      // HTTP/local resume targets need no tunnel, so they leave the primary active.
-      final resumeServerName = await QueueStore().peekResumeServer();
-      if (resumeServerName != null) {
-        final resumeServer = byLocalname(resumeServerName);
-        if (resumeServer != null && resumeServer.isIroh) {
-          currentServer = resumeServer;
+      // Bring up the tunnel for an iroh default server BEFORE the browser queries
+      // it.
+      await ensureActiveTunnel();
+      // Pre-warm the saved queue's iroh server (if it's a DIFFERENT server) in the
+      // BACKGROUND — without selecting it — so the queue restores against a live
+      // tunnel instead of a dead loopback port. The default stays selected; this
+      // just points the playback tunnel ahead of QueueStore.init (main.dart gates
+      // that on loadServerList completing). Bounded by awaitTunnelReady's cap.
+      final resumeName = await QueueStore().peekResumeServer();
+      if (resumeName != null && resumeName != currentServer?.localname) {
+        final rs = byLocalname(resumeName);
+        if (rs != null && rs.isIroh) {
+          setPlaybackServer(rs);
+          await awaitTunnelReady(server: rs);
         }
       }
-      // Bring up the tunnel for an iroh active server BEFORE the browser queries
-      // it and before the queue is restored.
-      await ensureActiveTunnel();
       BrowserManager().goToNavScreen();
       _currentServerStream.sink.add(currentServer);
       for (var s in serverList) {
@@ -319,6 +318,49 @@ class ServerManager {
   // can't race the single tunnel's start/stop (mirrors the cast _switchChain).
   Future<void> _tunnelChain = Future.value();
 
+  // The iroh server of the currently-playing/queued track, when it differs from
+  // (or equals) the browsed server. The single tunnel "follows playback": it
+  // serves this server so a queue from a non-default iroh server plays while the
+  // default stays selected. Pushed by the audio handler on every track change.
+  Server? _playbackServer;
+
+  /// Point the (single) tunnel at the iroh server backing the current track.
+  /// [s] is the playing track's server (or null for a local / HTTP / no track).
+  /// No-op when unchanged; otherwise re-evaluates the tunnel target.
+  void setPlaybackServer(Server? s) {
+    final next = (s != null && s.isIroh) ? s : null;
+    if (next?.localname == _playbackServer?.localname) return;
+    _playbackServer = next;
+    unawaited(ensureActiveTunnel());
+  }
+
+  // Which iroh server the single tunnel should currently serve. Playback wins:
+  // the playing track's iroh server (so a background queue plays under a non-iroh
+  // default); otherwise the browsed server when it's iroh. Null → no tunnel.
+  // (With one tunnel, browsing a *different* iroh server than the one playing
+  // can't load until playback stops — rare, since setups usually have one.)
+  Server? _tunnelTargetServer() {
+    final p = _playbackServer;
+    if (p != null && p.isIroh) return p;
+    final c = currentServer;
+    return (c != null && c.isIroh) ? c : null;
+  }
+
+  /// True when the tunnel currently has a server to serve (the browsed iroh server
+  /// OR a background playback server). Drives the status banner — which must show
+  /// for a background tunnel even while a non-iroh default is the selected server.
+  bool get tunnelActive => _tunnelTargetServer() != null;
+
+  /// True when the single tunnel is currently assigned to [s] (regardless of its
+  /// connection state) — i.e. [s] is the server we last (re)started it for.
+  bool tunnelAssignedTo(Server s) =>
+      s.isIroh && _activeTunnelCode != null && s.irohPairingCode == _activeTunnelCode;
+
+  /// True when the tunnel is assigned to [s] AND reports connected — i.e. [s]'s
+  /// loopback is live right now.
+  bool tunnelServes(Server s) =>
+      tunnelAssignedTo(s) && IrohTunnel.instance.status == IrohTunnelStatus.connected;
+
   /// Bring the single iroh tunnel in line with the active server. With [verify],
   /// also force a rebuild when the native tunnel is fully *down* despite our
   /// bookkeeping (the shim's supervisor self-heals transient drops, so this only
@@ -331,7 +373,7 @@ class ServerManager {
 
   Future<void> _ensureActiveTunnel(bool verify) async {
     if (!IrohTunnel.isSupported) return;
-    final s = currentServer;
+    final s = _tunnelTargetServer();
     if (s != null && s.isIroh && s.irohPairingCode != null) {
       // NB: don't drop an active cast here at the top. A renderer reaches an iroh
       // server through the LAN proxy (LocalMediaServer), so casting iroh is
@@ -409,8 +451,9 @@ class ServerManager {
   /// (it can't self-detect on Android) and rebuild the tunnel if it's hard-down.
   /// Cheap and safe when the active server isn't iroh.
   Future<void> handleNetworkChange() async {
-    final s = currentServer;
-    if (!IrohTunnel.isSupported || s == null || !s.isIroh) return;
+    // Nudge whichever server the tunnel serves (a background playback server, not
+    // just the browsed one) so a Wi-Fi/cellular switch re-probes the live tunnel.
+    if (!IrohTunnel.isSupported || _tunnelTargetServer() == null) return;
     IrohTunnel.instance.networkChanged();
     await ensureActiveTunnel(verify: true);
   }
@@ -433,7 +476,9 @@ class ServerManager {
   bool _tunnelStarting = false;
 
   void _refreshTunnelStatus() {
-    final isIroh = IrohTunnel.isSupported && currentServer?.isIroh == true;
+    // Status reflects the tunnel's target (which may be a background playback
+    // server, not the browsed one).
+    final isIroh = IrohTunnel.isSupported && _tunnelTargetServer() != null;
     final IrohTunnelStatus st;
     if (!isIroh) {
       st = IrohTunnelStatus.down;
@@ -452,7 +497,7 @@ class ServerManager {
   void _startStatusPolling() {
     _statusPoll ??= Timer.periodic(const Duration(seconds: 2), (_) {
       _refreshTunnelStatus();
-      if (currentServer?.isIroh != true) _stopStatusPolling();
+      if (_tunnelTargetServer() == null) _stopStatusPolling();
     });
     _refreshTunnelStatus();
   }
@@ -472,8 +517,10 @@ class ServerManager {
   /// verify-rebuild in case it's hard-down. Returns true once connected; false on
   /// a rejected (re-pair) state or timeout. Non-iroh servers are ready immediately.
   Future<bool> awaitTunnelReady(
-      {Duration timeout = const Duration(seconds: 12)}) async {
-    final s = currentServer;
+      {Server? server, Duration timeout = const Duration(seconds: 12)}) async {
+    // Default to the browsed server; callers on the playback path pass the
+    // track's server (which the single tunnel may be serving instead).
+    final s = server ?? currentServer;
     if (!IrohTunnel.isSupported || s == null || !s.isIroh) return true;
     unawaited(ensureActiveTunnel(verify: true));
     // start() can take ~30s; don't report not-ready while a dial is in flight.
@@ -481,13 +528,17 @@ class ServerManager {
     final hardCap = DateTime.now().add(const Duration(seconds: 45));
     var deadline = DateTime.now().add(timeout);
     while (DateTime.now().isBefore(deadline) && DateTime.now().isBefore(hardCap)) {
-      final st = IrohTunnel.instance.status;
-      if (st == IrohTunnelStatus.connected) return true;
-      if (st == IrohTunnelStatus.rejected) return false;
+      // Ready only when the tunnel is connected AND serving THIS server — with one
+      // tunnel, a different server being served means s isn't reachable yet.
+      if (tunnelServes(s)) return true;
+      if (tunnelAssignedTo(s) &&
+          IrohTunnel.instance.status == IrohTunnelStatus.rejected) {
+        return false; // this server's code was rejected (needs re-pair)
+      }
       if (_tunnelStarting) deadline = DateTime.now().add(timeout);
       await Future.delayed(const Duration(milliseconds: 300));
     }
-    return IrohTunnel.instance.status == IrohTunnelStatus.connected;
+    return tunnelServes(s);
   }
 
   /// Re-pair the active iroh server with a fresh pairing code (after a rotated
@@ -496,7 +547,10 @@ class ServerManager {
   /// and nothing is written — so a wrong/typo code can't destroy a working one.
   /// Returns true iff the new code connected.
   Future<bool> repairIrohPairingCode(String newCode) async {
-    final s = currentServer;
+    // Re-pair whichever server the tunnel actually serves — that's the one whose
+    // code was rejected (it may be a background playback server, not the browsed
+    // one). Falls back to the browsed server.
+    final s = _tunnelTargetServer() ?? currentServer;
     if (s == null || !s.isIroh) return false;
     final oldCode = s.irohPairingCode;
 


### PR DESCRIPTION
Three related playback bugfixes for iroh users (independent of the cast feature in [#77](https://github.com/IrosTheBeggar/mstream_music/pull/77)).

## 1. First-connect queue rebind (all iroh users)

A restored queue's stream URLs are baked at restore via `buildServerStreamUrl`, using `effectiveBaseUrl` = `http://127.0.0.1:<tunnelPort>` + the `&__lt=<token>` loopback token. Both are **runtime-only** (never persisted), so they start `null` each launch. If the first tunnel connect is slow or fails, the queue is restored against a not-yet-ready tunnel → `http://127.0.0.1:0/...` with no token. The rebuild was gated on `oldPort != null && oldPort != port`, which a first connect (or a retry after a failed connect) never satisfies → the saved queue stayed dead (browse worked, since it resolves URLs live per-call).

**Fix:** rebuild the queue URLs **unconditionally after a successful (re)bind**. Only an actual (re)start reaches that code, and the rebuild no-ops when no URL changed.

## 2. Non-primary iroh server (multi-server edge case)

The shim holds **one tunnel at a time**, brought up only for the active server, and the active server at launch is hardcoded to the first server. A saved queue from a **non-primary** iroh server baked against a dead port and was only fixed by manually re-selecting that server.

**Fix:** peek the saved queue's resume (current-index) item's server before restoring; if it's a configured iroh server that isn't already active, make it active so its tunnel comes up before the queue restores. HTTP/local resume targets leave the primary active.

## 3. Warn + skip a track that won't play

Previously a just_audio playback error did nothing unless it was an iroh tunnel drop (recovers in place); a genuinely failed source — missing/bad track, server 500, dead URL — left playback stalled with no feedback.

**Fix:** `_onPlaybackError` now splits the two. A non-connected iroh tunnel still recovers in place; any other failure **warns (debounced — one toast per 4s) and skips to the next track**. A loop guard (`failures >= queue.length`) stops instead of spinning when the whole queue is unplayable (notably under repeat-all), and it stops cleanly at the end of a no-repeat queue. The failure count resets when a track reaches `ready`.

Hardened after an adversarial review of the diff:
- skip serialized through `_switchChain` + a `_skipPending` gate so an error burst can't double-count, race the index read, or interleave with recovery / a cast switch;
- `_onPlaybackError` runs one handler at a time, so a stale error mid-recovery can't skip the just-recovered track;
- recover-vs-skip routes on the **failed item's** server (a local/HTTP/other-iroh-server item failing on a disconnected iroh server skips rather than waiting on a tunnel that can't help it);
- skip budget resets when recovery starts; a queued skip bails if the backend switched to a renderer.

## Scope

Pre-existing from the iroh tunnel feature (#76). `flutter analyze` clean. Verified on-device.

## Test plan

- [ ] iroh **primary** + saved queue → restored queue plays without clearing it
- [ ] iroh server that is **NOT** primary + a queue from it → resumes on that server, plays (no manual re-select)
- [ ] Bad track mid-queue → warns once, skips, keeps playing
- [ ] Run of bad tracks → one (debounced) toast, skips to the next playable one
- [ ] Whole queue unplayable under repeat-all → stops with a warning instead of looping
- [ ] iroh tunnel blip mid-song → recovers in place, does NOT skip
- [ ] Airplane-mode toggle mid-session → reconnect → queue still plays
- [ ] Primary HTTP / local resume target → still lands on the primary (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)