### PR TITLE
chore(deps): bump Flutter 3.44.4, share_plus 13, package_info_plus 10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         # same day doesn't surprise us mid-release-cut.
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.44.0'
+          flutter-version: '3.44.4'
           cache: true
 
       - name: Restore keystore from secret

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -7,7 +7,7 @@ A tight regression-detection loop for an existing Flutter app whose modernizatio
 ## What we have today
 
 - **App version**: 0.14.0+25
-- **Flutter**: 3.44.4 / Dart 3.12.0 (Android: AGP 9.0.1 / Gradle 9.1.0 / Kotlin 2.3.20)
+- **Flutter**: 3.44.4 / Dart 3.12.2 (Android: AGP 9.0.1 / Gradle 9.1.0 / Kotlin 2.3.20)
 - **Source tree**: `lib/main.dart` (root UI), `lib/screens/*` (page widgets), `lib/singletons/*` (state + side effects), `lib/objects/*` (data classes), `lib/media/*` (audio_service handler)
 - **Existing tests**: a 2021 boilerplate counter test that never matched the app — replaced.
 - **Baseline `flutter analyze`**: 2 minor issues

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -7,7 +7,7 @@ A tight regression-detection loop for an existing Flutter app whose modernizatio
 ## What we have today
 
 - **App version**: 0.14.0+25
-- **Flutter**: 3.44.0 / Dart 3.12.0 (Android: AGP 9.0.1 / Gradle 9.1.0 / Kotlin 2.3.20)
+- **Flutter**: 3.44.4 / Dart 3.12.0 (Android: AGP 9.0.1 / Gradle 9.1.0 / Kotlin 2.3.20)
 - **Source tree**: `lib/main.dart` (root UI), `lib/screens/*` (page widgets), `lib/singletons/*` (state + side effects), `lib/objects/*` (data classes), `lib/media/*` (audio_service handler)
 - **Existing tests**: a 2021 boilerplate counter test that never matched the app — replaced.
 - **Baseline `flutter analyze`**: 2 minor issues

