### PR TITLE
feat(audio): retry HTTP playback errors at position + self-heal on outage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -194,6 +194,9 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
     _connectivitySub = Connectivity().onConnectivityChanged.listen((results) {
       if (results.any((r) => r != ConnectivityResult.none)) {
         unawaited(ServerManager().handleNetworkChange());
+        // Resume on-device playback if a network outage had paused it (no-op
+        // unless the audio handler is in the network-stalled state).
+        MediaManager().audioHandler.onNetworkRegained();
       }
     });
   }

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -607,10 +607,12 @@ class AudioPlayerHandler extends BaseAudioHandler
       // failed.
       final pos = _localBackend.position;
       final idx = _localBackend.currentIndex ?? 0;
-      // Rebuild the playlist to force a clean reload of the failed source, then
-      // resume at that spot with the user's play intent.
-      await _localBackend.setSources(queue.value);
-      await _localBackend.seek(pos, index: idx, play: _playIntent);
+      // Rebuild the playlist to force a clean reload of the failed source,
+      // loading DIRECTLY at the failed track/position so it doesn't flash track
+      // 0 in the now-playing UI on the way, then honour the user's play intent.
+      await _localBackend.setSources(queue.value,
+          initialIndex: idx, initialPosition: pos);
+      if (_playIntent) unawaited(_localBackend.play());
     }).catchError((Object e) {
       castLog('http playback retry failed', error: e);
     }).whenComplete(() => _recoveringPlayback = false);
@@ -632,8 +634,9 @@ class AudioPlayerHandler extends BaseAudioHandler
       if (queue.value.isEmpty || !identical(_backend, _localBackend)) return;
       final pos = _localBackend.position;
       final idx = _localBackend.currentIndex ?? 0;
-      await _localBackend.setSources(queue.value);
-      await _localBackend.seek(pos, index: idx, play: _playIntent);
+      await _localBackend.setSources(queue.value,
+          initialIndex: idx, initialPosition: pos);
+      if (_playIntent) unawaited(_localBackend.play());
     }).catchError((Object e) {
       castLog('network-regained resume failed', error: e);
     }).whenComplete(() => _recoveringPlayback = false);

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -429,23 +429,10 @@ class AudioPlayerHandler extends BaseAudioHandler
       _recoverIrohPlayback(itemServer);
       return;
     }
-    // A transient network/transport failure on a plain-HTTP source — retry the
-    // same track at the same spot (bounded, with backoff) instead of skipping.
-    // A clear bad source (404 / unsupported / missing file), or once the retry
-    // budget is spent, falls through to the skip below.
-    if (_isTransientNetworkError(error) && _httpRetries < _kMaxHttpRetries) {
-      _retryHttpPlayback();
-      return;
-    }
-    // Serialize the skip through _switchChain (shared with recovery + backend
-    // switches, so none run concurrently on the backend); _skipPending collapses
-    // a burst of error events into the single skip.
-    _skipPending = true;
-    _switchChain = _switchChain
-        .then((_) => _skipFailedTrack(error))
-        .catchError((Object e) =>
-            castLog('skip-to-next after playback error failed', error: e))
-        .whenComplete(() => _skipPending = false);
+    // Non-iroh source failed → hand off to _recoverHttpError, which (with an
+    // async connectivity probe) pauses-and-holds on a real outage, retries a
+    // transient blip in place, or skips a genuinely bad source.
+    _recoverHttpError(error);
   }
 
   // Resume after an iroh playback error whose tunnel isn't live yet: a mid-stream
@@ -580,41 +567,68 @@ class AudioPlayerHandler extends BaseAudioHandler
     showGlobalSnack(message);
   }
 
