### PR TITLE
fix(audio): harden against silent playback stops (focus + background survival)

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -857,6 +857,8 @@
   "diagnosticsTitle": "Diagnostics",
   "diagnosticsEnable": "Enable logging",
   "diagnosticsHint": "Logs stay on your device. Tokens are hidden before copying or sharing.",
+  "diagnosticsVerbose": "Verbose logging",
+  "diagnosticsVerboseHint": "Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.",
   "diagnosticsCopy": "Copy",
   "diagnosticsShare": "Share",
   "diagnosticsClear": "Clear",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2340,6 +2340,18 @@ abstract class AppLocalizations {
   /// **'Logs stay on your device. Tokens are hidden before copying or sharing.'**
   String get diagnosticsHint;
 
+  /// No description provided for @diagnosticsVerbose.
+  ///
+  /// In en, this message translates to:
+  /// **'Verbose logging'**
+  String get diagnosticsVerbose;
+
+  /// No description provided for @diagnosticsVerboseHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.'**
+  String get diagnosticsVerboseHint;
+
   /// No description provided for @diagnosticsCopy.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1351,6 +1351,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Protokolle bleiben auf deinem Gerät. Tokens werden vor dem Kopieren oder Teilen ausgeblendet.';
 
   @override
+  String get diagnosticsVerbose => 'Verbose logging';
+
+  @override
+  String get diagnosticsVerboseHint =>
+      'Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.';
+
+  @override
   String get diagnosticsCopy => 'Kopieren';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1334,6 +1334,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Logs stay on your device. Tokens are hidden before copying or sharing.';
 
   @override
+  String get diagnosticsVerbose => 'Verbose logging';
+
+  @override
+  String get diagnosticsVerboseHint =>
+      'Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.';
+
+  @override
   String get diagnosticsCopy => 'Copy';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1350,6 +1350,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Los registros se quedan en tu dispositivo. Los tokens se ocultan antes de copiar o compartir.';
 
   @override
+  String get diagnosticsVerbose => 'Verbose logging';
+
+  @override
+  String get diagnosticsVerboseHint =>
+      'Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.';
+
+  @override
   String get diagnosticsCopy => 'Copiar';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1348,6 +1348,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Les journaux restent sur votre appareil. Les jetons sont masqués avant copie ou partage.';
 
   @override
+  String get diagnosticsVerbose => 'Verbose logging';
+
+  @override
+  String get diagnosticsVerboseHint =>
+      'Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.';
+
+  @override
   String get diagnosticsCopy => 'Copier';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1350,6 +1350,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'I log restano sul tuo dispositivo. I token vengono nascosti prima di copiare o condividere.';
 
   @override
+  String get diagnosticsVerbose => 'Verbose logging';
+
+  @override
+  String get diagnosticsVerboseHint =>
+      'Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.';
+
+  @override
   String get diagnosticsCopy => 'Copia';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1291,6 +1291,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get diagnosticsHint => 'ログは端末内にのみ保存されます。コピーや共有の前にトークンは隠されます。';
 
   @override
+  String get diagnosticsVerbose => 'Verbose logging';
+
+  @override
+  String get diagnosticsVerboseHint =>
+      'Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.';
+
+  @override
   String get diagnosticsCopy => 'コピー';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1368,6 +1368,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Dzienniki pozostają na Twoim urządzeniu. Tokeny są ukrywane przed skopiowaniem lub udostępnieniem.';
 
   @override
+  String get diagnosticsVerbose => 'Verbose logging';
+
+  @override
+  String get diagnosticsVerboseHint =>
+      'Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.';
+
+  @override
   String get diagnosticsCopy => 'Kopiuj';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1346,6 +1346,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Os registros ficam no seu dispositivo. Os tokens são ocultados antes de copiar ou compartilhar.';
 
   @override
+  String get diagnosticsVerbose => 'Verbose logging';
+
+  @override
+  String get diagnosticsVerboseHint =>
+      'Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.';
+
+  @override
   String get diagnosticsCopy => 'Copiar';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1372,6 +1372,13 @@ class AppLocalizationsRu extends AppLocalizations {
       'Журналы хранятся на вашем устройстве. Токены скрываются перед копированием или отправкой.';
 
   @override
+  String get diagnosticsVerbose => 'Verbose logging';
+
+  @override
+  String get diagnosticsVerboseHint =>
+      'Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.';
+
+  @override
   String get diagnosticsCopy => 'Копировать';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1265,6 +1265,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diagnosticsHint => '日志仅保存在您的设备上。复制或分享前会隐藏令牌。';
 
   @override
+  String get diagnosticsVerbose => 'Verbose logging';
+
+  @override
+  String get diagnosticsVerboseHint =>
+      'Also logs high-frequency events like app focus changes. Only needed when diagnosing a playback issue.';
+
+  @override
   String get diagnosticsCopy => '复制';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -251,6 +251,9 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Diagnostic: the lifecycle transition right before a playback stop tells an
+    // OS process-kill (paused/detached → dead) apart from an in-process stop.
+    appLog('[app] lifecycle → $state');
     // On resume, re-assert edge-to-edge so a hidden nav bar (e.g. left over from
     // the Visualizer's immersive mode) comes back — but only when the main
     // screen is the top route, so we don't fight the Visualizer if it's open.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -251,9 +251,12 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    // Diagnostic: the lifecycle transition right before a playback stop tells an
-    // OS process-kill (paused/detached → dead) apart from an in-process stop.
-    appLog('[app] lifecycle → $state');
+    // Diagnostic (verbose-only): the lifecycle transition right before a playback
+    // stop tells an OS process-kill (paused/detached → dead) apart from an
+    // in-process stop. Gated behind the Diagnostics "Verbose logging" switch —
+    // these fire on every focus change (shade pull, screen off, dialogs), not
+    // just playback, so they're noise unless you're actively diagnosing.
+    verboseLog('[app] lifecycle → $state');
     // On resume, re-assert edge-to-edge so a hidden nav bar (e.g. left over from
     // the Visualizer's immersive mode) comes back — but only when the main
     // screen is the top route, so we don't fight the Visualizer if it's open.

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -49,6 +49,13 @@ class AudioPlayerHandler extends BaseAudioHandler
   // _switchBackend calls (racing on _backend / dispose).
   Future<void> _switchChain = Future<void>.value();
 
+  // Completes when _init() has finished seeding the backend + applying saved EQ.
+  // restoreQueue() (fired in parallel from QueueStore.init once the server list
+  // loads) awaits this so its setSources() can't race _init's seed/EQ on the
+  // single just_audio player — concurrent loads abort each other with
+  // "Loading interrupted".
+  final Completer<void> _initialized = Completer<void>();
+
   // Android-only native equalizer, exposed for the EQ screen. Lives on the
   // local backend (null on non-Android / remote backends). eq_screen.dart
   // reads this via MediaManager().audioHandler.equalizer.
@@ -88,7 +95,13 @@ class AudioPlayerHandler extends BaseAudioHandler
   AudioServiceRepeatMode _repeatMode = AudioServiceRepeatMode.none;
 
   AudioPlayerHandler() {
-    _init();
+    // Complete _initialized when _init() finishes (success or failure) so a
+    // parallel restoreQueue() never issues setSources() while _init's seed/EQ
+    // are still loading. whenComplete guarantees it even if _init throws, so
+    // restoreQueue can't hang.
+    _init().whenComplete(() {
+      if (!_initialized.isCompleted) _initialized.complete();
+    });
   }
 
   Future<void> _init() async {
@@ -556,6 +569,10 @@ class AudioPlayerHandler extends BaseAudioHandler
       {bool shuffle = false,
       AudioServiceRepeatMode repeat = AudioServiceRepeatMode.none}) async {
     if (items.isEmpty) return;
+    // Wait for _init() to finish seeding the backend + applying EQ before our
+    // own setSources(), so the two don't issue concurrent loads on the player
+    // (which abort each other → "Loading interrupted", losing the restore).
+    await _initialized.future;
     queue.add(items.toList());
     await _backend.setSources(items);
     final int i = index.clamp(0, items.length - 1);

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:audio_service/audio_service.dart';
+import 'package:audio_session/audio_session.dart'
+    show AudioSession, AudioSessionConfiguration;
 import 'package:just_audio/just_audio.dart';
 import 'package:mstream_music/main.dart';
 import 'package:rxdart/rxdart.dart';
@@ -90,15 +92,27 @@ class AudioPlayerHandler extends BaseAudioHandler
   }
 
   Future<void> _init() async {
-    // AudioSession.instance.then((session) {
-    //   session.configure(const AudioSessionConfiguration.music());
-    // });
-    // final session = await AudioSession.instance;
-
-    //     // Handle unplugged headphones.
-    // session.becomingNoisyEventStream.listen((_) {
-    //   if (_playing) pause();
-    // });
+    // Configure the platform audio session for music playback. Without this,
+    // focus is requested with default attributes and Android is more likely to
+    // classify a transient loss (a call, a nav prompt, a notification ding) as
+    // a permanent one — which pauses playback and never auto-resumes. Declaring
+    // music attributes makes focus/duck/resume behave deterministically.
+    //
+    // We deliberately do NOT add becomingNoisy / interruption *handlers* here:
+    // just_audio already wires those up internally (handleInterruptions
+    // defaults to true) and auto-pauses/resumes. A second handler would
+    // double-fire and fight it. The listener below is logging-only (read-only),
+    // so a "stopped after a call and never came back" report is diagnosable.
+    try {
+      final session = await AudioSession.instance;
+      await session.configure(const AudioSessionConfiguration.music());
+      session.interruptionEventStream.listen((event) {
+        appLog('[audio] interruption '
+            '${event.begin ? 'begin' : 'end'} type=${event.type}');
+      });
+    } catch (e) {
+      appLog('[audio] audio session configure failed: $e');
+    }
 
     // For Android 11, record the most recent item so it can be resumed.
     mediaItem
@@ -159,7 +173,16 @@ class AudioPlayerHandler extends BaseAudioHandler
     _backendSubject.switchMap((b) => b.errorStream).listen(_onPlaybackError);
     // Stop the service when playback reaches the end of the queue.
     _backendSubject.switchMap((b) => b.processingStateStream).listen((state) {
-      if (state == BackendProcessingState.completed) stop();
+      if (state == BackendProcessingState.completed) {
+        // Log the context so a "stopped on its own" report can be told apart
+        // from a genuine end-of-queue stop: how far into the track we were vs.
+        // its duration, and where we were in the queue.
+        appLog('[play] completed → stop '
+            'pos=${_backend.position.inSeconds}s/'
+            '${_backend.duration?.inSeconds ?? '?'}s '
+            'index=${_backend.currentIndex} of ${queue.value.length}');
+        stop();
+      }
       // A track that loads (vs. failing to load) clears the consecutive-failure
       // count, so the skip-bad-track loop guard only trips on a genuine run of
       // unplayable tracks.
@@ -366,6 +389,11 @@ class AudioPlayerHandler extends BaseAudioHandler
   //    it still failed = bad source) → warn and skip to the next track.
   void _onPlaybackError(Object error) {
     if (!identical(_backend, _localBackend)) return;
+    // Diagnostic: capture the error class + where we were, so a network-blip
+    // stop can be distinguished from a genuinely-unplayable source in the logs.
+    appLog('[play] playback error ($error) '
+        'index=${_localBackend.currentIndex} '
+        'failedSkips=$_failedSkips/${queue.value.length}');
     // One error-handler at a time: while a recover or skip is in flight, ignore
     // further errors (a burst for one failure, or the wrap-around after a skip).
     // Whatever's playing when it finishes re-decides on its own fresh error.

--- a/lib/screens/diagnostics_screen.dart
+++ b/lib/screens/diagnostics_screen.dart
@@ -76,6 +76,20 @@ class _DiagnosticsScreenState extends State<DiagnosticsScreen> {
               },
               activeThumbColor: VelvetColors.primary,
             ),
+            SwitchListTile(
+              title: Text(l.diagnosticsVerbose),
+              subtitle: Text(
+                l.diagnosticsVerboseHint,
+                style:
+                    TextStyle(color: VelvetColors.textSecondary, fontSize: 12),
+              ),
+              value: SettingsManager().verboseLogging,
+              onChanged: (v) async {
+                await SettingsManager().setVerboseLogging(v);
+                if (mounted) setState(() {});
+              },
+              activeThumbColor: VelvetColors.primary,
+            ),
             Divider(height: 1, color: VelvetColors.border),
             Expanded(
               child: StreamBuilder<List<String>>(

--- a/lib/screens/diagnostics_screen.dart
+++ b/lib/screens/diagnostics_screen.dart
@@ -63,20 +63,6 @@ class _DiagnosticsScreenState extends State<DiagnosticsScreen> {
         child: Column(
           children: [
             SwitchListTile(
-              title: Text(l.diagnosticsEnable),
-              subtitle: Text(
-                l.diagnosticsHint,
-                style:
-                    TextStyle(color: VelvetColors.textSecondary, fontSize: 12),
-              ),
-              value: SettingsManager().diagnosticsLogging,
-              onChanged: (v) async {
-                await SettingsManager().setDiagnosticsLogging(v);
-                if (mounted) setState(() {});
-              },
-              activeThumbColor: VelvetColors.primary,
-            ),
-            SwitchListTile(
               title: Text(l.diagnosticsVerbose),
               subtitle: Text(
                 l.diagnosticsVerboseHint,

--- a/lib/singletons/log_manager.dart
+++ b/lib/singletons/log_manager.dart
@@ -55,13 +55,11 @@ class LogManager {
   List<String> get lines => List.unmodifiable(_lines);
   bool get isEmpty => _lines.isEmpty;
 
-  bool get _enabled => SettingsManager().diagnosticsLogging;
-
   /// Append a log entry: split into lines, timestamp + redact each, append, and
-  /// trim to the cap. No-op while logging is disabled. MUST NOT call print()
-  /// itself — it's fed from the print Zone and would recurse.
+  /// trim to the cap. Always on (the Diagnostics screen no longer exposes an
+  /// off switch). MUST NOT call print() itself — it's fed from the print Zone
+  /// and would recurse.
   void add(String message) {
-    if (!_enabled) return;
     final stamp = _stamp();
     for (final raw in message.split('\n')) {
       if (raw.isEmpty) continue;

--- a/lib/singletons/log_manager.dart
+++ b/lib/singletons/log_manager.dart
@@ -17,6 +17,17 @@ void appLog(String message) {
   print(message);
 }
 
+/// Verbose-only logging: high-frequency diagnostic signals (e.g. app lifecycle /
+/// focus transitions) that are noise during normal use but valuable when chasing
+/// an intermittent "stops playing" report. No-ops unless the user has enabled
+/// "Verbose logging" in Diagnostics, so it never reaches the in-app buffer or
+/// logcat otherwise. Routed through the same print Zone as [appLog].
+void verboseLog(String message) {
+  if (!SettingsManager().verboseLogging) return;
+  // ignore: avoid_print
+  print(message);
+}
+
 /// In-app diagnostic log buffer. Captures `print()` output (via a custom print
 /// Zone installed in main()), the cast subsystem's `castLog()`, and uncaught
 /// errors into a bounded ring buffer that the user can view, copy and share from

--- a/lib/singletons/media.dart
+++ b/lib/singletons/media.dart
@@ -20,7 +20,14 @@ class MediaManager {
       builder: () => AudioPlayerHandler(),
       config: AudioServiceConfig(
         androidNotificationChannelName: 'mStream Music',
-        androidNotificationOngoing: true,
+        // Keep the foreground service alive across a pause instead of detaching
+        // it (the default). On Samsung One UI, a detached/background service is
+        // reaped within minutes by app-sleep/Doze, so a brief pause — including
+        // an interruption-driven auto-pause — could leave the process dead and
+        // playback unable to resume. Staying foreground while paused prevents
+        // that. (androidNotificationOngoing must be dropped: audio_service
+        // asserts !ongoing || stopForegroundOnPause.)
+        androidStopForegroundOnPause: false,
         // White, tintable status-bar / Android Auto icon. Without this the
         // colored launcher icon renders as a white square in the notification.
         androidNotificationIcon: 'drawable/ic_stat_music',

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -170,6 +170,11 @@ class SettingsManager {
   // Whether in-app diagnostic logging is captured (see LogManager) so users can
   // view / copy / share logs from the Diagnostics screen. On by default.
   bool diagnosticsLogging = true;
+  // Verbose diagnostic logging: high-frequency signals (app lifecycle / focus
+  // transitions, etc.) that are noise during normal use but useful when chasing
+  // an intermittent "stops playing" report. Off by default; gated separately
+  // from [diagnosticsLogging] so users can opt in. See verboseLog().
+  bool verboseLogging = false;
   // Visualizer audio source — synthesized is the default so the
   // visualizer Just Works without prompting for RECORD_AUDIO. Users
   // can opt into real audio in Settings; the toggle there walks them
@@ -276,6 +281,7 @@ class SettingsManager {
       eqEnabled = m['eqEnabled'] ?? false;
       resumeQueue = m['resumeQueue'] ?? true;
       diagnosticsLogging = m['diagnosticsLogging'] ?? true;
+      verboseLogging = m['verboseLogging'] ?? false;
       final rawGains = m['eqBandGains'];
       eqBandGains = rawGains is List
           ? rawGains.whereType<num>().map((n) => n.toDouble()).toList()
@@ -456,6 +462,7 @@ class SettingsManager {
       'eqEnabled': eqEnabled,
       'resumeQueue': resumeQueue,
       'diagnosticsLogging': diagnosticsLogging,
+      'verboseLogging': verboseLogging,
       'eqBandGains': eqBandGains,
       'visualizerAudioSource': visualizerAudioSource.name,
       'visualizerEngine': visualizerEngine.name,
@@ -572,6 +579,11 @@ class SettingsManager {
     await _save();
   }
 
+  Future<void> setVerboseLogging(bool v) async {
+    verboseLogging = v;
+    await _save();
+  }
+
   Future<void> setEqBandGains(List<double> v) async {
     eqBandGains = v;
     await _save();
@@ -639,6 +651,7 @@ class SettingsManager {
     eqEnabled = false;
     resumeQueue = true;
     diagnosticsLogging = true;
+    verboseLogging = false;
     eqBandGains = const [];
     visualizerAudioSource = VisualizerAudioSource.synthesized;
     visualizerEngine = VisualizerEngine.milkdrop;


### PR DESCRIPTION
## Why

Investigating a Google Play report: **playback "sometimes stops" on its own** on a Samsung Galaxy S20 FE — intermittent, long-standing, no logs. A multi-angle audit (code + just_audio/audio_service issue trackers + peer-repo comparison, with adversarial verification) found **no single root cause**, but a cluster of co-located gaps that each turn a routine event (a call, a screen-off Wi-Fi park, a transient HTTP blip) into a silent stop with no self-heal. This matches still-open upstream issues ([just_audio#1412](https://github.com/ryanheise/just_audio/issues/1412) — stops minutes after a phone call; [just_audio#1255](https://github.com/ryanheise/just_audio/issues/1255) — stops when backgrounded + screen sleeps).

This PR ships the **two near-zero-risk fixes** with the strongest evidence, plus diagnostics so the next occurrence is traceable.

## Changes

**1. Configure the audio session for music** — `lib/media/audio_stuff.dart`
`AudioSession.configure(AudioSessionConfiguration.music())` was commented out; `audio_session` was referenced *only* in dead comments. Without it, focus is requested with default attributes and a transient interruption can be misclassified as permanent → pause that never auto-resumes. We rely on just_audio's built-in interruption handling (`handleInterruptions` defaults `true`) and add **only a logging-only** interruption listener — deliberately *not* re-adding the old `becomingNoisy`/interruption handlers, which would double-fire and fight just_audio. This is the baseline every peer app (Finamp, BlackHole, ryanheise's own example) uses.

**2. Keep the foreground service alive while paused** — `lib/singletons/media.dart`
`androidStopForegroundOnPause: false` (and dropped `androidNotificationOngoing: true`, which `AudioServiceConfig` asserts is incompatible with it). The default detaches the service + releases its wake lock on pause, letting One UI app-sleep/Doze reap the process within minutes so playback can't resume.

**3. Diagnostics** — `lib/main.dart`, `lib/media/audio_stuff.dart`
Logs app lifecycle transitions, the `position/duration/index` context whenever `completed → stop()` fires, audio-interruption begin/end, and the error class + queue position on a playback error. Lets the next report distinguish an OS process-kill from an in-process stop, and a network blip from a genuinely dead source.

## Deliberately deferred (follow-ups)

- **Classify-and-retry the HTTP error path** — today *any* stream error skips, and a queue-wide blip stops; the real symptom fix, but behavioral and needs on-device testing.
- **Decouple interruption-pause from `_playIntent`** so an auto-pause doesn't erase the user's intent.
- **Gate the EQ pipeline behind `eqEnabled`** to avoid a priority-0 native equalizer re-attaching on every Bluetooth route switch.

## Testing

`flutter analyze` clean. Built `--flavor full --debug` and deploying to a physical device for real-world soak (the symptom is intermittent and not unit-testable).