### PR TITLE
fix(queue): don't restore playback to a position at/past the track end

### DIFF
--- a/lib/singletons/queue_store.dart
+++ b/lib/singletons/queue_store.dart
@@ -128,7 +128,11 @@ class QueueStore {
 
     int index = (raw['index'] is int) ? raw['index'] as int : 0;
     if (index < 0 || index >= items.length) index = 0;
-    final int positionMs = (raw['positionMs'] is int) ? raw['positionMs'] as int : 0;
+    // Clamp against the restored track's saved duration so a position at/past its
+    // end (which would seek-past-end → complete → stop on play) starts fresh.
+    final int positionMs = clampResumePositionMs(
+        (raw['positionMs'] is int) ? raw['positionMs'] as int : 0,
+        items[index].duration?.inMilliseconds);
 
     await MediaManager().audioHandler.restoreQueue(
           items,
@@ -194,7 +198,8 @@ class QueueStore {
       final snapshot = <String, dynamic>{
         'version': _schemaVersion,
         'index': state.queueIndex ?? 0,
-        'positionMs': handler.position.inMilliseconds,
+        'positionMs': clampResumePositionMs(handler.position.inMilliseconds,
+            handler.mediaItem.value?.duration?.inMilliseconds),
         'shuffle': state.shuffleMode == AudioServiceShuffleMode.all,
         'repeat': _repeatName(state.repeatMode),
         'items': queue.map(itemToJson).toList(),
@@ -206,6 +211,23 @@ class QueueStore {
   }
 
   // ── (de)serialization — pure & static so they're unit-testable ──
+
+  // Guard against resuming at/past a track's end. A saved position can land at
+  // or beyond the track length — captured as the queue finished, via just_audio's
+  // post-completion position overrun, or from an index/position skew during a
+  // track transition. Restoring there and pressing play seeks past the end → the
+  // player reports `completed` → the handler stops, so playback "won't start" on
+  // reopen. When the position is within [_kResumeEndGuard] of the end (or beyond
+  // a known duration), start the track fresh instead. Returned unchanged when the
+  // duration is unknown (can't judge).
+  static const Duration _kResumeEndGuard = Duration(seconds: 1);
+  static int clampResumePositionMs(int positionMs, int? durationMs) {
+    if (positionMs <= 0) return 0;
+    if (durationMs == null || durationMs <= 0) return positionMs;
+    return positionMs >= durationMs - _kResumeEndGuard.inMilliseconds
+        ? 0
+        : positionMs;
+  }
 
   /// Serialize a [MediaItem] to a JSON-safe map.
   static Map<String, dynamic> itemToJson(MediaItem m) => {

--- a/test/singletons/queue_store_test.dart
+++ b/test/singletons/queue_store_test.dart
@@ -139,4 +139,28 @@ void main() {
       expect(restored, isNull);
     });
   });
+
+  group('QueueStore.clampResumePositionMs', () {
+    test('keeps a mid-track position', () {
+      expect(QueueStore.clampResumePositionMs(23000, 240000), 23000);
+    });
+    test('resets a position at or past the end to 0', () {
+      expect(QueueStore.clampResumePositionMs(240000, 240000), 0);
+      expect(QueueStore.clampResumePositionMs(999999, 240000), 0);
+    });
+    test('resets a position within 1s of the end to 0', () {
+      expect(QueueStore.clampResumePositionMs(239500, 240000), 0);
+    });
+    test('keeps a position more than 1s before the end', () {
+      expect(QueueStore.clampResumePositionMs(238000, 240000), 238000);
+    });
+    test('leaves the position unchanged when the duration is unknown', () {
+      expect(QueueStore.clampResumePositionMs(700000, null), 700000);
+      expect(QueueStore.clampResumePositionMs(700000, 0), 700000);
+    });
+    test('floors a non-positive position to 0', () {
+      expect(QueueStore.clampResumePositionMs(-5, 240000), 0);
+      expect(QueueStore.clampResumePositionMs(0, 240000), 0);
+    });
+  });
 }


### PR DESCRIPTION
## Problem
Found while smoke-testing the playback fixes: after reopening the app, pressing play could make playback **stop instantly**. The saved resume position for the current track had landed **at/beyond that track's length**, so on restore `seek(savedPosition)` + play → seek-past-end → ExoPlayer reports `completed` → the `completed→stop` handler stops it. The track "refuses to start."

A position past the end can be persisted several ways: captured as the whole queue finished, via just_audio's post-completion position overrun, or from a brief index/position skew during a track transition (the save reads `state.queueIndex` and `handler.position` from different sources).

## Fix
A shared, pure helper `clampResumePositionMs(positionMs, durationMs)`:
- position within `_kResumeEndGuard` (1s) of the end, or beyond a **known** duration → returns `0` (resume the track from the start);
- unknown/zero duration → returns the position unchanged (can't judge);
- non-positive → `0`.

Applied at **both** ends, so existing bad `queue.json` files are also healed:
- `saveNow` clamps against the now-playing item's duration before persisting (don't write a past-end position);
- `_restore` clamps the saved `positionMs` against the restored track's persisted `durationMs` (line already saved per item) before handing it to `restoreQueue`.

Net behavior: a track that was essentially finished restarts cleanly on reopen instead of instant-stopping; a genuinely mid-track resume (e.g. 23s/240s) is untouched.

## Tests
New `QueueStore.clampResumePositionMs` unit group (mid-track kept, at/past-end → 0, within-1s → 0, >1s-before-end kept, unknown-duration untouched, negatives floored). `flutter test test/singletons/queue_store_test.dart` → **12/12 pass**; `flutter analyze` clean.

## Notes
- Independent of the audio-stop PRs — touches only `queue_store.dart`, so it's based off `master`.
- The pure helper is unit-tested; the end-to-end on-device path (plant a past-end `queue.json` → reopen → play resumes from 0) hasn't been run yet since it requires deploying this build.