-  // Retry the current plain-HTTP source at the same position after a transient
-  // network error, with bounded exponential backoff (1s, 2s, 4s). Mirrors
-  // _recoverIrohPlayback but needs no tunnel — the HTTP URL is already live.
-  // Driven by the error-event loop: each failed reload re-enters
-  // _onPlaybackError, which retries again until _httpRetries hits the cap (then
-  // it skips). Serialized via _switchChain + guarded by _recoveringPlayback so
-  // an error burst can't spin up concurrent retries.
-  void _retryHttpPlayback() {
-    if (_recoveringPlayback) return;
+  // Recover from a non-iroh playback error. The decision needs an async
+  // connectivity probe, so it runs serialized on _switchChain + guarded by
+  // _recoveringPlayback / _skipPending (an error burst can't spin up concurrent
+  // recoveries):
+  //  • clearly bad source (404 / format / missing file) → skip now;
+  //  • NO network (a real outage) → pause-and-hold + arm onNetworkRegained so we
+  //    self-heal when it returns. This is the key fix: relying on the retry/skip
+  //    counters to climb never paused, because a brief `ready` from the preload
+  //    buffer kept resetting _httpRetries, so it spun in retries forever;
+  //  • network up but the track errored (a transient blip) → retry the SAME track
+  //    at its spot, bounded by _kMaxHttpRetries; once spent it's a bad source → skip.
+  void _recoverHttpError(Object error) {
+    if (_recoveringPlayback || _skipPending) return;
+    // Clearly bad/unplayable source → skip now (no network probe / retry needed).
+    if (!_isTransientNetworkError(error)) {
+      _skipPending = true;
+      _switchChain = _switchChain
+          .then((_) => _skipFailedTrack(error))
+          .catchError((Object e) =>
+              castLog('skip-to-next after playback error failed', error: e))
+          .whenComplete(() => _skipPending = false);
+      return;
+    }
     _recoveringPlayback = true;
-    _httpRetries++;
-    final attempt = _httpRetries;
-    // 0s, 1s, 2s — first retry is immediate so a momentary blip recovers fast
-    // (and a genuinely dead source is skipped quickly), later ones give the
-    // network a moment.
-    final backoff = Duration(seconds: attempt - 1);
     _switchChain = _switchChain.then((_) async {
       if (queue.value.isEmpty || !identical(_backend, _localBackend)) return;
-      appLog('[play] network error — retry $attempt/$_kMaxHttpRetries '
-          'after ${backoff.inSeconds}s');
-      await Future<void>.delayed(backoff);
-      if (queue.value.isEmpty || !identical(_backend, _localBackend)) return;
-      // Read the spot AFTER the backoff so a skip/seek made during the wait is
-      // honoured — resume wherever the user actually is now, not the track that
-      // failed.
-      final pos = _localBackend.position;
-      final idx = _localBackend.currentIndex ?? 0;
-      // Rebuild the playlist to force a clean reload of the failed source,
-      // loading DIRECTLY at the failed track/position so it doesn't flash track
-      // 0 in the now-playing UI on the way, then honour the user's play intent.
-      await _localBackend.setSources(queue.value,
-          initialIndex: idx, initialPosition: pos);
-      if (_playIntent) unawaited(_localBackend.play());
+      // No network → an outage: pause-and-hold and let onNetworkRegained resume
+      // us when it's back, instead of churning retries/skips that all fail.
+      if (!await _hasNetwork()) {
+        _httpRetries = 0;
+        _failedSkips = 0;
+        _networkStalled = true;
+        _showPlaybackErrorToast(
+            'Lost the connection — paused. Resumes when you’re back online.');
+        await _localBackend.pause();
+        _broadcastState();
+        return;
+      }
+      // Network is up but the track errored — a transient blip. Retry the SAME
+      // track at its spot (bounded); once retries are spent it's a genuinely bad
+      // source → skip.
+      if (_httpRetries < _kMaxHttpRetries) {
+        _httpRetries++;
+        final attempt = _httpRetries;
+        // 0s, then 1s, 2s — first retry immediate so a momentary blip recovers
+        // fast; later ones give the connection a moment.
+        await Future<void>.delayed(Duration(seconds: attempt - 1));
+        if (queue.value.isEmpty || !identical(_backend, _localBackend)) return;
+        // Read the spot AFTER the backoff so a skip/seek during the wait is
+        // honoured, and load DIRECTLY at it (initialIndex/Position) so the
+        // now-playing UI doesn't flash track 0 on the reload.
+        final pos = _localBackend.position;
+        final idx = _localBackend.currentIndex ?? 0;
+        appLog('[play] network error — retry $attempt/$_kMaxHttpRetries');
+        await _localBackend.setSources(queue.value,
+            initialIndex: idx, initialPosition: pos);
+        if (_playIntent) unawaited(_localBackend.play());
+      } else {
+        await _skipFailedTrack(error);
+      }
     }).catchError((Object e) {
-      castLog('http playback retry failed', error: e);
+      castLog('http error recovery failed', error: e);
     }).whenComplete(() => _recoveringPlayback = false);
   }
 

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -8,6 +8,7 @@ import 'package:just_audio/just_audio.dart';
 import 'package:mstream_music/main.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:http/http.dart' as http;
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'playback_backend.dart';
 import 'local_playback_backend.dart';
 import 'dlna_playback_backend.dart';
@@ -196,10 +197,14 @@ class AudioPlayerHandler extends BaseAudioHandler
             'index=${_backend.currentIndex} of ${queue.value.length}');
         stop();
       }
