### PR TITLE
feat(add-server): first-run Quick Setup card + colorful Add Server button

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -66,8 +66,6 @@
   "visualizerEngineSubtitleMilkdrop": "Milkdrop-Presets über projectM (Standard). Reichhaltigere Effekte, höhere GPU-Last.",
   "visualizerEngineSubtitleShaders": "Fragment-Shader im Shadertoy-Stil. Leichter, modular – lege .glsl-Dateien in assets/shaders/ ab, um den Katalog zu erweitern.",
   "settingsVisualizerSource": "Visualizer-Audioquelle",
-  "visualizerSourceSubtitleSynthesized": "Standard. Der Visualizer reagiert nur auf das Wiedergabe-Timing – keine Mikrofonberechtigung erforderlich.",
-  "visualizerSourceSubtitleReal": "Der Visualizer reagiert auf die tatsächliche Audioausgabe. Erfordert die RECORD_AUDIO-Berechtigung unter Android.",
   "settingsAlbumGrid": "Album-Rasteransicht",
   "settingsAlbumGridSubtitle": "Alben als Raster von Karten mit Cover-Art statt als einfache Liste anzeigen.",
   "settingsFileMetadata": "Song-Metadaten im Datei-Explorer lesen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -217,6 +217,7 @@
   "settingsVisualizerSource": "Visualizer audio source",
   "visualizerSourceSubtitleSynthesized": "Default. Visualizer reacts to playback timing only — no microphone permission required.",
   "visualizerSourceSubtitleReal": "Visualizer reacts to actual audio output. Requires the RECORD_AUDIO permission on Android.",
+  "visualizerSourcePermission": "Real Audio requires the RECORD_AUDIO permission.",
   "@settingsVisualizerSource": {
     "description": "Visualizer audio-source picker row label + per-source subtitles."
   },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -215,11 +215,9 @@
     "description": "Visualizer-engine picker row label + per-engine subtitles."
   },
   "settingsVisualizerSource": "Visualizer audio source",
-  "visualizerSourceSubtitleSynthesized": "Default. Visualizer reacts to playback timing only — no microphone permission required.",
-  "visualizerSourceSubtitleReal": "Visualizer reacts to actual audio output. Requires the RECORD_AUDIO permission on Android.",
   "visualizerSourcePermission": "Real Audio requires the RECORD_AUDIO permission.",
   "@settingsVisualizerSource": {
-    "description": "Visualizer audio-source picker row label + per-source subtitles."
+    "description": "Visualizer audio-source picker row label."
   },
   "settingsAlbumGrid": "Album grid view",
   "settingsAlbumGridSubtitle": "Show albums as a grid of cards with cover art instead of a plain list.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -198,8 +198,8 @@
   "settingsTapBehavior": "When you tap a song",
   "settingsStartupPage": "Startup page",
   "settingsStartupPageSubtitle": "Open the app to this browser view; Back returns to the browser.",
