### PR TITLE
fix(audio): don't let an error-induced idle stop the foreground service

### DIFF
--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -527,6 +527,7 @@ class AudioPlayerHandler extends BaseAudioHandler
       } else {
         _showPlaybackErrorToast(
             "Can't play these tracks — check the files or server.");
+        _intentionalStop = true;
         await _localBackend.stop();
       }
       _broadcastState();
@@ -547,6 +548,7 @@ class AudioPlayerHandler extends BaseAudioHandler
         await _localBackend.pause();
         _networkStalled = true;
       } else {
+        _intentionalStop = true;
         await _localBackend.stop();
       }
       _broadcastState();
@@ -734,6 +736,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     // own setSources(), so the two don't issue concurrent loads on the player
     // (which abort each other → "Loading interrupted", losing the restore).
     await _initialized.future;
+    _intentionalStop = false;
     queue.add(items.toList());
     await _backend.setSources(items);
     final int i = index.clamp(0, items.length - 1);
@@ -766,6 +769,7 @@ class AudioPlayerHandler extends BaseAudioHandler
   Future<void> play() {
     appLog('[play] play');
     _playIntent = true;
+    _intentionalStop = false;
     return _backend.play();
   }
 
@@ -789,10 +793,19 @@ class AudioPlayerHandler extends BaseAudioHandler
   @override
   Future<void> seek(Duration position) => _backend.seek(position);
 
