### PR TITLE
fix(downloads): survive a network blip and an iroh tunnel rebuild

### DIFF
--- a/lib/objects/download_tracker.dart
+++ b/lib/objects/download_tracker.dart
@@ -12,5 +12,13 @@ class DownloadTracker {
   // for downloads with no on-screen row (e.g. the queue's Sync action).
   DisplayItem? referenceDisplayItem;
 
+  // Originating server localname + data path, kept so a failed iroh download can
+  // be re-resolved against the live tunnel and re-enqueued (see DownloadManager).
+  String? serverName;
+  String? dataPath;
+  // Times this download has been re-resolved onto a fresh iroh tunnel URL; bounds
+  // the re-enqueue so a repeatedly-rotating tunnel / dead source can't loop.
+  int reResolves = 0;
+
   DownloadTracker(this.serverUrl, this.filePath);
 }

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -237,6 +237,14 @@ class DownloadManager {
         baseDirectory: BaseDirectory.root,
         directory: targetDir,
         updates: Updates.statusAndProgress,
+        // Survive a transient network interruption (Wi-Fi blip, Wi-Fi<->cellular
+        // handover). Without this, background_downloader defaults to retries: 0,
+        // so the moment the network drops WorkManager cancels the in-flight
+        // worker and the download fails permanently instead of resuming when the
+        // network returns. Retries back off exponentially and only surface a
+        // terminal `failed` once exhausted; the intermediate `waitingToRetry`
+        // status is already treated as non-terminal in _onUpdate.
+        retries: 5,
       );
 
       _inFlight.add(downloadDirectory);

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -14,6 +14,7 @@ import 'package:path/path.dart' as path;
 import '../objects/download_tracker.dart';
 import '../objects/display_item.dart';
 import '../objects/server.dart';
