### PR TITLE
fix(add-server): iroh edit form + Play storage simplification + Quick Connect

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -929,7 +929,11 @@
 
   "addServerTabUrl": "Server URL",
   "@addServerTabUrl": {
-    "description": "Add-server form: tab label for the classic HTTP URL connection (paired with the 'iroh' tab)."
+    "description": "Add-server form: tab label for the classic HTTP URL connection (paired with the 'Quick Connect' tab)."
+  },
+  "addServerTabQuickConnect": "Quick Connect",
+  "@addServerTabQuickConnect": {
+    "description": "Add-server form: tab label for the iroh peer-to-peer pairing flow (paired with the 'Server URL' tab)."
   },
   "irohConnectHeader": "Connect peer-to-peer",
   "@irohConnectHeader": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -763,6 +763,8 @@
   "storageAppLocal": "App local",
   "storagePermanent": "Permanent",
   "storageSdCard": "SD card",
+  "storageSdSwitchTitle": "Save to SD card",
+  "storageSdSwitchSubtitle": "Stored in the SD card's app folder — no permission needed, but removed if you uninstall the app.",
   "storageHelpAppLocal": "Saved inside the app. Deleted when you uninstall or clear the app.",
   "storageHelpPermanent": "Saved to a folder you choose. Survives uninstalling the app. Requires \"All files access\".",
   "storageHelpSdCard": "Saved to a folder on the SD card you choose. May become unavailable if the card is removed. Some devices don't let apps write to SD cards — if folder selection keeps failing, use Permanent or App local.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1938,6 +1938,18 @@ abstract class AppLocalizations {
   /// **'SD card'**
   String get storageSdCard;
 
+  /// No description provided for @storageSdSwitchTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Save to SD card'**
+  String get storageSdSwitchTitle;
+
+  /// No description provided for @storageSdSwitchSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Stored in the SD card\'s app folder — no permission needed, but removed if you uninstall the app.'**
+  String get storageSdSwitchSubtitle;
+
   /// No description provided for @storageHelpAppLocal.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2484,11 +2484,17 @@ abstract class AppLocalizations {
   /// **'Storage permission is needed to read Downloads'**
   String get importedShadersDownloadsNoPermission;
 
-  /// Add-server form: tab label for the classic HTTP URL connection (paired with the 'iroh' tab).
+  /// Add-server form: tab label for the classic HTTP URL connection (paired with the 'Quick Connect' tab).
   ///
   /// In en, this message translates to:
   /// **'Server URL'**
   String get addServerTabUrl;
+
+  /// Add-server form: tab label for the iroh peer-to-peer pairing flow (paired with the 'Server URL' tab).
+  ///
+  /// In en, this message translates to:
+  /// **'Quick Connect'**
+  String get addServerTabQuickConnect;
 
   /// Header of the iroh tab on the add-server form.
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1108,6 +1108,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get storageSdCard => 'SD-Karte';
 
   @override
+  String get storageSdSwitchTitle => 'Save to SD card';
+
+  @override
+  String get storageSdSwitchSubtitle =>
+      'Stored in the SD card\'s app folder — no permission needed, but removed if you uninstall the app.';
+
+  @override
   String get storageHelpAppLocal =>
       'Innerhalb der App gespeichert. Wird beim Deinstallieren oder Leeren der App gelöscht.';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1437,6 +1437,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get addServerTabUrl => 'Server URL';
 
   @override
+  String get addServerTabQuickConnect => 'Quick Connect';
+
+  @override
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1093,6 +1093,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get storageSdCard => 'SD card';
 
   @override
+  String get storageSdSwitchTitle => 'Save to SD card';
+
+  @override
+  String get storageSdSwitchSubtitle =>
+      'Stored in the SD card\'s app folder — no permission needed, but removed if you uninstall the app.';
+
+  @override
   String get storageHelpAppLocal =>
       'Saved inside the app. Deleted when you uninstall or clear the app.';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1420,6 +1420,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get addServerTabUrl => 'Server URL';
 
   @override