+  // True while the handler itself is tearing playback down (user stop, cleared
+  // queue, unplayable-queue give-up), so _broadcastState can tell a deliberate
+  // idle apart from just_audio's error-induced idle. Cleared only at the
+  // explicit restart entry points (play / restoreQueue) — NOT from observed
+  // backend states, where a straggler ready event racing a stop could clear it
+  // early and turn the stop's own idle into a bogus 'error' broadcast.
+  bool _intentionalStop = false;
+
   @override
   Future<void> stop() async {
     appLog('[play] stop');
     _playIntent = false;
+    _intentionalStop = true;
     // Don't touch the tunnel here: it follows the QUEUE, not the play/stop state,
     // so a stopped-but-still-queued iroh song keeps its tunnel (the queue listener
     // tears it down when the iroh songs are actually removed/cleared).
@@ -895,6 +908,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     switch (name) {
       case 'clearPlaylist':
         appLog('[queue] cleared');
+        _intentionalStop = true;
         await _backend.stop();
         await super.stop();
         await _backend.clearSources();
@@ -1086,6 +1100,35 @@ class AudioPlayerHandler extends BaseAudioHandler
     _broadcastState();
   }
 
+  /// The processing state to publish for the backend's [state]. A deliberate
+  /// teardown (intentional stop, or nothing queued) passes `idle` through —
+  /// audio_service stops the Android service on every published
+  /// non-idle→idle transition, which is exactly right there. But just_audio
+  /// also flips to `idle` on ANY playback error; publishing that would let
+  /// audio_service stopSelf() while the UI activity is unbound (backgrounded /
+  /// swiped away), destroying the FlutterEngine before the error recovery in
+  /// _onPlaybackError can run. An unintentional idle with tracks still queued
+  /// publishes `error` instead, keeping the service (and notification) alive.
+  static AudioProcessingState publishProcessingState(
+      BackendProcessingState state,
+      {required bool intentionalStop,
+      required bool queueEmpty}) {
+    switch (state) {
+      case BackendProcessingState.idle:
+        return (intentionalStop || queueEmpty)
+            ? AudioProcessingState.idle
+            : AudioProcessingState.error;
+      case BackendProcessingState.loading:
+        return AudioProcessingState.loading;
+      case BackendProcessingState.buffering:
+        return AudioProcessingState.buffering;
+      case BackendProcessingState.ready:
+        return AudioProcessingState.ready;
+      case BackendProcessingState.completed:
+        return AudioProcessingState.completed;
+    }
+  }
+
   /// Broadcasts the current state to all clients.
   void _broadcastState() {
     final playing = _backend.playing;
@@ -1115,13 +1158,9 @@ class AudioPlayerHandler extends BaseAudioHandler
       shuffleMode: shuffle,
       repeatMode: repeat,
       androidCompactActionIndices: [0, 1, 3],
-      processingState: const {
-        BackendProcessingState.idle: AudioProcessingState.idle,
-        BackendProcessingState.loading: AudioProcessingState.loading,
-        BackendProcessingState.buffering: AudioProcessingState.buffering,
-        BackendProcessingState.ready: AudioProcessingState.ready,
-        BackendProcessingState.completed: AudioProcessingState.completed,
-      }[_backend.processingState]!,
+      processingState: publishProcessingState(_backend.processingState,
+          intentionalStop: _intentionalStop,
+          queueEmpty: queue.value.isEmpty),
       playing: playing,
       updatePosition: _backend.position,
       bufferedPosition: _backend.bufferedPosition,

--- a/test/media/publish_processing_state_test.dart
+++ b/test/media/publish_processing_state_test.dart
@@ -1,0 +1,59 @@
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/audio_stuff.dart';
+import 'package:mstream_music/media/playback_backend.dart';
+
+void main() {
+  group('AudioPlayerHandler.publishProcessingState', () {
+    // audio_service stops the Android service on every published
+    // non-idle→idle transition, so which idles pass through is load-bearing:
+    // deliberate teardown must publish idle (service stops, notification
+    // clears); an error-induced idle with tracks still queued must NOT
+    // (backgrounded, that teardown destroys the engine mid-recovery).
+
+    test('error-induced idle with a queued track publishes error', () {
+      expect(
+        AudioPlayerHandler.publishProcessingState(BackendProcessingState.idle,
+            intentionalStop: false, queueEmpty: false),
+        AudioProcessingState.error,
+      );
+    });
+
+    test('intentional stop passes idle through', () {
+      expect(
+        AudioPlayerHandler.publishProcessingState(BackendProcessingState.idle,
+            intentionalStop: true, queueEmpty: false),
+        AudioProcessingState.idle,
+      );
+    });
+
+    test('idle with an empty queue passes through (cleared / cold start)', () {
+      expect(
+        AudioPlayerHandler.publishProcessingState(BackendProcessingState.idle,
+            intentionalStop: false, queueEmpty: true),
+        AudioProcessingState.idle,
+      );
+    });
+
+    test('non-idle states map straight through regardless of flags', () {
+      const expected = {
+        BackendProcessingState.loading: AudioProcessingState.loading,
+        BackendProcessingState.buffering: AudioProcessingState.buffering,
+        BackendProcessingState.ready: AudioProcessingState.ready,
+        BackendProcessingState.completed: AudioProcessingState.completed,
+      };
+      for (final entry in expected.entries) {
+        for (final intentional in [true, false]) {
+          for (final empty in [true, false]) {
+            expect(
+              AudioPlayerHandler.publishProcessingState(entry.key,
+                  intentionalStop: intentional, queueEmpty: empty),
+              entry.value,
+              reason: '${entry.key} intentional=$intentional empty=$empty',
+            );
+          }
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
## The bug

just_audio flips its processing state to **idle on ANY playback error**, and `_broadcastState` mapped that straight to `AudioProcessingState.idle`. Verified in audio_service 0.18.19 source (`_observePlaybackState`, lib/audio_service.dart:1132): **every published non-idle→idle transition calls `AudioService._stop()` → `stopSelf()`**.

- App in foreground (activity bound): the service survives `stopSelf` — which is why this never reproduces at the desk.
- App swiped away / screen off (activity unbound): `stopSelf` → `onDestroy` → the **FlutterEngine is destroyed mid-recovery**. The retry / outage self-heal from #94 never runs, the notification vanishes, and playback is dead until the user relaunches. This is the background "playback just stops" mechanism, and it fires on a *single* transient network error.

## The fix

`_broadcastState` now publishes via `publishProcessingState(...)`:

- backend idle + `_intentionalStop` set **or** queue empty → publish `idle` (unchanged: user stop, cleared queue, end-of-queue, unplayable-queue give-up all still tear the service + notification down);
- backend idle, tracks still queued, no intentional stop → publish **`error`** — audio_service's only teardown trigger is `idle`, so the service, notification, and engine stay alive for the #94 recovery (same-track retry, outage pause-and-hold + `onNetworkRegained` resume).

`_intentionalStop` is set at the four deliberate-stop sites (`stop()`, `clearPlaylist`, the two give-up stops in `_skipFailedTrack`) and cleared only at restart entry points (`play()` / `restoreQueue`) — deliberately **not** cleared from observed backend states, where a straggler `ready` event racing a stop could clear it early and turn the stop's own idle into a bogus `error` broadcast that leaves the notification behind.

Side benefit: a cast receiver blipping to idle mid-session can no longer tear down the service either (the emulated backends only report idle intentionally on an emptied list, which passes through via the queue-empty condition).

## Verification

- New unit tests for the publish decision (error-idle suppressed; intentional/empty-queue idle passes; non-idle states map through): `flutter test` 70/70 pass
- `flutter analyze`: no issues in changed files
- Only in-app consumer of the published processing state is the EQ screen's `!= idle` retry trigger, which tolerates `error`

Fixes the highest-severity finding from the playback-stops review (follows #94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)