-  "tapSubtitleAddToQueue": "Tapping a song appends it to the queue. If the queue is empty, playback starts automatically.",
-  "tapSubtitlePlayFromHere": "Replaces the queue with the songs in the current view and plays from the tapped song — the usual streaming-app (Spotify-style) behaviour.",
+  "tapSubtitleAddToQueue": "Append the song to the end of the queue. For Spotify-like behavior, use 'Play from here'.",
+  "tapSubtitlePlayFromHere": "Replaces the queue with the songs in the current view and plays from the tapped song.",
   "tapSubtitleAppendAndJump": "Tapping a song appends it to the queue and jumps playback to it, interrupting whatever was playing.",
   "@settingsTapBehavior": {
     "description": "Tap-behavior picker row label + per-mode subtitles."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -33,7 +33,7 @@
   "@settingsLanguage": {
     "description": "Settings row label for the language picker."
   },
-  "languageSystemDefault": "System default",
+  "languageSystemDefault": "Default",
   "@languageSystemDefault": {
     "description": "First entry in the language picker: follow the OS locale."
   },
@@ -118,9 +118,13 @@
   "@lyricsRetry": {
     "description": "Button to retry loading lyrics after an error."
   },
-  "onboardingSectionTitle": "Quick setup",
-  "@onboardingSectionTitle": {
-    "description": "Header above the preference controls on the first-run Add Server screen."
+  "quickSetupTheme": "Theme",
+  "@quickSetupTheme": {
+    "description": "Section header in the first-run Quick setup (accent colour)."
+  },
+  "quickSetupConfig": "Config",
+  "@quickSetupConfig": {
+    "description": "Section header in the first-run Quick setup (language / tap / visualizer)."
   },
   "eqTitle": "Equalizer",
   "@eqTitle": {
@@ -195,7 +199,7 @@
   "settingsStartupPage": "Startup page",
   "settingsStartupPageSubtitle": "Open the app to this browser view; Back returns to the browser.",
   "tapSubtitleAddToQueue": "Tapping a song appends it to the queue. If the queue is empty, playback starts automatically.",
-  "tapSubtitlePlayFromHere": "Tapping a song replaces the queue with the songs in the current view and starts playback at the tapped song.",
+  "tapSubtitlePlayFromHere": "Replaces the queue with the songs in the current view and plays from the tapped song — the usual streaming-app (Spotify-style) behaviour.",
   "tapSubtitleAppendAndJump": "Tapping a song appends it to the queue and jumps playback to it, interrupting whatever was playing.",
   "@settingsTapBehavior": {
     "description": "Tap-behavior picker row label + per-mode subtitles."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -118,6 +118,10 @@
   "@lyricsRetry": {
     "description": "Button to retry loading lyrics after an error."
   },
+  "onboardingSectionTitle": "Quick setup",
+  "@onboardingSectionTitle": {
+    "description": "Header above the preference controls on the first-run Add Server screen."
+  },
   "eqTitle": "Equalizer",
   "@eqTitle": {
     "description": "Equalizer screen title / switch label."

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -66,8 +66,6 @@
   "visualizerEngineSubtitleMilkdrop": "Presets de Milkdrop mediante projectM (predeterminado). Efectos más ricos, mayor carga en la GPU.",
   "visualizerEngineSubtitleShaders": "Shaders de fragmento al estilo Shadertoy. Más ligeros y modulares — coloca archivos .glsl en assets/shaders/ para ampliar el catálogo.",
   "settingsVisualizerSource": "Fuente de audio del visualizador",
-  "visualizerSourceSubtitleSynthesized": "Predeterminado. El visualizador reacciona solo a la sincronización de reproducción — no requiere permiso de micrófono.",
-  "visualizerSourceSubtitleReal": "El visualizador reacciona a la salida de audio real. Requiere el permiso RECORD_AUDIO en Android.",
   "settingsAlbumGrid": "Vista de cuadrícula de álbumes",
   "settingsAlbumGridSubtitle": "Muestra los álbumes como una cuadrícula de tarjetas con la portada en lugar de una lista simple.",
   "settingsFileMetadata": "Leer metadatos de canciones en el explorador de archivos",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -66,8 +66,6 @@
   "visualizerEngineSubtitleMilkdrop": "Préréglages Milkdrop via projectM (par défaut). Effets plus riches, plus exigeants pour le GPU.",
   "visualizerEngineSubtitleShaders": "Fragment shaders de style Shadertoy. Plus légers et modulaires — déposez des fichiers .glsl dans assets/shaders/ pour enrichir le catalogue.",
   "settingsVisualizerSource": "Source audio du visualiseur",
-  "visualizerSourceSubtitleSynthesized": "Par défaut. Le visualiseur réagit uniquement au rythme de lecture — aucune autorisation micro requise.",
-  "visualizerSourceSubtitleReal": "Le visualiseur réagit à la sortie audio réelle. Nécessite l'autorisation RECORD_AUDIO sur Android.",
   "settingsAlbumGrid": "Vue en grille des albums",
   "settingsAlbumGridSubtitle": "Afficher les albums sous forme de grille de cartes avec les pochettes au lieu d'une simple liste.",
   "settingsFileMetadata": "Lire les métadonnées dans l'explorateur de fichiers",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -66,8 +66,6 @@
   "visualizerEngineSubtitleMilkdrop": "Preset di Milkdrop tramite projectM (predefinito). Effetti più ricchi, più impegnativi per la GPU.",
   "visualizerEngineSubtitleShaders": "Shader di frammento in stile Shadertoy. Più leggeri e modulari — inserisci file .glsl in assets/shaders/ per ampliare il catalogo.",
   "settingsVisualizerSource": "Sorgente audio del visualizzatore",
-  "visualizerSourceSubtitleSynthesized": "Predefinito. Il visualizzatore reagisce solo alla temporizzazione della riproduzione — non richiede il permesso del microfono.",
-  "visualizerSourceSubtitleReal": "Il visualizzatore reagisce all’uscita audio reale. Richiede il permesso RECORD_AUDIO su Android.",
   "settingsAlbumGrid": "Vista a griglia degli album",
   "settingsAlbumGridSubtitle": "Mostra gli album come una griglia di schede con la copertina invece di un semplice elenco.",
   "settingsFileMetadata": "Leggi i metadati dei brani nell’esplora file",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -66,8 +66,6 @@
   "visualizerEngineSubtitleMilkdrop": "projectM による Milkdrop プリセット（デフォルト）。効果が豊かで、GPU への負荷が高めです。",
   "visualizerEngineSubtitleShaders": "Shadertoy スタイルのフラグメントシェーダー。軽量でモジュール式 — assets/shaders/ に .glsl ファイルを置くとカタログを拡張できます。",
   "settingsVisualizerSource": "ビジュアライザーの音声ソース",
-  "visualizerSourceSubtitleSynthesized": "デフォルト。ビジュアライザーは再生タイミングのみに反応します — マイクの権限は不要です。",
-  "visualizerSourceSubtitleReal": "ビジュアライザーが実際の音声出力に反応します。Android では RECORD_AUDIO 権限が必要です。",
   "settingsAlbumGrid": "アルバムのグリッド表示",
   "settingsAlbumGridSubtitle": "アルバムを単純なリストではなく、ジャケット付きのカードのグリッドで表示します。",
   "settingsFileMetadata": "ファイルエクスプローラーで曲のメタデータを読み取る",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -300,6 +300,12 @@ abstract class AppLocalizations {
   /// **'Retry'**
   String get lyricsRetry;
 
+  /// Header above the preference controls on the first-run Add Server screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Quick setup'**
+  String get onboardingSectionTitle;
+
   /// Equalizer screen title / switch label.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -501,13 +501,13 @@ abstract class AppLocalizations {
   /// No description provided for @tapSubtitleAddToQueue.
   ///
   /// In en, this message translates to:
-  /// **'Tapping a song appends it to the queue. If the queue is empty, playback starts automatically.'**
+  /// **'Append the song to the end of the queue. For Spotify-like behavior, use \'Play from here\'.'**
   String get tapSubtitleAddToQueue;
 
   /// No description provided for @tapSubtitlePlayFromHere.
   ///
   /// In en, this message translates to:
-  /// **'Replaces the queue with the songs in the current view and plays from the tapped song — the usual streaming-app (Spotify-style) behaviour.'**
+  /// **'Replaces the queue with the songs in the current view and plays from the tapped song.'**
   String get tapSubtitlePlayFromHere;
 
   /// No description provided for @tapSubtitleAppendAndJump.

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -540,23 +540,11 @@ abstract class AppLocalizations {
   /// **'Shadertoy-style fragment shaders. Lighter, modular — drop .glsl files in assets/shaders/ to extend the catalog.'**
   String get visualizerEngineSubtitleShaders;
 
-  /// Visualizer audio-source picker row label + per-source subtitles.
+  /// Visualizer audio-source picker row label.
   ///
   /// In en, this message translates to:
   /// **'Visualizer audio source'**
   String get settingsVisualizerSource;
-
-  /// No description provided for @visualizerSourceSubtitleSynthesized.
-  ///
-  /// In en, this message translates to:
-  /// **'Default. Visualizer reacts to playback timing only — no microphone permission required.'**
-  String get visualizerSourceSubtitleSynthesized;
-
-  /// No description provided for @visualizerSourceSubtitleReal.
-  ///
-  /// In en, this message translates to:
-  /// **'Visualizer reacts to actual audio output. Requires the RECORD_AUDIO permission on Android.'**
-  String get visualizerSourceSubtitleReal;
 
   /// No description provided for @visualizerSourcePermission.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -558,6 +558,12 @@ abstract class AppLocalizations {
   /// **'Visualizer reacts to actual audio output. Requires the RECORD_AUDIO permission on Android.'**
   String get visualizerSourceSubtitleReal;
 
+  /// No description provided for @visualizerSourcePermission.
+  ///
+  /// In en, this message translates to:
+  /// **'Real Audio requires the RECORD_AUDIO permission.'**
+  String get visualizerSourcePermission;
+
   /// Album-grid toggle row.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -171,7 +171,7 @@ abstract class AppLocalizations {
   /// First entry in the language picker: follow the OS locale.
   ///
   /// In en, this message translates to:
-  /// **'System default'**
+  /// **'Default'**
   String get languageSystemDefault;
 
   /// Subtitle under the language picker row in Settings.
@@ -300,11 +300,17 @@ abstract class AppLocalizations {
   /// **'Retry'**
   String get lyricsRetry;
 
-  /// Header above the preference controls on the first-run Add Server screen.
+  /// Section header in the first-run Quick setup (accent colour).
   ///
   /// In en, this message translates to:
-  /// **'Quick setup'**
-  String get onboardingSectionTitle;
+  /// **'Theme'**
+  String get quickSetupTheme;
+
+  /// Section header in the first-run Quick setup (language / tap / visualizer).
+  ///
+  /// In en, this message translates to:
+  /// **'Config'**
+  String get quickSetupConfig;
 
   /// Equalizer screen title / switch label.
   ///
@@ -501,7 +507,7 @@ abstract class AppLocalizations {
   /// No description provided for @tapSubtitlePlayFromHere.
   ///
   /// In en, this message translates to:
-  /// **'Tapping a song replaces the queue with the songs in the current view and starts playback at the tapped song.'**
+  /// **'Replaces the queue with the songs in the current view and plays from the tapped song — the usual streaming-app (Spotify-style) behaviour.'**
   String get tapSubtitlePlayFromHere;
 
   /// No description provided for @tapSubtitleAppendAndJump.

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -257,14 +257,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsVisualizerSource => 'Visualizer-Audioquelle';
 
   @override
-  String get visualizerSourceSubtitleSynthesized =>
-      'Standard. Der Visualizer reagiert nur auf das Wiedergabe-Timing – keine Mikrofonberechtigung erforderlich.';
-
-  @override
-  String get visualizerSourceSubtitleReal =>
-      'Der Visualizer reagiert auf die tatsächliche Audioausgabe. Erfordert die RECORD_AUDIO-Berechtigung unter Android.';
-
-  @override
   String get visualizerSourcePermission =>
       'Real Audio requires the RECORD_AUDIO permission.';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -117,7 +117,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
-  String get onboardingSectionTitle => 'Quick setup';
+  String get quickSetupTheme => 'Theme';
+
+  @override
+  String get quickSetupConfig => 'Config';
 
   @override
   String get eqTitle => 'Equalizer';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -117,6 +117,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
+  String get onboardingSectionTitle => 'Quick setup';
+
+  @override
   String get eqTitle => 'Equalizer';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -265,6 +265,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Der Visualizer reagiert auf die tatsächliche Audioausgabe. Erfordert die RECORD_AUDIO-Berechtigung unter Android.';
 
   @override
+  String get visualizerSourcePermission =>
+      'Real Audio requires the RECORD_AUDIO permission.';
+
+  @override
   String get settingsAlbumGrid => 'Album-Rasteransicht';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -227,11 +227,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get tapSubtitleAddToQueue =>
-      'Tapping a song appends it to the queue. If the queue is empty, playback starts automatically.';
+      'Append the song to the end of the queue. For Spotify-like behavior, use \'Play from here\'.';
 
   @override
   String get tapSubtitlePlayFromHere =>
-      'Replaces the queue with the songs in the current view and plays from the tapped song — the usual streaming-app (Spotify-style) behaviour.';
+      'Replaces the queue with the songs in the current view and plays from the tapped song.';
 
   @override
   String get tapSubtitleAppendAndJump =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -255,14 +255,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsVisualizerSource => 'Visualizer audio source';
 
   @override
-  String get visualizerSourceSubtitleSynthesized =>
-      'Default. Visualizer reacts to playback timing only — no microphone permission required.';
-
-  @override
-  String get visualizerSourceSubtitleReal =>
-      'Visualizer reacts to actual audio output. Requires the RECORD_AUDIO permission on Android.';
-
-  @override
   String get visualizerSourcePermission =>
       'Real Audio requires the RECORD_AUDIO permission.';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -117,6 +117,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
+  String get onboardingSectionTitle => 'Quick setup';
+
+  @override
   String get eqTitle => 'Equalizer';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -37,7 +37,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsLanguage => 'Language';
 
   @override
-  String get languageSystemDefault => 'System default';
+  String get languageSystemDefault => 'Default';
 
   @override
   String get settingsLanguageSubtitle =>
@@ -117,7 +117,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
-  String get onboardingSectionTitle => 'Quick setup';
+  String get quickSetupTheme => 'Theme';
+
+  @override
+  String get quickSetupConfig => 'Config';
 
   @override
   String get eqTitle => 'Equalizer';
@@ -228,7 +231,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get tapSubtitlePlayFromHere =>
-      'Tapping a song replaces the queue with the songs in the current view and starts playback at the tapped song.';
+      'Replaces the queue with the songs in the current view and plays from the tapped song — the usual streaming-app (Spotify-style) behaviour.';
 
   @override
   String get tapSubtitleAppendAndJump =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -263,6 +263,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Visualizer reacts to actual audio output. Requires the RECORD_AUDIO permission on Android.';
 
   @override
+  String get visualizerSourcePermission =>
+      'Real Audio requires the RECORD_AUDIO permission.';
+
+  @override
   String get settingsAlbumGrid => 'Album grid view';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -264,6 +264,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'El visualizador reacciona a la salida de audio real. Requiere el permiso RECORD_AUDIO en Android.';
 
   @override
+  String get visualizerSourcePermission =>
+      'Real Audio requires the RECORD_AUDIO permission.';
+
+  @override
   String get settingsAlbumGrid => 'Vista de cuadrícula de álbumes';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -256,14 +256,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsVisualizerSource => 'Fuente de audio del visualizador';
 
   @override
-  String get visualizerSourceSubtitleSynthesized =>
-      'Predeterminado. El visualizador reacciona solo a la sincronización de reproducción — no requiere permiso de micrófono.';
-
-  @override
-  String get visualizerSourceSubtitleReal =>
-      'El visualizador reacciona a la salida de audio real. Requiere el permiso RECORD_AUDIO en Android.';
-
-  @override
   String get visualizerSourcePermission =>
       'Real Audio requires the RECORD_AUDIO permission.';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -117,6 +117,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
+  String get onboardingSectionTitle => 'Quick setup';
+
+  @override
   String get eqTitle => 'Ecualizador';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -117,7 +117,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
-  String get onboardingSectionTitle => 'Quick setup';
+  String get quickSetupTheme => 'Theme';
+
+  @override
+  String get quickSetupConfig => 'Config';
 
   @override
   String get eqTitle => 'Ecualizador';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -117,7 +117,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
-  String get onboardingSectionTitle => 'Quick setup';
+  String get quickSetupTheme => 'Theme';
+
+  @override
+  String get quickSetupConfig => 'Config';
 
   @override
   String get eqTitle => 'Égaliseur';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -264,6 +264,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Le visualiseur réagit à la sortie audio réelle. Nécessite l\'autorisation RECORD_AUDIO sur Android.';
 
   @override
+  String get visualizerSourcePermission =>
+      'Real Audio requires the RECORD_AUDIO permission.';
+
+  @override
   String get settingsAlbumGrid => 'Vue en grille des albums';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -256,14 +256,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsVisualizerSource => 'Source audio du visualiseur';
 
   @override
-  String get visualizerSourceSubtitleSynthesized =>
-      'Par défaut. Le visualiseur réagit uniquement au rythme de lecture — aucune autorisation micro requise.';
-
-  @override
-  String get visualizerSourceSubtitleReal =>
-      'Le visualiseur réagit à la sortie audio réelle. Nécessite l\'autorisation RECORD_AUDIO sur Android.';
-
-  @override
   String get visualizerSourcePermission =>
       'Real Audio requires the RECORD_AUDIO permission.';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -117,6 +117,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
+  String get onboardingSectionTitle => 'Quick setup';
+
+  @override
   String get eqTitle => 'Égaliseur';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -117,7 +117,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
-  String get onboardingSectionTitle => 'Quick setup';
+  String get quickSetupTheme => 'Theme';
+
+  @override
+  String get quickSetupConfig => 'Config';
 
   @override
   String get eqTitle => 'Equalizzatore';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -256,14 +256,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsVisualizerSource => 'Sorgente audio del visualizzatore';
 
   @override
-  String get visualizerSourceSubtitleSynthesized =>
-      'Predefinito. Il visualizzatore reagisce solo alla temporizzazione della riproduzione — non richiede il permesso del microfono.';
-
-  @override
-  String get visualizerSourceSubtitleReal =>
-      'Il visualizzatore reagisce all’uscita audio reale. Richiede il permesso RECORD_AUDIO su Android.';
-
-  @override
   String get visualizerSourcePermission =>
       'Real Audio requires the RECORD_AUDIO permission.';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -117,6 +117,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
+  String get onboardingSectionTitle => 'Quick setup';
+
+  @override
   String get eqTitle => 'Equalizzatore';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -264,6 +264,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Il visualizzatore reagisce all’uscita audio reale. Richiede il permesso RECORD_AUDIO su Android.';
 
   @override
+  String get visualizerSourcePermission =>
+      'Real Audio requires the RECORD_AUDIO permission.';
+
+  @override
   String get settingsAlbumGrid => 'Vista a griglia degli album';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -259,6 +259,10 @@ class AppLocalizationsJa extends AppLocalizations {
       'ビジュアライザーが実際の音声出力に反応します。Android では RECORD_AUDIO 権限が必要です。';
 
   @override
+  String get visualizerSourcePermission =>
+      'Real Audio requires the RECORD_AUDIO permission.';
+
+  @override
   String get settingsAlbumGrid => 'アルバムのグリッド表示';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -115,6 +115,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
+  String get onboardingSectionTitle => 'Quick setup';
+
+  @override
   String get eqTitle => 'イコライザー';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -115,7 +115,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
-  String get onboardingSectionTitle => 'Quick setup';
+  String get quickSetupTheme => 'Theme';
+
+  @override
+  String get quickSetupConfig => 'Config';
 
   @override
   String get eqTitle => 'イコライザー';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -251,14 +251,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsVisualizerSource => 'ビジュアライザーの音声ソース';
 
   @override
-  String get visualizerSourceSubtitleSynthesized =>
-      'デフォルト。ビジュアライザーは再生タイミングのみに反応します — マイクの権限は不要です。';
-
-  @override
-  String get visualizerSourceSubtitleReal =>
-      'ビジュアライザーが実際の音声出力に反応します。Android では RECORD_AUDIO 権限が必要です。';
-
-  @override
   String get visualizerSourcePermission =>
       'Real Audio requires the RECORD_AUDIO permission.';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -258,14 +258,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsVisualizerSource => 'Źródło dźwięku wizualizatora';
 
   @override
-  String get visualizerSourceSubtitleSynthesized =>
-      'Domyślnie. Wizualizator reaguje tylko na taktowanie odtwarzania — nie wymaga uprawnienia do mikrofonu.';
-
-  @override
-  String get visualizerSourceSubtitleReal =>
-      'Wizualizator reaguje na rzeczywiste wyjście dźwięku. Wymaga uprawnienia RECORD_AUDIO na Androidzie.';
-
-  @override
   String get visualizerSourcePermission =>
       'Real Audio requires the RECORD_AUDIO permission.';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -266,6 +266,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Wizualizator reaguje na rzeczywiste wyjście dźwięku. Wymaga uprawnienia RECORD_AUDIO na Androidzie.';
 
   @override
+  String get visualizerSourcePermission =>
+      'Real Audio requires the RECORD_AUDIO permission.';
+
+  @override
   String get settingsAlbumGrid => 'Widok siatki albumów';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -119,7 +119,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
-  String get onboardingSectionTitle => 'Quick setup';
+  String get quickSetupTheme => 'Theme';
+
+  @override
+  String get quickSetupConfig => 'Config';
 
   @override
   String get eqTitle => 'Korektor';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -119,6 +119,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
+  String get onboardingSectionTitle => 'Quick setup';
+
+  @override
   String get eqTitle => 'Korektor';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -256,14 +256,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsVisualizerSource => 'Fonte de áudio do visualizador';
 
   @override
-  String get visualizerSourceSubtitleSynthesized =>
-      'Padrão. O visualizador reage apenas ao tempo da reprodução — não exige permissão de microfone.';
-
-  @override
-  String get visualizerSourceSubtitleReal =>
-      'O visualizador reage à saída de áudio real. Exige a permissão RECORD_AUDIO no Android.';
-
-  @override
   String get visualizerSourcePermission =>
       'Real Audio requires the RECORD_AUDIO permission.';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -117,7 +117,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
-  String get onboardingSectionTitle => 'Quick setup';
+  String get quickSetupTheme => 'Theme';
+
+  @override
+  String get quickSetupConfig => 'Config';
 
   @override
   String get eqTitle => 'Equalizador';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -117,6 +117,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
+  String get onboardingSectionTitle => 'Quick setup';
+
+  @override
   String get eqTitle => 'Equalizador';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -264,6 +264,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'O visualizador reage à saída de áudio real. Exige a permissão RECORD_AUDIO no Android.';
 
   @override
+  String get visualizerSourcePermission =>
+      'Real Audio requires the RECORD_AUDIO permission.';
+
+  @override
   String get settingsAlbumGrid => 'Visualização em grade de álbuns';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -119,6 +119,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
+  String get onboardingSectionTitle => 'Quick setup';
+
+  @override
   String get eqTitle => 'Эквалайзер';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -119,7 +119,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
-  String get onboardingSectionTitle => 'Quick setup';
+  String get quickSetupTheme => 'Theme';
+
+  @override
+  String get quickSetupConfig => 'Config';
 
   @override
   String get eqTitle => 'Эквалайзер';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -266,6 +266,10 @@ class AppLocalizationsRu extends AppLocalizations {
       'Визуализация реагирует на реальный аудиовыход. Требуется разрешение RECORD_AUDIO на Android.';
 
   @override
+  String get visualizerSourcePermission =>
+      'Real Audio requires the RECORD_AUDIO permission.';
+
+  @override
   String get settingsAlbumGrid => 'Альбомы сеткой';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -258,14 +258,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settingsVisualizerSource => 'Источник звука визуализации';
 
   @override
-  String get visualizerSourceSubtitleSynthesized =>
-      'По умолчанию. Визуализация реагирует только на тайминг воспроизведения — разрешение на микрофон не требуется.';
-
-  @override
-  String get visualizerSourceSubtitleReal =>
-      'Визуализация реагирует на реальный аудиовыход. Требуется разрешение RECORD_AUDIO на Android.';
-
-  @override
   String get visualizerSourcePermission =>
       'Real Audio requires the RECORD_AUDIO permission.';
 

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -114,7 +114,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
-  String get onboardingSectionTitle => 'Quick setup';
+  String get quickSetupTheme => 'Theme';
+
+  @override
+  String get quickSetupConfig => 'Config';
 
   @override
   String get eqTitle => '均衡器';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -114,6 +114,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get lyricsRetry => 'Retry';
 
   @override
+  String get onboardingSectionTitle => 'Quick setup';
+
+  @override
   String get eqTitle => '均衡器';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -252,6 +252,10 @@ class AppLocalizationsZh extends AppLocalizations {
       '可视化效果根据实际音频输出作出反应。需要 Android 的 RECORD_AUDIO 权限。';
 
   @override
+  String get visualizerSourcePermission =>
+      'Real Audio requires the RECORD_AUDIO permission.';
+
+  @override
   String get settingsAlbumGrid => '专辑网格视图';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -244,14 +244,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsVisualizerSource => '可视化音频来源';
 
   @override
-  String get visualizerSourceSubtitleSynthesized =>
-      '默认。可视化效果仅根据播放时间作出反应 — 无需麦克风权限。';
-
-  @override
-  String get visualizerSourceSubtitleReal =>
-      '可视化效果根据实际音频输出作出反应。需要 Android 的 RECORD_AUDIO 权限。';
-
-  @override
   String get visualizerSourcePermission =>
       'Real Audio requires the RECORD_AUDIO permission.';
 

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -66,8 +66,6 @@
   "visualizerEngineSubtitleMilkdrop": "Presety Milkdrop przez projectM (domyślnie). Bogatsze efekty, większe obciążenie GPU.",
   "visualizerEngineSubtitleShaders": "Shadery fragmentów w stylu Shadertoy. Lżejsze, modułowe — umieść pliki .glsl w assets/shaders/, aby rozszerzyć katalog.",
   "settingsVisualizerSource": "Źródło dźwięku wizualizatora",
-  "visualizerSourceSubtitleSynthesized": "Domyślnie. Wizualizator reaguje tylko na taktowanie odtwarzania — nie wymaga uprawnienia do mikrofonu.",
-  "visualizerSourceSubtitleReal": "Wizualizator reaguje na rzeczywiste wyjście dźwięku. Wymaga uprawnienia RECORD_AUDIO na Androidzie.",
   "settingsAlbumGrid": "Widok siatki albumów",
   "settingsAlbumGridSubtitle": "Pokazuj albumy jako siatkę kart z okładkami zamiast zwykłej listy.",
   "settingsFileMetadata": "Odczytuj metadane utworów w eksploratorze plików",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -66,8 +66,6 @@
   "visualizerEngineSubtitleMilkdrop": "Predefinições do Milkdrop via projectM (padrão). Efeitos mais ricos, mais pesados para a GPU.",
   "visualizerEngineSubtitleShaders": "Shaders de fragmento no estilo Shadertoy. Mais leves e modulares — coloque arquivos .glsl em assets/shaders/ para ampliar o catálogo.",
   "settingsVisualizerSource": "Fonte de áudio do visualizador",
-  "visualizerSourceSubtitleSynthesized": "Padrão. O visualizador reage apenas ao tempo da reprodução — não exige permissão de microfone.",
-  "visualizerSourceSubtitleReal": "O visualizador reage à saída de áudio real. Exige a permissão RECORD_AUDIO no Android.",
   "settingsAlbumGrid": "Visualização em grade de álbuns",
   "settingsAlbumGridSubtitle": "Mostra os álbuns como uma grade de cartões com capas em vez de uma lista simples.",
   "settingsFileMetadata": "Ler metadados das músicas no explorador de arquivos",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -66,8 +66,6 @@
   "visualizerEngineSubtitleMilkdrop": "Пресеты Milkdrop через projectM (по умолчанию). Более насыщенные эффекты, выше нагрузка на GPU.",
   "visualizerEngineSubtitleShaders": "Фрагментные шейдеры в стиле Shadertoy. Легче и модульнее — добавляйте файлы .glsl в assets/shaders/, чтобы расширить каталог.",
   "settingsVisualizerSource": "Источник звука визуализации",
-  "visualizerSourceSubtitleSynthesized": "По умолчанию. Визуализация реагирует только на тайминг воспроизведения — разрешение на микрофон не требуется.",
-  "visualizerSourceSubtitleReal": "Визуализация реагирует на реальный аудиовыход. Требуется разрешение RECORD_AUDIO на Android.",
   "settingsAlbumGrid": "Альбомы сеткой",
   "settingsAlbumGridSubtitle": "Показывать альбомы сеткой карточек с обложками вместо обычного списка.",
   "settingsFileMetadata": "Читать метаданные треков в проводнике файлов",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -66,8 +66,6 @@
   "visualizerEngineSubtitleMilkdrop": "通过 projectM 使用 Milkdrop 预设（默认）。效果更丰富，但更消耗 GPU。",
   "visualizerEngineSubtitleShaders": "Shadertoy 风格的片段着色器。更轻量、模块化 — 将 .glsl 文件放入 assets/shaders/ 即可扩展目录。",
   "settingsVisualizerSource": "可视化音频来源",
-  "visualizerSourceSubtitleSynthesized": "默认。可视化效果仅根据播放时间作出反应 — 无需麦克风权限。",
-  "visualizerSourceSubtitleReal": "可视化效果根据实际音频输出作出反应。需要 Android 的 RECORD_AUDIO 权限。",
   "settingsAlbumGrid": "专辑网格视图",
   "settingsAlbumGridSubtitle": "以带封面的卡片网格显示专辑，而非普通列表。",
   "settingsFileMetadata": "在文件浏览器中读取歌曲元数据",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -513,15 +513,7 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
           resizeToAvoidBottomInset: false,
           drawer: _appDrawer(context, l),
           body: Stack(children: [
-            // Rebuild the home scaffold (and its app-bar toolbar) when the
-            // server list flips empty <-> non-empty, so the first-run view can
-            // drop the browse toolbar entirely (no "Browser" label / dead icons).
-            StreamBuilder<List<Server>>(
-              stream: ServerManager().serverListStream,
-              initialData: ServerManager().serverList,
-              builder: (context, snap) => _homeScaffold(
-                  context, l, (snap.data ?? const <Server>[]).isEmpty),
-            ),
+            _homeScaffold(context, l),
             // Full-screen player overlay — collapsed it's the bottom mini-player;
             // expanded it rises over the app bar into the full Now Playing view.
             // RepaintBoundary isolates the playing scrubber/waveform's per-frame
@@ -537,8 +529,7 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
   // over the browser ↔ album-detail body. It sits BELOW the player overlay and
   // the outer Scaffold's drawer in build()'s Stack, so an open drawer dims it
   // like any other content.
-  Widget _homeScaffold(
-      BuildContext context, AppLocalizations l, bool noServers) {
+  Widget _homeScaffold(BuildContext context, AppLocalizations l) {
     return Scaffold(
       // The only text input over this Scaffold is the search field in the
       // toolbar (always at the top, never under the keyboard), so don't
@@ -668,7 +659,7 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
         // Consolidated browser chrome (back · label/album · search ·
         // download · add-all) — replaces both the old label-only strip and
         // the Browser's in-body header row. See widgets/browser_toolbar.dart.
-        bottom: noServers ? null : const BrowserToolbar(),
+        bottom: const BrowserToolbar(),
       ),
       body: Column(children: [
         _migrationBanner(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -513,7 +513,15 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
           resizeToAvoidBottomInset: false,
           drawer: _appDrawer(context, l),
           body: Stack(children: [
-            _homeScaffold(context, l),
+            // Rebuild the home scaffold (and its app-bar toolbar) when the
+            // server list flips empty <-> non-empty, so the first-run view can
+            // drop the browse toolbar entirely (no "Browser" label / dead icons).
+            StreamBuilder<List<Server>>(
+              stream: ServerManager().serverListStream,
+              initialData: ServerManager().serverList,
+              builder: (context, snap) => _homeScaffold(
+                  context, l, (snap.data ?? const <Server>[]).isEmpty),
+            ),
             // Full-screen player overlay — collapsed it's the bottom mini-player;
             // expanded it rises over the app bar into the full Now Playing view.
             // RepaintBoundary isolates the playing scrubber/waveform's per-frame
@@ -529,7 +537,8 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
   // over the browser ↔ album-detail body. It sits BELOW the player overlay and
   // the outer Scaffold's drawer in build()'s Stack, so an open drawer dims it
   // like any other content.
-  Widget _homeScaffold(BuildContext context, AppLocalizations l) {
+  Widget _homeScaffold(
+      BuildContext context, AppLocalizations l, bool noServers) {
     return Scaffold(
       // The only text input over this Scaffold is the search field in the
       // toolbar (always at the top, never under the keyboard), so don't
@@ -659,7 +668,7 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
         // Consolidated browser chrome (back · label/album · search ·
         // download · add-all) — replaces both the old label-only strip and
         // the Browser's in-body header row. See widgets/browser_toolbar.dart.
-        bottom: const BrowserToolbar(),
+        bottom: noServers ? null : const BrowserToolbar(),
       ),
       body: Column(children: [
         _migrationBanner(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -519,7 +519,16 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
             // RepaintBoundary isolates the playing scrubber/waveform's per-frame
             // repaints so they don't redraw the browser list painted behind it.
             Positioned.fill(
-              child: RepaintBoundary(child: PlayerPanel(key: _panelKey)),
+              // Hidden on the first-run (no-servers) view — there's nothing to
+              // play, so the bar would just be dead chrome.
+              child: StreamBuilder<List<Server>>(
+                stream: ServerManager().serverListStream,
+                initialData: ServerManager().serverList,
+                builder: (context, snap) =>
+                    (snap.data ?? const <Server>[]).isEmpty
+                        ? const SizedBox.shrink()
+                        : RepaintBoundary(child: PlayerPanel(key: _panelKey)),
+              ),
             ),
           ]),
         ));

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -740,6 +740,33 @@ class AudioPlayerHandler extends BaseAudioHandler
         queue.add(queue.value..clear());
         _broadcastState();
         break;
+      case 'removeServerFromQueue':
+        // A server was deleted — drop every queued track that streamed from it
+        // (matched by the localname stored in extras['server']); they're no
+        // longer playable.
+        final gone = extras?['server'] as String?;
+        if (gone != null) {
+          final q = queue.value;
+          final victims = <int>[
+            for (var i = 0; i < q.length; i++)
+              if (q[i].extras?['server'] == gone) i
+          ];
+          if (victims.isNotEmpty) {
+            if (victims.length == q.length) {
+              // The whole queue was from that server — clear + stop.
+              await customAction('clearPlaylist');
+            } else {
+              // Remove high->low so earlier indices stay valid (reuses the
+              // single-item path; see removeQueueItemAt).
+              for (final i in victims.reversed) {
+                await removeQueueItemAt(i);
+              }
+            }
+            appLog('[queue] dropped ${victims.length} track(s) from '
+                'removed server "$gone"');
+          }
+        }
+        break;
       case 'moveQueueItem':
         // Drag-to-reorder. [to] is the post-removal target index
         // (ReorderableListView convention). Reorder the queue list first, then

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -17,7 +17,6 @@ import '../l10n/app_localizations.dart';
 import '../objects/server.dart';
 import '../singletons/file_explorer.dart';
 import '../singletons/server_list.dart';
-import '../widgets/settings_controls.dart';
 import '../singletons/log_manager.dart';
 import '../singletons/app_messenger.dart';
 import '../singletons/browser_list.dart';
@@ -1740,42 +1739,6 @@ class MyCustomFormState extends State<MyCustomForm> {
     );
   }
 
-  // First-run "Quick setup" card shown above the Add Server form: the key
-  // preferences a new user benefits from setting immediately, built from the
-  // same reusable controls as the Settings screen (language / tap behavior /
-  // visualizer source). The battery-optimization tile is intentionally Settings-
-  // only, not surfaced here.
-  Widget _onboardingCard(BuildContext context, AppLocalizations l) {
-    return Container(
-      decoration: BoxDecoration(
-        color: VelvetColors.surface,
-        borderRadius: BorderRadius.circular(VelvetColors.radiusSmall),
-        border: Border.all(color: VelvetColors.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: EdgeInsets.fromLTRB(16, 14, 16, 2),
-            child: Text(
-              l.onboardingSectionTitle.toUpperCase(),
-              style: TextStyle(
-                color: VelvetColors.primary,
-                fontSize: 11,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 1.6,
-              ),
-            ),
-          ),
-          const LanguageSettingTile(),
-          const TapBehaviorSettingTile(),
-          const VisualizerSourceSettingTile(),
-          SizedBox(height: 6),
-        ],
-      ),
-    );
-  }
-
   Widget _buildStandardForm(BuildContext context) {
     final l = AppLocalizations.of(context);
     return SafeArea(
@@ -1789,13 +1752,6 @@ class MyCustomFormState extends State<MyCustomForm> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
-              // First-run only (no servers yet, add mode): surface the key
-              // preferences up front so a new user sees them before connecting.
-              if (widget.editThisServer == null &&
-                  ServerManager().serverList.isEmpty) ...[
-                _onboardingCard(context, l),
-                SizedBox(height: 20),
-              ],
               TextFormField(
                 controller: _urlCtrl,
                 // iroh server: reached through the loopback tunnel, not this URL

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -17,6 +17,7 @@ import '../l10n/app_localizations.dart';
 import '../objects/server.dart';
 import '../singletons/file_explorer.dart';
 import '../singletons/server_list.dart';
+import '../widgets/settings_controls.dart';
 import '../singletons/log_manager.dart';
 import '../singletons/app_messenger.dart';
 import '../singletons/browser_list.dart';
@@ -1739,6 +1740,42 @@ class MyCustomFormState extends State<MyCustomForm> {
     );
   }
 
+  // First-run "Quick setup" card shown above the Add Server form: the key
+  // preferences a new user benefits from setting immediately, built from the
+  // same reusable controls as the Settings screen (language / tap behavior /
+  // visualizer source). The battery-optimization tile is intentionally Settings-
+  // only, not surfaced here.
+  Widget _onboardingCard(BuildContext context, AppLocalizations l) {
+    return Container(
+      decoration: BoxDecoration(
+        color: VelvetColors.surface,
+        borderRadius: BorderRadius.circular(VelvetColors.radiusSmall),
+        border: Border.all(color: VelvetColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: EdgeInsets.fromLTRB(16, 14, 16, 2),
+            child: Text(
+              l.onboardingSectionTitle.toUpperCase(),
+              style: TextStyle(
+                color: VelvetColors.primary,
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 1.6,
+              ),
+            ),
+          ),
+          const LanguageSettingTile(),
+          const TapBehaviorSettingTile(),
+          const VisualizerSourceSettingTile(),
+          SizedBox(height: 6),
+        ],
+      ),
+    );
+  }
+
   Widget _buildStandardForm(BuildContext context) {
     final l = AppLocalizations.of(context);
     return SafeArea(
@@ -1752,6 +1789,13 @@ class MyCustomFormState extends State<MyCustomForm> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
+              // First-run only (no servers yet, add mode): surface the key
+              // preferences up front so a new user sees them before connecting.
+              if (widget.editThisServer == null &&
+                  ServerManager().serverList.isEmpty) ...[
+                _onboardingCard(context, l),
+                SizedBox(height: 20),
+              ],
               TextFormField(
                 controller: _urlCtrl,
                 // iroh server: reached through the loopback tunnel, not this URL
@@ -2049,37 +2093,47 @@ class MyCustomFormState extends State<MyCustomForm> {
               // OutlinedButton.icon block here + uncomment the dep
               // when scanning is back online. The parseQrCode helper
               // above is preserved.
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: VelvetColors.primary,
-                  foregroundColor: Colors.white,
-                  padding: EdgeInsets.symmetric(vertical: 16),
-                  shape: RoundedRectangleBorder(
-                    borderRadius:
-                        BorderRadius.circular(VelvetColors.radiusSmall),
+              // Colorful primary CTA: a gradient fill (brighter → base accent)
+              // plus a leading icon so the "add server" action pops on the
+              // first-run screen. onPrimary keeps the label legible whatever
+              // accent the user has picked.
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [VelvetColors.primaryHover, VelvetColors.primary],
                   ),
-                  textStyle: TextStyle(
-                      fontSize: 15, fontWeight: FontWeight.w600),
+                  borderRadius:
+                      BorderRadius.circular(VelvetColors.radiusSmall),
                 ),
-                onPressed: submitPending ? null : _onSavePressed,
-                child: submitPending
-                    ? Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              valueColor:
-                                  AlwaysStoppedAnimation(Colors.white),
-                            ),
+                child: ElevatedButton.icon(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.transparent,
+                    shadowColor: Colors.transparent,
+                    foregroundColor: VelvetColors.onPrimary,
+                    padding: EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius:
+                          BorderRadius.circular(VelvetColors.radiusSmall),
+                    ),
+                    textStyle:
+                        TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+                  ),
+                  onPressed: submitPending ? null : _onSavePressed,
+                  icon: submitPending
+                      ? SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation(
+                                VelvetColors.onPrimary),
                           ),
-                          SizedBox(width: 12),
-                          Text(l.connecting),
-                        ],
-                      )
-                    : Text(l.save),
+                        )
+                      : Icon(Icons.add_rounded),
+                  label: Text(submitPending ? l.connecting : l.save),
+                ),
               ),
             ],
           ),

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -700,27 +700,14 @@ class _BrowserState extends State<Browser> {
                     color: VelvetColors.onPrimary, size: 30),
                 const SizedBox(width: 14),
                 Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        l.browserWelcomeTitle,
-                        style: TextStyle(
-                          color: VelvetColors.onPrimary,
-                          fontSize: 17,
-                          fontWeight: FontWeight.w700,
-                          letterSpacing: 0.2,
-                        ),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        l.browserWelcomeSubtitle,
-                        style: TextStyle(
-                          color: VelvetColors.onPrimary.withValues(alpha: 0.85),
-                          fontSize: 13,
-                        ),
-                      ),
-                    ],
+                  child: Text(
+                    l.browserWelcomeSubtitle,
+                    style: TextStyle(
+                      color: VelvetColors.onPrimary,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0.2,
+                    ),
                   ),
                 ),
                 Icon(Icons.chevron_right, color: VelvetColors.onPrimary),

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -13,6 +13,7 @@ import '../widgets/letter_strip.dart';
 import '../widgets/player_panel.dart';
 import '../widgets/playlist_name_dialog.dart';
 import '../widgets/star_rating.dart';
+import '../widgets/settings_controls.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 
 import '../singletons/media.dart';
@@ -625,6 +626,58 @@ class _BrowserState extends State<Browser> {
   }
 
   // ── Default browser landing: section shortcuts as a modern card grid ──
+  // First-run welcome state: the lone "Welcome to mStream" (addServer) tile,
+  // shown with a Quick-setup card of the key first-run preferences below it.
+  Widget _welcomeView(BuildContext context, List<DisplayItem> items) {
+    final l = AppLocalizations.of(context);
+    return SingleChildScrollView(
+      padding: const EdgeInsets.only(bottom: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          makeListItem(items, 0, context),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+            child: _quickSetupCard(context, l),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // The key first-run preferences, built from the same reusable controls as the
+  // Settings screen (language / "when you tap a song" / visualizer source).
+  Widget _quickSetupCard(BuildContext context, AppLocalizations l) {
+    return Container(
+      decoration: BoxDecoration(
+        color: VelvetColors.surface,
+        borderRadius: BorderRadius.circular(VelvetColors.radiusSmall),
+        border: Border.all(color: VelvetColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 14, 16, 2),
+            child: Text(
+              l.onboardingSectionTitle.toUpperCase(),
+              style: TextStyle(
+                color: VelvetColors.primary,
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 1.6,
+              ),
+            ),
+          ),
+          const LanguageSettingTile(),
+          const TapBehaviorSettingTile(),
+          const VisualizerSourceSettingTile(),
+          const SizedBox(height: 6),
+        ],
+      ),
+    );
+  }
+
   Widget _homeView(BuildContext context, List<DisplayItem> items) {
     final l = AppLocalizations.of(context);
     return GridView.builder(
@@ -933,6 +986,14 @@ class _BrowserState extends State<Browser> {
                                 BrowserManager().listName == 'Playlists');
                     if (isPlaylistView) {
                       return _playlistsView(context, browserList);
+                    }
+
+                    // First run: the lone "Welcome to mStream" (addServer) tile.
+                    // Render it with a Quick-setup card of the key first-run prefs
+                    // below — so a brand-new user sees them before adding a server.
+                    if (browserList.length == 1 &&
+                        browserList[0].type == 'addServer') {
+                      return _welcomeView(context, browserList);
                     }
 
                     // If the whole list is albums and the user has the

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -637,7 +637,7 @@ class _BrowserState extends State<Browser> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          makeListItem(items, 0, context),
+          _welcomeButton(context, l, items),
           _quickSetupHeader(l.quickSetupTheme),
           const AccentColorSettingTile(),
           _quickSetupHeader(l.quickSetupConfig),
@@ -660,6 +660,73 @@ class _BrowserState extends State<Browser> {
           fontSize: 11,
           fontWeight: FontWeight.w700,
           letterSpacing: 1.6,
+        ),
+      ),
+    );
+  }
+
+  // The first-run call to action: a bold gradient "Welcome to mStream" button so
+  // the primary action stands out. Taps route to Add Server via the addServer
+  // DisplayItem's handleTap (items[0]).
+  Widget _welcomeButton(
+      BuildContext context, AppLocalizations l, List<DisplayItem> items) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 4),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(VelvetColors.radiusSmall),
+          onTap: () => handleTap(items, 0, context),
+          child: Ink(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [VelvetColors.primaryHover, VelvetColors.primary],
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+              ),
+              borderRadius: BorderRadius.circular(VelvetColors.radiusSmall),
+              boxShadow: [
+                BoxShadow(
+                  color: VelvetColors.primaryGlow,
+                  blurRadius: 18,
+                  offset: const Offset(0, 6),
+                ),
+              ],
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 18),
+            child: Row(
+              children: [
+                Icon(Icons.add_circle_outline,
+                    color: VelvetColors.onPrimary, size: 30),
+                const SizedBox(width: 14),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        l.browserWelcomeTitle,
+                        style: TextStyle(
+                          color: VelvetColors.onPrimary,
+                          fontSize: 17,
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 0.2,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        l.browserWelcomeSubtitle,
+                        style: TextStyle(
+                          color: VelvetColors.onPrimary.withValues(alpha: 0.85),
+                          fontSize: 13,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(Icons.chevron_right, color: VelvetColors.onPrimary),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -627,7 +627,9 @@ class _BrowserState extends State<Browser> {
 
   // ── Default browser landing: section shortcuts as a modern card grid ──
   // First-run welcome state: the lone "Welcome to mStream" (addServer) tile,
-  // shown with a Quick-setup card of the key first-run preferences below it.
+  // shown with the key first-run preferences below it. No bordered card — the
+  // controls run edge-to-edge to save horizontal space — split into a Theme
+  // section (accent colour) and a Config section (language / tap / visualizer).
   Widget _welcomeView(BuildContext context, List<DisplayItem> items) {
     final l = AppLocalizations.of(context);
     return SingleChildScrollView(
@@ -636,44 +638,29 @@ class _BrowserState extends State<Browser> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           makeListItem(items, 0, context),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-            child: _quickSetupCard(context, l),
-          ),
+          _quickSetupHeader(l.quickSetupTheme),
+          const AccentColorSettingTile(),
+          _quickSetupHeader(l.quickSetupConfig),
+          const LanguageSettingTile(compact: true),
+          const TapBehaviorSettingTile(),
+          const VisualizerSourceSettingTile(),
+          const SizedBox(height: 12),
         ],
       ),
     );
   }
 
-  // The key first-run preferences, built from the same reusable controls as the
-  // Settings screen (language / "when you tap a song" / visualizer source).
-  Widget _quickSetupCard(BuildContext context, AppLocalizations l) {
-    return Container(
-      decoration: BoxDecoration(
-        color: VelvetColors.surface,
-        borderRadius: BorderRadius.circular(VelvetColors.radiusSmall),
-        border: Border.all(color: VelvetColors.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 14, 16, 2),
-            child: Text(
-              l.onboardingSectionTitle.toUpperCase(),
-              style: TextStyle(
-                color: VelvetColors.primary,
-                fontSize: 11,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 1.6,
-              ),
-            ),
-          ),
-          const LanguageSettingTile(),
-          const TapBehaviorSettingTile(),
-          const VisualizerSourceSettingTile(),
-          const SizedBox(height: 6),
-        ],
+  Widget _quickSetupHeader(String label) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 6),
+      child: Text(
+        label.toUpperCase(),
+        style: TextStyle(
+          color: VelvetColors.primary,
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 1.6,
+        ),
       ),
     );
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:permission_handler/permission_handler.dart';
 
 import '../l10n/app_localizations.dart';
 import '../l10n/enum_labels.dart';
@@ -9,6 +8,7 @@ import '../singletons/settings.dart';
 import '../singletons/app_messenger.dart';
 import '../theme/velvet_theme.dart';
 import '../widgets/accent_color_sheet.dart';
+import '../widgets/settings_controls.dart';
 import 'eq_screen.dart';
 import 'imported_shaders_screen.dart';
 
@@ -20,23 +20,6 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  // A language's name in its own language. Intentionally NOT translated —
-  // users recognize their language by its endonym. Keyed by language
-  // code; the picker is built from AppLocalizations.supportedLocales so
-  // it auto-grows as ARB files are added.
-  static const _endonyms = <String, String>{
-    'en': 'English',
-    'es': 'Español',
-    'fr': 'Français',
-    'de': 'Deutsch',
-    'pt': 'Português',
-    'zh': '中文',
-    'ru': 'Русский',
-    'it': 'Italiano',
-    'pl': 'Polski',
-    'ja': '日本語',
-  };
-
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
@@ -122,43 +105,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               },
             ),
           ),
-          ListTile(
-            title: Text(l.settingsLanguage),
-            subtitle: Text(
-              l.settingsLanguageSubtitle,
-              style: TextStyle(
-                  color: VelvetColors.textSecondary, fontSize: 12),
-            ),
-            trailing: DropdownButton<String?>(
-              value: SettingsManager().language,
-              underline: SizedBox.shrink(),
-              dropdownColor: VelvetColors.surface,
-              style: TextStyle(color: VelvetColors.textPrimary, fontSize: 14),
-              // "System default" (null) first, then one entry per
-              // supported locale — derived from the generated
-              // supportedLocales so new ARB files appear automatically.
-              items: [
-                DropdownMenuItem<String?>(
-                  value: null,
-                  child: Text(l.languageSystemDefault),
-                ),
-                ...AppLocalizations.supportedLocales.map(
-                  (loc) => DropdownMenuItem<String?>(
-                    value: loc.languageCode,
-                    child: Text(
-                        _endonyms[loc.languageCode] ?? loc.languageCode),
-                  ),
-                ),
-              ],
-              // null is a valid choice here (follow device), so unlike the
-              // theme picker we don't early-return on null.
-              onChanged: (v) async {
-                setState(() {});
-                await SettingsManager().setLanguage(v);
-                setState(() {});
-              },
-            ),
-          ),
+          const LanguageSettingTile(),
           ListTile(
             title: Text(l.settingsStartupPage),
             subtitle: Text(
@@ -222,32 +169,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             },
             activeThumbColor: VelvetColors.primary,
           ),
-          ListTile(
-            title: Text(l.settingsTapBehavior),
-            subtitle: Text(
-              _tapBehaviorSubtitle(l, SettingsManager().tapBehavior),
-              style: TextStyle(
-                  color: VelvetColors.textSecondary, fontSize: 12),
-            ),
-            trailing: DropdownButton<TapBehavior>(
-              value: SettingsManager().tapBehavior,
-              underline: SizedBox.shrink(),
-              dropdownColor: VelvetColors.surface,
-              style: TextStyle(color: VelvetColors.textPrimary, fontSize: 14),
-              items: TapBehavior.values
-                  .map((b) => DropdownMenuItem(
-                        value: b,
-                        child: Text(b.label(l)),
-                      ))
-                  .toList(),
-              onChanged: (v) async {
-                if (v == null) return;
-                setState(() {});
-                await SettingsManager().setTapBehavior(v);
-                setState(() {});
-              },
-            ),
-          ),
+          const TapBehaviorSettingTile(),
           ListTile(
             leading: Icon(Icons.equalizer, color: VelvetColors.textSecondary),
             title: Text(l.eqTitle),
@@ -287,28 +209,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               },
             ),
           ),
-          ListTile(
-            title: Text(l.settingsVisualizerSource),
-            subtitle: Text(
-              _visualizerSourceSubtitle(
-                  l, SettingsManager().visualizerAudioSource),
-              style: TextStyle(
-                  color: VelvetColors.textSecondary, fontSize: 12),
-            ),
-            trailing: DropdownButton<VisualizerAudioSource>(
-              value: SettingsManager().visualizerAudioSource,
-              underline: SizedBox.shrink(),
-              dropdownColor: VelvetColors.surface,
-              style: TextStyle(color: VelvetColors.textPrimary, fontSize: 14),
-              items: VisualizerAudioSource.values
-                  .map((s) => DropdownMenuItem(
-                        value: s,
-                        child: Text(s.label(l)),
-                      ))
-                  .toList(),
-              onChanged: (v) => _onVisualizerSourceChanged(v),
-            ),
-          ),
+          const VisualizerSourceSettingTile(),
           SwitchListTile(
             title: Text(l.settingsVisualizerKnobs),
             subtitle: Text(
@@ -531,97 +432,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
         return l.settingsCastQualitySubtitle1080;
       case CastVisualizerQuality.uhd2160:
         return l.settingsCastQualitySubtitle4k;
-    }
-  }
-
-  String _visualizerSourceSubtitle(AppLocalizations l, VisualizerAudioSource s) {
-    switch (s) {
-      case VisualizerAudioSource.synthesized:
-        return l.visualizerSourceSubtitleSynthesized;
-      case VisualizerAudioSource.real:
-        return l.visualizerSourceSubtitleReal;
-    }
-  }
-
-  // Dropdown handler for the visualizer source. Switching to "real"
-  // walks the user through the RECORD_AUDIO permission flow with an
-  // up-front explanation of *why* a music app is asking for the
-  // microphone permission. If the user denies (or cancels), we revert
-  // the setting so the dropdown stays honest.
-  Future<void> _onVisualizerSourceChanged(VisualizerAudioSource? v) async {
-    if (v == null) return;
-    final current = SettingsManager().visualizerAudioSource;
-    if (v == current) return;
-
-    if (v == VisualizerAudioSource.real) {
-      final ok = await _confirmRealAudioPermission();
-      if (!ok) return;
-    }
-
-    await SettingsManager().setVisualizerAudioSource(v);
-    if (mounted) setState(() {});
-  }
-
-  // Two-step: explanation dialog → OS permission prompt. Returns true
-  // only if the user accepted both and the permission is granted.
-  Future<bool> _confirmRealAudioPermission() async {
-    final l = AppLocalizations.of(context);
-    final consented = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: VelvetColors.surface,
-        title: Text(l.realAudioDialogTitle,
-            style: TextStyle(color: VelvetColors.textPrimary)),
-        content: Text(
-          l.realAudioDialogBody,
-          style: TextStyle(color: VelvetColors.textSecondary),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(l.cancel,
-                style: TextStyle(color: VelvetColors.textSecondary)),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(l.continueLabel,
-                style: TextStyle(color: VelvetColors.primary)),
-          ),
-        ],
-      ),
-    );
-    if (consented != true || !mounted) return false;
-
-    final status = await Permission.microphone.request();
-    if (status.isGranted) return true;
-
-    if (mounted) {
-      final permanentlyDenied = status.isPermanentlyDenied;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(permanentlyDenied
-              ? l.realAudioPermPermanentlyDenied
-              : l.realAudioPermDenied),
-          action: permanentlyDenied
-              ? SnackBarAction(
-                  label: l.openSettings,
-                  onPressed: openAppSettings,
-                )
-              : null,
-        ),
-      );
-    }
-    return false;
-  }
-
-  String _tapBehaviorSubtitle(AppLocalizations l, TapBehavior b) {
-    switch (b) {
-      case TapBehavior.addToQueue:
-        return l.tapSubtitleAddToQueue;
-      case TapBehavior.playFromHere:
-        return l.tapSubtitlePlayFromHere;
-      case TapBehavior.appendAndJump:
-        return l.tapSubtitleAppendAndJump;
     }
   }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -7,7 +7,6 @@ import '../singletons/queue_store.dart';
 import '../singletons/settings.dart';
 import '../singletons/app_messenger.dart';
 import '../theme/velvet_theme.dart';