+  String get addServerTabQuickConnect => 'Quick Connect';
+
+  @override
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1106,6 +1106,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get storageSdCard => 'Tarjeta SD';
 
   @override
+  String get storageSdSwitchTitle => 'Save to SD card';
+
+  @override
+  String get storageSdSwitchSubtitle =>
+      'Stored in the SD card\'s app folder — no permission needed, but removed if you uninstall the app.';
+
+  @override
   String get storageHelpAppLocal =>
       'Guardado dentro de la aplicación. Se elimina al desinstalar o borrar los datos de la app.';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1436,6 +1436,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get addServerTabUrl => 'Server URL';
 
   @override
+  String get addServerTabQuickConnect => 'Quick Connect';
+
+  @override
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1105,6 +1105,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get storageSdCard => 'Carte SD';
 
   @override
+  String get storageSdSwitchTitle => 'Save to SD card';
+
+  @override
+  String get storageSdSwitchSubtitle =>
+      'Stored in the SD card\'s app folder — no permission needed, but removed if you uninstall the app.';
+
+  @override
   String get storageHelpAppLocal =>
       'Enregistré dans l\'application. Supprimé lorsque vous désinstallez ou videz l\'application.';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1435,6 +1435,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get addServerTabUrl => 'Server URL';
 
   @override
+  String get addServerTabQuickConnect => 'Quick Connect';
+
+  @override
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1106,6 +1106,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get storageSdCard => 'Scheda SD';
 
   @override
+  String get storageSdSwitchTitle => 'Save to SD card';
+
+  @override
+  String get storageSdSwitchSubtitle =>
+      'Stored in the SD card\'s app folder — no permission needed, but removed if you uninstall the app.';
+
+  @override
   String get storageHelpAppLocal =>
       'Salvato dentro l’app. Eliminato quando disinstalli o cancelli i dati dell’app.';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1437,6 +1437,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get addServerTabUrl => 'Server URL';
 
   @override
+  String get addServerTabQuickConnect => 'Quick Connect';
+
+  @override
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1063,6 +1063,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get storageSdCard => 'SD カード';
 
   @override
+  String get storageSdSwitchTitle => 'Save to SD card';
+
+  @override
+  String get storageSdSwitchSubtitle =>
+      'Stored in the SD card\'s app folder — no permission needed, but removed if you uninstall the app.';
+
+  @override
   String get storageHelpAppLocal => 'アプリ内に保存されます。アンインストールまたはアプリのデータ消去で削除されます。';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1374,6 +1374,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get addServerTabUrl => 'Server URL';
 
   @override
+  String get addServerTabQuickConnect => 'Quick Connect';
+
+  @override
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1454,6 +1454,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get addServerTabUrl => 'Server URL';
 
   @override
+  String get addServerTabQuickConnect => 'Quick Connect';
+
+  @override
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1120,6 +1120,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get storageSdCard => 'Karta SD';
 
   @override
+  String get storageSdSwitchTitle => 'Save to SD card';
+
+  @override
+  String get storageSdSwitchSubtitle =>
+      'Stored in the SD card\'s app folder — no permission needed, but removed if you uninstall the app.';
+
+  @override
   String get storageHelpAppLocal =>
       'Zapisywane wewnątrz aplikacji. Usuwane po odinstalowaniu lub wyczyszczeniu aplikacji.';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1433,6 +1433,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get addServerTabUrl => 'Server URL';
 
   @override
+  String get addServerTabQuickConnect => 'Quick Connect';
+
+  @override
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1102,6 +1102,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get storageSdCard => 'Cartão SD';
 
   @override
