### PR TITLE
feat(quick-connect): auto-detect public servers, drop the public toggle

### DIFF
--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -1419,13 +1419,41 @@ class MyCustomFormState extends State<MyCustomForm> {
       final v = version;
       final base =
           v != null ? l.irohTestConnectedVersion(v) : l.irohTestConnected;
+      // Detect whether the server requires auth: an unauthenticated ping that
+      // returns 200 means it's public. Public -> skip the sign-in form and save
+      // straight away; otherwise reveal the form (no public toggle — we already
+      // know it isn't public).
+      bool isPublic = false;
+      try {
+        final ping = await http
+            .get(Uri.parse('http://127.0.0.1:$port/api/v1/ping?__lt=$lt'))
+            .timeout(Duration(seconds: 8));
+        isPublic = ping.statusCode == 200;
+      } catch (_) {
+        // Probe failed (blip / endpoint quirk) — fall back to the sign-in form
+        // rather than wrongly saving a public server.
+      }
+      if (!mounted) {
+        IrohTunnel.instance.stop();
+        return;
+      }
       setState(() {
-        _irohTesting = false;
+        // Public: stay "testing" through the straight-to-save below so the Test
+        // button can't be re-tapped mid-save. Private: clear it and reveal the
+        // sign-in form.
+        _irohTesting = isPublic;
         _irohTestSuccess = true;
         _irohTestResult = base + pathSuffix;
         _irohPort = port;
-        _irohSignedInReady = true;
+        _irohPublic = isPublic;
+        _irohSignedInReady = !isPublic;
       });
+      if (isPublic) {
+        // No credentials needed — save immediately (the form pops on success;
+        // the one-iroh cap backstop in _saveIrohServer clears state otherwise).
+        showGlobalSnack(l.connectionSuccessful);
+        await _saveIrohServer(code: code, port: port, jwt: '');
+      }
     } on IrohTunnelException catch (e) {
       IrohTunnel.instance.stop();
       _showIrohResult(false, e.message);
@@ -1647,19 +1675,12 @@ class MyCustomFormState extends State<MyCustomForm> {
                       color: VelvetColors.textPrimary,
                       fontSize: 14,
                       fontWeight: FontWeight.w700)),
-              SwitchListTile(
-                contentPadding: EdgeInsets.zero,
-                title: Text(l.irohPublicServer,
-                    style: TextStyle(
-                        color: VelvetColors.textPrimary, fontSize: 14)),
-                value: _irohPublic,
-                onChanged:
-                    _irohSaving ? null : (v) => setState(() => _irohPublic = v),
-                activeThumbColor: VelvetColors.primary,
-              ),
+              SizedBox(height: 12),
+              // No public-server toggle: the test already determined this server
+              // needs auth (a public one would have skipped straight to saved).
               TextField(
                 controller: _irohUserCtrl,
-                enabled: !_irohPublic && !_irohSaving,
+                enabled: !_irohSaving,
                 autocorrect: false,
                 keyboardType: TextInputType.emailAddress,
                 style: TextStyle(color: VelvetColors.textPrimary),
@@ -1671,7 +1692,7 @@ class MyCustomFormState extends State<MyCustomForm> {
               SizedBox(height: 12),
               TextField(
                 controller: _irohPassCtrl,
-                enabled: !_irohPublic && !_irohSaving,
+                enabled: !_irohSaving,
                 obscureText: true,
                 autocorrect: false,
                 enableSuggestions: false,


### PR DESCRIPTION
## What
In the Quick Connect (iroh) add‑server flow, **Test connection** now decides public vs. private and acts on it:
- **Public server** — an unauthenticated `/api/v1/ping` through the live tunnel returns 200 → skip the sign‑in form and **save immediately**.
- **Private server** → reveal the sign‑in form, now **without the public‑server toggle** (the test already determined it needs auth, so the switch was redundant).

A failed/timed‑out probe falls back to the sign‑in form, so a blip never wrongly saves a server as public.

## Why
Mirrors the classic HTTP add flow (`/api/v1/ping` 200 == public → save without login) and removes a decision the user shouldn't have to make — the test detects it.

## Notes
- Only `lib/screens/add_server.dart` changed. `_irohPublic` is still set by the test and read on save; only the toggle widget is gone (its l10n key `irohPublicServer` is now unused but harmless).
- `flutter analyze` clean; adversarial review (public path / private path + UI / edge cases): **0 findings**.

## Test plan
- [ ] Quick Connect to a **public** iroh server → Test → saved + active, no login form shown
- [ ] Quick Connect to a **private** iroh server → Test → sign‑in form (no public toggle) → sign in → saved
- [ ] Probe failure / bad code → falls back to the form / clean error; re‑test works

🤖 Generated with [Claude Code](https://claude.com/claude-code)