### PR TITLE
feat(battery): battery-optimization exemption tile (Settings)

### DIFF
--- a/android/app/src/main/kotlin/com/example/mstream_music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/MainActivity.kt
@@ -1,8 +1,11 @@
 package com.example.mstream_music
 
+import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.PowerManager
 import android.os.StatFs
+import android.provider.Settings
 import com.ryanheise.audioservice.AudioServiceActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -65,6 +68,37 @@ class MainActivity : AudioServiceActivity() {
                     "stopMove" -> {
                         try {
                             stopService(Intent(this, MigrationService::class.java))
+                            result.success(true)
+                        } catch (e: Exception) {
+                            result.success(false)
+                        }
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+
+        // Battery-optimization (Doze / OEM app-sleeping) exemption. A
+        // foreground-service music player that isn't exempt can be frozen or
+        // killed with the screen off → "playback stops". We CHECK the state and
+        // open the system screen; we deliberately use the permission-free
+        // settings-list intent, not the restricted one-tap request.
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "mstream/battery")
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "isIgnoringBatteryOptimizations" -> {
+                        try {
+                            val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+                            result.success(
+                                pm.isIgnoringBatteryOptimizations(packageName))
+                        } catch (e: Exception) {
+                            result.success(false)
+                        }
+                    }
+                    "openBatterySettings" -> {
+                        try {
+                            startActivity(
+                                Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
                             result.success(true)
                         } catch (e: Exception) {
                             result.success(false)

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -122,6 +122,18 @@
   "@onboardingSectionTitle": {
     "description": "Header above the preference controls on the first-run Add Server screen."
   },
+  "batterySettingTitle": "Keep playback alive",
+  "@batterySettingTitle": {
+    "description": "Title of the battery-optimization exemption tile in Settings."
+  },
+  "batterySettingOn": "Battery optimization is off — background playback won't be interrupted",
+  "@batterySettingOn": {
+    "description": "Battery tile subtitle when the app is already exempt from battery optimization."
+  },
+  "batterySettingOff": "Stop Android from pausing playback when the screen is off",
+  "@batterySettingOff": {
+    "description": "Battery tile subtitle when the app is NOT yet exempt; tapping opens the system screen."
+  },
   "eqTitle": "Equalizer",
   "@eqTitle": {
     "description": "Equalizer screen title / switch label."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -306,6 +306,24 @@ abstract class AppLocalizations {
   /// **'Quick setup'**
   String get onboardingSectionTitle;
 
+  /// Title of the battery-optimization exemption tile in Settings.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep playback alive'**
+  String get batterySettingTitle;
+
+  /// Battery tile subtitle when the app is already exempt from battery optimization.
+  ///
+  /// In en, this message translates to:
+  /// **'Battery optimization is off — background playback won\'t be interrupted'**
+  String get batterySettingOn;
+
+  /// Battery tile subtitle when the app is NOT yet exempt; tapping opens the system screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop Android from pausing playback when the screen is off'**
+  String get batterySettingOff;
+
   /// Equalizer screen title / switch label.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -120,6 +120,17 @@ class AppLocalizationsDe extends AppLocalizations {
   String get onboardingSectionTitle => 'Quick setup';
 
   @override
+  String get batterySettingTitle => 'Keep playback alive';
+
+  @override
+  String get batterySettingOn =>
+      'Battery optimization is off — background playback won\'t be interrupted';
+
+  @override
+  String get batterySettingOff =>
+      'Stop Android from pausing playback when the screen is off';
+
+  @override
   String get eqTitle => 'Equalizer';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -120,6 +120,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get onboardingSectionTitle => 'Quick setup';
 
   @override
+  String get batterySettingTitle => 'Keep playback alive';
+
+  @override
+  String get batterySettingOn =>
+      'Battery optimization is off — background playback won\'t be interrupted';
+
+  @override
+  String get batterySettingOff =>
+      'Stop Android from pausing playback when the screen is off';
+
+  @override
   String get eqTitle => 'Equalizer';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -120,6 +120,17 @@ class AppLocalizationsEs extends AppLocalizations {
   String get onboardingSectionTitle => 'Quick setup';
 
   @override
+  String get batterySettingTitle => 'Keep playback alive';
+
+  @override
+  String get batterySettingOn =>
+      'Battery optimization is off — background playback won\'t be interrupted';
+
+  @override
+  String get batterySettingOff =>
+      'Stop Android from pausing playback when the screen is off';
+
+  @override
   String get eqTitle => 'Ecualizador';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -120,6 +120,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get onboardingSectionTitle => 'Quick setup';
 
   @override
+  String get batterySettingTitle => 'Keep playback alive';
+
+  @override
+  String get batterySettingOn =>
+      'Battery optimization is off — background playback won\'t be interrupted';
+
+  @override
+  String get batterySettingOff =>
+      'Stop Android from pausing playback when the screen is off';
+
+  @override
   String get eqTitle => 'Égaliseur';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -120,6 +120,17 @@ class AppLocalizationsIt extends AppLocalizations {
   String get onboardingSectionTitle => 'Quick setup';
 
   @override
+  String get batterySettingTitle => 'Keep playback alive';
+
+  @override
+  String get batterySettingOn =>
+      'Battery optimization is off — background playback won\'t be interrupted';
+
+  @override
+  String get batterySettingOff =>
+      'Stop Android from pausing playback when the screen is off';
+
+  @override
   String get eqTitle => 'Equalizzatore';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -118,6 +118,17 @@ class AppLocalizationsJa extends AppLocalizations {
   String get onboardingSectionTitle => 'Quick setup';
 
   @override
+  String get batterySettingTitle => 'Keep playback alive';
+
+  @override
+  String get batterySettingOn =>
+      'Battery optimization is off — background playback won\'t be interrupted';
+
+  @override
+  String get batterySettingOff =>
+      'Stop Android from pausing playback when the screen is off';
+
+  @override
   String get eqTitle => 'イコライザー';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -122,6 +122,17 @@ class AppLocalizationsPl extends AppLocalizations {
   String get onboardingSectionTitle => 'Quick setup';
 
   @override
+  String get batterySettingTitle => 'Keep playback alive';
+
+  @override
+  String get batterySettingOn =>
+      'Battery optimization is off — background playback won\'t be interrupted';
+
+  @override
+  String get batterySettingOff =>
+      'Stop Android from pausing playback when the screen is off';
+
+  @override
   String get eqTitle => 'Korektor';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -120,6 +120,17 @@ class AppLocalizationsPt extends AppLocalizations {
   String get onboardingSectionTitle => 'Quick setup';
 
   @override
+  String get batterySettingTitle => 'Keep playback alive';
+
+  @override
+  String get batterySettingOn =>
+      'Battery optimization is off — background playback won\'t be interrupted';
+
+  @override
+  String get batterySettingOff =>
+      'Stop Android from pausing playback when the screen is off';
+
+  @override
   String get eqTitle => 'Equalizador';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -122,6 +122,17 @@ class AppLocalizationsRu extends AppLocalizations {
   String get onboardingSectionTitle => 'Quick setup';
 
   @override
+  String get batterySettingTitle => 'Keep playback alive';
+
+  @override
+  String get batterySettingOn =>
+      'Battery optimization is off — background playback won\'t be interrupted';
+
+  @override
+  String get batterySettingOff =>
+      'Stop Android from pausing playback when the screen is off';
+
+  @override
   String get eqTitle => 'Эквалайзер';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -117,6 +117,17 @@ class AppLocalizationsZh extends AppLocalizations {
   String get onboardingSectionTitle => 'Quick setup';
 
   @override
+  String get batterySettingTitle => 'Keep playback alive';
+
+  @override
+  String get batterySettingOn =>
+      'Battery optimization is off — background playback won\'t be interrupted';
+
+  @override
+  String get batterySettingOff =>
+      'Stop Android from pausing playback when the screen is off';
+
+  @override
   String get eqTitle => '均衡器';
 
   @override

--- a/lib/native/battery_optimization.dart
+++ b/lib/native/battery_optimization.dart
@@ -1,0 +1,40 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/services.dart';
+
+/// Thin wrapper over the `mstream/battery` native channel (Android only).
+///
+/// Lets the app check whether it's exempt from battery optimization (Doze / OEM
+/// app-sleeping) and open the system screen so the user can exempt it — so a
+/// foreground-service music player isn't frozen/killed with the screen off.
+/// Every method no-ops (returns false) off Android.
+class BatteryOptimization {
+  BatteryOptimization._();
+  static final BatteryOptimization _instance = BatteryOptimization._();
+  factory BatteryOptimization() => _instance;
+
+  static const MethodChannel _channel = MethodChannel('mstream/battery');
+
+  /// True when the app is already exempt from battery optimization.
+  Future<bool> isIgnored() async {
+    if (!Platform.isAndroid) return false;
+    try {
+      return await _channel
+              .invokeMethod<bool>('isIgnoringBatteryOptimizations') ??
+          false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  /// Open the system battery-optimization settings so the user can exempt the
+  /// app. Returns false if the screen couldn't be opened.
+  Future<bool> openSettings() async {
+    if (!Platform.isAndroid) return false;
+    try {
+      return await _channel.invokeMethod<bool>('openBatterySettings') ?? false;
+    } on PlatformException {
+      return false;
+    }
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -133,6 +133,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
           Divider(color: VelvetColors.border, height: 1),
           _sectionHeader(l.settingsSectionPlayback),
+          const BatteryOptimizationTile(),
           SwitchListTile(
             title: Text(l.settingsResumeQueue),
             subtitle: Text(

--- a/lib/widgets/settings_controls.dart
+++ b/lib/widgets/settings_controls.dart
@@ -3,11 +3,14 @@
 // self-contained StatefulWidget that reads/writes SettingsManager and owns its
 // own setState, so it looks and behaves identically wherever it's dropped in.
 
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../l10n/app_localizations.dart';
 import '../l10n/enum_labels.dart';
+import '../native/battery_optimization.dart';
 import '../singletons/settings.dart';
 import '../theme/velvet_theme.dart';
 
@@ -228,6 +231,66 @@ class _VisualizerSourceSettingTileState
             .toList(),
         onChanged: _onChanged,
       ),
+    );
+  }
+}
+
+// ── Battery-optimization exemption (Android-only; hides elsewhere) ───────────
+class BatteryOptimizationTile extends StatefulWidget {
+  const BatteryOptimizationTile({super.key});
+
+  @override
+  State<BatteryOptimizationTile> createState() =>
+      _BatteryOptimizationTileState();
+}
+
+class _BatteryOptimizationTileState extends State<BatteryOptimizationTile>
+    with WidgetsBindingObserver {
+  bool _exempt = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _refresh();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  // Re-check after the user comes back from the system settings screen.
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) _refresh();
+  }
+
+  Future<void> _refresh() async {
+    final v = await BatteryOptimization().isIgnored();
+    if (mounted) setState(() => _exempt = v);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // The exemption is an Android concept; render nothing on other platforms.
+    if (!Platform.isAndroid) return const SizedBox.shrink();
+    final l = AppLocalizations.of(context);
+    return ListTile(
+      leading: Icon(
+        _exempt ? Icons.battery_charging_full : Icons.battery_alert,
+        color: _exempt ? VelvetColors.primary : VelvetColors.textSecondary,
+      ),
+      title: Text(l.batterySettingTitle, overflow: TextOverflow.ellipsis),
+      subtitle: Text(_exempt ? l.batterySettingOn : l.batterySettingOff,
+          style: _subtitleStyle),
+      trailing: _exempt
+          ? Icon(Icons.check_circle, color: VelvetColors.primary)
+          : Icon(Icons.chevron_right, color: VelvetColors.textSecondary),
+      // Already exempt → nothing to do; otherwise open the system screen and
+      // let didChangeAppLifecycleState refresh the state on return.
+      onTap: _exempt ? null : () => BatteryOptimization().openSettings(),
     );
   }
 }


### PR DESCRIPTION
## What
A **Settings-only** battery-optimization exemption for users on aggressive OEMs.

- **Native channel** — `mstream/battery` (`isIgnoringBatteryOptimizations` + open the permission-free `ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS`) + a `BatteryOptimization` Dart wrapper (Android-only).
- **Settings tile** — "Keep playback alive" in Settings → Playback (reflects exemption state, opens the system screen, re-checks on resume).

## Stacking
Stacked on **#93** (the Add Server / shared-controls PR) because the tile lives alongside those extracted controls. Retarget to `master` once #93 merges.

## Note
An earlier revision had a proactive upgrade nudge; dropped after observing even YouTube Music runs "Optimized" (a correct foreground service is the real mechanism; Google/OEM apps get privileged treatment mStream can't access). The exemption is a passive opt-in only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)