+import '../media/cast_origin.dart' show irohLoopbackUri;
 
 class DownloadManager {
   DownloadManager._privateConstructor();
@@ -36,6 +37,9 @@ class DownloadManager {
   // doesn't queue one snackbar per skipped file.
   DateTime? _lastFatWarn;
   StreamSubscription<TaskUpdate>? _updatesSub;
+  // Cap on how many times a single download is re-resolved onto a fresh iroh
+  // tunnel URL after a hard rebuild, so a repeatedly-rotating tunnel can't loop.
+  static const int _kMaxReResolves = 2;
 
   Future<void> initDownloader() async {
     // background_downloader delivers status + progress for every task on a
@@ -44,7 +48,7 @@ class DownloadManager {
     _updatesSub = FileDownloader().updates.listen(_onUpdate);
   }
 
-  void _onUpdate(TaskUpdate update) {
+  Future<void> _onUpdate(TaskUpdate update) async {
     final DownloadTracker? dt = downloadMap[update.task.taskId];
     if (dt == null) return;
 
@@ -63,15 +67,21 @@ class DownloadManager {
           // local copy without a queue rebuild.
           break;
         case TaskStatus.failed:
-        case TaskStatus.notFound:
-          // Reset the row so a stuck partial bar doesn't imply a cached
-          // file that isn't there, and tell the user it didn't work.
+          // An iroh download's URL bakes in the loopback port + __lt token, and a
+          // hard tunnel rebuild rotates both (background_downloader's own retries
+          // reuse the same dead URL). Re-resolve against the live tunnel and
+          // re-enqueue before giving up — only then is it a genuine failure. The
+          // re-enqueued task carries its own tracker, so bail here without a toast.
+          if (await _reEnqueueOnLiveTunnel(dt, update.task)) return;
           dt.progress = 0;
           terminal = true;
-          final ctx = rootMessengerKey.currentContext;
-          showGlobalSnack(ctx != null
-              ? AppLocalizations.of(ctx).dlFailed
-              : 'A download failed — check your connection.');
+          _warnDownloadFailed();
+          break;
+        case TaskStatus.notFound:
+          // 404 — the source is genuinely gone; re-resolving wouldn't help.
+          dt.progress = 0;
+          terminal = true;
+          _warnDownloadFailed();
           break;
         case TaskStatus.canceled:
           dt.progress = 0;
@@ -106,6 +116,52 @@ class DownloadManager {
 
     // Re-emit so the Downloads screen's StreamBuilder rebuilds.
     _downloadStream.add(downloadMap);
+  }
+
+  void _warnDownloadFailed() {
+    final ctx = rootMessengerKey.currentContext;
+    // Reset the row (handled by the caller) and tell the user it didn't work.
+    showGlobalSnack(ctx != null
+        ? AppLocalizations.of(ctx).dlFailed
+        : 'A download failed — check your connection.');
+  }
+
+  // A failed iroh download may just have a stale loopback URL: the captured
+  // http://127.0.0.1:<port>/...&__lt=<token> is invalidated by a hard tunnel
+  // rebuild (server switch / re-pair / verify-when-down), and
+  // background_downloader's retries reuse it. Bring the tunnel back up, re-origin
+  // the URL onto the live port + token, and re-enqueue under a fresh task.
+  // Returns true when it re-enqueued (the caller treats the failure as
+  // non-terminal). Bounded by [_kMaxReResolves]; only fires when the URL actually
+  // changed, so a genuinely dead source or an unchanged tunnel still fails.
+  Future<bool> _reEnqueueOnLiveTunnel(DownloadTracker dt, Task failed) async {
+    final name = dt.serverName;
+    final dataPath = dt.dataPath;
+    if (name == null || dataPath == null) return false;
+    if (dt.reResolves >= _kMaxReResolves) return false;
+
+    final Server server;
+    try {
+      server = ServerManager().lookupServer(name);
+    } catch (_) {
+      return false; // server removed while the download lingered
+    }
+    if (!server.isIroh) return false; // only loopback URLs rotate this way
+
+    // Bring the tunnel up (rebuilds it if hard-down) and wait for a live port;
+    // if it can't connect, this is a real failure.
+    if (!await ServerManager().awaitTunnelReady(server: server)) return false;
+    final freshUrl = irohLoopbackUri(server, dt.serverUrl).toString();
+    if (freshUrl == dt.serverUrl) return false; // port + token didn't rotate
+
+    // Hand off to a fresh task: drop this one's bookkeeping so the re-enqueue's
+    // existence / in-flight guards pass, then go through the normal enqueue path
+    // (re-resolves the destination dir, applies retries) carrying the bumped count.
+    downloadMap.remove(failed.taskId);
+    _inFlight.remove(dt.filePath);
+    await downloadOneFile(freshUrl, name, dataPath,
+        referenceItem: dt.referenceDisplayItem, reResolves: dt.reResolves + 1);
+    return true;
   }
 
   void disposeDownloader() {}
@@ -170,7 +226,7 @@ class DownloadManager {
 
   Future<void> downloadOneFile(String downloadUrl, String serverName,
       String filepath,
-      {DisplayItem? referenceItem}) async {
+      {DisplayItem? referenceItem, int reResolves = 0}) async {
     String downloadDirectory = serverName + filepath;
 
     // The originating server may have been removed while this track lingered
@@ -250,7 +306,10 @@ class DownloadManager {
       _inFlight.add(downloadDirectory);
       downloadMap[task.taskId] =
           DownloadTracker(downloadUrl, downloadDirectory)
-            ..referenceDisplayItem = referenceItem;
+            ..referenceDisplayItem = referenceItem
+            ..serverName = serverName
+            ..dataPath = filepath
+            ..reResolves = reResolves;
       _downloadStream.add(downloadMap);
 
       await FileDownloader().enqueue(task);


### PR DESCRIPTION
Makes downloads resilient to the two ways an iroh download "randomly" fails: a transient network blip, and a hard tunnel rebuild. Diagnosed from on-device logs (a forced Wi-Fi blip during a "Download all").

## 1. Retry through a transient network blip (all servers)

`DownloadTask` was created with no `retries`, and `background_downloader` defaults to **`retries: 0`**. So any network blip mid-download — Wi-Fi drop, Wi-Fi↔cellular handover — makes WorkManager cancel the running worker and the download terminates as `failed` (the "A download failed" toast) instead of resuming once the network is back.

Evidence (on-device): a forced ~12s Wi-Fi blip during a "Download all" cancelled every in-flight worker at once and none re-ran —
```
WM-NetworkStateTracker(11343): Network connection lost
WM-WorkerWrapper: Work [ ...DownloadTaskWorker, taskId=959613512... ] was cancelled
  androidx.work.impl.WorkerStoppedException
```

**Fix:** `retries: 5`. background_downloader backs off exponentially and only surfaces the terminal `failed` once exhausted; the intermediate `waitingToRetry` is already non-terminal in `_onUpdate`.

## 2. Re-resolve the iroh loopback URL on a hard rebuild

An iroh download's URL bakes in `http://127.0.0.1:<port>/…&__lt=<token>`, captured at enqueue. background_downloader's retries reuse that URL, so they ride out a transient blip (port + token stay put) but **not** a hard tunnel rebuild (server switch / re-pair / verify-when-down), which rotates both — the captured URL then points at a dead loopback listener and every retry fails.

**Fix:** on a terminal `failed` for an iroh server, bring the tunnel back up (`awaitTunnelReady` kicks a verify-rebuild), re-origin the URL onto the live port + token (`irohLoopbackUri`), and re-enqueue under a fresh task. Bounded:
- only when the URL actually changed (no rotation → genuine failure, no re-enqueue);
- at most `_kMaxReResolves` (2) times (a repeatedly-rotating tunnel / dead source still surfaces the toast, never loops);
- `notFound` (404) skips re-resolve — the source is really gone.

`DownloadTracker` now carries `serverName` / `dataPath` / `reResolves` so a failed task is rebuilt and re-enqueued through the normal `downloadOneFile` path.

## Validation

- `flutter analyze` clean.
- Two adversarial reviews (one per fix): **0 findings** — loop-bound, concurrency/state, and non-iroh regression all verified.
- Deployed to device; on-device blip re-test pending.

## Test plan

- [ ] "Download all" with a forced Wi-Fi blip → in-flight downloads resume and complete
- [ ] Hard tunnel rebuild mid-download (server switch / re-pair) → downloads re-resolve to the live tunnel and complete
- [ ] Genuinely dead source (bad URL / missing track) → failure toast after retries exhausted; no infinite spin
- [ ] Non-iroh (plain HTTP) download → unaffected; normal completion unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)