--- a/lib/screens/diagnostics_screen.dart
+++ b/lib/screens/diagnostics_screen.dart
@@ -41,10 +41,15 @@ class _DiagnosticsScreenState extends State<DiagnosticsScreen> {
       final file = File(
           '${dir.path}/mstream-log-${DateTime.now().millisecondsSinceEpoch}.txt');
       await file.writeAsString(body);
-      await Share.shareXFiles([XFile(file.path, mimeType: 'text/plain')],
-          subject: 'mStream logs');
+      await SharePlus.instance.share(ShareParams(
+        files: [XFile(file.path, mimeType: 'text/plain')],
+        subject: 'mStream logs',
+      ));
     } catch (_) {
-      await Share.share(body, subject: 'mStream logs');
+      await SharePlus.instance.share(ShareParams(
+        text: body,
+        subject: 'mStream logs',
+      ));
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: "67cf6d84013f9c601e42a6f8a6b74c4c0d9dc1a1619d775f2b28b732d3551b85"
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
+      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.14"
+    version: "0.7.13"
   fading_edge_scrollview:
     dependency: transitive
     description:
@@ -193,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -291,10 +299,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: a41af4e8fc687cd6d33de9751eb936c8c0204ebe2bcb6c15ecf707504bf47f31
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.2"
   http:
     dependency: "direct main"
     description:
@@ -315,10 +323,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.1"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -512,18 +520,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      sha256: f5c435dc0e0d461e5b32471a870f769b6a1cc46930637efe24fbc535314e78ad
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "10.2.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "4.1.0"
   path:
     dependency: "direct main"
     description:
@@ -536,10 +544,10 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
@@ -560,18 +568,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:
@@ -584,10 +592,10 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
+      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "12.0.3"
   permission_handler_android:
     dependency: transitive
     description:
@@ -600,10 +608,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.7"
+    version: "9.4.10"
   permission_handler_html:
     dependency: transitive
     description:
@@ -696,18 +704,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      sha256: "9eee8283462d91a7a1c8bdb67d08874abd75a2f8fae3bc0ca033035e375fb3d8"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.4"
+    version: "13.2.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "7.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -725,42 +733,42 @@ packages:
     dependency: transitive
     description:
       name: sqflite
-      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
+      sha256: "58a799e6ac17dd32fbab93813d39ed835a75ccc0f8f85b8955fe318c6712b082"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2+1"
+    version: "2.4.3"
   sqflite_android:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
+      sha256: d0548f9d7422a2dae99ec6f8b0a3074463b132d216fa5ba0d230eeefc901983b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2+3"
+    version: "2.4.3"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465"
+      sha256: "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.8"
+    version: "2.5.11"
   sqflite_darwin:
     dependency: transitive
     description:
       name: sqflite_darwin
-      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      sha256: c86ca18b8f666bbf903924687fe21cc16fc385d086005067e26619ca530bef9f
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3+1"
   sqflite_platform_interface:
     dependency: transitive
     description:
       name: sqflite_platform_interface
-      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      sha256: f84939f84350d92d04416f8bc4dc52d3896aec7716cc9e80cf0146342139dc50
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   stack_trace:
     dependency: transitive
     description:
@@ -797,10 +805,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
+      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0+1"
+    version: "3.4.1"
   term_glyph:
     dependency: transitive
     description:
@@ -837,10 +845,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.30"
+    version: "6.3.32"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -933,10 +941,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.3.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -949,10 +957,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:
@@ -963,4 +971,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,11 +51,11 @@ dependencies:
   media_cast_dlna: ^0.3.1
   flutter_chrome_cast: ^1.4.6
   # Native share sheet for exporting diagnostic logs (Diagnostics screen).
-  share_plus: ^10.1.4
+  share_plus: ^13.2.0
   meta: any
   # Package name (applicationId) lookup so the album-art ContentProvider
   # authority always matches the manifest, regardless of --dart-define flags.
-  package_info_plus: ^8.0.0
+  package_info_plus: ^10.2.0
 dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:


### PR DESCRIPTION
## What

Upgrade the pinned Flutter version and refresh dependencies.

### Flutter 3.44.0 → 3.44.4
Patch release on the same `3.44` minor, so the AGP 9 transitional hold (which pins us to 3.44.x) is unaffected. Updates the CI pin in `release.yml` and the reference in `TEST_PLAN.md`. The Flutter SDK isn't vendored in the repo, so these are the only places the version is declared.

### share_plus `^10.1.4` → `^13.2.0`
The static `Share.share()` / `Share.shareXFiles()` APIs were removed in the 11→13 line. Migrated the diagnostics log export (`lib/screens/diagnostics_screen.dart`) to the new instance API:

```dart
await SharePlus.instance.share(ShareParams(files: [...], subject: ...));
await SharePlus.instance.share(ShareParams(text: body, subject: ...));
```

### package_info_plus `^8.0.0` → `^10.2.0`
Pulled in transitively: **share_plus 13 requires `win32 ^6`, which package_info_plus 8 caps at `<6`** — so taking the latest share_plus forces this bump too. No code change needed; `PackageInfo.fromPlatform()` / `.packageName` (used for the album-art ContentProvider authority) are unchanged.

### Minor / within-constraint bumps (`flutter pub upgrade`)
- `path_provider` 2.1.5 → 2.1.6
- `permission_handler` 12.0.1 → 12.0.3
- transitive: `image` 4.9.1, `sqflite*` 2.4.3, `xml` 7.0.1, `url_launcher_android` 6.3.32, `win32` 6.3.0, and others

### Deliberately out of scope
`connectivity_plus` stays at 6.x (its 7.x major bump touches the iroh reconnect path and is a separate change).

## Verification
- ✅ `flutter pub get` resolves
- ✅ `flutter analyze` — no new issues (16 pre-existing `info`-level lints, all in `native/`/visualizer, unrelated)
- ✅ `flutter build apk --debug --flavor full` builds successfully

> Note: the local/global Flutter SDK was **not** upgraded (it's shared across worktrees and not required for any of these packages to resolve). Run `flutter upgrade` locally when convenient to match CI's 3.44.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)