+  String get storageSdSwitchTitle => 'Save to SD card';
+
+  @override
+  String get storageSdSwitchSubtitle =>
+      'Stored in the SD card\'s app folder — no permission needed, but removed if you uninstall the app.';
+
+  @override
   String get storageHelpAppLocal =>
       'Salvo dentro do app. Excluído ao desinstalar ou limpar o app.';
 

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1458,6 +1458,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get addServerTabUrl => 'Server URL';
 
   @override
+  String get addServerTabQuickConnect => 'Quick Connect';
+
+  @override
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1124,6 +1124,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get storageSdCard => 'SD-карта';
 
   @override
+  String get storageSdSwitchTitle => 'Save to SD card';
+
+  @override
+  String get storageSdSwitchSubtitle =>
+      'Stored in the SD card\'s app folder — no permission needed, but removed if you uninstall the app.';
+
+  @override
   String get storageHelpAppLocal =>
       'Сохраняется внутри приложения. Удаляется при удалении приложения или очистке его данных.';
 

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1346,6 +1346,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get addServerTabUrl => 'Server URL';
 
   @override
+  String get addServerTabQuickConnect => 'Quick Connect';
+
+  @override
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1044,6 +1044,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get storageSdCard => 'SD 卡';
 
   @override
+  String get storageSdSwitchTitle => 'Save to SD card';
+
+  @override
+  String get storageSdSwitchSubtitle =>
+      'Stored in the SD card\'s app folder — no permission needed, but removed if you uninstall the app.';
+
+  @override
   String get storageHelpAppLocal => '保存在应用内部。卸载或清除应用时会被删除。';
 
   @override

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -1261,7 +1261,7 @@ class MyCustomFormState extends State<MyCustomForm> {
               indicatorColor: VelvetColors.primary,
               tabs: [
                 Tab(text: AppLocalizations.of(context).addServerTabUrl),
-                const Tab(text: 'iroh'),
+                Tab(text: AppLocalizations.of(context).addServerTabQuickConnect),
               ],
             ),
           ),

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -87,6 +87,10 @@ class MyCustomFormState extends State<MyCustomForm> {
   String _storageMode = 'appLocal';
   // Full flavor only: accept a self-signed / untrusted TLS cert for this server.
   bool _allowSelfSigned = false;
+  // True when editing an existing iroh server. iroh connects through the loopback
+  // tunnel, not a fetchable URL, so the URL field is read-only, the self-signed
+  // TLS switch + Test-connection button are hidden, and Save skips the HTTP probe.
+  bool _editingIroh = false;
 
   // Show/hide toggle for the password field.
   bool _obscurePassword = true;
@@ -142,6 +146,7 @@ class MyCustomFormState extends State<MyCustomForm> {
       _storageBasePath = s.storageBasePath;
       _downloadFolderCtrl.text = s.localname;
       isEdit = true;
+      _editingIroh = s.isIroh;
       // An existing server saved without credentials is a public
       // server — start in public mode so the toggle reflects reality.
       if ((s.username ?? '').isEmpty && (s.password ?? '').isEmpty) {
@@ -866,6 +871,15 @@ class MyCustomFormState extends State<MyCustomForm> {
   void _onSavePressed() {
     if (!_formKey.currentState!.validate()) return;
     _formKey.currentState!.save();
+    if (_editingIroh) {
+      // iroh reaches the backend through the loopback tunnel, not a fetchable
+      // URL — the HTTP ping/login probe in checkServer() can't reach an iroh://
+      // URL and would always fail. The pairing already validated the connection,
+      // so persist the edited credentials/folder directly (URL stays unchanged).
+      setState(() => submitPending = true);
+      saveServer(Uri.parse(_urlCtrl.text));
+      return;
+    }
     checkServer();
   }
 
@@ -1715,22 +1729,29 @@ class MyCustomFormState extends State<MyCustomForm> {
             children: <Widget>[
               TextFormField(
                 controller: _urlCtrl,
+                // iroh server: reached through the loopback tunnel, not this URL
+                // (it's an iroh:// pairing id), so it's read-only when editing one.
+                enabled: !_editingIroh,
                 keyboardType: TextInputType.url,
                 autocorrect: false,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return l.validatorUrlNeeded;
-                  }
-                  try {
-                    final parsed = Uri.parse(value);
-                    if (parsed.origin is Error || parsed.origin.isEmpty) {
-                      return l.validatorUrlParse;
-                    }
-                  } catch (_) {
-                    return l.validatorUrlParse;
-                  }
-                  return null;
-                },
+                // Skip the http/https validator for iroh — an iroh:// URL has no
+                // origin, so it would otherwise fail validation and block Save.
+                validator: _editingIroh
+                    ? null
+                    : (value) {
+                        if (value == null || value.isEmpty) {
+                          return l.validatorUrlNeeded;
+                        }
+                        try {
+                          final parsed = Uri.parse(value);
+                          if (parsed.origin is Error || parsed.origin.isEmpty) {
+                            return l.validatorUrlParse;
+                          }
+                        } catch (_) {
+                          return l.validatorUrlParse;
+                        }
+                        return null;
+                      },
                 decoration: InputDecoration(
                   labelText: l.fieldServerUrl,
                   hintText: 'https://mstream.example.com',
@@ -1754,8 +1775,9 @@ class MyCustomFormState extends State<MyCustomForm> {
                 activeThumbColor: VelvetColors.primary,
               ),
               // Full flavor only: opt into a self-signed / untrusted TLS cert
-              // for this server (API + streaming). Hidden on the Play build.
-              if (!isPlayBuild)
+              // for this server (API + streaming). Hidden on the Play build, and
+              // for iroh (it tunnels over QUIC — there's no TLS cert to trust).
+              if (!isPlayBuild && !_editingIroh)
                 SwitchListTile(
                   contentPadding: EdgeInsets.zero,
                   title: Text(l.selfSignedTitle),
@@ -1811,35 +1833,40 @@ class MyCustomFormState extends State<MyCustomForm> {
                 ),
                 onSaved: (v) => _passwordCtrl.text = v ?? '',
               ),
-              SizedBox(height: 16),
-              OutlinedButton.icon(
-                style: OutlinedButton.styleFrom(
-                  foregroundColor: VelvetColors.textPrimary,
-                  side: BorderSide(color: VelvetColors.border2),
-                  padding: EdgeInsets.symmetric(vertical: 14),
-                  shape: RoundedRectangleBorder(
-                    borderRadius:
-                        BorderRadius.circular(VelvetColors.radiusSmall),
+              // Test connection is an HTTP probe — meaningless for an iroh server
+              // (it's reached through the tunnel, tested during pairing), so hide
+              // it when editing one.
+              if (!_editingIroh) ...[
+                SizedBox(height: 16),
+                OutlinedButton.icon(
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: VelvetColors.textPrimary,
+                    side: BorderSide(color: VelvetColors.border2),
+                    padding: EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(
+                      borderRadius:
+                          BorderRadius.circular(VelvetColors.radiusSmall),
+                    ),
                   ),
+                  icon: _testing
+                      ? SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor:
+                                AlwaysStoppedAnimation(VelvetColors.primary),
+                          ),
+                        )
+                      : Icon(Icons.network_check),
+                  label: Text(_testing ? l.testing : l.testConnectionButton),
+                  onPressed:
+                      _testing || submitPending ? null : _testConnection,
                 ),
-                icon: _testing
-                    ? SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          valueColor:
-                              AlwaysStoppedAnimation(VelvetColors.primary),
-                        ),
-                      )
-                    : Icon(Icons.network_check),
-                label: Text(_testing ? l.testing : l.testConnectionButton),
-                onPressed:
-                    _testing || submitPending ? null : _testConnection,
-              ),
-              if (_testResult != null) ...[
-                SizedBox(height: 10),
-                _statusBanner(_testResult!, _testSuccess ?? false),
+                if (_testResult != null) ...[
+                  SizedBox(height: 10),
+                  _statusBanner(_testResult!, _testSuccess ?? false),
+                ],
               ],
               // Storage location: App local (default) / Permanent / SD card
               // (the SD option only when a removable card is present, or when

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -194,11 +194,11 @@ class MyCustomFormState extends State<MyCustomForm> {
     }
   }
 
-  // The auto folder name: "${subdomain}-${domain}", plus a stable short id
-  // when another configured server already uses that name — so two servers
-  // on the same domain don't share one download directory. (Checks the
-  // server list, not the filesystem, so re-adding a lost server can still
-  // reuse its orphaned folder for recovery.)
+  // The auto folder name: "${subdomain}-${domain}-${id}" — always suffixed with
+  // a short random id (stable per screen) so no two servers ever share a
+  // download directory, even on the same domain or after a re-add. The folder
+  // field stays editable, so re-adding a lost server can still recover its
+  // downloads by pointing at the old folder name.
   //
   // A bare IP host (e.g. a LAN server at 192.168.1.71) makes a poor,
   // collision-prone folder name, so those become "my-server-N" with the lowest
@@ -207,7 +207,7 @@ class MyCustomFormState extends State<MyCustomForm> {
     if (_hostIsIp(_urlCtrl.text)) return _nextMyServerName();
     final base = _defaultLocalName(_urlCtrl.text);
     if (base == null) return null;
-    return _localNameTaken(base) ? '$base-$_folderSuffix' : base;
+    return '$base-$_folderSuffix';
   }
 
   // True when the server URL's host is a bare IP address (v4 or v6).
@@ -1868,54 +1868,74 @@ class MyCustomFormState extends State<MyCustomForm> {
                   _statusBanner(_testResult!, _testSuccess ?? false),
                 ],
               ],
-              // Storage location: App local (default) / Permanent / SD card
-              // (the SD option only when a removable card is present, or when
-              // this server is already configured for it). Replaces the old
-              // SD-card toggle; see _storageHelp for the per-mode caveats.
-              SizedBox(height: 16),
-              Text(l.storageLocationLabel,
-                  style: TextStyle(
-                      color: VelvetColors.textSecondary,
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600)),
-              SizedBox(height: 6),
-              InputDecorator(
-                decoration: InputDecoration(
-                  isDense: true,
-                  prefixIcon: Icon(Icons.sd_storage_outlined),
-                ),
-                child: DropdownButtonHideUnderline(
-                  child: DropdownButton<String>(
-                    value: _displayStorageMode,
-                    isExpanded: true,
+              // Storage location. Play build keeps it simple: internal storage by
+              // default, with an optional "Save to SD card" switch when a
+              // removable card is present (the card's app-specific dir — no
+              // permission, but cleared on uninstall). Full build offers the
+              // app-local / external / permanent / SD modes via a dropdown. Either
+              // way the download folder is auto-named (the field below).
+              if (isPlayBuild) ...[
+                if (_hasSdCard) ...[
+                  SizedBox(height: 16),
+                  SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    secondary: Icon(Icons.sd_storage_outlined),
+                    title: Text(l.storageSdSwitchTitle),
+                    subtitle: Text(
+                      l.storageSdSwitchSubtitle,
+                      style: TextStyle(
+                          color: VelvetColors.textSecondary, fontSize: 12),
+                    ),
+                    value: _storageMode == 'sdCardApp',
+                    onChanged: submitPending
+                        ? null
+                        : (v) => setState(() =>
+                            _storageMode = v ? 'sdCardApp' : 'appLocal'),
+                    activeThumbColor: VelvetColors.primary,
+                  ),
+                ],
+              ] else ...[
+                SizedBox(height: 16),
+                Text(l.storageLocationLabel,
+                    style: TextStyle(
+                        color: VelvetColors.textSecondary,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600)),
+                SizedBox(height: 6),
+                InputDecorator(
+                  decoration: InputDecoration(
                     isDense: true,
-                    dropdownColor: VelvetColors.surface,
-                    style: TextStyle(color: VelvetColors.textPrimary),
-                    items: [
-                      DropdownMenuItem(
-                          value: 'appLocal', child: Text(l.storageAppLocal)),
-                      DropdownMenuItem(
-                          value: 'appExternal',
-                          child: Text(l.storageAppExternal)),
-                      // Permanent / SD card write to a user-chosen shared-storage
-                      // folder, which needs All-files-access — full flavor only.
-                      // The Play build omits the permission from its manifest, so
-                      // these modes aren't offered there.
-                      if (!isPlayBuild)
+                    prefixIcon: Icon(Icons.sd_storage_outlined),
+                  ),
+                  child: DropdownButtonHideUnderline(
+                    child: DropdownButton<String>(
+                      value: _displayStorageMode,
+                      isExpanded: true,
+                      isDense: true,
+                      dropdownColor: VelvetColors.surface,
+                      style: TextStyle(color: VelvetColors.textPrimary),
+                      items: [
+                        DropdownMenuItem(
+                            value: 'appLocal', child: Text(l.storageAppLocal)),
+                        DropdownMenuItem(
+                            value: 'appExternal',
+                            child: Text(l.storageAppExternal)),
+                        // Permanent / SD card write to a user-chosen shared-storage
+                        // folder, which needs All-files-access (full flavor only).
                         DropdownMenuItem(
                             value: 'permanent',
                             child: Text(l.storagePermanent)),
-                      if (!isPlayBuild &&
-                          (_hasSdCard || _storageMode == 'sdCard'))
-                        DropdownMenuItem(
-                            value: 'sdCard', child: Text(l.storageSdCard)),
-                    ],
-                    onChanged: submitPending ? null : _onStorageModeChanged,
+                        if (_hasSdCard || _storageMode == 'sdCard')
+                          DropdownMenuItem(
+                              value: 'sdCard', child: Text(l.storageSdCard)),
+                      ],
+                      onChanged: submitPending ? null : _onStorageModeChanged,
+                    ),
                   ),
                 ),
-              ),
-              SizedBox(height: 8),
-              _storageHelp(),
+                SizedBox(height: 8),
+                _storageHelp(),
+              ],
               if (_storageMode == 'permanent' ||
                   _storageMode == 'sdCard') ...[
                 SizedBox(height: 10),

--- a/lib/screens/attributions_screen.dart
+++ b/lib/screens/attributions_screen.dart
@@ -12,7 +12,7 @@ import '../theme/velvet_theme.dart';
 ///   * every bundled visualizer shader with author + license + source
 ///     (CC-BY-3.0 attribution for Cyber Fuji is a license requirement,
 ///     not just courtesy),
-///   * vendored native libraries (projectM, KissFFT),
+///   * vendored native libraries (projectM, KissFFT, iroh),
 ///   * a link to Flutter's auto-generated license page for the rest of
 ///     the pub dependencies.
 class AttributionsScreen extends StatelessWidget {
@@ -44,6 +44,8 @@ class AttributionsScreen extends StatelessWidget {
         'LGPL-2.1', 'https://github.com/projectM-visualizer/projectm'),
     _Attribution('KissFFT', 'Mark Borgerding', 'BSD-3-Clause',
         'https://github.com/mborgerding/kissfft'),
+    _Attribution('iroh', 'n0 — peer-to-peer QUIC networking',
+        'Apache-2.0 / MIT', 'https://github.com/n0-computer/iroh'),
   ];
 
   const AttributionsScreen({super.key});

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -255,16 +255,14 @@ class DownloadManager {
       return;
     }
 
-    // A user-chosen folder (Permanent / SD card) may sit on a FAT/exFAT
-    // filesystem that can't store certain names. When the name is illegal,
-    // probe the actual destination (cached) — the same source of truth
-    // migration uses, rather than trusting the mode label — and skip it
-    // (it would fail to write anyway), warning once.
-    final isUserFolder =
-        server.storageMode == 'permanent' || server.storageMode == 'sdCard';
-    if (isUserFolder &&
-        hasFatIllegalChars(downloadDirectory) &&
-        await isFatLikeDir(dir.path)) {
+    // Any destination that can sit on a FAT/exFAT volume — the SD card
+    // (sdCardApp) or a user-chosen Permanent/SD folder — may be unable to store
+    // certain names. The name check is cheap; only when it trips do we probe the
+    // actual destination filesystem (cached — the same source of truth migration
+    // uses, rather than trusting the mode label) and skip the file (it would fail
+    // to write anyway), warning once. Internal storage (ext4/f2fs) never trips
+    // isFatLikeDir, so this is a no-op there.
+    if (hasFatIllegalChars(downloadDirectory) && await isFatLikeDir(dir.path)) {
       _warnFatSkip();
       return;
     }

--- a/lib/singletons/file_explorer.dart
+++ b/lib/singletons/file_explorer.dart
@@ -174,6 +174,14 @@ class FileExplorer {
         // option offered in the UI; 'legacyExternal' is the migration-only
         // value that resolves to the same place.
         return getExternalStorageDirectory();
+      case 'sdCardApp':
+        // The SD card's app-specific dir (Android/data/<pkg>/files on the
+        // removable volume). Play-compliant (no permission), but cleared on
+        // uninstall. getExternalStorageDirectories returns one Directory per
+        // volume; the second is the SD card. Null when no card is present — the
+        // caller null-guards, so that reads as "no local copy here".
+        final dirs = await getExternalStorageDirectories();
+        return (dirs != null && dirs.length > 1) ? dirs[1] : null;
       case 'appLocal':
       default:
         return getApplicationDocumentsDirectory();


### PR DESCRIPTION
A round of add/edit‑server form fixes and simplifications.

## 1. Edit form works for iroh servers (`19a26cb`)
Editing an iroh server was completely broken — Save silently did nothing. The Server‑URL validator calls `Uri.parse(value).origin`, which **throws** on the `iroh://` scheme → form validation failed; and even past that, Save ran an HTTP ping/login probe that can't reach an `iroh://` loopback URL. Now, for an iroh server: the URL field is read‑only (no validator), the self‑signed‑TLS switch and the Test‑connection button are hidden (both HTTP‑only concepts), and Save persists the edited credentials/folder directly via the existing edit path (URL unchanged; `editServer` + `getServerPaths` are iroh‑safe).

## 2. Play‑build storage simplification + unique folders (`9fd69a8`)
- New `sdCardApp` storage mode → the SD card's **app‑specific** dir (`getExternalStorageDirectories()[1]`): Play‑compliant, no permission (cleared on uninstall, like the other app‑scoped modes).
- On Play the storage‑location dropdown is replaced by a single **"Save to SD card"** switch, shown only when a removable card is present (off = internal, on = SD). No card → no storage UI at all. Full build is unchanged.
- The FAT‑illegal‑name guard in `downloadOneFile` no longer keys off the mode label (which missed `sdCardApp`, the one mode that targets a likely‑FAT card); it now relies on the name check + cached filesystem probe, matching the migration path.
- Download‑folder auto‑name now **always** appends a short random id, so no two servers ever share a download directory (only affects newly‑added servers; editing keeps existing folders).

## 3. "Quick Connect" tab (`832a174`)
The peer‑to‑peer pairing tab now reads **"Quick Connect"** instead of the implementation name "iroh" (localized to match the sibling "Server URL" tab).

## 4. iroh attribution (`62a6f1e`)
Credit iroh (n0, Apache‑2.0 / MIT) in the attributions page's vendored‑native‑libraries section.

## Validation
`flutter analyze` clean throughout. Each substantive change adversarially reviewed (the storage review caught + fixed the FAT‑guard gap above). On‑device smoke test in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)