-import '../widgets/accent_color_sheet.dart';
 import '../widgets/settings_controls.dart';
 import 'eq_screen.dart';
 import 'imported_shaders_screen.dart';
@@ -56,29 +55,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               },
             ),
           ),
-          ListTile(
-            title: Text(l.settingsAccentColor),
-            subtitle: Text(
-              l.settingsAccentColorSubtitle,
-              style: TextStyle(
-                  color: VelvetColors.textSecondary, fontSize: 12),
-            ),
-            trailing: Container(
-              width: 26,
-              height: 26,
-              decoration: BoxDecoration(
-                color: VelvetColors.primary,
-                shape: BoxShape.circle,
-                border: Border.all(color: VelvetColors.border),
-              ),
-            ),
-            onTap: () => showModalBottomSheet(
-              context: context,
-              backgroundColor: VelvetColors.surface,
-              isScrollControlled: true,
-              builder: (_) => const AccentColorSheet(),
-            ),
-          ),
+          const AccentColorSettingTile(),
           ListTile(
             title: const Text('Now Playing layout'),
             subtitle: Text(

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -580,6 +580,11 @@ class ServerManager {
       _queueIrohServer = null;
     }
 
+    // Drop any queued tracks that streamed from the now-removed server — they
+    // can no longer be played.
+    await MediaManager().audioHandler.customAction(
+        'removeServerFromQueue', {'server': removeThisServer.localname});
+
     if (serverList.isEmpty) {
       // force the browser to rerender so it displays
       BrowserManager().noServerScreen();

--- a/lib/widgets/browser_toolbar.dart
+++ b/lib/widgets/browser_toolbar.dart
@@ -272,6 +272,15 @@ class _BrowserToolbarState extends State<BrowserToolbar> {
   }
 
   Widget _content(BuildContext context, AppLocalizations l, _Tb s) {
+    // First run (no servers): the list is a single "add server" tile. Show just
+    // the welcome title — there's nothing to search / download / add yet.
+    if (s.list.length == 1 && s.list[0].type == 'addServer') {
+      return Row(children: [
+        const SizedBox(width: 12),
+        _title(l.browserWelcomeTitle),
+      ]);
+    }
+
     // Album detail: back · name · download · add-all (Play/Shuffle stay in the
     // banner). Acts on the album's loaded songs.
     if (s.album != null) {

--- a/lib/widgets/settings_controls.dart
+++ b/lib/widgets/settings_controls.dart
@@ -1,0 +1,233 @@
+// Reusable preference controls shared between the Settings screen and the
+// first-run "Quick setup" card on the Add Server screen. Each is a
+// self-contained StatefulWidget that reads/writes SettingsManager and owns its
+// own setState, so it looks and behaves identically wherever it's dropped in.
+
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import '../l10n/app_localizations.dart';
+import '../l10n/enum_labels.dart';
+import '../singletons/settings.dart';
+import '../theme/velvet_theme.dart';
+
+// Not const: VelvetColors.* are theme-dependent globals, so this re-evaluates
+// per build (matching the original inline style and picking up theme changes).
+TextStyle get _subtitleStyle =>
+    TextStyle(color: VelvetColors.textSecondary, fontSize: 12);
+
+// ── Language ──────────────────────────────────────────────────────────────
+class LanguageSettingTile extends StatefulWidget {
+  const LanguageSettingTile({super.key});
+
+  @override
+  State<LanguageSettingTile> createState() => _LanguageSettingTileState();
+}
+
+class _LanguageSettingTileState extends State<LanguageSettingTile> {
+  // A language's name in its own language. Intentionally NOT translated —
+  // users recognize their language by its endonym. The picker is built from
+  // AppLocalizations.supportedLocales so it auto-grows as ARB files are added.
+  static const _endonyms = <String, String>{
+    'en': 'English',
+    'es': 'Español',
+    'fr': 'Français',
+    'de': 'Deutsch',
+    'pt': 'Português',
+    'zh': '中文',
+    'ru': 'Русский',
+    'it': 'Italiano',
+    'pl': 'Polski',
+    'ja': '日本語',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return ListTile(
+      title: Text(l.settingsLanguage, overflow: TextOverflow.ellipsis),
+      subtitle: Text(l.settingsLanguageSubtitle, style: _subtitleStyle),
+      trailing: DropdownButton<String?>(
+        value: SettingsManager().language,
+        underline: SizedBox.shrink(),
+        dropdownColor: VelvetColors.surface,
+        style: TextStyle(color: VelvetColors.textPrimary, fontSize: 14),
+        // "System default" (null) first, then one entry per supported locale.
+        items: [
+          DropdownMenuItem<String?>(
+            value: null,
+            child: Text(l.languageSystemDefault),
+          ),
+          ...AppLocalizations.supportedLocales.map(
+            (loc) => DropdownMenuItem<String?>(
+              value: loc.languageCode,
+              child: Text(_endonyms[loc.languageCode] ?? loc.languageCode),
+            ),
+          ),
+        ],
+        // null is a valid choice (follow device), so we don't early-return on it.
+        onChanged: (v) async {
+          setState(() {});
+          await SettingsManager().setLanguage(v);
+          if (mounted) setState(() {});
+        },
+      ),
+    );
+  }
+}
+
+// ── "When you tap a song" ───────────────────────────────────────────────────
+class TapBehaviorSettingTile extends StatefulWidget {
+  const TapBehaviorSettingTile({super.key});
+
+  @override
+  State<TapBehaviorSettingTile> createState() => _TapBehaviorSettingTileState();
+}
+
+class _TapBehaviorSettingTileState extends State<TapBehaviorSettingTile> {
+  String _subtitle(AppLocalizations l, TapBehavior b) {
+    switch (b) {
+      case TapBehavior.addToQueue:
+        return l.tapSubtitleAddToQueue;
+      case TapBehavior.playFromHere:
+        return l.tapSubtitlePlayFromHere;
+      case TapBehavior.appendAndJump:
+        return l.tapSubtitleAppendAndJump;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return ListTile(
+      title: Text(l.settingsTapBehavior, overflow: TextOverflow.ellipsis),
+      subtitle: Text(_subtitle(l, SettingsManager().tapBehavior),
+          style: _subtitleStyle),
+      trailing: DropdownButton<TapBehavior>(
+        value: SettingsManager().tapBehavior,
+        underline: SizedBox.shrink(),
+        dropdownColor: VelvetColors.surface,
+        style: TextStyle(color: VelvetColors.textPrimary, fontSize: 14),
+        items: TapBehavior.values
+            .map((b) => DropdownMenuItem(value: b, child: Text(b.label(l))))
+            .toList(),
+        onChanged: (v) async {
+          if (v == null) return;
+          setState(() {});
+          await SettingsManager().setTapBehavior(v);
+          if (mounted) setState(() {});
+        },
+      ),
+    );
+  }
+}
+
+// ── Visualizer audio source (carries the RECORD_AUDIO permission flow) ───────
+class VisualizerSourceSettingTile extends StatefulWidget {
+  const VisualizerSourceSettingTile({super.key});
+
+  @override
+  State<VisualizerSourceSettingTile> createState() =>
+      _VisualizerSourceSettingTileState();
+}
+
+class _VisualizerSourceSettingTileState
+    extends State<VisualizerSourceSettingTile> {
+  String _subtitle(AppLocalizations l, VisualizerAudioSource s) {
+    switch (s) {
+      case VisualizerAudioSource.synthesized:
+        return l.visualizerSourceSubtitleSynthesized;
+      case VisualizerAudioSource.real:
+        return l.visualizerSourceSubtitleReal;
+    }
+  }
+
+  // Switching to "real" walks the user through the RECORD_AUDIO permission flow
+  // with an up-front explanation of *why* a music app wants the microphone. If
+  // the user denies (or cancels), we revert so the dropdown stays honest.
+  Future<void> _onChanged(VisualizerAudioSource? v) async {
+    if (v == null) return;
+    final current = SettingsManager().visualizerAudioSource;
+    if (v == current) return;
+
+    if (v == VisualizerAudioSource.real) {
+      final ok = await _confirmRealAudioPermission();
+      if (!ok) return;
+    }
+
+    await SettingsManager().setVisualizerAudioSource(v);
+    if (mounted) setState(() {});
+  }
+
+  // Two-step: explanation dialog → OS permission prompt. Returns true only if
+  // the user accepted both and the permission is granted.
+  Future<bool> _confirmRealAudioPermission() async {
+    final l = AppLocalizations.of(context);
+    final consented = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: VelvetColors.surface,
+        title: Text(l.realAudioDialogTitle,
+            style: TextStyle(color: VelvetColors.textPrimary)),
+        content: Text(
+          l.realAudioDialogBody,
+          style: TextStyle(color: VelvetColors.textSecondary),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l.cancel,
+                style: TextStyle(color: VelvetColors.textSecondary)),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(l.continueLabel,
+                style: TextStyle(color: VelvetColors.primary)),
+          ),
+        ],
+      ),
+    );
+    if (consented != true || !mounted) return false;
+
+    final status = await Permission.microphone.request();
+    if (status.isGranted) return true;
+
+    if (mounted) {
+      final permanentlyDenied = status.isPermanentlyDenied;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(permanentlyDenied
+              ? l.realAudioPermPermanentlyDenied
+              : l.realAudioPermDenied),
+          action: permanentlyDenied
+              ? SnackBarAction(
+                  label: l.openSettings,
+                  onPressed: openAppSettings,
+                )
+              : null,
+        ),
+      );
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return ListTile(
+      title: Text(l.settingsVisualizerSource, overflow: TextOverflow.ellipsis),
+      subtitle: Text(_subtitle(l, SettingsManager().visualizerAudioSource),
+          style: _subtitleStyle),
+      trailing: DropdownButton<VisualizerAudioSource>(
+        value: SettingsManager().visualizerAudioSource,
+        underline: SizedBox.shrink(),
+        dropdownColor: VelvetColors.surface,
+        style: TextStyle(color: VelvetColors.textPrimary, fontSize: 14),
+        items: VisualizerAudioSource.values
+            .map((s) => DropdownMenuItem(value: s, child: Text(s.label(l))))
+            .toList(),
+        onChanged: _onChanged,
+      ),
+    );
+  }
+}

--- a/lib/widgets/settings_controls.dart
+++ b/lib/widgets/settings_controls.dart
@@ -10,6 +10,7 @@ import '../l10n/app_localizations.dart';
 import '../l10n/enum_labels.dart';
 import '../singletons/settings.dart';
 import '../theme/velvet_theme.dart';
+import 'accent_color_sheet.dart';
 
 // Not const: VelvetColors.* are theme-dependent globals, so this re-evaluates
 // per build (matching the original inline style and picking up theme changes).
@@ -18,7 +19,9 @@ TextStyle get _subtitleStyle =>
 
 // ── Language ──────────────────────────────────────────────────────────────
 class LanguageSettingTile extends StatefulWidget {
-  const LanguageSettingTile({super.key});
+  // When compact, the subtitle is dropped (used in the tight first-run card).
+  final bool compact;
+  const LanguageSettingTile({super.key, this.compact = false});
 
   @override
   State<LanguageSettingTile> createState() => _LanguageSettingTileState();
@@ -46,7 +49,9 @@ class _LanguageSettingTileState extends State<LanguageSettingTile> {
     final l = AppLocalizations.of(context);
     return ListTile(
       title: Text(l.settingsLanguage, overflow: TextOverflow.ellipsis),
-      subtitle: Text(l.settingsLanguageSubtitle, style: _subtitleStyle),
+      subtitle: widget.compact
+          ? null
+          : Text(l.settingsLanguageSubtitle, style: _subtitleStyle),
       trailing: DropdownButton<String?>(
         value: SettingsManager().language,
         underline: SizedBox.shrink(),
@@ -228,6 +233,43 @@ class _VisualizerSourceSettingTileState
             .toList(),
         onChanged: _onChanged,
       ),
+    );
+  }
+}
+
+// ── Accent colour picker ────────────────────────────────────────────────────
+class AccentColorSettingTile extends StatefulWidget {
+  const AccentColorSettingTile({super.key});
+
+  @override
+  State<AccentColorSettingTile> createState() => _AccentColorSettingTileState();
+}
+
+class _AccentColorSettingTileState extends State<AccentColorSettingTile> {
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return ListTile(
+      title: Text(l.settingsAccentColor, overflow: TextOverflow.ellipsis),
+      subtitle: Text(l.settingsAccentColorSubtitle, style: _subtitleStyle),
+      trailing: Container(
+        width: 26,
+        height: 26,
+        decoration: BoxDecoration(
+          color: VelvetColors.primary,
+          shape: BoxShape.circle,
+          border: Border.all(color: VelvetColors.border),
+        ),
+      ),
+      onTap: () async {
+        await showModalBottomSheet(
+          context: context,
+          backgroundColor: VelvetColors.surface,
+          isScrollControlled: true,
+          builder: (_) => const AccentColorSheet(),
+        );
+        if (mounted) setState(() {}); // refresh the swatch to the new accent
+      },
     );
   }
 }

