### PR TITLE
chore(deps): bump connectivity_plus 7.2.0 + just_audio/audio_service/audio_session

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: audio_service
-      sha256: cb122c7c2639d2a992421ef96b67948ad88c5221da3365ccef1031393a76e044
+      sha256: "95f3267f3449eb5cf71c8fcf1d556f57af1e898e2dc5815fb168d1843653edb7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.18"
+    version: "0.18.19"
   audio_service_platform_interface:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: "direct main"
     description:
       name: audio_session
-      sha256: "7217b229db57cc4dc577a8abb56b7429a5a212b978517a5be578704bfe5e568b"
+      sha256: f9e7711a0e24ca8b40f5d7ac374c3c6e55016f3157912badd18199cdbbca5c4d
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4"
   background_downloader:
     dependency: "direct main"
     description:
@@ -376,10 +376,10 @@ packages:
     dependency: "direct main"
     description:
       name: just_audio
-      sha256: "9694e4734f515f2a052493d1d7e0d6de219ee0427c7c29492e246ff32a219908"
+      sha256: e60aa97b233ddea025e13dfac59195207f528fa5e9e4a4a49a8c0766701e5fe6
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.5"
+    version: "0.10.6"
   just_audio_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      sha256: cad0e811a289ea2a941119dc483c204ec1684cbb9a8fc7351fe4a230b8313160
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "7.2.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   mobile_scanner: ^7.2.0
   # Network-change signal that kicks the iroh tunnel's reconnect — iroh can't
   # self-detect interface changes (Wi-Fi<->cellular) on Android.
-  connectivity_plus: ^6.1.0
+  connectivity_plus: ^7.2.0
   cupertino_icons: ^1.0.8
   path: any
   # Visualizer: FFI bindings to libprojectM (loaded from jniLibs on Android).


### PR DESCRIPTION
## What

Two within-this-branch dependency bumps:

### 1. connectivity_plus `^6.1.0` → `^7.2.0` (original scope)
The last remaining direct-dependency major bump. Feeds the **iroh tunnel's network-change reconnect** ([main.dart:194](lib/main.dart#L194)). 7.0's breaking changes were Android build-toolchain floors (AGP ≥8.12.1 / Gradle ≥8.13 / Kotlin 2.2.0), all of which this app already clears — **no code change needed**; the single call site already uses the `Stream<List<ConnectivityResult>>` API.

### 2. just_audio 0.10.6 / audio_service 0.18.19 / audio_session 0.2.4 (added)
Within-constraint patch bumps (lockfile-only). All three are AGP 9 support + Kotlin-DSL build-file migrations — **no runtime/playback behavior change**.

Notable: **`audio_session` 0.2.4 converts to built-in Kotlin**, dropping it from Flutter's KGP warning — the warning shrinks from **4 plugins to 3** (remaining: `flutter_chrome_cast`, `media_cast_dlna`, `mobile_scanner`, which are upstream-blocked). `just_audio`/`audio_service` were already converted; their bumps are build-system no-ops at runtime.

## Verification
- ✅ `flutter pub upgrade` resolves — no transitive churn
- ✅ `flutter analyze` — no new issues (16 pre-existing `info` lints)
- ✅ `flutter build apk --debug --flavor full` builds
- ✅ KGP warning confirmed reduced to 3 plugins

## Smoke test
- **connectivity_plus:** on an active iroh remote session, toggle Wi-Fi ↔ cellular / airplane mode and confirm streaming resumes without a manual reconnect.
- **audio stack:** core playback sanity (play/pause/seek/next-prev, background + lock-screen controls, audio-focus interruption) — these are build-system-only bumps, so a quick pass is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)