-      // A track that loads (vs. failing to load) clears the consecutive-failure
-      // count, so the skip-bad-track loop guard only trips on a genuine run of
-      // unplayable tracks.
-      if (state == BackendProcessingState.ready) _failedSkips = 0;
+      // A track that loads clears the skip-budget AND the HTTP retry budget,
+      // and lifts any network-stall pause — so the guards only trip on a genuine
+      // run of failures, not after a recovery.
+      if (state == BackendProcessingState.ready) {
+        _failedSkips = 0;
+        _httpRetries = 0;
+        _networkStalled = false;
+      }
     });
     // A remote backend that loses its renderer mid-cast (TV off, Wi-Fi drop)
     // emits here; fall back to local playback at the same spot + a toast.
@@ -424,6 +429,14 @@ class AudioPlayerHandler extends BaseAudioHandler
       _recoverIrohPlayback(itemServer);
       return;
     }
+    // A transient network/transport failure on a plain-HTTP source — retry the
+    // same track at the same spot (bounded, with backoff) instead of skipping.
+    // A clear bad source (404 / unsupported / missing file), or once the retry
+    // budget is spent, falls through to the skip below.
+    if (_isTransientNetworkError(error) && _httpRetries < _kMaxHttpRetries) {
+      _retryHttpPlayback();
+      return;
+    }
     // Serialize the skip through _switchChain (shared with recovery + backend
     // switches, so none run concurrently on the backend); _skipPending collapses
     // a burst of error events into the single skip.
@@ -489,6 +502,20 @@ class AudioPlayerHandler extends BaseAudioHandler
   // shouldn't fire a snackbar per track).
   static const Duration _kErrorToastGap = Duration(seconds: 4);
 
+  // ── HTTP transient-error retry (resume-at-position) ──
+  // A plain-HTTP source that drops mid-stream (a network blip, screen-off Wi-Fi
+  // park, cellular handoff) used to skip immediately — and a queue-wide blip
+  // stopped everything. Instead we retry the SAME track at the same spot a few
+  // times with backoff before giving up. The counter resets to 0 when any track
+  // actually loads (`ready`), so it bounds total retry effort during a real
+  // outage: the first failing track retries, the rest skip fast.
+  static const int _kMaxHttpRetries = 3;
+  int _httpRetries = 0;
+  // Set when a queue-wide network failure has PAUSED (not stopped) playback, so
+  // a later connectivity-regained event (onNetworkRegained) resumes it. Cleared
+  // when a track loads again.
+  bool _networkStalled = false;
+
   // A source failed to play — warn (debounced) and skip to the next track, bounded
   // so an entirely-unplayable queue stops instead of looping (notably under
   // repeat-all). Serialized via _switchChain by the caller; local backend only.