--- a/lib/widgets/settings_controls.dart
+++ b/lib/widgets/settings_controls.dart
@@ -138,14 +138,6 @@ class VisualizerSourceSettingTile extends StatefulWidget {
 
 class _VisualizerSourceSettingTileState
     extends State<VisualizerSourceSettingTile> {
-  String _subtitle(AppLocalizations l, VisualizerAudioSource s) {
-    switch (s) {
-      case VisualizerAudioSource.synthesized:
-        return l.visualizerSourceSubtitleSynthesized;
-      case VisualizerAudioSource.real:
-        return l.visualizerSourceSubtitleReal;
-    }
-  }
 
   // Switching to "real" walks the user through the RECORD_AUDIO permission flow
   // with an up-front explanation of *why* a music app wants the microphone. If
@@ -221,8 +213,7 @@ class _VisualizerSourceSettingTileState
     final l = AppLocalizations.of(context);
     return ListTile(
       title: Text(l.settingsVisualizerSource, overflow: TextOverflow.ellipsis),
-      subtitle: Text(_subtitle(l, SettingsManager().visualizerAudioSource),
-          style: _subtitleStyle),
+      subtitle: Text(l.visualizerSourcePermission, style: _subtitleStyle),
       trailing: DropdownButton<VisualizerAudioSource>(
         value: SettingsManager().visualizerAudioSource,
         underline: SizedBox.shrink(),


### PR DESCRIPTION
## What
First-run Add Server improvements — **off `master`, self-contained.**

- **"Quick setup" card** — when no servers are configured yet (add mode), surface the key preferences at the top of the Add Server form: **Language**, **"when you tap a song"**, and **Visualizer audio source** — so a brand-new user sees them before connecting.
- **Reusable controls** — those three are extracted into `lib/widgets/settings_controls.dart` (the visualizer RECORD_AUDIO permission flow moved intact); the Settings screen composes the same widgets (pure refactor, behaviour identical).
- **Colorful Add Server button** — restyled as a gradient (primaryHover→primary) icon button; `onPrimary` keeps the label legible under custom accent colours.

## Related
The battery-optimization Settings tile + native channel are in **#92**, which stacks on this PR (it reuses these controls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)