### PR TITLE
feat(lyrics): show a lyrics badge on Song Info and add a lyrics page

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -591,8 +591,9 @@
   "searchCategoryAlbums": "Albums",
   "searchCategorySongs": "Songs",
   "searchCategoryFiles": "Files",
+  "searchCategoryLyrics": "Lyrics",
   "@searchCategoriesTooltip": {
-    "description": "Search-category checkbox dropdown: tooltip on the icon button, the menu header, and the four category labels (which categories the DB search queries — the user ticks any combination)."
+    "description": "Search-category checkbox dropdown: tooltip on the icon button, the menu header, and the five category labels (which categories the DB search queries — the user ticks any combination)."
   },
   "searchSubheaderResults": "Results for “{term}”",
   "@searchSubheaderResults": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -102,6 +102,22 @@
   "@songInfoTitle": {
     "description": "Metadata screen app bar title."
   },
+  "lyricsTitle": "Lyrics",
+  "@lyricsTitle": {
+    "description": "Lyrics page app bar title and the Song Info lyrics badge label."
+  },
+  "lyricsEmpty": "No lyrics found for this song",
+  "@lyricsEmpty": {
+    "description": "Empty state on the lyrics page when the server has no lyrics."
+  },
+  "lyricsError": "Couldn't load lyrics",
+  "@lyricsError": {
+    "description": "Error state on the lyrics page when the fetch fails."
+  },
+  "lyricsRetry": "Retry",
+  "@lyricsRetry": {
+    "description": "Button to retry loading lyrics after an error."
+  },
   "eqTitle": "Equalizer",
   "@eqTitle": {
     "description": "Equalizer screen title / switch label."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -276,6 +276,30 @@ abstract class AppLocalizations {
   /// **'Song Info'**
   String get songInfoTitle;
 
+  /// Lyrics page app bar title and the Song Info lyrics badge label.
+  ///
+  /// In en, this message translates to:
+  /// **'Lyrics'**
+  String get lyricsTitle;
+
+  /// Empty state on the lyrics page when the server has no lyrics.
+  ///
+  /// In en, this message translates to:
+  /// **'No lyrics found for this song'**
+  String get lyricsEmpty;
+
+  /// Error state on the lyrics page when the fetch fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load lyrics'**
+  String get lyricsError;
+
+  /// Button to retry loading lyrics after an error.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get lyricsRetry;
+
   /// Equalizer screen title / switch label.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1500,7 +1500,7 @@ abstract class AppLocalizations {
   /// **'Search Database'**
   String get browserSearchHint;
 
-  /// Search-category checkbox dropdown: tooltip on the icon button, the menu header, and the four category labels (which categories the DB search queries — the user ticks any combination).
+  /// Search-category checkbox dropdown: tooltip on the icon button, the menu header, and the five category labels (which categories the DB search queries — the user ticks any combination).
   ///
   /// In en, this message translates to:
   /// **'What to search'**
@@ -1535,6 +1535,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Files'**
   String get searchCategoryFiles;
+
+  /// No description provided for @searchCategoryLyrics.
+  ///
+  /// In en, this message translates to:
+  /// **'Lyrics'**
+  String get searchCategoryLyrics;
 
   /// Thin subheader on the search-results page echoing the submitted query.
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -105,6 +105,18 @@ class AppLocalizationsDe extends AppLocalizations {
   String get songInfoTitle => 'Songinfo';
 
   @override
+  String get lyricsTitle => 'Lyrics';
+
+  @override
+  String get lyricsEmpty => 'No lyrics found for this song';
+
+  @override
+  String get lyricsError => 'Couldn\'t load lyrics';
+
+  @override
+  String get lyricsRetry => 'Retry';
+
+  @override
   String get eqTitle => 'Equalizer';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -828,6 +828,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String get searchCategoryLyrics => 'Lyrics';
+
+  @override
   String searchSubheaderResults(String term) {
     return 'Results for “$term”';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -105,6 +105,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get songInfoTitle => 'Song Info';
 
   @override
+  String get lyricsTitle => 'Lyrics';
+
+  @override
+  String get lyricsEmpty => 'No lyrics found for this song';
+
+  @override
+  String get lyricsError => 'Couldn\'t load lyrics';
+
+  @override
+  String get lyricsRetry => 'Retry';
+
+  @override
   String get eqTitle => 'Equalizer';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -818,6 +818,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String get searchCategoryLyrics => 'Lyrics';
+
+  @override
   String searchSubheaderResults(String term) {
     return 'Results for “$term”';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -827,6 +827,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String get searchCategoryLyrics => 'Lyrics';
+
+  @override
   String searchSubheaderResults(String term) {
     return 'Results for “$term”';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -105,6 +105,18 @@ class AppLocalizationsEs extends AppLocalizations {
   String get songInfoTitle => 'Información de la canción';
 
   @override
+  String get lyricsTitle => 'Lyrics';
+
+  @override
+  String get lyricsEmpty => 'No lyrics found for this song';
+
+  @override
+  String get lyricsError => 'Couldn\'t load lyrics';
+
+  @override
+  String get lyricsRetry => 'Retry';
+
+  @override
   String get eqTitle => 'Ecualizador';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -105,6 +105,18 @@ class AppLocalizationsFr extends AppLocalizations {
   String get songInfoTitle => 'Infos du morceau';
 
   @override
+  String get lyricsTitle => 'Lyrics';
+
+  @override
+  String get lyricsEmpty => 'No lyrics found for this song';
+
+  @override
+  String get lyricsError => 'Couldn\'t load lyrics';
+
+  @override
+  String get lyricsRetry => 'Retry';
+
+  @override
   String get eqTitle => 'Égaliseur';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -826,6 +826,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String get searchCategoryLyrics => 'Lyrics';
+
+  @override
   String searchSubheaderResults(String term) {
     return 'Results for “$term”';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -825,6 +825,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String get searchCategoryLyrics => 'Lyrics';
+
+  @override
   String searchSubheaderResults(String term) {
     return 'Results for “$term”';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -105,6 +105,18 @@ class AppLocalizationsIt extends AppLocalizations {
   String get songInfoTitle => 'Informazioni brano';
 
   @override
+  String get lyricsTitle => 'Lyrics';
+
+  @override
+  String get lyricsEmpty => 'No lyrics found for this song';
+
+  @override
+  String get lyricsError => 'Couldn\'t load lyrics';
+
+  @override
+  String get lyricsRetry => 'Retry';
+
+  @override
   String get eqTitle => 'Equalizzatore';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -800,6 +800,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String get searchCategoryLyrics => 'Lyrics';
+
+  @override
   String searchSubheaderResults(String term) {
     return 'Results for “$term”';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -103,6 +103,18 @@ class AppLocalizationsJa extends AppLocalizations {
   String get songInfoTitle => '曲の情報';
 
   @override
+  String get lyricsTitle => 'Lyrics';
+
+  @override
+  String get lyricsEmpty => 'No lyrics found for this song';
+
+  @override
+  String get lyricsError => 'Couldn\'t load lyrics';
+
+  @override
+  String get lyricsRetry => 'Retry';
+
+  @override
   String get eqTitle => 'イコライザー';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -107,6 +107,18 @@ class AppLocalizationsPl extends AppLocalizations {
   String get songInfoTitle => 'Informacje o utworze';
 
   @override
+  String get lyricsTitle => 'Lyrics';
+
+  @override
+  String get lyricsEmpty => 'No lyrics found for this song';
+
+  @override
+  String get lyricsError => 'Couldn\'t load lyrics';
+
+  @override
+  String get lyricsRetry => 'Retry';
+
+  @override
   String get eqTitle => 'Korektor';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -829,6 +829,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String get searchCategoryLyrics => 'Lyrics';
+
+  @override
   String searchSubheaderResults(String term) {
     return 'Results for “$term”';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -105,6 +105,18 @@ class AppLocalizationsPt extends AppLocalizations {
   String get songInfoTitle => 'Informações da música';
 
   @override
+  String get lyricsTitle => 'Lyrics';
+
+  @override
+  String get lyricsEmpty => 'No lyrics found for this song';
+
+  @override
+  String get lyricsError => 'Couldn\'t load lyrics';
+
+  @override
+  String get lyricsRetry => 'Retry';
+
+  @override
   String get eqTitle => 'Equalizador';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -825,6 +825,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String get searchCategoryLyrics => 'Lyrics';
+
+  @override
   String searchSubheaderResults(String term) {
     return 'Results for “$term”';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -833,6 +833,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String get searchCategoryLyrics => 'Lyrics';
+
+  @override
   String searchSubheaderResults(String term) {
     return 'Results for “$term”';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -107,6 +107,18 @@ class AppLocalizationsRu extends AppLocalizations {
   String get songInfoTitle => 'Сведения о треке';
 
   @override
+  String get lyricsTitle => 'Lyrics';
+
+  @override
+  String get lyricsEmpty => 'No lyrics found for this song';
+
+  @override
+  String get lyricsError => 'Couldn\'t load lyrics';
+
+  @override
+  String get lyricsRetry => 'Retry';
+
+  @override
   String get eqTitle => 'Эквалайзер';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -102,6 +102,18 @@ class AppLocalizationsZh extends AppLocalizations {
   String get songInfoTitle => '歌曲信息';
 
   @override
+  String get lyricsTitle => 'Lyrics';
+
+  @override
+  String get lyricsEmpty => 'No lyrics found for this song';
+
+  @override
+  String get lyricsError => 'Couldn\'t load lyrics';
+
+  @override
+  String get lyricsRetry => 'Retry';
+
+  @override
   String get eqTitle => '均衡器';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -785,6 +785,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get searchCategoryFiles => 'Files';
 
   @override
+  String get searchCategoryLyrics => 'Lyrics';
+
+  @override
   String searchSubheaderResults(String term) {
     return 'Results for “$term”';
   }

--- a/lib/l10n/enum_labels.dart
+++ b/lib/l10n/enum_labels.dart
@@ -93,6 +93,8 @@ extension SearchCategoryLabel on SearchCategory {
         return l.searchCategorySongs;
       case SearchCategory.files:
         return l.searchCategoryFiles;
+      case SearchCategory.lyrics:
+        return l.searchCategoryLyrics;
     }
   }
 }

--- a/lib/media/auto_browse.dart
+++ b/lib/media/auto_browse.dart
@@ -901,6 +901,10 @@ class AutoApi {
       'noAlbums': false,
       'noTitles': false,
       'noFiles': true,
+      // Voice/car search wants name matches, not noisy full-text lyric hits, and
+      // this parser ignores the `lyrics` array anyway — opt out so the server
+      // skips the lyric FTS work.
+      'noLyrics': true,
     });
     final artists = <DisplayItem>[];
     for (final e in (res['artists'] as List? ?? const [])) {

--- a/lib/objects/display_item.dart
+++ b/lib/objects/display_item.dart
@@ -127,20 +127,26 @@ class DisplayItem {
   }
 
   Widget? getSubText({AppLocalizations? l}) {
-    if (metadata?.artist != null) {
+    // An explicitly-set subtext wins over the derived artist line. Search rows
+    // rely on this to keep their match context — a lyric snippet, a file's
+    // folder — visible even though the full metadata block (which carries the
+    // artist) is now attached so the queue can skip a /db/metadata fetch. Every
+    // browse row that has metadata leaves subtext null (or sets it to the artist
+    // itself), so those fall through to the artist exactly as before.
+    if (subtext != null) {
       return Text(
-        metadata!.artist!,
+        (l != null && type == 'addServer')
+            ? browserChromeLabel(l, subtext!)
+            : subtext!,
         style: TextStyle(fontSize: 13, color: VelvetColors.textPrimary),
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       );
     }
 
-    if (subtext != null) {
+    if (metadata?.artist != null) {
       return Text(
-        (l != null && type == 'addServer')
-            ? browserChromeLabel(l, subtext!)
-            : subtext!,
+        metadata!.artist!,
         style: TextStyle(fontSize: 13, color: VelvetColors.textPrimary),
         maxLines: 1,
         overflow: TextOverflow.ellipsis,

--- a/lib/objects/display_item.dart
+++ b/lib/objects/display_item.dart
@@ -18,6 +18,11 @@ class DisplayItem {
   Icon? icon;
   String name;
   MusicMetadata? metadata;
+  // When true, [metadata] is at most the lite subset the search endpoint returns
+  // (PR #685) — enough for the row's card, but missing the heavier fidelity /
+  // count fields. buildServerFileMediaItem refetches the full block before
+  // enqueuing so the now-playing / Song Info screens stay complete.
+  bool partialMetadata = false;
   String? altAlbumArt;
   String? subtext;
 

--- a/lib/objects/lyrics.dart
+++ b/lib/objects/lyrics.dart
@@ -1,0 +1,67 @@
+/// Parsed result of `GET /api/v1/lyrics`.
+///
+/// The server returns two typed containers — `lyrics` (plain text) and
+/// `syncedLyrics` (raw LRC) — each shaped `{ default: int, lyrics: [ { lang,
+/// source, data } ] }`. Today each holds 0 or 1 entry; we read the `default`
+/// index. Availability is advertised separately on song metadata
+/// (`has-lyrics`), so this payload is only fetched on demand when the user opens
+/// the lyrics page.
+class LyricsResult {
+  /// Plain-text lyrics, ready to render as-is (null when the server has none).
+  final String? plainText;
+
+  /// Raw LRC (`[mm:ss.xx]line…`) when the server has a synced version.
+  final String? syncedLrc;
+
+  const LyricsResult({this.plainText, this.syncedLrc});
+
+  factory LyricsResult.fromJson(Map<String, dynamic> json) => LyricsResult(
+        plainText: _pickData(json['lyrics']),
+        syncedLrc: _pickData(json['syncedLyrics']),
+      );
+
+  /// True when neither container carried any usable text.
+  bool get isEmpty => _blank(plainText) && _blank(syncedLrc);
+
+  /// True when the only lyrics available are time-synced (so [displayText] is
+  /// the LRC stripped down to plain lines).
+  bool get isSynced => _blank(plainText) && !_blank(syncedLrc);
+
+  /// Text to show: the plain lyrics when present, otherwise the synced LRC with
+  /// its `[mm:ss.xx]` timestamps and `[idtag:value]` headers stripped. Null when
+  /// there's nothing to show.
+  String? get displayText {
+    if (!_blank(plainText)) return plainText!.trim();
+    if (!_blank(syncedLrc)) return stripLrc(syncedLrc!);
+    return null;
+  }
+
+  /// Pulls the `default` entry's `data` out of one `{ default, lyrics:[…] }`
+  /// container, tolerating a missing/short list or a non-string `data`.
+  static String? _pickData(dynamic container) {
+    if (container is! Map) return null;
+    final list = container['lyrics'];
+    if (list is! List || list.isEmpty) return null;
+    final i = container['default'] is int ? container['default'] as int : 0;
+    final entry = (i >= 0 && i < list.length) ? list[i] : list.first;
+    final data = entry is Map ? entry['data'] : null;
+    return (data is String && data.trim().isNotEmpty) ? data : null;
+  }
+
+  /// Flattens synced LRC to plain text: drops `[idtag:value]` metadata headers
+  /// and removes inline `[mm:ss.xx]` time tags, keeping each line's words. Blank
+  /// lines within the song are preserved; leading/trailing blanks are trimmed.
+  static String stripLrc(String lrc) {
+    final timeTag = RegExp(r'\[\d{1,3}:\d{2}(?:[.:]\d{1,3})?\]');
+    final headerTag = RegExp(r'^\[[a-zA-Z#]+:.*\]$');
+    final lines = <String>[];
+    for (final raw in lrc.split('\n')) {
+      final line = raw.trim();
+      if (headerTag.hasMatch(line)) continue; // [ar:…], [ti:…], [length:…], …
+      lines.add(line.replaceAll(timeTag, '').trim());
+    }
+    return lines.join('\n').trim();
+  }
+
+  static bool _blank(String? s) => s == null || s.trim().isEmpty;
+}

--- a/lib/objects/metadata.dart
+++ b/lib/objects/metadata.dart
@@ -31,6 +31,11 @@ class MusicMetadata {
   int? trackTotal;
   int? discTotal;
   int? playCount;
+  // Whether the server has lyrics stored for this track (`has-lyrics`, from the
+  // lyrics-backfill API; true for embedded plain text OR a synced LRC). Absent
+  // on older servers → false. Gates the Song Info lyrics badge, which fetches
+  // the text on demand via GET /api/v1/lyrics rather than inlining it here.
+  bool hasLyrics;
   // Genre names for this track. Velvet servers emit `metadata.genres` as a
   // string list (many-to-many via track_genres); empty when untagged or on
   // servers that don't surface genres.
@@ -47,7 +52,8 @@ class MusicMetadata {
       this.format,
       this.trackTotal,
       this.discTotal,
-      this.playCount});
+      this.playCount,
+      this.hasLyrics = false});
 
   MusicMetadata.fromJson(Map<String, dynamic> json)
       : artist = json['artist'],
@@ -68,6 +74,7 @@ class MusicMetadata {
         trackTotal = json['trackTotal'],
         discTotal = json['discTotal'],
         playCount = json['playCount'],
+        hasLyrics = json['hasLyrics'] == true,
         genres = parseGenres(json['genres']);
 
   Map<String, dynamic> toJson() => {
@@ -89,6 +96,7 @@ class MusicMetadata {
         'trackTotal': trackTotal,
         'discTotal': discTotal,
         'playCount': playCount,
+        'hasLyrics': hasLyrics,
         'genres': genres,
       };
 
@@ -123,6 +131,10 @@ class MusicMetadata {
         trackTotal: _asInt(m['track-total'] ?? m['trackTotal']),
         discTotal: _asInt(m['disc-total'] ?? m['discTotal']),
         playCount: _asInt(m['play-count'] ?? m['playCount']),
+        // Lyrics-availability flag from the lyrics-backfill API; the synced
+        // variant (`has-synced-lyrics`) isn't threaded — the lyrics fetch
+        // reports plain vs synced itself.
+        hasLyrics: m['has-lyrics'] == true,
       );
 
   /// Parses the server's `genres` value (normally a string list) into a

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+
+import '../l10n/app_localizations.dart';
+import '../objects/lyrics.dart';
+import '../objects/server.dart';
+import '../singletons/api.dart';
+import '../theme/velvet_theme.dart';
+
+/// Full lyrics page, reached from the Song Info lyrics badge. Fetches the
+/// track's lyrics on open via `GET /api/v1/lyrics` and renders them as scrollable
+/// (selectable) text — the plain version when present, otherwise a synced LRC
+/// flattened to plain lines. Loading / empty / error states are handled inline so
+/// the badge is always one tap from *something* sensible.
+class LyricsScreen extends StatefulWidget {
+  const LyricsScreen({
+    super.key,
+    required this.server,
+    required this.path,
+    required this.title,
+    this.artist,
+  });
+
+  /// The track's source server and data path — together they address the
+  /// lyrics endpoint (the badge only opens this screen when both resolve).
+  final Server server;
+  final String path;
+
+  /// Shown in the app bar for context.
+  final String title;
+  final String? artist;
+
+  @override
+  State<LyricsScreen> createState() => _LyricsScreenState();
+}
+
+class _LyricsScreenState extends State<LyricsScreen> {
+  late Future<LyricsResult?> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<LyricsResult?> _load() =>
+      ApiManager().fetchLyrics(widget.server, widget.path);
+
+  void _retry() => setState(() => _future = _load());
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final hasArtist = widget.artist != null && widget.artist!.trim().isNotEmpty;
+
+    return Scaffold(
+      backgroundColor: VelvetColors.bg,
+      appBar: AppBar(
+        backgroundColor: VelvetColors.bg,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        foregroundColor: VelvetColors.textPrimary,
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              widget.title.trim().isNotEmpty ? widget.title : l.lyricsTitle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: VelvetColors.textPrimary,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            if (hasArtist)
+              Text(
+                widget.artist!,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: VelvetColors.textTertiary,
+                  fontSize: 12.5,
+                  fontWeight: FontWeight.w400,
+                ),
+              ),
+          ],
+        ),
+      ),
+      body: FutureBuilder<LyricsResult?>(
+        future: _future,
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return Center(
+              child: CircularProgressIndicator(color: VelvetColors.primary),
+            );
+          }
+          if (snap.hasError) {
+            return _Message(
+              icon: Icons.error_outline_rounded,
+              text: l.lyricsError,
+              action: TextButton(onPressed: _retry, child: Text(l.lyricsRetry)),
+            );
+          }
+          final text = snap.data?.displayText;
+          if (text == null) {
+            return _Message(
+              icon: Icons.lyrics_outlined,
+              text: l.lyricsEmpty,
+            );
+          }
+          return _LyricsBody(text: text);
+        },
+      ),
+    );
+  }
+}
+
+/// The lyrics text itself: a comfortable, centered, selectable reading column.
+class _LyricsBody extends StatelessWidget {
+  const _LyricsBody({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final mq = MediaQuery.of(context);
+    return ListView(
+      padding: EdgeInsets.fromLTRB(24, 20, 24, 32 + mq.padding.bottom),
+      children: [
+        SelectableText(
+          text,
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: VelvetColors.textSecondary,
+            fontSize: 16,
+            height: 1.8,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Centered glyph + message (+ optional action) for the empty / error states.
+class _Message extends StatelessWidget {
+  const _Message({required this.icon, required this.text, this.action});
+
+  final IconData icon;
+  final String text;
+  final Widget? action;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 44, color: VelvetColors.textTertiary),
+            const SizedBox(height: 14),
+            Text(
+              text,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: VelvetColors.textSecondary,
+                fontSize: 14.5,
+              ),
+            ),
+            if (action != null) ...[
+              const SizedBox(height: 8),
+              action!,
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -5,10 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../l10n/app_localizations.dart';
+import '../singletons/server_list.dart';
 import '../theme/velvet_theme.dart';
 import '../util/media_format.dart';
 import '../util/image_cache.dart';
 import '../widgets/star_rating.dart';
+import 'lyrics_screen.dart';
 
 /// Song-info screen shown from the queue row's Info action: a blurred album-art
 /// backdrop, a hero cover, the title / artist / album·year, a track/disc line,
@@ -31,6 +33,12 @@ class MetadataScreen extends StatelessWidget {
     final year = extras['year'];
     final key = extras['musicalKey'] as String?;
     final genre = item.genre;
+
+    // Lyrics badge: shown only when the server advertised lyrics for this track
+    // (`hasLyrics`) AND we can resolve its source server + path to fetch them —
+    // both null for a local file, so it stays hidden there.
+    final lyricsServer =
+        ServerManager().byLocalname(extras['server'] as String?);
 
     final subtitle = <String>[
       if (item.album != null && item.album!.trim().isNotEmpty) item.album!.trim(),
@@ -66,6 +74,21 @@ class MetadataScreen extends StatelessWidget {
       // a rateable track: a local file has no server-side rating, and adding it
       // unconditionally would force an empty chip row to render for one.
       if (MediaItemRating.canRate(item)) MediaItemRating(item: item, size: 18),
+      if (extras['hasLyrics'] == true && lyricsServer != null && path != null)
+        _lyricsChip(
+          l.lyricsTitle,
+          () => Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => LyricsScreen(
+                server: lyricsServer,
+                path: path,
+                title: item.title,
+                artist: item.artist,
+              ),
+            ),
+          ),
+        ),
       if (item.duration != null)
         _chip(Icons.schedule_rounded, formatDuration(item.duration!)),
       if (fidelity.isNotEmpty) _chip(Icons.high_quality_rounded, fidelity),
@@ -280,6 +303,44 @@ class MetadataScreen extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  /// Tappable sibling of [_chip] for the lyrics badge: the same pill plus an ink
+  /// ripple and a trailing chevron to signal that it opens the lyrics page.
+  Widget _lyricsChip(String label, VoidCallback onTap) {
+    return Material(
+      color: VelvetColors.raised,
+      borderRadius: BorderRadius.circular(20),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 7),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: VelvetColors.border),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.lyrics_rounded, size: 14, color: VelvetColors.primary),
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: TextStyle(
+                  color: VelvetColors.textSecondary,
+                  fontSize: 12.5,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(width: 2),
+              Icon(Icons.chevron_right_rounded,
+                  size: 16, color: VelvetColors.textTertiary),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -4,6 +4,7 @@ import './log_manager.dart';
 import './settings.dart';
 import '../objects/server.dart';
 import '../objects/display_item.dart';
+import '../objects/lyrics.dart';
 import '../objects/metadata.dart';
 import 'media.dart';
 import '../util/stream_url.dart';
@@ -79,6 +80,35 @@ class ApiManager {
       throw Exception('Share failed (HTTP ${response.statusCode})');
     }
     return jsonDecode(response.body) as Map<String, dynamic>;
+  }
+
+  /// `GET /api/v1/lyrics?path=<vpath/relpath>` — fetches the lyrics the server has
+  /// stored for a track (embedded plain text and/or a synced LRC). Returns null
+  /// when there are none for this track (404) or the server predates the lyrics
+  /// API; throws only on an unexpected transport / HTTP error so the lyrics
+  /// screen can offer a retry. Direct http (like [rateSong]) so it stays off the
+  /// browser loading bar. [filepath] is the track's data path — a leading slash
+  /// is tolerated, and each segment is encoded like the stream-URL builder so
+  /// spaces / specials are escaped while the `/` separators stay literal.
+  Future<LyricsResult?> fetchLyrics(Server server, String filepath) async {
+    final encodedPath = filepath
+        .split('/')
+        .where((s) => s.isNotEmpty)
+        .map(Uri.encodeComponent)
+        .join('/');
+    final uri = Uri.parse('${server.effectiveBaseUrl}/api/v1/lyrics'
+        '?path=$encodedPath${server.localTokenQuery}');
+
+    final response =
+        await http.get(uri, headers: {'x-access-token': server.jwt ?? ''});
+    if (response.statusCode == 404) return null; // no lyrics for this track
+    if (response.statusCode > 299) {
+      throw Exception('Lyrics fetch failed (HTTP ${response.statusCode})');
+    }
+    final decoded = jsonDecode(response.body);
+    if (decoded is! Map<String, dynamic>) return null;
+    final result = LyricsResult.fromJson(decoded);
+    return result.isEmpty ? null : result;
   }
 
   Future makeServerCall(Server? currentServer, String location, Map payload,

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -286,7 +286,7 @@ class ApiManager {
 
   Future<void> searchServer(String search) async {
     try {
-      // The user's ticked search categories map 1:1 onto the endpoint's four
+      // The user's ticked search categories map 1:1 onto the endpoint's five
       // `no*` flags — the server only does the work that's asked. The default
       // set (artists+albums+songs) reproduces mStream's classic search.
       final cats = SettingsManager().searchCategories;
@@ -296,6 +296,7 @@ class ApiManager {
         'noAlbums': !cats.contains(SearchCategory.albums),
         'noTitles': !cats.contains(SearchCategory.songs),
         'noFiles': !cats.contains(SearchCategory.files),
+        'noLyrics': !cats.contains(SearchCategory.lyrics),
       }, 'POST');
 
       BrowserManager().setBrowserLabel('Search');
@@ -350,6 +351,24 @@ class ApiManager {
             '/$fp',
             Icon(Icons.insert_drive_file, color: VelvetColors.accent),
             slash > 0 ? fp.substring(0, slash) : null);
+        newItem.altAlbumArt = e['album_art_file'];
+        newList.add(newItem);
+      });
+
+      // Lyric matches (only when the `lyrics` category is ticked; `?.` since
+      // older servers omit the key). Same play target as a title hit, but shown
+      // with a lyrics glyph and the matched excerpt (`snippet`) as the subtitle
+      // so the user sees WHY it matched. `snippet` is null on the LIKE fallback /
+      // non-FTS servers, so fall back to a plain label there.
+      res['lyrics']?.forEach((e) {
+        final snippet = (e['snippet'] as String?)?.trim();
+        DisplayItem newItem = DisplayItem(
+            ServerManager().currentServer,
+            e['name'],
+            'file',
+            '/${e['filepath']}',
+            Icon(Icons.lyrics, color: VelvetColors.accent),
+            snippet != null && snippet.isNotEmpty ? snippet : 'lyrics');
         newItem.altAlbumArt = e['album_art_file'];
         newList.add(newItem);
       });

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -544,6 +544,34 @@ class ApiManager {
     }
   }
 
+  /// POST /api/v1/db/metadata — the full metadata block for a single track by its
+  /// (library-prefixed) [filepath]. Used to enrich queue items built from the
+  /// lightweight search endpoint, which returns only name/filepath/art. Returns
+  /// null on a miss (the server 200s with `metadata: null`), any error, or an
+  /// older server without the route — so callers degrade to what they already
+  /// have. Best-effort: never throws. Direct http (like [rateSong]) so it stays
+  /// off the browser loading bar. A leading slash on [filepath] is tolerated.
+  Future<MusicMetadata?> fetchTrackMetadata(
+      Server server, String filepath) async {
+    final fp = filepath.startsWith('/') ? filepath.substring(1) : filepath;
+    try {
+      final response = await http.post(
+        server.apiUri('/api/v1/db/metadata'),
+        body: jsonEncode({'filepath': fp}),
+        headers: {
+          'Content-Type': 'application/json',
+          'x-access-token': server.jwt ?? '',
+        },
+      );
+      if (response.statusCode > 299) return null;
+      final decoded = jsonDecode(response.body);
+      final md = decoded is Map ? decoded['metadata'] : null;
+      return md is Map ? MusicMetadata.fromServerMap(md) : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
   Future<void> getArtists({Server? useThisServer}) async {
     dynamic res;
     try {

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -325,25 +325,37 @@ class ApiManager {
         newList.add(newItem);
       });
 
+      // Track hits now carry the full metadata block (PR #685, same shape as
+      // album-songs); attach it so the row shows the real title/artist AND the
+      // queue enqueues with full metadata, skipping the per-track /db/metadata
+      // fetch. Older servers omit the key → metadata stays null and
+      // buildServerFileMediaItem fetches it lazily. With metadata the artist is
+      // the subtitle, so the 'song' type hint only matters on the old path.
       res['title'].forEach((e) {
+        final md = e['metadata'];
+        final meta = md is Map ? MusicMetadata.fromServerMap(md) : null;
         DisplayItem newItem = DisplayItem(
             ServerManager().currentServer,
             e['name'],
             'file',
             '/${e['filepath']}',
             Icon(Icons.music_note, color: VelvetColors.accent),
-            'song');
+            meta != null ? null : 'song');
         newItem.altAlbumArt = e['album_art_file'];
+        newItem.metadata = meta;
         newList.add(newItem);
       });
 
       // Files (filepath matches) — only populated when the scope is `files`.
-      // Same shape as titles (name + filepath); guarded with `?.` because
-      // older servers may omit the key entirely. The row renders as a file:
-      // getText shows the filename, so we surface the folder as the subtitle.
+      // Carries the metadata block too (PR #685); `?.` because older servers may
+      // omit the `files` key entirely. We keep the folder as the subtitle (the
+      // match context — getSubText shows an explicit subtext over the metadata
+      // artist); getText shows the title once metadata is attached, the filename
+      // otherwise.
       res['files']?.forEach((e) {
         final String fp = e['filepath'];
         final int slash = fp.lastIndexOf('/');
+        final md = e['metadata'];
         DisplayItem newItem = DisplayItem(
             ServerManager().currentServer,
             e['name'],
@@ -352,16 +364,19 @@ class ApiManager {
             Icon(Icons.insert_drive_file, color: VelvetColors.accent),
             slash > 0 ? fp.substring(0, slash) : null);
         newItem.altAlbumArt = e['album_art_file'];
+        if (md is Map) newItem.metadata = MusicMetadata.fromServerMap(md);
         newList.add(newItem);
       });
 
       // Lyric matches (only when the `lyrics` category is ticked; `?.` since
-      // older servers omit the key). Same play target as a title hit, but shown
-      // with a lyrics glyph and the matched excerpt (`snippet`) as the subtitle
-      // so the user sees WHY it matched. `snippet` is null on the LIKE fallback /
-      // non-FTS servers, so fall back to a plain label there.
+      // older servers omit the key). Carries the metadata block (PR #685) for the
+      // queue, plus a `snippet` excerpt. We keep the snippet as the subtitle so
+      // the user sees WHY it matched (getSubText prefers an explicit subtext over
+      // the metadata artist); getText shows the real title once metadata is
+      // attached. `snippet` is null on the LIKE / non-FTS path → plain label.
       res['lyrics']?.forEach((e) {
         final snippet = (e['snippet'] as String?)?.trim();
+        final md = e['metadata'];
         DisplayItem newItem = DisplayItem(
             ServerManager().currentServer,
             e['name'],
@@ -370,6 +385,7 @@ class ApiManager {
             Icon(Icons.lyrics, color: VelvetColors.accent),
             snippet != null && snippet.isNotEmpty ? snippet : 'lyrics');
         newItem.altAlbumArt = e['album_art_file'];
+        if (md is Map) newItem.metadata = MusicMetadata.fromServerMap(md);
         newList.add(newItem);
       });
 

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -325,12 +325,13 @@ class ApiManager {
         newList.add(newItem);
       });
 
-      // Track hits now carry the full metadata block (PR #685, same shape as
-      // album-songs); attach it so the row shows the real title/artist AND the
-      // queue enqueues with full metadata, skipping the per-track /db/metadata
-      // fetch. Older servers omit the key → metadata stays null and
-      // buildServerFileMediaItem fetches it lazily. With metadata the artist is
-      // the subtitle, so the 'song' type hint only matters on the old path.
+      // Track hits carry the LITE metadata subset (PR #685, same kebab-case keys
+      // as the full block, so fromServerMap parses it directly). Attach it so the
+      // row renders a real card (title / artist) and flag it partial so the queue
+      // refetches the full block (fidelity / counts) on enqueue. Older servers
+      // omit the key → metadata stays null (still partial → still fetched). With
+      // metadata the artist is the subtitle, so the 'song' type hint only matters
+      // on the metadata-less path.
       res['title'].forEach((e) {
         final md = e['metadata'];
         final meta = md is Map ? MusicMetadata.fromServerMap(md) : null;
@@ -343,15 +344,16 @@ class ApiManager {
             meta != null ? null : 'song');
         newItem.altAlbumArt = e['album_art_file'];
         newItem.metadata = meta;
+        newItem.partialMetadata = true;
         newList.add(newItem);
       });
 
       // Files (filepath matches) — only populated when the scope is `files`.
-      // Carries the metadata block too (PR #685); `?.` because older servers may
-      // omit the `files` key entirely. We keep the folder as the subtitle (the
+      // Carries the lite metadata block too (PR #685); `?.` because older servers
+      // may omit the `files` key entirely. We keep the folder as the subtitle (the
       // match context — getSubText shows an explicit subtext over the metadata
       // artist); getText shows the title once metadata is attached, the filename
-      // otherwise.
+      // otherwise. Flagged partial so the queue refetches the full block.
       res['files']?.forEach((e) {
         final String fp = e['filepath'];
         final int slash = fp.lastIndexOf('/');
@@ -365,15 +367,17 @@ class ApiManager {
             slash > 0 ? fp.substring(0, slash) : null);
         newItem.altAlbumArt = e['album_art_file'];
         if (md is Map) newItem.metadata = MusicMetadata.fromServerMap(md);
+        newItem.partialMetadata = true;
         newList.add(newItem);
       });
 
       // Lyric matches (only when the `lyrics` category is ticked; `?.` since
-      // older servers omit the key). Carries the metadata block (PR #685) for the
-      // queue, plus a `snippet` excerpt. We keep the snippet as the subtitle so
-      // the user sees WHY it matched (getSubText prefers an explicit subtext over
-      // the metadata artist); getText shows the real title once metadata is
-      // attached. `snippet` is null on the LIKE / non-FTS path → plain label.
+      // older servers omit the key). Carries the lite metadata block (PR #685)
+      // plus a `snippet` excerpt. We keep the snippet as the subtitle so the user
+      // sees WHY it matched (getSubText prefers an explicit subtext over the
+      // metadata artist); getText shows the real title once metadata is attached.
+      // `snippet` is null on the LIKE / non-FTS path → plain label. Flagged
+      // partial so the queue refetches the full block.
       res['lyrics']?.forEach((e) {
         final snippet = (e['snippet'] as String?)?.trim();
         final md = e['metadata'];
@@ -386,6 +390,7 @@ class ApiManager {
             snippet != null && snippet.isNotEmpty ? snippet : 'lyrics');
         newItem.altAlbumArt = e['album_art_file'];
         if (md is Map) newItem.metadata = MusicMetadata.fromServerMap(md);
+        newItem.partialMetadata = true;
         newList.add(newItem);
       });
 

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -102,15 +102,16 @@ enum VisualizerAudioSource {
 }
 
 /// A category the whole-server DB search (POST /api/v1/db/search) can query.
-/// The endpoint exposes these four independently through its `noArtists` /
-/// `noAlbums` / `noTitles` / `noFiles` flags, so the search dropdown lets the
-/// user tick any combination (see [SettingsManager.searchCategories]).
+/// The endpoint exposes these five independently through its `noArtists` /
+/// `noAlbums` / `noTitles` / `noFiles` / `noLyrics` flags, so the search dropdown
+/// lets the user tick any combination (see [SettingsManager.searchCategories]).
 /// Persisted as a list of names under the JSON 'searchCategories' key.
 enum SearchCategory {
   artists,
   albums,
   songs,
-  files;
+  files,
+  lyrics;
 
   // Localized labels: SearchCategoryLabel extension in lib/l10n/enum_labels.dart.
 }
@@ -138,8 +139,9 @@ class SettingsManager {
   TapBehavior tapBehavior = TapBehavior.addToQueue;
   StartupView startupView = StartupView.browser;
   // Which categories the whole-server search queries. The default
-  // (artists + albums + songs, files off) reproduces mStream's classic search;
-  // files is opt-in because bare filepath matches are noisy next to titles.
+  // (artists + albums + songs; files + lyrics off) reproduces mStream's classic
+  // search; files and lyrics are opt-in because bare filepath matches and full-
+  // text lyric matches are noisy next to titles.
   // The browser toolbar's checkbox dropdown writes this; at least one category
   // is always kept selected (see [toggleSearchCategory]).
   static const Set<SearchCategory> defaultSearchCategories = {

--- a/lib/util/queue_actions.dart
+++ b/lib/util/queue_actions.dart
@@ -37,16 +37,19 @@ MediaItem buildLocalFileMediaItem(DisplayItem i) {
 /// playback can fall back to streaming if the local file goes missing; the local
 /// path lives in extras and is re-checked at play time.
 ///
-/// A metadata-less item — an OLDER server's search hit; newer servers inline the
-/// block (PR #685) and browse/album rows always carry it — has its full metadata
-/// fetched here (POST /api/v1/db/metadata) before the MediaItem is built, so the
-/// queued track doesn't land with no album / artist / cover / duration.
-/// Best-effort: a miss or a server without the route leaves [meta] null and we
-/// fall back to the row's altAlbumArt for the cover. Items that already carry
-/// metadata skip the fetch.
+/// A search hit carries at most the lite metadata subset (PR #685, flagged
+/// [DisplayItem.partialMetadata]) and an older server's hit carries none; either
+/// way the full block is fetched here (POST /api/v1/db/metadata) before the
+/// MediaItem is built, so the queued track has the fidelity / counts / play-count
+/// the now-playing + Song Info screens show. Browsed/album rows already carry the
+/// full block and skip the fetch. Best-effort: on a miss we keep whatever the row
+/// had (the lite block, or null) and fall back to its altAlbumArt for the cover.
 Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
-  final MusicMetadata? meta =
-      i.metadata ?? await ApiManager().fetchTrackMetadata(i.server!, i.data!);
+  MusicMetadata? meta = i.metadata;
+  if (meta == null || i.partialMetadata) {
+    final full = await ApiManager().fetchTrackMetadata(i.server!, i.data!);
+    if (full != null) meta = full;
+  }
 
   final String downloadDirectory = i.server!.localname + i.data!;
   final dir = await FileExplorer()

--- a/lib/util/queue_actions.dart
+++ b/lib/util/queue_actions.dart
@@ -83,6 +83,8 @@ Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
       'trackTotal': i.metadata?.trackTotal,
       'discTotal': i.metadata?.discTotal,
       'playCount': i.metadata?.playCount,
+      // Drives the Song Info lyrics badge (tap → fetch via GET /api/v1/lyrics).
+      'hasLyrics': i.metadata?.hasLyrics ?? false,
     },
   );
 }

--- a/lib/util/queue_actions.dart
+++ b/lib/util/queue_actions.dart
@@ -12,6 +12,8 @@ import 'package:audio_service/audio_service.dart';
 import 'package:uuid/uuid.dart';
 
 import '../objects/display_item.dart';
+import '../objects/metadata.dart';
+import '../singletons/api.dart';
 import '../singletons/file_explorer.dart';
 import '../singletons/media.dart';
 import '../singletons/settings.dart';
@@ -34,7 +36,18 @@ MediaItem buildLocalFileMediaItem(DisplayItem i) {
 /// The streaming URL is the MediaItem id for BOTH local and online items, so
 /// playback can fall back to streaming if the local file goes missing; the local
 /// path lives in extras and is re-checked at play time.
+///
+/// Search results carry no metadata block — the search endpoint returns only
+/// name/filepath/art (and a fused "Artist - Title" name) — so for a metadata-less
+/// item we fetch the full block (POST /api/v1/db/metadata) first; otherwise the
+/// queued track would land with no album / artist / cover / duration. Best-effort:
+/// a miss or an older server leaves [meta] null and we fall back to the row's
+/// altAlbumArt for the cover. Browsed/album items already carry metadata, so they
+/// skip the fetch.
 Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
+  final MusicMetadata? meta =
+      i.metadata ?? await ApiManager().fetchTrackMetadata(i.server!, i.data!);
+
   final String downloadDirectory = i.server!.localname + i.data!;
   final dir = await FileExplorer()
       .getDownloadDir(i.server!.storageMode, i.server!.storageBasePath);
@@ -45,19 +58,23 @@ Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
 
   final String streamUrl = buildServerStreamUrl(i.server!, i.data!);
 
-  final String? artUrl = i.metadata?.albumArt != null
-      ? buildAlbumArtUrl(i.server!, i.metadata!.albumArt!, compress: 'l')
+  // Prefer the (fetched) metadata cover; fall back to the search row's
+  // altAlbumArt so a queued search hit keeps its art even when the metadata
+  // fetch missed.
+  final String? artFile = meta?.albumArt ?? i.altAlbumArt;
+  final String? artUrl = artFile != null
+      ? buildAlbumArtUrl(i.server!, artFile, compress: 'l')
       : null;
 
   return MediaItem(
     id: streamUrl,
-    title: i.metadata?.title ?? i.name,
-    album: i.metadata?.album,
-    artist: i.metadata?.artist,
-    genre: i.metadata?.genreLabel,
+    title: meta?.title ?? i.name,
+    album: meta?.album,
+    artist: meta?.artist,
+    genre: meta?.genreLabel,
     // Duration when the server reported it — surfaces in the queue list and the
     // now-playing readout before playback loads (just_audio refines it later).
-    duration: i.metadata?.duration,
+    duration: meta?.duration,
     // Promote album art to artUri so the notification, lock screen, and Android
     // Auto now-playing render artwork — those surfaces ignore extras['artUrl']
     // (which the in-app UI reads). Both are kept in sync.
@@ -66,25 +83,25 @@ Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
       'server': i.server!.localname,
       'path': i.data,
       if (isLocal) 'localPath': finalString,
-      'year': i.metadata?.year,
-      'track': i.metadata?.track,
-      'disc': i.metadata?.disc,
+      'year': meta?.year,
+      'track': meta?.track,
+      'disc': meta?.disc,
       // Song rating (0–10 server scale) so the now-playing screen can show +
       // edit stars for the current track without a refetch.
-      'rating': i.metadata?.rating,
+      'rating': meta?.rating,
       'artUrl': artUrl,
       // bpm + musicalKey power AutoDJ's BPM-continuity / harmonic-mixing modes.
-      'bpm': i.metadata?.bpm,
-      'musicalKey': i.metadata?.musicalKey,
+      'bpm': meta?.bpm,
+      'musicalKey': meta?.musicalKey,
       // Fidelity + counts for the Song Info screen (it reads only from extras).
-      'bitrate': i.metadata?.bitrate,
-      'sampleRate': i.metadata?.sampleRate,
-      'format': i.metadata?.format,
-      'trackTotal': i.metadata?.trackTotal,
-      'discTotal': i.metadata?.discTotal,
-      'playCount': i.metadata?.playCount,
+      'bitrate': meta?.bitrate,
+      'sampleRate': meta?.sampleRate,
+      'format': meta?.format,
+      'trackTotal': meta?.trackTotal,
+      'discTotal': meta?.discTotal,
+      'playCount': meta?.playCount,
       // Drives the Song Info lyrics badge (tap → fetch via GET /api/v1/lyrics).
-      'hasLyrics': i.metadata?.hasLyrics ?? false,
+      'hasLyrics': meta?.hasLyrics ?? false,
     },
   );
 }

--- a/lib/util/queue_actions.dart
+++ b/lib/util/queue_actions.dart
@@ -37,13 +37,13 @@ MediaItem buildLocalFileMediaItem(DisplayItem i) {
 /// playback can fall back to streaming if the local file goes missing; the local
 /// path lives in extras and is re-checked at play time.
 ///
-/// Search results carry no metadata block — the search endpoint returns only
-/// name/filepath/art (and a fused "Artist - Title" name) — so for a metadata-less
-/// item we fetch the full block (POST /api/v1/db/metadata) first; otherwise the
-/// queued track would land with no album / artist / cover / duration. Best-effort:
-/// a miss or an older server leaves [meta] null and we fall back to the row's
-/// altAlbumArt for the cover. Browsed/album items already carry metadata, so they
-/// skip the fetch.
+/// A metadata-less item — an OLDER server's search hit; newer servers inline the
+/// block (PR #685) and browse/album rows always carry it — has its full metadata
+/// fetched here (POST /api/v1/db/metadata) before the MediaItem is built, so the
+/// queued track doesn't land with no album / artist / cover / duration.
+/// Best-effort: a miss or a server without the route leaves [meta] null and we
+/// fall back to the row's altAlbumArt for the cover. Items that already carry
+/// metadata skip the fetch.
 Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
   final MusicMetadata? meta =
       i.metadata ?? await ApiManager().fetchTrackMetadata(i.server!, i.data!);


### PR DESCRIPTION
## What & why

mStream recently added a lyrics API. This surfaces it in the app: a **"Lyrics" badge on the Song Info screen**, and tapping it opens a **lyrics page**.

The server advertises lyric availability on song metadata (`has-lyrics`) and serves the text from `GET /api/v1/lyrics?path=<vpath/relpath>`, so the app shows the badge with zero extra requests and only fetches the text on demand.

## How it works

- **Availability flag** — `MusicMetadata.hasLyrics` is parsed from the server's `metadata['has-lyrics']` in `fromServerMap` (the one shared parse site, so it rides every song-list endpoint) and threaded into `MediaItem.extras['hasLyrics']`.
- **Badge** — a tappable pill on Song Info, shown only when `hasLyrics == true` **and** the track's source server + path resolve (hidden for local files and against servers that don't send the flag). Styled to match the existing metadata chips, with a chevron + ripple to signal it navigates.
- **Lyrics page** — new `LyricsScreen` fetches on open via `ApiManager.fetchLyrics()` and renders selectable text. Prefers plain lyrics; if only a synced LRC is available it's flattened to plain lines (`LyricsResult.stripLrc`). Loading / empty / error+retry states handled inline.
- **Fetch** — direct `http` (like `rateSong`, so it stays off the browser loading bar); `404` → "no lyrics". Path is per-segment encoded like the stream-URL builder, and the iroh `__lt` token is appended via `localTokenQuery`.

## Files

- `lib/objects/lyrics.dart` *(new)* — `LyricsResult` model + LRC→plain parsing
- `lib/screens/lyrics_screen.dart` *(new)* — the lyrics page
- `lib/screens/metadata_screen.dart` — the badge
- `lib/objects/metadata.dart`, `lib/util/queue_actions.dart` — `hasLyrics` plumbing
- `lib/singletons/api.dart` — `fetchLyrics`
- `lib/l10n/*` — 4 new strings (`lyricsTitle/Empty/Error/Retry`), regenerated

## Server dependency ⚠️

The `/api/v1/lyrics` endpoint and the `has-lyrics` flag live on the mStream **`feat/lyrics-backfill`** branch — **not** in master / any release yet. The app degrades gracefully: against a current server the flag is absent and the badge never appears. It lights up once the server ships the lyrics API.

## Testing

- `flutter analyze` clean on all changed files.
- Rebased onto current `master` with l10n regenerated, so the diff is a clean superset (no clobbering of PR #85's `diagnosticsVerbose` string).
- **Not** exercised at runtime — that needs a server running the lyrics branch.

## Follow-ups

- Live (karaoke) sync for synced lyrics — currently shown as static text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)