@@ -499,11 +526,23 @@ class AudioPlayerHandler extends BaseAudioHandler
     castLog('playback error — skipping track', error: error);
     _failedSkips++;
     if (_failedSkips >= q.length) {
-      // Tried every track once and none loaded — the whole queue is unplayable.
+      // Tried every track once and none loaded. The error string can't tell a
+      // 404 from a network drop on Android (ExoPlayer reports both as a generic
+      // "Source error"), so probe the actual network: no connectivity → a real
+      // outage, PAUSE (don't stop) and arm onNetworkRegained to resume when it
+      // returns; connectivity present → the sources/server are bad, so stop.
       _failedSkips = 0;
-      _showPlaybackErrorToast(
-          "Can't play these tracks — check your connection or server.");
-      await _localBackend.stop();
+      if (!await _hasNetwork()) {
+        _showPlaybackErrorToast(
+            'Lost the connection — paused. Resumes when you’re back online.');
+        await _localBackend.pause();
+        _networkStalled = true;
+      } else {
+        _showPlaybackErrorToast(
+            "Can't play these tracks — check the files or server.");
+        await _localBackend.stop();
+      }
+      _broadcastState();
       return;
     }
     _showPlaybackErrorToast('Skipping a track that won’t play.', debounce: true);
@@ -512,10 +551,18 @@ class AudioPlayerHandler extends BaseAudioHandler
     // so the post-await read reliably reflects the new position.
     await _localBackend.seekToNext(); // shuffle/repeat-aware
     if (_localBackend.currentIndex == before) {
-      // No-op → end of the queue with no repeat; stop rather than replay the
-      // failed track.
+      // No-op → end of the queue with no repeat. Probe the network (the error
+      // string can't distinguish outage from bad source on Android): no
+      // connectivity → pause + arm self-heal so the user's spot survives;
+      // otherwise stop.
       _failedSkips = 0;
-      await _localBackend.stop();
+      if (!await _hasNetwork()) {
+        await _localBackend.pause();
+        _networkStalled = true;
+      } else {
+        await _localBackend.stop();
+      }
+      _broadcastState();
       return;
     }
     unawaited(_localBackend.play());
@@ -531,6 +578,100 @@ class AudioPlayerHandler extends BaseAudioHandler
       _lastErrorToast = now;
     }
     showGlobalSnack(message);
+  }
+
+  // Retry the current plain-HTTP source at the same position after a transient
+  // network error, with bounded exponential backoff (1s, 2s, 4s). Mirrors
+  // _recoverIrohPlayback but needs no tunnel — the HTTP URL is already live.
+  // Driven by the error-event loop: each failed reload re-enters
+  // _onPlaybackError, which retries again until _httpRetries hits the cap (then
+  // it skips). Serialized via _switchChain + guarded by _recoveringPlayback so
+  // an error burst can't spin up concurrent retries.
+  void _retryHttpPlayback() {
+    if (_recoveringPlayback) return;
+    _recoveringPlayback = true;
+    _httpRetries++;
+    final attempt = _httpRetries;
+    // 0s, 1s, 2s — first retry is immediate so a momentary blip recovers fast
+    // (and a genuinely dead source is skipped quickly), later ones give the
+    // network a moment.
+    final backoff = Duration(seconds: attempt - 1);
+    _switchChain = _switchChain.then((_) async {
+      if (queue.value.isEmpty || !identical(_backend, _localBackend)) return;
+      appLog('[play] network error — retry $attempt/$_kMaxHttpRetries '
+          'after ${backoff.inSeconds}s');
+      await Future<void>.delayed(backoff);
+      if (queue.value.isEmpty || !identical(_backend, _localBackend)) return;
+      // Read the spot AFTER the backoff so a skip/seek made during the wait is
+      // honoured — resume wherever the user actually is now, not the track that
+      // failed.
+      final pos = _localBackend.position;
+      final idx = _localBackend.currentIndex ?? 0;
+      // Rebuild the playlist to force a clean reload of the failed source, then
+      // resume at that spot with the user's play intent.
+      await _localBackend.setSources(queue.value);
+      await _localBackend.seek(pos, index: idx, play: _playIntent);
+    }).catchError((Object e) {
+      castLog('http playback retry failed', error: e);
+    }).whenComplete(() => _recoveringPlayback = false);
+  }
+
+  // Resume after a queue-wide network stall when connectivity returns. Wired to
+  // the app's connectivity listener (main.dart). No-op unless we actually paused
+  // on a network outage (_networkStalled); resumes the current track at its spot
+  // with the user's play intent.
+  void onNetworkRegained() {
+    if (!identical(_backend, _localBackend)) return;
+    if (!_networkStalled || _recoveringPlayback) return;
+    if (queue.value.isEmpty) return;
+    _networkStalled = false;
+    _httpRetries = 0;
+    _recoveringPlayback = true;
+    appLog('[play] connectivity back — resuming after network stall');
+    _switchChain = _switchChain.then((_) async {
+      if (queue.value.isEmpty || !identical(_backend, _localBackend)) return;
+      final pos = _localBackend.position;
+      final idx = _localBackend.currentIndex ?? 0;
+      await _localBackend.setSources(queue.value);
+      await _localBackend.seek(pos, index: idx, play: _playIntent);
+    }).catchError((Object e) {
+      castLog('network-regained resume failed', error: e);
+    }).whenComplete(() => _recoveringPlayback = false);
+  }
+
+  // Is any network interface up right now? After every queued track has failed,
+  // this is the reliable signal for outage (pause + self-heal) vs bad sources
+  // (stop) — the error string can't distinguish them on Android. Best-effort: a
+  // failed probe assumes online, so we stop rather than leave a stuck pause.
+  Future<bool> _hasNetwork() async {
+    try {
+      final r = await Connectivity().checkConnectivity();
+      return r.any((c) => c != ConnectivityResult.none);
+    } catch (_) {
+      return true;
+    }
+  }
+
+  // Heuristic: does this error look like a clearly bad/unplayable source (skip
+  // now) vs something worth retrying (a network/transport blip)? Best-effort and
+  // platform-limited: on Android ExoPlayer reports almost everything — INCLUDING
+  // 404s — as a generic "(0) Source error" and doesn't forward the real cause to
+  // Dart, so most failures fall through to "retry" (bounded by _kMaxHttpRetries).
+  // The needles below mainly catch iOS/web, where the message is richer. The real
+  // outage-vs-bad-source decision for the END state is made by _hasNetwork().
+  static bool _isTransientNetworkError(Object error) {
+    final s = error.toString().toLowerCase();
+    // Clear "bad/unplayable source" signals → not transient (skip, don't retry).
+    const badSource = [
+      'response code: 4', // 4xx (404/403/401…)
+      'unsupported', 'no suitable', 'decoder', 'unrecognized',
+      'malformed', 'file not found', 'does not exist',
+    ];
+    for (final m in badSource) {
+      if (s.contains(m)) return false;
+    }
+    // Everything else (network/transport, generic "Source error") → retry.
+    return true;
   }
 
   // Re-seed the inherited customState with a typed CustomEvent default (it

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -596,6 +596,9 @@ class AudioPlayerHandler extends BaseAudioHandler
       // No network → an outage: pause-and-hold and let onNetworkRegained resume
       // us when it's back, instead of churning retries/skips that all fail.
       if (!await _hasNetwork()) {
+        appLog('[play] network outage — pausing at '
+            'track ${(_localBackend.currentIndex ?? 0) + 1}; '
+            'will self-heal when connectivity returns');
         _httpRetries = 0;
         _failedSkips = 0;
         _networkStalled = true;

--- a/lib/media/emulated_playlist_backend.dart
+++ b/lib/media/emulated_playlist_backend.dart
@@ -135,9 +135,19 @@ abstract class EmulatedPlaylistBackend implements PlaybackBackend {
 
   // ── Source list (mirrors just_audio's on-player playlist API) ──
   @override
-  Future<void> setSources(List<MediaItem> items) async {
+  Future<void> setSources(List<MediaItem> items,
+      {int? initialIndex, Duration? initialPosition}) async {
     _items = List<MediaItem>.from(items);
-    _index = _items.isEmpty ? -1 : 0;
+    // Honour initialIndex so a reload/restore lands on the right track (no
+    // index-0 flash). The renderer gets the position via the seek that follows;
+    // initialPosition isn't needed here.
+    _index = _items.isEmpty
+        ? -1
+        : (initialIndex != null &&
+                initialIndex >= 0 &&
+                initialIndex < _items.length
+            ? initialIndex
+            : 0);
     _loadedIndex = -1;
     emitIndex(_index < 0 ? null : _index);
     setProcessingState(_items.isEmpty

--- a/lib/media/local_playback_backend.dart
+++ b/lib/media/local_playback_backend.dart
@@ -27,8 +27,12 @@ class LocalPlaybackBackend implements PlaybackBackend {
   // just_audio 0.10 deprecated ConcatenatingAudioSource; the playlist API now
   // lives on AudioPlayer directly.
   @override
-  Future<void> setSources(List<MediaItem> items) => _player.setAudioSources(
-      items.map((i) => AudioSource.uri(_uriFor(i))).toList());
+  Future<void> setSources(List<MediaItem> items,
+          {int? initialIndex, Duration? initialPosition}) =>
+      _player.setAudioSources(
+          items.map((i) => AudioSource.uri(_uriFor(i))).toList(),
+          initialIndex: initialIndex,
+          initialPosition: initialPosition);
 
   @override
   Future<void> addSource(MediaItem item) =>

--- a/lib/media/playback_backend.dart
+++ b/lib/media/playback_backend.dart
@@ -32,7 +32,11 @@ abstract class PlaybackBackend {
   // Takes [MediaItem]s (not bare URIs) so remote backends can build rich
   // metadata (title/artist/album/art) for the renderer; the local backend
   // extracts the playable URI itself.
-  Future<void> setSources(List<MediaItem> items);
+  /// [initialIndex]/[initialPosition] load the list directly at that track/spot
+  /// instead of defaulting to index 0 and needing a follow-up seek — so a
+  /// reload/restore doesn't briefly flash track 0 in the now-playing UI.
+  Future<void> setSources(List<MediaItem> items,
+      {int? initialIndex, Duration? initialPosition});
   Future<void> addSource(MediaItem item);
   Future<void> removeSourceAt(int index);
 

--- a/lib/singletons/queue_store.dart
+++ b/lib/singletons/queue_store.dart
@@ -128,7 +128,11 @@ class QueueStore {
 
     int index = (raw['index'] is int) ? raw['index'] as int : 0;
     if (index < 0 || index >= items.length) index = 0;
-    final int positionMs = (raw['positionMs'] is int) ? raw['positionMs'] as int : 0;
+    // Clamp against the restored track's saved duration so a position at/past its
+    // end (which would seek-past-end → complete → stop on play) starts fresh.
+    final int positionMs = clampResumePositionMs(
+        (raw['positionMs'] is int) ? raw['positionMs'] as int : 0,
+        items[index].duration?.inMilliseconds);
 
     await MediaManager().audioHandler.restoreQueue(
           items,
@@ -194,7 +198,8 @@ class QueueStore {
       final snapshot = <String, dynamic>{
         'version': _schemaVersion,
         'index': state.queueIndex ?? 0,
-        'positionMs': handler.position.inMilliseconds,
+        'positionMs': clampResumePositionMs(handler.position.inMilliseconds,
+            handler.mediaItem.value?.duration?.inMilliseconds),
         'shuffle': state.shuffleMode == AudioServiceShuffleMode.all,
         'repeat': _repeatName(state.repeatMode),
         'items': queue.map(itemToJson).toList(),
@@ -206,6 +211,23 @@ class QueueStore {
   }
 
   // ── (de)serialization — pure & static so they're unit-testable ──
+
+  // Guard against resuming at/past a track's end. A saved position can land at
+  // or beyond the track length — captured as the queue finished, via just_audio's
+  // post-completion position overrun, or from an index/position skew during a
+  // track transition. Restoring there and pressing play seeks past the end → the
+  // player reports `completed` → the handler stops, so playback "won't start" on
+  // reopen. When the position is within [_kResumeEndGuard] of the end (or beyond
+  // a known duration), start the track fresh instead. Returned unchanged when the
+  // duration is unknown (can't judge).
+  static const Duration _kResumeEndGuard = Duration(seconds: 1);
+  static int clampResumePositionMs(int positionMs, int? durationMs) {
+    if (positionMs <= 0) return 0;
+    if (durationMs == null || durationMs <= 0) return positionMs;
+    return positionMs >= durationMs - _kResumeEndGuard.inMilliseconds
+        ? 0
+        : positionMs;
+  }
 
   /// Serialize a [MediaItem] to a JSON-safe map.
   static Map<String, dynamic> itemToJson(MediaItem m) => {

--- a/test/singletons/queue_store_test.dart
+++ b/test/singletons/queue_store_test.dart
@@ -139,4 +139,28 @@ void main() {
       expect(restored, isNull);
     });
   });
+
+  group('QueueStore.clampResumePositionMs', () {
+    test('keeps a mid-track position', () {
+      expect(QueueStore.clampResumePositionMs(23000, 240000), 23000);
+    });
+    test('resets a position at or past the end to 0', () {
+      expect(QueueStore.clampResumePositionMs(240000, 240000), 0);
+      expect(QueueStore.clampResumePositionMs(999999, 240000), 0);
+    });
+    test('resets a position within 1s of the end to 0', () {
+      expect(QueueStore.clampResumePositionMs(239500, 240000), 0);
+    });
+    test('keeps a position more than 1s before the end', () {
+      expect(QueueStore.clampResumePositionMs(238000, 240000), 238000);
+    });
+    test('leaves the position unchanged when the duration is unknown', () {
+      expect(QueueStore.clampResumePositionMs(700000, null), 700000);
+      expect(QueueStore.clampResumePositionMs(700000, 0), 700000);
+    });
+    test('floors a non-positive position to 0', () {
+      expect(QueueStore.clampResumePositionMs(-5, 240000), 0);
+      expect(QueueStore.clampResumePositionMs(0, 240000), 0);
+    });
+  });
 }


### PR DESCRIPTION
Stacked on #85 (base = `claude/heuristic-tereshkova-24e1cb`; GitHub will retarget to `master` when #85 merges).

## Why
The deferred behavioral fix for the "playback sometimes stops" report. Before this, a plain-HTTP source that dropped mid-stream (a momentary network blip, screen-off Wi-Fi park, cellular handoff) was **skipped on the first error**, and a queue-wide blip **stopped playback entirely** — losing the user's spot. just_audio/ExoPlayer do no HTTP retry on their own.

## What
- **Retry at position with bounded backoff.** On a playback error, retry the *same* track at the same spot — immediate, then 1s, 2s (max 3) — instead of skipping. Driven by the existing error-event loop, serialized via `_switchChain`, guarded by `_recoveringPlayback`. The budget resets only on a successful load (`ready`), so a real outage retries the first track then skips the rest fast (bounded total effort).
- **Self-heal on outage.** On whole-queue / end-of-queue exhaustion, **pause-and-hold** (don't stop) and arm `onNetworkRegained()` — wired to the connectivity listener in `main.dart` — to resume the current track at its spot when the network returns.
- **Connectivity-gated pause-vs-stop.** The decision uses an actual `Connectivity.checkConnectivity()` probe, *not* the error string: on Android, ExoPlayer reports a 404 and a network drop identically as `"(0) Source error"` and doesn't forward the cause, so the string can't tell them apart. No network → pause + self-heal; network present → stop (sources/server genuinely bad).

## Reviewed
Ran a 10-agent adversarial review (concurrency / termination / just_audio-behavior / edge-cases + verification). Confirmed bugs fixed: index/position are read **after** the backoff (a user skip/seek during the wait is no longer clobbered); the classifier comment now states the Android limitation honestly; state is broadcast after the exhaustion pause/stop. Verified-sound: the serialization/guards prevent concurrent loads (no "Loading interrupted" reintroduction), the loop is bounded and self-driving via `errorStream`, and cast/DLNA backends are inert.

## Known limitation
With just_audio 0.10.5 + media3 1.4.1, the HTTP status isn't observable from Dart, so a genuinely-bad source (e.g. 404) costs a short bounded retry (~a few seconds) before skipping. Eliminating that fully would require forwarding ExoPlayer's source-exception cause (a vendored-plugin patch) — deliberately out of scope.

## Testing
`flutter analyze` clean. Not yet soak-tested on-device (inducing real mid-stream network failures is manual — toggle airplane mode mid-track). Recommend verifying on the device once the current build's soak is done.