### PR TITLE
fix(cast): recover from renderer failures — the "casting just stops" cluster

### DIFF
--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -353,6 +353,7 @@ class AudioPlayerHandler extends BaseAudioHandler
           .timeout(const Duration(seconds: 12));
       return true;
     } catch (_) {
+      appLog('[cast] remote start timed out (12s)');
       return false;
     }
   }
@@ -362,6 +363,8 @@ class AudioPlayerHandler extends BaseAudioHandler
   // so the UI reverts to "This device" and shows a message.
   Future<void> _fallBackToLocal(PlaybackBackend prev, PlaybackBackend failed,
       Duration pos, int idx) async {
+    appLog('[cast] cast failed to start — back to this phone '
+        'at track ${idx + 1}, ${pos.inSeconds}s');
     await failed.pause();
     await _localBackend.setSources(queue.value);
     _backendSubject.add(_localBackend);
@@ -389,6 +392,8 @@ class AudioPlayerHandler extends BaseAudioHandler
       final pos = failed.position;
       final idx = failed.currentIndex ?? 0;
       final wasPlaying = failed.playing;
+      appLog('[cast] renderer lost mid-cast — back to this phone at '
+          'track ${idx + 1}, ${pos.inSeconds}s (playing=$wasPlaying)');
       await _localBackend.setSources(queue.value);
       _backendSubject.add(_localBackend);
       if (queue.value.isNotEmpty) {
@@ -1005,7 +1010,8 @@ class AudioPlayerHandler extends BaseAudioHandler
         break;
       case 'rebuildTranscodeUrls':
         await _rebuildTranscodeUrls(
-            upcomingOnly: extras?['upcomingOnly'] == true);
+            upcomingOnly: extras?['upcomingOnly'] == true,
+            auto: extras?['auto'] == true);
         break;
     }
   }
@@ -1024,16 +1030,54 @@ class AudioPlayerHandler extends BaseAudioHandler
     final server = _serverFor(m);
     if (path == null || server == null) return m; // local-only / unknown server
     final newId = buildServerStreamUrl(server, path);
-    return newId == m.id ? m : m.copyWith(id: newId);
+    return sameStreamUrl(newId, m.id) ? m : m.copyWith(id: newId);
   }
 
-  /// Rebuild queue stream URLs after a transcode-setting change.
+  /// Whether two stream URLs point at the same stream. buildServerStreamUrl
+  /// stamps a fresh cache-busting `app_uuid` on EVERY call, so a raw string
+  /// compare sees every rebuild as a change — and the auto-fired rebuild on
+  /// each tunnel (re)connect then reloads the whole queue (dumping the
+  /// player's buffer, or clobbering an active cast) even when endpoint, port
+  /// and token are identical. Compare everything except the cache-buster.
+  static bool sameStreamUrl(String a, String b) {
+    if (a == b) return true;
+    final ua = Uri.tryParse(a);
+    final ub = Uri.tryParse(b);
+    if (ua == null || ub == null) return false;
+    if (ua.scheme != ub.scheme ||
+        ua.host != ub.host ||
+        ua.port != ub.port ||
+        ua.path != ub.path) {
+      return false;
+    }
+    final qa = Map.of(ua.queryParameters)..remove('app_uuid');
+    final qb = Map.of(ub.queryParameters)..remove('app_uuid');
+    if (qa.length != qb.length) return false;
+    for (final e in qa.entries) {
+      if (qb[e.key] != e.value) return false;
+    }
+    return true;
+  }
+
+  /// Rebuild queue stream URLs after a transcode-setting change ([auto] false)
+  /// or a tunnel (re)connect ([auto] true, fired by ServerManager).
   ///
   /// [upcomingOnly] leaves the current track playing and only swaps the
   /// not-yet-played tracks; otherwise the whole queue reloads at the current
   /// index/position (the current track briefly re-buffers). No-op when no URL
   /// actually changes (e.g. nothing to convert, or transcoding unavailable).
-  Future<void> _rebuildTranscodeUrls({required bool upcomingOnly}) async {
+  Future<void> _rebuildTranscodeUrls(
+      {required bool upcomingOnly, bool auto = false}) async {
+    // An auto rebuild must not touch an active cast: the cast backends
+    // re-resolve every track's URL at load time (irohProxyUri rebinds to the
+    // live tunnel), so the reload is unnecessary — and issuing it mid-session
+    // clobbers the Cast SDK's own suspend/resume recovery (observed
+    // on-device: zombie TV + double audio after a Wi-Fi blip). A user-driven
+    // transcode change still applies while casting.
+    if (auto && !identical(_backend, _localBackend)) {
+      appLog('[queue] auto URL rebuild skipped while casting');
+      return;
+    }
     final q = queue.value;
     if (q.isEmpty) return;
     final cur = (_backend.currentIndex ?? 0).clamp(0, q.length - 1);
@@ -1069,9 +1113,11 @@ class AudioPlayerHandler extends BaseAudioHandler
       final rebuilt = q.map(_withRebuiltUrl).toList();
       bool changed = false;
       for (int i = 0; i < q.length; i++) {
-        if (rebuilt[i].id != q[i].id) changed = true;
+        if (!identical(rebuilt[i], q[i])) changed = true;
       }
       if (!changed) return;
+      appLog('[queue] stream URLs rebuilt — reloading at track ${cur + 1}'
+          '${auto ? ' (auto)' : ''}');
       final pos = _backend.position;
       final wasPlaying = _backend.playing;
       final wasShuffle = _backend.shuffleEnabled;

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -8,7 +8,6 @@ import 'package:just_audio/just_audio.dart';
 import 'package:mstream_music/main.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:http/http.dart' as http;
-import 'package:connectivity_plus/connectivity_plus.dart';
 import 'playback_backend.dart';
 import 'local_playback_backend.dart';
 import 'dlna_playback_backend.dart';
@@ -26,6 +25,7 @@ import '../singletons/log_manager.dart';
 import '../singletons/settings.dart';
 import '../singletons/server_list.dart';
 import '../util/camelot.dart';
+import '../util/connectivity_probe.dart';
 import '../util/stream_url.dart';
 
 /// An [AudioHandler] for playing a list of podcast episodes.
@@ -296,7 +296,12 @@ class AudioPlayerHandler extends BaseAudioHandler
 
     await next.setShuffleEnabled(prev.shuffleEnabled);
     await next.setRepeat(prev.repeat);
-    await next.setSources(queue.value);
+    // Returning to the phone must re-derive queue URLs (the auto rebuild is
+    // skipped while casting; a tunnel restart mid-cast leaves stale loopback
+    // ports in the stored ids). Cast backends re-resolve per track instead.
+    await next.setSources(identical(next, _localBackend)
+        ? _queueWithFreshUrls()
+        : queue.value);
     _backendSubject.add(next);
     if (queue.value.isNotEmpty) {
       // Carry the play state into the load: a renderer then auto-plays when its
@@ -368,25 +373,16 @@ class AudioPlayerHandler extends BaseAudioHandler
     try {
       await failed.pause();
     } catch (_) {}
-    // Subject swap first, disposals in a finally — same reasoning as
-    // _onRendererLost: a fallback load fighting a dead server must not leak
-    // the remote backends or strand the handler on one of them.
-    _backendSubject.add(_localBackend);
-    try {
-      await _localBackend.setSources(queue.value);
-      if (queue.value.isNotEmpty) {
-        await _localBackend.seek(pos, index: idx, play: true);
-      }
-    } finally {
-      _broadcastState();
-      if (!identical(failed, _localBackend)) await failed.dispose();
-      if (!identical(prev, _localBackend) && !identical(prev, failed)) {
-        await prev.dispose();
-      }
-      await LocalMediaServer().stop();
-      CastManager().reportCastFailed(
-          "Couldn't play on the cast device — back on this phone");
-    }
+    await _reseedLocalAfterCastLoss(
+      pos: pos,
+      idx: idx,
+      play: true,
+      dispose: [
+        if (!identical(failed, _localBackend)) failed,
+        if (!identical(prev, _localBackend) && !identical(prev, failed)) prev,
+      ],
+      message: "Couldn't play on the cast device — back on this phone",
+    );
   }
 
   // A remote renderer dropped offline *during* playback (not at switch time —
@@ -402,27 +398,66 @@ class AudioPlayerHandler extends BaseAudioHandler
       final wasPlaying = failed.playing;
       appLog('[cast] renderer lost mid-cast — back to this phone at '
           'track ${idx + 1}, ${pos.inSeconds}s (playing=$wasPlaying)');
-      // Hand control to the local backend BEFORE its (fallible) load, and
-      // dispose the failed one in a finally: the reseed can throw when the
-      // fallback is itself fighting a dead server (its errors then flow to
-      // _onPlaybackError, whose recovery owns them) — skipping the dispose
-      // leaked the cast backend's ticker + session listener, and skipping
-      // the subject swap stranded the handler on a dead backend.
-      _backendSubject.add(_localBackend);
-      try {
-        await _localBackend.setSources(queue.value);
-        if (queue.value.isNotEmpty) {
-          await _localBackend.seek(pos, index: idx, play: wasPlaying);
-        }
-      } finally {
-        _broadcastState();
-        await failed.dispose();
-        await LocalMediaServer().stop();
-        CastManager().reportCastFailed(message);
-      }
+      await _reseedLocalAfterCastLoss(
+          pos: pos, idx: idx, play: wasPlaying, dispose: [failed], message: message);
     }).catchError((Object e) {
       castLog('Renderer-lost fallback failed', error: e);
     });
+  }
+
+  /// Shared tail of every lost/failed-cast fallback: reseed the LOCAL backend
+  /// with the queue (URLs refreshed — see [_queueWithFreshUrls]) and park/play
+  /// at [pos]/[idx], then — in a `finally`, so a reseed fighting a dead server
+  /// can't skip it — hand the subject over, dispose the remote [dispose]
+  /// backends (leaking one leaves its tickers + session listeners running),
+  /// stop the LAN file server, and surface [message]. The subject swap sits in
+  /// the `finally` too: after a THROWING reseed the handler must still point
+  /// at the local backend (whose errorStream recovery owns dead-server
+  /// handling), and on the happy path swapping after the load means the
+  /// switchMap listeners replay a loaded player, not a stale idle one.
+  Future<void> _reseedLocalAfterCastLoss({
+    required Duration pos,
+    required int idx,
+    required bool play,
+    required List<PlaybackBackend> dispose,
+    required String message,
+  }) async {
+    try {
+      final items = _queueWithFreshUrls();
+      await _localBackend.setSources(items);
+      if (items.isNotEmpty) {
+        await _localBackend.seek(pos, index: idx, play: play);
+      }
+    } finally {
+      _backendSubject.add(_localBackend);
+      _broadcastState();
+      for (final b in dispose) {
+        await b.dispose();
+      }
+      await LocalMediaServer().stop();
+      CastManager().reportCastFailed(message);
+    }
+  }
+
+  /// The queue with every stream URL re-derived against the CURRENT tunnel /
+  /// transcode state, updating the queue subject when anything changed. The
+  /// auto rebuild is skipped while casting (cast loads re-resolve per track),
+  /// so this is the deferred catch-up every return-to-local must run: after a
+  /// tunnel restart mid-cast the stored ids still carry the OLD loopback
+  /// port/token, and seeding just_audio with those fails on a tunnel that
+  /// LOOKS healthy (tunnelServes == true), which sidesteps the iroh recovery.
+  List<MediaItem> _queueWithFreshUrls() {
+    final q = queue.value;
+    if (q.isEmpty) return q;
+    final rebuilt = q.map(_withRebuiltUrl).toList();
+    var changed = false;
+    for (int i = 0; i < q.length; i++) {
+      if (!identical(rebuilt[i], q[i])) changed = true;
+    }
+    if (!changed) return q;
+    appLog('[queue] stream URLs refreshed on return to local playback');
+    queue.add(rebuilt);
+    return rebuilt;
   }
 
   // just_audio surfaced a playback error (local stream path only — remote
@@ -548,7 +583,7 @@ class AudioPlayerHandler extends BaseAudioHandler
       // outage, PAUSE (don't stop) and arm onNetworkRegained to resume when it
       // returns; connectivity present → the sources/server are bad, so stop.
       _failedSkips = 0;
-      if (!await _hasNetwork()) {
+      if (!await hasConnectivity()) {
         _showPlaybackErrorToast(
             'Lost the connection — paused. Resumes when you’re back online.');
         await _localBackend.pause();
@@ -572,7 +607,7 @@ class AudioPlayerHandler extends BaseAudioHandler
       // connectivity → pause + arm self-heal so the user's spot survives;
       // otherwise stop.
       _failedSkips = 0;
-      if (!await _hasNetwork()) {
+      if (!await hasConnectivity()) {
         await _localBackend.pause();
         _networkStalled = true;
       } else {
@@ -624,7 +659,7 @@ class AudioPlayerHandler extends BaseAudioHandler
       if (queue.value.isEmpty || !identical(_backend, _localBackend)) return;
       // No network → an outage: pause-and-hold and let onNetworkRegained resume
       // us when it's back, instead of churning retries/skips that all fail.
-      if (!await _hasNetwork()) {
+      if (!await hasConnectivity()) {
         appLog('[play] network outage — pausing at '
             'track ${(_localBackend.currentIndex ?? 0) + 1}; '
             'will self-heal when connectivity returns');
@@ -688,26 +723,13 @@ class AudioPlayerHandler extends BaseAudioHandler
     }).whenComplete(() => _recoveringPlayback = false);
   }
 
-  // Is any network interface up right now? After every queued track has failed,
-  // this is the reliable signal for outage (pause + self-heal) vs bad sources
-  // (stop) — the error string can't distinguish them on Android. Best-effort: a
-  // failed probe assumes online, so we stop rather than leave a stuck pause.
-  Future<bool> _hasNetwork() async {
-    try {
-      final r = await Connectivity().checkConnectivity();
-      return r.any((c) => c != ConnectivityResult.none);
-    } catch (_) {
-      return true;
-    }
-  }
-
   // Heuristic: does this error look like a clearly bad/unplayable source (skip
   // now) vs something worth retrying (a network/transport blip)? Best-effort and
   // platform-limited: on Android ExoPlayer reports almost everything — INCLUDING
   // 404s — as a generic "(0) Source error" and doesn't forward the real cause to
   // Dart, so most failures fall through to "retry" (bounded by _kMaxHttpRetries).
   // The needles below mainly catch iOS/web, where the message is richer. The real
-  // outage-vs-bad-source decision for the END state is made by _hasNetwork().
+  // outage-vs-bad-source decision for the END state is made by hasConnectivity().
   static bool _isTransientNetworkError(Object error) {
     final s = error.toString().toLowerCase();
     // Clear "bad/unplayable source" signals → not transient (skip, don't retry).
@@ -1048,32 +1070,6 @@ class AudioPlayerHandler extends BaseAudioHandler
     if (path == null || server == null) return m; // local-only / unknown server
     final newId = buildServerStreamUrl(server, path);
     return sameStreamUrl(newId, m.id) ? m : m.copyWith(id: newId);
-  }
-
-  /// Whether two stream URLs point at the same stream. buildServerStreamUrl
-  /// stamps a fresh cache-busting `app_uuid` on EVERY call, so a raw string
-  /// compare sees every rebuild as a change — and the auto-fired rebuild on
-  /// each tunnel (re)connect then reloads the whole queue (dumping the
-  /// player's buffer, or clobbering an active cast) even when endpoint, port
-  /// and token are identical. Compare everything except the cache-buster.
-  static bool sameStreamUrl(String a, String b) {
-    if (a == b) return true;
-    final ua = Uri.tryParse(a);
-    final ub = Uri.tryParse(b);
-    if (ua == null || ub == null) return false;
-    if (ua.scheme != ub.scheme ||
-        ua.host != ub.host ||
-        ua.port != ub.port ||
-        ua.path != ub.path) {
-      return false;
-    }
-    final qa = Map.of(ua.queryParameters)..remove('app_uuid');
-    final qb = Map.of(ub.queryParameters)..remove('app_uuid');
-    if (qa.length != qb.length) return false;
-    for (final e in qa.entries) {
-      if (qb[e.key] != e.value) return false;
-    }
-    return true;
   }
 
   /// Rebuild queue stream URLs after a transcode-setting change ([auto] false)

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -323,6 +323,13 @@ class AudioPlayerHandler extends BaseAudioHandler
     }
 
     if (!identical(prev, _localBackend)) {
+      // Chromecast → Chromecast (device change or visualizer toggle): the Cast
+      // session is app-global, shared by both backend instances — the outgoing
+      // one must not end the session the new one just loaded media on.
+      if (prev is ChromecastPlaybackBackend &&
+          next is ChromecastPlaybackBackend) {
+        prev.prepareCastToCastHandoff(next);
+      }
       await prev.dispose();
     }
     // Switched back to the phone — tear down the local file server (no-op if it

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -365,20 +365,28 @@ class AudioPlayerHandler extends BaseAudioHandler
       Duration pos, int idx) async {
     appLog('[cast] cast failed to start — back to this phone '
         'at track ${idx + 1}, ${pos.inSeconds}s');
-    await failed.pause();
-    await _localBackend.setSources(queue.value);
+    try {
+      await failed.pause();
+    } catch (_) {}
+    // Subject swap first, disposals in a finally — same reasoning as
+    // _onRendererLost: a fallback load fighting a dead server must not leak
+    // the remote backends or strand the handler on one of them.
     _backendSubject.add(_localBackend);
-    if (queue.value.isNotEmpty) {
-      await _localBackend.seek(pos, index: idx, play: true);
+    try {
+      await _localBackend.setSources(queue.value);
+      if (queue.value.isNotEmpty) {
+        await _localBackend.seek(pos, index: idx, play: true);
+      }
+    } finally {
+      _broadcastState();
+      if (!identical(failed, _localBackend)) await failed.dispose();
+      if (!identical(prev, _localBackend) && !identical(prev, failed)) {
+        await prev.dispose();
+      }
+      await LocalMediaServer().stop();
+      CastManager().reportCastFailed(
+          "Couldn't play on the cast device — back on this phone");
     }
-    _broadcastState();
-    if (!identical(failed, _localBackend)) await failed.dispose();
-    if (!identical(prev, _localBackend) && !identical(prev, failed)) {
-      await prev.dispose();
-    }
-    await LocalMediaServer().stop();
-    CastManager().reportCastFailed(
-        "Couldn't play on the cast device — back on this phone");
   }
 
   // A remote renderer dropped offline *during* playback (not at switch time —
@@ -394,15 +402,24 @@ class AudioPlayerHandler extends BaseAudioHandler
       final wasPlaying = failed.playing;
       appLog('[cast] renderer lost mid-cast — back to this phone at '
           'track ${idx + 1}, ${pos.inSeconds}s (playing=$wasPlaying)');
-      await _localBackend.setSources(queue.value);
+      // Hand control to the local backend BEFORE its (fallible) load, and
+      // dispose the failed one in a finally: the reseed can throw when the
+      // fallback is itself fighting a dead server (its errors then flow to
+      // _onPlaybackError, whose recovery owns them) — skipping the dispose
+      // leaked the cast backend's ticker + session listener, and skipping
+      // the subject swap stranded the handler on a dead backend.
       _backendSubject.add(_localBackend);
-      if (queue.value.isNotEmpty) {
-        await _localBackend.seek(pos, index: idx, play: wasPlaying);
+      try {
+        await _localBackend.setSources(queue.value);
+        if (queue.value.isNotEmpty) {
+          await _localBackend.seek(pos, index: idx, play: wasPlaying);
+        }
+      } finally {
+        _broadcastState();
+        await failed.dispose();
+        await LocalMediaServer().stop();
+        CastManager().reportCastFailed(message);
       }
-      _broadcastState();
-      await failed.dispose();
-      await LocalMediaServer().stop();
-      CastManager().reportCastFailed(message);
     }).catchError((Object e) {
       castLog('Renderer-lost fallback failed', error: e);
     });

--- a/lib/media/cast_origin.dart
+++ b/lib/media/cast_origin.dart
@@ -46,8 +46,18 @@ Uri irohLoopbackUri(Server server, String stored) {
 /// `__lt` token rides only the inward leg and never appears in the LAN-facing
 /// URL. The caller must have started [LocalMediaServer] first
 /// ([LocalMediaServer.ensureStarted]).
-Uri irohProxyUri(Server server, String loopback) =>
-    LocalMediaServer().registerProxy(irohLoopbackUri(server, loopback));
+Uri irohProxyUri(Server server, String loopback) {
+  // Fail fast when the tunnel isn't live: handing the renderer a proxy URL
+  // whose upstream can't answer leaves the receiver stuck 'loading' (observed
+  // on-device on a demo→iroh queue jump with the server down). Throwing here
+  // fails the load, which feeds the bounded cast failure walk immediately —
+  // and the walk's renderer-lost fallback lands on the phone, whose local
+  // iroh recovery owns waiting for the tunnel.
+  if (!ServerManager().tunnelServes(server)) {
+    throw StateError('iroh tunnel is not serving ${server.localname}');
+  }
+  return LocalMediaServer().registerProxy(irohLoopbackUri(server, loopback));
+}
 
 /// The album-art URL to hand a renderer: full-resolution [castArtUrl], re-
 /// originated through the LAN proxy when the track is from an iroh server.

--- a/lib/media/cast_origin.dart
+++ b/lib/media/cast_origin.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show File;
+
 import 'package:audio_service/audio_service.dart' show MediaItem;
 
 import '../objects/server.dart';
@@ -68,5 +70,42 @@ String? castArtUriFor(MediaItem item) {
   final art = castArtUrl(item);
   if (art == null) return null;
   final server = irohServerFor(item);
-  return server == null ? art : irohProxyUri(server, art).toString();
+  if (server == null) return art;
+  try {
+    return irohProxyUri(server, art).toString();
+  } catch (_) {
+    // Art is optional: a dead tunnel must not fail the whole load — notably a
+    // DOWNLOADED iroh track streams from disk and needs no tunnel at all.
+    return null;
+  }
+}
+
+/// Resolve the URL a RENDERER can fetch [item] from. Shared by both cast
+/// backends: a plain HTTP server id is handed over as-is; a local-only item
+/// (file-explorer track — id is a UUID) is served from the phone's
+/// [LocalMediaServer]; an iroh server's id is the phone-loopback tunnel URL a
+/// device across the LAN can't reach, so it's relayed through the
+/// [LocalMediaServer] proxy (re-bound to the live tunnel). A downloaded iroh
+/// track is served from disk — faster, and it needs no tunnel.
+/// Throws (via [irohProxyUri]) when a needed tunnel isn't serving, so the
+/// load fails fast into the cast failure walk.
+Future<Uri> resolveRendererUri(MediaItem item) async {
+  final localPath = item.extras?['localPath'] as String?;
+  final isNetwork =
+      item.id.startsWith('http://') || item.id.startsWith('https://');
+  if (!isNetwork && localPath != null && File(localPath).existsSync()) {
+    await LocalMediaServer().ensureStarted();
+    return LocalMediaServer().registerFile(localPath);
+  }
+  final iroh = irohServerFor(item);
+  if (iroh != null) {
+    await LocalMediaServer().ensureStarted();
+    // A downloaded iroh track's id is a 127.0.0.1 loopback URL, so isNetwork
+    // is true and the disk branch above is bypassed; handle it here.
+    if (localPath != null && File(localPath).existsSync()) {
+      return LocalMediaServer().registerFile(localPath);
+    }
+    return irohProxyUri(iroh, item.id);
+  }
+  return Uri.parse(item.id);
 }

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -118,32 +118,28 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   // interpolated locally). Mirrors the DLNA backend's poll-failure detection.
   Timer? _staleTicker;
   DateTime _lastRendererEvent = DateTime.now();
-  bool _reattaching = false;
+  // Serializes the recovery loop: _onGraceExpired is the ONLY actor (probe /
+  // SDK window / re-attach / give up); the watchdog and session events merely
+  // ARM its timer. Round-4 smoke had the watchdog re-attaching directly —
+  // racing the grace loop's own re-attach (double session starts) and firing
+  // renderer-lost after a single attempt made at the worst possible moment
+  // (Play Services needs seconds back on the LAN before it can start
+  // sessions), which burned the whole budget in 12s.
+  bool _lossBusy = false;
   static const Duration _kStaleAfter = Duration(seconds: 20);
 
   void _noteRendererEvent() => _lastRendererEvent = DateTime.now();
 
   Future<void> _checkStale() async {
-    if (_disposing || _lostFired || _reattaching || !playing) return;
+    if (_disposing || _lostFired || !playing) return;
+    if (_sessionLossGrace != null || _lossBusy) return; // recovery already live
     if (DateTime.now().difference(_lastRendererEvent) < _kStaleAfter) return;
-    _reattaching = true;
-    try {
-      appLog('[cast] no renderer events for ${_kStaleAfter.inSeconds}s '
-          'while playing — probing the session');
-      if (!await _hasLanNetwork()) {
-        // Same as an offline session drop: wait out the LAN via the grace loop.
-        _graceWasOffline = true;
-        _sessionLossGrace ??= Timer(_kSessionLossGrace, _onGraceExpired);
-        return;
-      }
-      if (await _tryReattach()) {
-        appLog('[cast] re-attached after a silent session loss');
-        return;
-      }
-      _fireRendererLost();
-    } finally {
-      _reattaching = false;
-    }
+    appLog('[cast] no renderer events for ${_kStaleAfter.inSeconds}s '
+        'while playing — starting loss recovery');
+    // Offline waits out the LAN like any drop; a half-dead socket with the
+    // LAN up skips the SDK-courtesy window (the SDK hasn't even noticed).
+    _graceWasOffline = !await _hasLanNetwork();
+    _sessionLossGrace ??= Timer(_kSessionLossGrace, _onGraceExpired);
   }
 
   void _ensureListeners() {
@@ -207,39 +203,50 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     // double-driving this handler.
     _sessionLossGrace?.cancel();
     _sessionLossGrace = null;
-    if (_disposing || _lostFired || _sessions.hasConnectedSession) return;
-    if (_graceExtensions < _kMaxGraceExtensions) {
+    if (_disposing || _lostFired || _lossBusy) return;
+    if (_sessions.hasConnectedSession) return; // SDK recovered on its own
+    _lossBusy = true;
+    try {
+      if (_graceExtensions >= _kMaxGraceExtensions) {
+        _fireRendererLost();
+        return;
+      }
+      _graceExtensions++;
       if (!await _hasLanNetwork()) {
         // The LAN is still down — neither the SDK nor we can reach the
         // renderer yet.
-        _graceExtensions++;
         _graceWasOffline = true;
-        _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
+        _rearmLossRecovery();
         return;
       }
       if (_graceWasOffline) {
-        // The network came back since the last check. The SDK auto-resumes a
-        // SUSPENDED session from here (give it the window below) — but a
-        // network drop that surfaced as an END won't resume on its own, so
-        // actively re-attach: rejoin (or relaunch) the receiver and pick
-        // playback back up. The receiver keeps playing through a sender-side
-        // drop, so a successful rejoin is usually seamless.
-        _graceExtensions++;
-        if (await _tryReattach()) {
-          appLog('[cast] re-attached to the cast device after a network drop');
-          _graceWasOffline = false;
-          _graceExtensions = 0;
-          return;
-        }
-        if (_sessions.hasConnectedSession) return; // SDK resumed meanwhile
-        // Not yet (device not re-discovered / session won't start) — another
-        // window, bounded by the extension budget.
-        _sessionLossGrace?.cancel();
-        _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
+        // First window after the LAN returned: the SDK auto-resumes a merely
+        // SUSPENDED session in this time, and Play Services itself needs a
+        // few seconds back on the network before it can start sessions — one
+        // quiet window before we intervene.
+        _graceWasOffline = false;
+        _rearmLossRecovery();
         return;
       }
+      // The LAN is up and the SDK had its window: re-attach ourselves —
+      // rejoin (or relaunch) the receiver and pick playback back up. The
+      // receiver keeps playing through a sender-side drop, so a successful
+      // rejoin is usually seamless. Retries ride the extension budget.
+      if (await _tryReattach()) {
+        appLog('[cast] re-attached to the cast device');
+        _graceExtensions = 0;
+        return;
+      }
+      if (_sessions.hasConnectedSession) return; // SDK resumed meanwhile
+      _rearmLossRecovery();
+    } finally {
+      _lossBusy = false;
     }
-    _fireRendererLost();
+  }
+
+  void _rearmLossRecovery() {
+    _sessionLossGrace?.cancel();
+    _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
   }
 
   // Rebuild the session after a network-drop END and pick playback back up.

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -256,7 +256,26 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   // hiccup. Otherwise (receiver relaunched idle / nothing arrives) reload the
   // current track at the last known position.
   Future<bool> _tryReattach() async {
+    var startedDiscovery = false;
     try {
+      // startSessionWithDevice resolves through MediaRouter's LIVE route list
+      // — the plugin's native selectRoute silently no-ops when the route is
+      // absent — and routes are only maintained while discovery runs, which
+      // is normally only while the cast picker is open. Round-5 smoke burned
+      // its whole retry budget on that silent no-op. Re-populate the routes
+      // and wait for OUR device to reappear (post-blip mDNS takes seconds).
+      final discovery = GoogleCastDiscoveryManager.instance;
+      if (!discovery.devices.any((d) => d.deviceID == _deviceId)) {
+        await discovery.startDiscovery();
+        startedDiscovery = true;
+        try {
+          await discovery.devicesStream
+              .firstWhere((ds) => ds.any((d) => d.deviceID == _deviceId))
+              .timeout(const Duration(seconds: 8));
+        } catch (_) {
+          return false; // device hasn't reappeared — retry next window
+        }
+      }
       _sessionStarted = false; // force _ensureSession to re-connect
       await _ensureSession();
       if (!_sessions.hasConnectedSession) return false;
@@ -289,6 +308,14 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     } catch (e) {
       castLog('cast re-attach failed', error: e);
       return false;
+    } finally {
+      if (startedDiscovery) {
+        // Don't leave a background mDNS scan running (battery); the picker
+        // manages its own discovery lifecycle when open.
+        try {
+          await GoogleCastDiscoveryManager.instance.stopDiscovery();
+        } catch (_) {}
+      }
     }
   }
 

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -118,6 +118,12 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   // interpolated locally). Mirrors the DLNA backend's poll-failure detection.
   Timer? _staleTicker;
   DateTime _lastRendererEvent = DateTime.now();
+  // A receiver stuck fetching media it can never get (dead iroh tunnel, dead
+  // server) keeps its status channel ALIVE — event-silence staleness never
+  // trips. Track how long we've been in loading/buffering without reaching
+  // playback; past the threshold the track is failed into the bounded walk.
+  DateTime? _loadingSince;
+  static const Duration _kStuckLoadingAfter = Duration(seconds: 30);
   // Serializes the recovery loop: _onGraceExpired is the ONLY actor (probe /
   // SDK window / re-attach / give up); the watchdog and session events merely
   // ARM its timer. Round-4 smoke had the watchdog re-attaching directly —
@@ -131,8 +137,18 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   void _noteRendererEvent() => _lastRendererEvent = DateTime.now();
 
   Future<void> _checkStale() async {
-    if (_disposing || _lostFired || !playing) return;
+    if (_disposing || _lostFired) return;
     if (_sessionLossGrace != null || _lossBusy) return; // recovery already live
+    final loading = _loadingSince;
+    if (loading != null &&
+        DateTime.now().difference(loading) > _kStuckLoadingAfter) {
+      _loadingSince = null;
+      appLog('[cast] receiver stuck loading for '
+          '${_kStuckLoadingAfter.inSeconds}s — treating as a failed track');
+      unawaited(trackFailed('receiver stuck loading'));
+      return;
+    }
+    if (!playing) return;
     if (DateTime.now().difference(_lastRendererEvent) < _kStaleAfter) return;
     appLog('[cast] no renderer events for ${_kStaleAfter.inSeconds}s '
         'while playing — starting loss recovery');
@@ -405,16 +421,20 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       case CastMediaPlayerState.playing:
         playing = true;
         trackPlaying();
+        _loadingSince = null;
         setProcessingState(BackendProcessingState.ready);
         break;
       case CastMediaPlayerState.paused:
         playing = false;
+        _loadingSince = null;
         setProcessingState(BackendProcessingState.ready);
         break;
       case CastMediaPlayerState.buffering:
+        _loadingSince ??= DateTime.now();
         setProcessingState(BackendProcessingState.buffering);
         break;
       case CastMediaPlayerState.loading:
+        _loadingSince ??= DateTime.now();
         setProcessingState(BackendProcessingState.loading);
         break;
       case CastMediaPlayerState.idle:
@@ -533,8 +553,9 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     index = target;
     emitIndex(target);
     // A load (visualizer warm-up especially) legitimately produces no renderer
-    // events for many seconds — restart the staleness clock.
+    // events for many seconds — restart the staleness and stuck-loading clocks.
     _noteRendererEvent();
+    _loadingSince = DateTime.now();
     setProcessingState(BackendProcessingState.loading);
     try {
       await _ensureSession();

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -76,6 +76,26 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   Timer? _sessionLossGrace;
   static const Duration _kSessionLossGrace = Duration(seconds: 10);
 
+  // Set via prepareCastToCastHandoff when the backend replacing this one is
+  // also a Chromecast backend — teardown then leaves the shared session (and,
+  // when the successor casts the visualizer, the global transcode pipeline)
+  // to the successor instead of destroying what it is already using.
+  bool _keepSharedSession = false;
+  bool _handoffToVisualizer = false;
+
+  /// Called by the handler before disposing this backend on a Chromecast →
+  /// Chromecast switch (device change or visualizer toggle). The Cast SDK
+  /// holds ONE session per app, shared by every backend instance through the
+  /// singleton session manager — ending it in [disposeRenderer] would stop
+  /// the session the successor just loaded media on. Likewise the visualizer
+  /// transcode pipeline is global: when the successor runs the visualizer,
+  /// its own first load already stopped ours and started its own, so stopping
+  /// "the" transcode here would cut the successor's stream.
+  void prepareCastToCastHandoff(ChromecastPlaybackBackend next) {
+    _keepSharedSession = true;
+    _handoffToVisualizer = next._visualizer;
+  }
+
   void _ensureListeners() {
     _statusSub ??= _client.mediaStatusStream.listen(_onStatus);
     _positionSub ??= _client.playerPositionStream.listen((pos) {
@@ -169,6 +189,17 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     }
     if (device == null) {
       throw StateError('Chromecast device $_deviceId not found in discovery');
+    }
+    if (_sessions.hasConnectedSession &&
+        _sessions.currentSession?.device?.deviceID != _deviceId) {
+      // The existing session is on a DIFFERENT Chromecast (cast→cast device
+      // switch). The SDK holds one session per app, so it must be moved —
+      // reusing it would keep casting to the old device.
+      try {
+        await _sessions.endSessionAndStopCasting();
+      } catch (e) {
+        castLog('Ending the previous cast session failed', error: e);
+      }
     }
     if (!_sessions.hasConnectedSession) {
       await _sessions.startSessionWithDevice(device);
@@ -500,9 +531,11 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   Future<void> disposeRenderer() async {
     _disposing = true;
     _sessionLossGrace?.cancel();
-    if (_visualizer) {
+    if (_visualizer && !_handoffToVisualizer) {
       // Stop the off-screen transcode so it isn't left encoding after we switch
       // away. (LocalMediaServer is torn down by the handler on switch-to-local.)
+      // Skipped on a handoff to another visualizer backend, whose first load
+      // already stopped ours and now owns the global pipeline.
       try {
         await VisualizerBridge.stopTranscode();
       } catch (_) {}
@@ -511,8 +544,10 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     await _statusSub?.cancel();
     await _positionSub?.cancel();
     await _sessionSub?.cancel();
-    try {
-      await _sessions.endSessionAndStopCasting();
-    } catch (_) {}
+    if (!_keepSharedSession) {
+      try {
+        await _sessions.endSessionAndStopCasting();
+      } catch (_) {}
+    }
   }
 }

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -56,7 +56,6 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   // Readiness poll: 20 × 500 ms = 10 s for the first segments before giving up.
   static const int _kReadyPollAttempts = 20;
 
-  bool _advancing = false;
   bool _sessionStarted = false;
 
   StreamSubscription<GoggleCastMediaStatus?>? _statusSub;
@@ -101,7 +100,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     switch (status.playerState) {
       case CastMediaPlayerState.playing:
         playing = true;
-        _advancing = false;
+        trackPlaying();
         setProcessingState(BackendProcessingState.ready);
         break;
       case CastMediaPlayerState.paused:
@@ -115,29 +114,22 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
         setProcessingState(BackendProcessingState.loading);
         break;
       case CastMediaPlayerState.idle:
-        // Only a natural FINISH means end-of-track; cancelled/interrupted are
-        // our own load/stop transitions and must not trigger an advance.
+        // A natural FINISH advances. ERROR means the receiver couldn't fetch
+        // or decode the track (server blip, proxy 502, bad media) — walk on,
+        // bounded, instead of leaving the TV silent with the state stuck on
+        // 'playing'. cancelled/interrupted are our own load/stop transitions
+        // and must not trigger anything.
         if (status.idleReason == GoogleCastMediaIdleReason.finished) {
-          _onTrackEnded();
+          advanceOnComplete();
+        } else if (status.idleReason == GoogleCastMediaIdleReason.error) {
+          playing = false;
+          trackFailed('receiver reported a media error');
         }
         break;
       case CastMediaPlayerState.unknown:
         break;
     }
     change();
-  }
-
-  Future<void> _onTrackEnded() async {
-    if (_advancing) return;
-    _advancing = true;
-    final n = nextIndex(onComplete: true);
-    if (n != null) {
-      await loadIndex(n, play: true);
-    } else {
-      playing = false;
-      _advancing = false;
-      setProcessingState(BackendProcessingState.completed);
-    }
   }
 
   Future<void> _ensureSession() async {

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -291,12 +291,26 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
               .firstWhere((ds) => ds.any((d) => d.deviceID == _deviceId))
               .timeout(const Duration(seconds: 8));
         } catch (_) {
+          appLog('[cast] re-attach: device not re-discovered yet');
           return false; // device hasn't reappeared — retry next window
         }
       }
+      if (_sessions.currentSession != null && !_sessions.hasConnectedSession) {
+        // A stale SUSPENDED session lingers — startSessionWithDevice collides
+        // with it (round-7 smoke: every connect wait expired). End it
+        // gracefully (endSession does NOT stop the receiver, which keeps
+        // playing) so the fresh start below can cleanly JOIN the receiver.
+        appLog('[cast] re-attach: clearing the stale suspended session');
+        try {
+          await _sessions.endSession();
+        } catch (_) {}
+      }
       _sessionStarted = false; // force _ensureSession to re-connect
       await _ensureSession();
-      if (!_sessions.hasConnectedSession) return false;
+      if (!_sessions.hasConnectedSession) {
+        appLog('[cast] re-attach: session did not connect');
+        return false;
+      }
       _lostFired = false;
       GoggleCastMediaStatus? fresh;
       try {
@@ -320,7 +334,10 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
           if (!_sessions.hasConnectedSession) return false;
         }
         final ok = await loadIndex(index, play: playing, startAt: position);
-        if (!ok) return false;
+        if (!ok) {
+          appLog('[cast] re-attach: reload on the rejoined session failed');
+          return false;
+        }
       }
       return true;
     } catch (e) {

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -137,7 +137,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   void _noteRendererEvent() => _lastRendererEvent = DateTime.now();
 
   Future<void> _checkStale() async {
-    if (_disposing || _lostFired) return;
+    if (_disposing || _lostFired || rendererLostEmitted) return;
     if (_sessionLossGrace != null || _lossBusy) return; // recovery already live
     final loading = _loadingSince;
     if (loading != null &&

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -181,7 +181,10 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
         unawaited(_onSessionEnded());
         return;
       }
-      _sessionLossGrace ??= Timer(_kSessionLossGrace, _onGraceExpired);
+      if (_sessionLossGrace == null && !_lossBusy) {
+        appLog('[cast] session suspended — starting loss recovery');
+        _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
+      }
     });
   }
 
@@ -192,6 +195,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       _fireRendererLost();
       return;
     }
+    appLog('[cast] session ended while the LAN is down — starting loss recovery');
     _graceWasOffline = true;
     _sessionLossGrace ??= Timer(_kSessionLossGrace, _onGraceExpired);
   }
@@ -215,6 +219,8 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       if (!await _hasLanNetwork()) {
         // The LAN is still down — neither the SDK nor we can reach the
         // renderer yet.
+        appLog('[cast] loss recovery $_graceExtensions/$_kMaxGraceExtensions: '
+            'LAN still down, waiting');
         _graceWasOffline = true;
         _rearmLossRecovery();
         return;
@@ -224,6 +230,8 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
         // SUSPENDED session in this time, and Play Services itself needs a
         // few seconds back on the network before it can start sessions — one
         // quiet window before we intervene.
+        appLog('[cast] loss recovery $_graceExtensions/$_kMaxGraceExtensions: '
+            'LAN back — giving the SDK one window to resume');
         _graceWasOffline = false;
         _rearmLossRecovery();
         return;
@@ -231,8 +239,18 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       // The LAN is up and the SDK had its window: re-attach ourselves —
       // rejoin (or relaunch) the receiver and pick playback back up. The
       // receiver keeps playing through a sender-side drop, so a successful
-      // rejoin is usually seamless. Retries ride the extension budget.
-      if (await _tryReattach()) {
+      // rejoin is usually seamless. Retries ride the extension budget. The
+      // hard timeout is load-bearing: plugin calls against a broken session
+      // can hang forever (round-6 smoke froze the whole recovery machine —
+      // a hanging await never reaches finally, so _lossBusy never cleared).
+      appLog('[cast] loss recovery $_graceExtensions/$_kMaxGraceExtensions: '
+          're-attaching');
+      final ok = await _tryReattach().timeout(const Duration(seconds: 30),
+          onTimeout: () {
+        appLog('[cast] re-attach attempt hung (30s) — will retry');
+        return false;
+      });
+      if (ok) {
         appLog('[cast] re-attached to the cast device');
         _graceExtensions = 0;
         return;
@@ -306,7 +324,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       }
       return true;
     } catch (e) {
-      castLog('cast re-attach failed', error: e);
+      appLog('[cast] re-attach attempt failed: $e');
       return false;
     } finally {
       if (startedDiscovery) {

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -63,10 +63,18 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   StreamSubscription<dynamic>? _sessionSub;
 
   // Guards the renderer-lost emit. _disposing suppresses our own teardown;
-  // _lostFired makes it one-shot (disconnecting → disconnected would otherwise
-  // emit twice).
+  // _lostFired makes it one-shot per drop (disconnecting → disconnected would
+  // otherwise emit twice); it re-arms when the session reconnects.
   bool _disposing = false;
   bool _lostFired = false;
+
+  // Grace timer for a not-connected session: the Cast SDK SUSPENDS a session
+  // on a transient network blip and auto-resumes it (the receiver keeps
+  // playing from its buffer), so tearing down immediately would turn a
+  // 3-second Wi-Fi blip into a dead cast. A session that ENDS outright
+  // (stream payload null) gets no grace — nothing will resume it.
+  Timer? _sessionLossGrace;
+  static const Duration _kSessionLossGrace = Duration(seconds: 10);
 
   void _ensureListeners() {
     _statusSub ??= _client.mediaStatusStream.listen(_onStatus);
@@ -77,17 +85,35 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     });
     // Detect an unexpected session drop (TV off, Wi-Fi lost). Listeners attach
     // only after _ensureSession connected (_sessionStarted), so a transition to
-    // not-connected we didn't initiate means the renderer is gone.
-    _sessionSub ??= _sessions.currentSessionStream.listen((_) {
-      if (_sessionStarted &&
-          !_disposing &&
-          !_lostFired &&
-          !_sessions.hasConnectedSession) {
-        _lostFired = true;
-        emitRendererLost(
-            'Lost connection to the cast device — back on this phone');
+    // not-connected we didn't initiate means the renderer is gone — after the
+    // suspend grace above, in case the SDK resumes it.
+    _sessionSub ??= _sessions.currentSessionStream.listen((session) {
+      if (_disposing || !_sessionStarted) return;
+      if (_sessions.hasConnectedSession) {
+        // (Re)connected — a suspended session resumed. Cancel any pending
+        // loss and re-arm one-shot detection for the next drop.
+        _sessionLossGrace?.cancel();
+        _sessionLossGrace = null;
+        _lostFired = false;
+        return;
       }
+      if (_lostFired) return;
+      if (session == null) {
+        _fireRendererLost(); // ended outright — no resume coming
+        return;
+      }
+      _sessionLossGrace ??= Timer(_kSessionLossGrace, () {
+        if (_disposing || _lostFired || _sessions.hasConnectedSession) return;
+        _fireRendererLost();
+      });
     });
+  }
+
+  void _fireRendererLost() {
+    _sessionLossGrace?.cancel();
+    _sessionLossGrace = null;
+    _lostFired = true;
+    emitRendererLost('Lost connection to the cast device — back on this phone');
   }
 
   void _onStatus(GoggleCastMediaStatus? status) {
@@ -473,6 +499,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   @override
   Future<void> disposeRenderer() async {
     _disposing = true;
+    _sessionLossGrace?.cancel();
     if (_visualizer) {
       // Stop the off-screen transcode so it isn't left encoding after we switch
       // away. (LocalMediaServer is torn down by the handler on switch-to-local.)

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -149,9 +149,9 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   }
 
   Future<void> _onSessionEnded() async {
-    final online = await _hasNetwork();
+    final lanUp = await _hasLanNetwork();
     if (_disposing || _lostFired || _sessions.hasConnectedSession) return;
-    if (online) {
+    if (lanUp) {
       _fireRendererLost();
       return;
     }
@@ -160,11 +160,17 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   }
 
   Future<void> _onGraceExpired() async {
+    // cancel() too, not just null: the session listener can have armed a FRESH
+    // timer in the gap between this one firing and this handler running —
+    // dropping that reference without cancelling would leave an orphan timer
+    // double-driving this handler.
+    _sessionLossGrace?.cancel();
     _sessionLossGrace = null;
     if (_disposing || _lostFired || _sessions.hasConnectedSession) return;
     if (_graceExtensions < _kMaxGraceExtensions) {
-      if (!await _hasNetwork()) {
-        // Our own network is still down — the SDK can't possibly have resumed.
+      if (!await _hasLanNetwork()) {
+        // The LAN is still down — neither the SDK nor we can reach the
+        // renderer yet.
         _graceExtensions++;
         _graceWasOffline = true;
         _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
@@ -187,6 +193,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
         if (_sessions.hasConnectedSession) return; // SDK resumed meanwhile
         // Not yet (device not re-discovered / session won't start) — another
         // window, bounded by the extension budget.
+        _sessionLossGrace?.cancel();
         _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
         return;
       }
@@ -226,12 +233,17 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     }
   }
 
-  // Any network interface up right now? Best-effort: a failed probe counts as
-  // online so the grace can't extend forever on a broken probe.
-  Future<bool> _hasNetwork() async {
+  // Is a LAN-capable transport (Wi-Fi / ethernet) up right now? A cast session
+  // lives on the LAN, so "any connectivity" is the wrong question: when Wi-Fi
+  // blips, the phone fails over to MOBILE DATA within seconds and a generic
+  // probe reports online — which made a null-session during a Wi-Fi blip look
+  // like a genuine end (verified on-device). Best-effort: a failed probe
+  // counts as online so the grace can't extend forever on a broken probe.
+  Future<bool> _hasLanNetwork() async {
     try {
       final r = await Connectivity().checkConnectivity();
-      return r.any((c) => c != ConnectivityResult.none);
+      return r.contains(ConnectivityResult.wifi) ||
+          r.contains(ConnectivityResult.ethernet);
     } catch (_) {
       return true;
     }

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -2,12 +2,12 @@ import 'dart:async';
 import 'dart:io' show Directory, File;
 
 import 'package:audio_service/audio_service.dart' show MediaItem;
-import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_chrome_cast/flutter_chrome_cast.dart';
 import 'package:meta/meta.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../native/visualizer_bridge.dart';
+import '../util/connectivity_probe.dart';
 import '../singletons/cast_manager.dart';
 import '../singletons/log_manager.dart';
 import '../singletons/settings.dart';
@@ -64,11 +64,10 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   StreamSubscription<Duration>? _positionSub;
   StreamSubscription<dynamic>? _sessionSub;
 
-  // Guards the renderer-lost emit. _disposing suppresses our own teardown;
-  // _lostFired makes it one-shot per drop (disconnecting → disconnected would
-  // otherwise emit twice); it re-arms when the session reconnects.
+  // Suppresses loss handling during our own teardown. (The renderer-lost
+  // emit itself is one-shot at the single emit point in the base class —
+  // see EmulatedPlaylistBackend.emitRendererLost / rendererLostEmitted.)
   bool _disposing = false;
-  bool _lostFired = false;
 
   // Grace timer for a not-connected session: the Cast SDK SUSPENDS a session
   // on a transient network blip and auto-resumes it (the receiver keeps
@@ -86,7 +85,19 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   int _graceExtensions = 0;
   bool _graceWasOffline = false;
   static const Duration _kSessionLossGrace = Duration(seconds: 10);
-  static const int _kMaxGraceExtensions = 8; // ≈90s worst case, offline only
+  // Attempt budgets: an episode that spent time OFFLINE deserves the long
+  // budget (Wi-Fi reassociation + SDK re-bind take tens of seconds); one that
+  // stayed online throughout (receiver crashed / rebooted) should give up —
+  // and fall back to the phone — much sooner.
+  static const int _kMaxGraceExtensions = 8; // ≈90s+ worst case
+  static const int _kMaxOnlineAttempts = 3; // ≈30-60s when never offline
+  bool _episodeWentOffline = false;
+  // Bumped per _tryReattach and on dispose: a re-attach that outlives its
+  // 30s outer timeout (Future.timeout does NOT cancel the underlying future)
+  // or the backend itself must become inert at its next await, not keep
+  // starting/ending sessions under the live attempt or after disposal.
+  int _reattachGen = 0;
+  bool _reattachDiscoveryActive = false;
 
   // Set via prepareCastToCastHandoff when the backend replacing this one is
   // also a Chromecast backend — teardown then leaves the shared session (and,
@@ -126,18 +137,15 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   static const Duration _kStuckLoadingAfter = Duration(seconds: 30);
   // Serializes the recovery loop: _onGraceExpired is the ONLY actor (probe /
   // SDK window / re-attach / give up); the watchdog and session events merely
-  // ARM its timer. Round-4 smoke had the watchdog re-attaching directly —
-  // racing the grace loop's own re-attach (double session starts) and firing
-  // renderer-lost after a single attempt made at the worst possible moment
-  // (Play Services needs seconds back on the LAN before it can start
-  // sessions), which burned the whole budget in 12s.
+  // ARM its timer. Two concurrent actors double-start sessions and burn the
+  // retry budget on attempts made before Play Services can serve them.
   bool _lossBusy = false;
   static const Duration _kStaleAfter = Duration(seconds: 20);
 
   void _noteRendererEvent() => _lastRendererEvent = DateTime.now();
 
   Future<void> _checkStale() async {
-    if (_disposing || _lostFired || rendererLostEmitted) return;
+    if (_disposing || rendererLostEmitted) return;
     if (_sessionLossGrace != null || _lossBusy) return; // recovery already live
     final loading = _loadingSince;
     if (loading != null &&
@@ -145,17 +153,28 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       _loadingSince = null;
       appLog('[cast] receiver stuck loading for '
           '${_kStuckLoadingAfter.inSeconds}s — treating as a failed track');
-      unawaited(trackFailed('receiver stuck loading'));
+      unawaited(trackFailed('receiver stuck loading', play: playing));
       return;
     }
     if (!playing) return;
     if (DateTime.now().difference(_lastRendererEvent) < _kStaleAfter) return;
-    appLog('[cast] no renderer events for ${_kStaleAfter.inSeconds}s '
-        'while playing — starting loss recovery');
     // Offline waits out the LAN like any drop; a half-dead socket with the
     // LAN up skips the SDK-courtesy window (the SDK hasn't even noticed).
-    _graceWasOffline = !await _hasLanNetwork();
-    _sessionLossGrace ??= Timer(_kSessionLossGrace, _onGraceExpired);
+    _armLossRecovery(
+        offline: !await hasConnectivity(lanOnly: true),
+        why: 'no renderer events for ${_kStaleAfter.inSeconds}s while playing');
+  }
+
+  /// Single entry point for arming the loss-recovery timer. No-ops when
+  /// recovery is already armed/running or moot, so every detector (suspend
+  /// event, offline session-end, staleness watchdog) can call it blindly.
+  void _armLossRecovery({required bool offline, required String why}) {
+    if (_disposing || rendererLostEmitted || _lossBusy) return;
+    if (_sessionLossGrace != null) return;
+    appLog('[cast] $why — starting loss recovery');
+    _graceWasOffline = offline;
+    if (offline) _episodeWentOffline = true;
+    _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
   }
 
   void _ensureListeners() {
@@ -180,7 +199,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       if (_lossBusy) return;
       if (_sessions.hasConnectedSession) {
         // (Re)connected — a suspended session resumed. Cancel any pending
-        // loss and re-arm one-shot detection for the next drop.
+        // loss and reset the episode bookkeeping for the next drop.
         if (_sessionLossGrace != null) {
           appLog('[cast] session resumed within the grace window');
         }
@@ -188,10 +207,10 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
         _sessionLossGrace = null;
         _graceExtensions = 0;
         _graceWasOffline = false;
-        _lostFired = false;
+        _episodeWentOffline = false;
         return;
       }
-      if (_lostFired) return;
+      if (rendererLostEmitted) return;
       if (session == null) {
         // On Android a NETWORK drop surfaces as a full session END (a null
         // push), not a suspend — verified on-device. Probe connectivity
@@ -201,23 +220,22 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
         unawaited(_onSessionEnded());
         return;
       }
-      if (_sessionLossGrace == null && !_lossBusy) {
-        appLog('[cast] session suspended — starting loss recovery');
-        _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
-      }
+      _armLossRecovery(offline: false, why: 'session suspended');
     });
   }
 
   Future<void> _onSessionEnded() async {
-    final lanUp = await _hasLanNetwork();
-    if (_disposing || _lostFired || _sessions.hasConnectedSession) return;
+    final lanUp = await hasConnectivity(lanOnly: true);
+    // Recheck EVERYTHING after the async probe: the grace timer or the
+    // recovery loop can have started meanwhile, and firing renderer-lost
+    // under a running re-attach would tear down the session it is building.
+    if (_disposing || rendererLostEmitted || _lossBusy) return;
+    if (_sessionLossGrace != null || _sessions.hasConnectedSession) return;
     if (lanUp) {
       _fireRendererLost();
       return;
     }
-    appLog('[cast] session ended while the LAN is down — starting loss recovery');
-    _graceWasOffline = true;
-    _sessionLossGrace ??= Timer(_kSessionLossGrace, _onGraceExpired);
+    _armLossRecovery(offline: true, why: 'session ended while the LAN is down');
   }
 
   Future<void> _onGraceExpired() async {
@@ -227,21 +245,24 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     // double-driving this handler.
     _sessionLossGrace?.cancel();
     _sessionLossGrace = null;
-    if (_disposing || _lostFired || _lossBusy) return;
+    if (_disposing || rendererLostEmitted || _lossBusy) return;
     if (_sessions.hasConnectedSession) return; // SDK recovered on its own
     _lossBusy = true;
     try {
-      if (_graceExtensions >= _kMaxGraceExtensions) {
+      final budget =
+          _episodeWentOffline ? _kMaxGraceExtensions : _kMaxOnlineAttempts;
+      if (_graceExtensions >= budget) {
         _fireRendererLost();
         return;
       }
       _graceExtensions++;
-      if (!await _hasLanNetwork()) {
+      if (!await hasConnectivity(lanOnly: true)) {
         // The LAN is still down — neither the SDK nor we can reach the
         // renderer yet.
         appLog('[cast] loss recovery $_graceExtensions/$_kMaxGraceExtensions: '
             'LAN still down, waiting');
         _graceWasOffline = true;
+        _episodeWentOffline = true;
         _rearmLossRecovery();
         return;
       }
@@ -261,8 +282,8 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       // receiver keeps playing through a sender-side drop, so a successful
       // rejoin is usually seamless. Retries ride the extension budget. The
       // hard timeout is load-bearing: plugin calls against a broken session
-      // can hang forever (round-6 smoke froze the whole recovery machine —
-      // a hanging await never reaches finally, so _lossBusy never cleared).
+      // can hang FOREVER, and a hanging await never reaches finally — the
+      // recovery machine (and everything gated on _lossBusy) would freeze.
       appLog('[cast] loss recovery $_graceExtensions/$_kMaxGraceExtensions: '
           're-attaching');
       final ok = await _tryReattach().timeout(const Duration(seconds: 30),
@@ -273,6 +294,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       if (ok) {
         appLog('[cast] re-attached to the cast device');
         _graceExtensions = 0;
+        _episodeWentOffline = false;
         return;
       }
       if (_sessions.hasConnectedSession) return; // SDK resumed meanwhile
@@ -294,18 +316,26 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   // hiccup. Otherwise (receiver relaunched idle / nothing arrives) reload the
   // current track at the last known position.
   Future<bool> _tryReattach() async {
+    final gen = ++_reattachGen;
+    // Inert-after-supersession: the caller's Future.timeout does NOT cancel
+    // this future, and dispose can arrive mid-await — a superseded or
+    // orphaned attempt must stop acting (no session starts/ends, no reloads)
+    // the moment it resumes.
+    bool dead() => _disposing || gen != _reattachGen;
     var startedDiscovery = false;
     try {
-      // startSessionWithDevice resolves through MediaRouter's LIVE route list
-      // — the plugin's native selectRoute silently no-ops when the route is
-      // absent — and routes are only maintained while discovery runs, which
-      // is normally only while the cast picker is open. Round-5 smoke burned
-      // its whole retry budget on that silent no-op. Re-populate the routes
-      // and wait for OUR device to reappear (post-blip mDNS takes seconds).
+      // startSessionWithDevice resolves through MediaRouter's LIVE route
+      // list — the plugin's native selectRoute silently no-ops (reporting
+      // success) when the route is absent — and routes are only maintained
+      // while discovery runs, which is normally only while the cast picker
+      // is open. Re-populate the routes and wait for OUR device to reappear
+      // (post-blip mDNS takes seconds).
       final discovery = GoogleCastDiscoveryManager.instance;
       if (!discovery.devices.any((d) => d.deviceID == _deviceId)) {
         await discovery.startDiscovery();
         startedDiscovery = true;
+        _reattachDiscoveryActive = true;
+        if (dead()) return false;
         try {
           await discovery.devicesStream
               .firstWhere((ds) => ds.any((d) => d.deviceID == _deviceId))
@@ -314,32 +344,26 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
           appLog('[cast] re-attach: device not re-discovered yet');
           return false; // device hasn't reappeared — retry next window
         }
+        if (dead()) return false;
       }
       _sessionStarted = false; // force _ensureSession to re-connect
       if (_sessions.currentSession != null && !_sessions.hasConnectedSession) {
-        // A stale SUSPENDED session lingers, keeping its route selected —
-        // startSessionWithDevice collides with it and every connect wait
-        // expires (round-7 smoke). The graceful endSession() no-ops on a
-        // suspended session (round-8), so force it: the stop command rides
-        // the dead socket and never reaches the receiver, which keeps
-        // playing — the fresh start below then JOINs it. Wait for the
-        // teardown to actually settle before starting.
+        // A stale SUSPENDED session lingers, keeping its route selected, and
+        // startSessionWithDevice collides with it (every connect wait
+        // expires). The graceful endSession() NO-OPs on a suspended session,
+        // so force it: the stop command rides the dead socket and never
+        // reaches the receiver, which keeps playing — the fresh start below
+        // then JOINs it.
         appLog('[cast] re-attach: force-clearing the stale suspended session');
-        try {
-          await _sessions.endSessionAndStopCasting();
-        } catch (_) {}
-        try {
-          await _sessions.currentSessionStream
-              .firstWhere((s) => s == null)
-              .timeout(const Duration(seconds: 3));
-        } catch (_) {}
+        await _endSessionQuietly(waitForTeardown: true);
+        if (dead()) return false;
       }
       await _ensureSession();
+      if (dead()) return false;
       if (!_sessions.hasConnectedSession) {
         appLog('[cast] re-attach: session did not connect');
         return false;
       }
-      _lostFired = false;
       GoggleCastMediaStatus? fresh;
       try {
         fresh = await _client.mediaStatusStream
@@ -347,6 +371,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
             .first
             .timeout(const Duration(seconds: 3));
       } catch (_) {}
+      if (dead()) return false;
       final alive = fresh?.playerState == CastMediaPlayerState.playing ||
           fresh?.playerState == CastMediaPlayerState.buffering;
       if (!alive) {
@@ -354,11 +379,11 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
           // The session claims connected but delivers nothing — a half-dead
           // socket the SDK hasn't noticed. Force a genuinely fresh session
           // before reloading, or the loadMedia below goes into the same void.
-          try {
-            await _sessions.endSessionAndStopCasting();
-          } catch (_) {}
+          await _endSessionQuietly(waitForTeardown: true);
+          if (dead()) return false;
           _sessionStarted = false;
           await _ensureSession();
+          if (dead()) return false;
           if (!_sessions.hasConnectedSession) return false;
         }
         final ok = await loadIndex(index, play: playing, startAt: position);
@@ -372,9 +397,11 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       appLog('[cast] re-attach attempt failed: $e');
       return false;
     } finally {
-      if (startedDiscovery) {
-        // Don't leave a background mDNS scan running (battery); the picker
-        // manages its own discovery lifecycle when open.
+      // Don't leave a background mDNS scan running (battery); the picker
+      // manages its own discovery lifecycle when open. A superseded attempt
+      // leaves the scan to its successor; dispose stops any leftover scan.
+      if (startedDiscovery && (gen == _reattachGen || _disposing)) {
+        _reattachDiscoveryActive = false;
         try {
           await GoogleCastDiscoveryManager.instance.stopDiscovery();
         } catch (_) {}
@@ -382,26 +409,25 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     }
   }
 
-  // Is a LAN-capable transport (Wi-Fi / ethernet) up right now? A cast session
-  // lives on the LAN, so "any connectivity" is the wrong question: when Wi-Fi
-  // blips, the phone fails over to MOBILE DATA within seconds and a generic
-  // probe reports online — which made a null-session during a Wi-Fi blip look
-  // like a genuine end (verified on-device). Best-effort: a failed probe
-  // counts as online so the grace can't extend forever on a broken probe.
-  Future<bool> _hasLanNetwork() async {
+  /// Force-end the current Cast session, swallowing failures. With
+  /// [waitForTeardown], also wait (bounded) for the session stream to settle
+  /// on null — starting a new session against a half-torn-down one collides
+  /// and times out its connect wait.
+  Future<void> _endSessionQuietly({bool waitForTeardown = false}) async {
     try {
-      final r = await Connectivity().checkConnectivity();
-      return r.contains(ConnectivityResult.wifi) ||
-          r.contains(ConnectivityResult.ethernet);
-    } catch (_) {
-      return true;
-    }
+      await _sessions.endSessionAndStopCasting();
+    } catch (_) {}
+    if (!waitForTeardown) return;
+    try {
+      await _sessions.currentSessionStream
+          .firstWhere((s) => s == null)
+          .timeout(const Duration(seconds: 3));
+    } catch (_) {}
   }
 
   void _fireRendererLost() {
     _sessionLossGrace?.cancel();
     _sessionLossGrace = null;
-    _lostFired = true;
     appLog(_graceExtensions == 0
         ? '[cast] session ended while online — falling back to this phone'
         : '[cast] session lost after $_graceExtensions recovery attempts — '
@@ -446,8 +472,9 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
         if (status.idleReason == GoogleCastMediaIdleReason.finished) {
           advanceOnComplete();
         } else if (status.idleReason == GoogleCastMediaIdleReason.error) {
+          final wasPlaying = playing;
           playing = false;
-          trackFailed('receiver reported a media error');
+          trackFailed('receiver reported a media error', play: wasPlaying);
         }
         break;
       case CastMediaPlayerState.unknown:
@@ -473,11 +500,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       // The existing session is on a DIFFERENT Chromecast (cast→cast device
       // switch). The SDK holds one session per app, so it must be moved —
       // reusing it would keep casting to the old device.
-      try {
-        await _sessions.endSessionAndStopCasting();
-      } catch (e) {
-        castLog('Ending the previous cast session failed', error: e);
-      }
+      await _endSessionQuietly();
     }
     if (!_sessions.hasConnectedSession) {
       await _sessions.startSessionWithDevice(device);
@@ -494,37 +517,10 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     _sessionStarted = true;
   }
 
-  // ── Media construction ──
-  // A plain HTTP server id is sent as-is; a local-only item (file-explorer track
-  // — id is a UUID) is served from the phone's LocalMediaServer; an iroh server's
-  // id is the phone-loopback tunnel URL the receiver can't reach, so it's relayed
-  // through the LocalMediaServer proxy (re-bound to the live tunnel).
-  Future<Uri> _resolveUri(MediaItem item) async {
-    final localPath = item.extras?['localPath'] as String?;
-    final isNetwork =
-        item.id.startsWith('http://') || item.id.startsWith('https://');
-    if (!isNetwork && localPath != null && File(localPath).existsSync()) {
-      await LocalMediaServer().ensureStarted();
-      return LocalMediaServer().registerFile(localPath);
-    }
-    final iroh = irohServerFor(item);
-    if (iroh != null) {
-      await LocalMediaServer().ensureStarted();
-      // A downloaded iroh track is already on disk — serve it from there (faster,
-      // and it skips the tunnel relay). Its id is a 127.0.0.1 loopback URL, so
-      // isNetwork is true and the disk branch above is bypassed; handle it here.
-      if (localPath != null && File(localPath).existsSync()) {
-        return LocalMediaServer().registerFile(localPath);
-      }
-      return irohProxyUri(iroh, item.id);
-    }
-    return Uri.parse(item.id);
-  }
-
   GoogleCastMediaInformation _mediaInfo(MediaItem item, String url) {
     // Full-res art (drop the compress= size param) — looks sharp on a TV; for an
     // iroh server it's relayed through the LAN proxy (LocalMediaServer already
-    // started by _resolveUri above) so the receiver can fetch it.
+    // started by resolveRendererUri) so the receiver can fetch it.
     final art = castArtUriFor(item);
     return GoogleCastMediaInformation(
       contentId: url,
@@ -590,13 +586,13 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
           _deleteDir(_currentVizDir);
           CastManager().reportCastInfo(
               "Couldn't start the visualizer — casting audio to the TV");
-          final url = (await _resolveUri(items[target])).toString();
+          final url = (await resolveRendererUri(items[target])).toString();
           if (gen != _loadGen) return true;
           await _client.loadMedia(_mediaInfo(items[target], url),
               autoPlay: play, playPosition: startAt);
         }
       } else {
-        final url = (await _resolveUri(items[target])).toString();
+        final url = (await resolveRendererUri(items[target])).toString();
         if (gen != _loadGen) return true;
         await _client.loadMedia(_mediaInfo(items[target], url),
             autoPlay: play, playPosition: startAt);
@@ -738,7 +734,8 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   Future<void> play() async {
     if (index < 0) return;
     if (loadedIndex != index) {
-      await loadIndex(index, play: true);
+      final ok = await loadIndex(index, play: true);
+      if (!ok) unawaited(trackFailed('load failed', play: true));
       return;
     }
     try {
@@ -775,7 +772,12 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   Future<void> seek(Duration position, {int? index, bool? play}) async {
     final target = index ?? this.index;
     if (target >= 0 && target != loadedIndex) {
-      await loadIndex(target, play: play ?? playing, startAt: position);
+      final intent = play ?? playing;
+      final ok = await loadIndex(target, play: intent, startAt: position);
+      // A failed user-driven load has no watchdog before the first successful
+      // _ensureSession (the ticker arms in _ensureListeners) — walk instead
+      // of stranding the backend in 'loading'.
+      if (!ok) unawaited(trackFailed('load failed', play: intent));
       return;
     }
     try {
@@ -789,13 +791,19 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   @override
   Future<void> seekToNext() async {
     final n = nextIndex();
-    if (n != null) await loadIndex(n, play: playing);
+    if (n != null) {
+      final intent = playing;
+      final ok = await loadIndex(n, play: intent);
+      if (!ok) unawaited(trackFailed('load failed', play: intent));
+    }
   }
 
   @override
   Future<void> seekToPrevious() async {
     if (index > 0) {
-      await loadIndex(index - 1, play: playing);
+      final intent = playing;
+      final ok = await loadIndex(index - 1, play: intent);
+      if (!ok) unawaited(trackFailed('load failed', play: intent));
     } else {
       await seek(Duration.zero);
     }
@@ -812,8 +820,15 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   @override
   Future<void> disposeRenderer() async {
     _disposing = true;
+    _reattachGen++; // any in-flight re-attach becomes inert at its next await
     _sessionLossGrace?.cancel();
     _staleTicker?.cancel();
+    if (_reattachDiscoveryActive) {
+      _reattachDiscoveryActive = false;
+      try {
+        await GoogleCastDiscoveryManager.instance.stopDiscovery();
+      } catch (_) {}
+    }
     if (_visualizer && !_handoffToVisualizer) {
       // Stop the off-screen transcode so it isn't left encoding after we switch
       // away. (LocalMediaServer is torn down by the handler on switch-to-local.)
@@ -828,9 +843,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     await _positionSub?.cancel();
     await _sessionSub?.cancel();
     if (!_keepSharedSession) {
-      try {
-        await _sessions.endSessionAndStopCasting();
-      } catch (_) {}
+      await _endSessionQuietly();
     }
   }
 }

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -386,8 +386,10 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     _sessionLossGrace?.cancel();
     _sessionLossGrace = null;
     _lostFired = true;
-    appLog('[cast] session lost (grace exhausted: $_graceExtensions '
-        'extensions) — falling back to this phone');
+    appLog(_graceExtensions == 0
+        ? '[cast] session ended while online — falling back to this phone'
+        : '[cast] session lost after $_graceExtensions recovery attempts — '
+            'falling back to this phone');
     emitRendererLost('Lost connection to the cast device — back on this phone');
   }
 

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -136,11 +136,27 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       }
       if (_lostFired) return;
       if (session == null) {
-        _fireRendererLost(); // ended outright — no resume coming
+        // On Android a NETWORK drop surfaces as a full session END (a null
+        // push), not a suspend — verified on-device. Probe connectivity
+        // before believing it: while offline the "end" is just our own dead
+        // network, so it gets the reconnect grace + re-attach like a suspend.
+        // A null while online is a genuine end (TV quit) — fall back now.
+        unawaited(_onSessionEnded());
         return;
       }
       _sessionLossGrace ??= Timer(_kSessionLossGrace, _onGraceExpired);
     });
+  }
+
+  Future<void> _onSessionEnded() async {
+    final online = await _hasNetwork();
+    if (_disposing || _lostFired || _sessions.hasConnectedSession) return;
+    if (online) {
+      _fireRendererLost();
+      return;
+    }
+    _graceWasOffline = true;
+    _sessionLossGrace ??= Timer(_kSessionLossGrace, _onGraceExpired);
   }
 
   Future<void> _onGraceExpired() async {
@@ -155,18 +171,59 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
         return;
       }
       if (_graceWasOffline) {
-        // The network came back since the last check. The SDK's session
-        // resume takes several seconds FROM HERE, so an expiry landing right
-        // after reconnect must grant one more window — firing now tears down
-        // a session that is about to recover (observed on-device: fallback +
-        // zombie TV + double audio).
-        _graceWasOffline = false;
+        // The network came back since the last check. The SDK auto-resumes a
+        // SUSPENDED session from here (give it the window below) — but a
+        // network drop that surfaced as an END won't resume on its own, so
+        // actively re-attach: rejoin (or relaunch) the receiver and pick
+        // playback back up. The receiver keeps playing through a sender-side
+        // drop, so a successful rejoin is usually seamless.
         _graceExtensions++;
+        if (await _tryReattach()) {
+          appLog('[cast] re-attached to the cast device after a network drop');
+          _graceWasOffline = false;
+          _graceExtensions = 0;
+          return;
+        }
+        if (_sessions.hasConnectedSession) return; // SDK resumed meanwhile
+        // Not yet (device not re-discovered / session won't start) — another
+        // window, bounded by the extension budget.
         _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
         return;
       }
     }
     _fireRendererLost();
+  }
+
+  // Rebuild the session after a network-drop END and pick playback back up.
+  // If the rejoined receiver reports our media still going (first FRESH
+  // status — skip(1) bypasses the stream's stale replayed value), adopt it
+  // as-is: the status/position streams resume driving state with no audible
+  // hiccup. Otherwise (receiver relaunched idle / nothing arrives) reload the
+  // current track at the last known position.
+  Future<bool> _tryReattach() async {
+    try {
+      _sessionStarted = false; // force _ensureSession to re-connect
+      await _ensureSession();
+      if (!_sessions.hasConnectedSession) return false;
+      _lostFired = false;
+      GoggleCastMediaStatus? fresh;
+      try {
+        fresh = await _client.mediaStatusStream
+            .skip(1)
+            .first
+            .timeout(const Duration(seconds: 3));
+      } catch (_) {}
+      final alive = fresh?.playerState == CastMediaPlayerState.playing ||
+          fresh?.playerState == CastMediaPlayerState.buffering;
+      if (!alive) {
+        final ok = await loadIndex(index, play: playing, startAt: position);
+        if (!ok) return false;
+      }
+      return true;
+    } catch (e) {
+      castLog('cast re-attach failed', error: e);
+      return false;
+    }
   }
 
   // Any network interface up right now? Best-effort: a failed probe counts as

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -9,6 +9,7 @@ import 'package:path_provider/path_provider.dart';
 
 import '../native/visualizer_bridge.dart';
 import '../singletons/cast_manager.dart';
+import '../singletons/log_manager.dart';
 import '../singletons/settings.dart';
 import 'cast_art.dart';
 import 'cast_log.dart';
@@ -83,6 +84,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   // _kMaxGraceExtensions so a genuinely dead session still falls back.
   Timer? _sessionLossGrace;
   int _graceExtensions = 0;
+  bool _graceWasOffline = false;
   static const Duration _kSessionLossGrace = Duration(seconds: 10);
   static const int _kMaxGraceExtensions = 8; // ≈90s worst case, offline only
 
@@ -122,9 +124,13 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       if (_sessions.hasConnectedSession) {
         // (Re)connected — a suspended session resumed. Cancel any pending
         // loss and re-arm one-shot detection for the next drop.
+        if (_sessionLossGrace != null) {
+          appLog('[cast] session resumed within the grace window');
+        }
         _sessionLossGrace?.cancel();
         _sessionLossGrace = null;
         _graceExtensions = 0;
+        _graceWasOffline = false;
         _lostFired = false;
         return;
       }
@@ -140,13 +146,25 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   Future<void> _onGraceExpired() async {
     _sessionLossGrace = null;
     if (_disposing || _lostFired || _sessions.hasConnectedSession) return;
-    if (_graceExtensions < _kMaxGraceExtensions && !await _hasNetwork()) {
-      // Our own network is still down — the SDK can't have resumed yet. Wait
-      // another window; once connectivity returns the SDK gets one final
-      // window to deliver its resume before we declare the renderer lost.
-      _graceExtensions++;
-      _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
-      return;
+    if (_graceExtensions < _kMaxGraceExtensions) {
+      if (!await _hasNetwork()) {
+        // Our own network is still down — the SDK can't possibly have resumed.
+        _graceExtensions++;
+        _graceWasOffline = true;
+        _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
+        return;
+      }
+      if (_graceWasOffline) {
+        // The network came back since the last check. The SDK's session
+        // resume takes several seconds FROM HERE, so an expiry landing right
+        // after reconnect must grant one more window — firing now tears down
+        // a session that is about to recover (observed on-device: fallback +
+        // zombie TV + double audio).
+        _graceWasOffline = false;
+        _graceExtensions++;
+        _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
+        return;
+      }
     }
     _fireRendererLost();
   }
@@ -166,6 +184,8 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     _sessionLossGrace?.cancel();
     _sessionLossGrace = null;
     _lostFired = true;
+    appLog('[cast] session lost (grace exhausted: $_graceExtensions '
+        'extensions) — falling back to this phone');
     emitRendererLost('Lost connection to the cast device — back on this phone');
   }
 

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io' show Directory, File;
 
 import 'package:audio_service/audio_service.dart' show MediaItem;
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_chrome_cast/flutter_chrome_cast.dart';
 import 'package:meta/meta.dart';
 import 'package:path_provider/path_provider.dart';
@@ -73,8 +74,17 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   // playing from its buffer), so tearing down immediately would turn a
   // 3-second Wi-Fi blip into a dead cast. A session that ENDS outright
   // (stream payload null) gets no grace — nothing will resume it.
+  //
+  // The grace must not expire while the PHONE ITSELF has no network: the blip
+  // that suspended the session usually took our connectivity too, and the SDK
+  // cannot resume until it returns (Wi-Fi reassociation alone can exceed any
+  // sane fixed window — verified on-device: a 5s blip took ~20s end to end).
+  // While offline, the window re-arms instead of firing, bounded by
+  // _kMaxGraceExtensions so a genuinely dead session still falls back.
   Timer? _sessionLossGrace;
+  int _graceExtensions = 0;
   static const Duration _kSessionLossGrace = Duration(seconds: 10);
+  static const int _kMaxGraceExtensions = 8; // ≈90s worst case, offline only
 
   // Set via prepareCastToCastHandoff when the backend replacing this one is
   // also a Chromecast backend — teardown then leaves the shared session (and,
@@ -114,6 +124,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
         // loss and re-arm one-shot detection for the next drop.
         _sessionLossGrace?.cancel();
         _sessionLossGrace = null;
+        _graceExtensions = 0;
         _lostFired = false;
         return;
       }
@@ -122,11 +133,33 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
         _fireRendererLost(); // ended outright — no resume coming
         return;
       }
-      _sessionLossGrace ??= Timer(_kSessionLossGrace, () {
-        if (_disposing || _lostFired || _sessions.hasConnectedSession) return;
-        _fireRendererLost();
-      });
+      _sessionLossGrace ??= Timer(_kSessionLossGrace, _onGraceExpired);
     });
+  }
+
+  Future<void> _onGraceExpired() async {
+    _sessionLossGrace = null;
+    if (_disposing || _lostFired || _sessions.hasConnectedSession) return;
+    if (_graceExtensions < _kMaxGraceExtensions && !await _hasNetwork()) {
+      // Our own network is still down — the SDK can't have resumed yet. Wait
+      // another window; once connectivity returns the SDK gets one final
+      // window to deliver its resume before we declare the renderer lost.
+      _graceExtensions++;
+      _sessionLossGrace = Timer(_kSessionLossGrace, _onGraceExpired);
+      return;
+    }
+    _fireRendererLost();
+  }
+
+  // Any network interface up right now? Best-effort: a failed probe counts as
+  // online so the grace can't extend forever on a broken probe.
+  Future<bool> _hasNetwork() async {
+    try {
+      final r = await Connectivity().checkConnectivity();
+      return r.any((c) => c != ConnectivityResult.none);
+    } catch (_) {
+      return true;
+    }
   }
 
   void _fireRendererLost() {

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -108,9 +108,50 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     _handoffToVisualizer = next._visualizer;
   }
 
+  // ── Silent-death watchdog ──
+  // A sender-side network blip can sever the session with NO SessionManager
+  // event at all (observed on-device: no suspend, no null — the SDK's
+  // heartbeat takes minutes to notice, if ever, while the app sits 'playing'
+  // with a frozen position). While the receiver plays, status/position events
+  // tick ~every second — prolonged silence IS the failure signal (verified:
+  // the progress listener genuinely stops on a dead session, it is not
+  // interpolated locally). Mirrors the DLNA backend's poll-failure detection.
+  Timer? _staleTicker;
+  DateTime _lastRendererEvent = DateTime.now();
+  bool _reattaching = false;
+  static const Duration _kStaleAfter = Duration(seconds: 20);
+
+  void _noteRendererEvent() => _lastRendererEvent = DateTime.now();
+
+  Future<void> _checkStale() async {
+    if (_disposing || _lostFired || _reattaching || !playing) return;
+    if (DateTime.now().difference(_lastRendererEvent) < _kStaleAfter) return;
+    _reattaching = true;
+    try {
+      appLog('[cast] no renderer events for ${_kStaleAfter.inSeconds}s '
+          'while playing — probing the session');
+      if (!await _hasLanNetwork()) {
+        // Same as an offline session drop: wait out the LAN via the grace loop.
+        _graceWasOffline = true;
+        _sessionLossGrace ??= Timer(_kSessionLossGrace, _onGraceExpired);
+        return;
+      }
+      if (await _tryReattach()) {
+        appLog('[cast] re-attached after a silent session loss');
+        return;
+      }
+      _fireRendererLost();
+    } finally {
+      _reattaching = false;
+    }
+  }
+
   void _ensureListeners() {
+    _staleTicker ??=
+        Timer.periodic(const Duration(seconds: 5), (_) => _checkStale());
     _statusSub ??= _client.mediaStatusStream.listen(_onStatus);
     _positionSub ??= _client.playerPositionStream.listen((pos) {
+      _noteRendererEvent();
       position = pos;
       emitPos(pos);
       change();
@@ -223,6 +264,17 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       final alive = fresh?.playerState == CastMediaPlayerState.playing ||
           fresh?.playerState == CastMediaPlayerState.buffering;
       if (!alive) {
+        if (_sessions.hasConnectedSession) {
+          // The session claims connected but delivers nothing — a half-dead
+          // socket the SDK hasn't noticed. Force a genuinely fresh session
+          // before reloading, or the loadMedia below goes into the same void.
+          try {
+            await _sessions.endSessionAndStopCasting();
+          } catch (_) {}
+          _sessionStarted = false;
+          await _ensureSession();
+          if (!_sessions.hasConnectedSession) return false;
+        }
         final ok = await loadIndex(index, play: playing, startAt: position);
         if (!ok) return false;
       }
@@ -259,6 +311,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   }
 
   void _onStatus(GoggleCastMediaStatus? status) {
+    _noteRendererEvent();
     if (status == null) return;
     final d = status.mediaInformation?.duration;
     if (d != null) {
@@ -396,6 +449,9 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     final gen = ++_loadGen; // this load owns the pipeline until a newer load starts
     index = target;
     emitIndex(target);
+    // A load (visualizer warm-up especially) legitimately produces no renderer
+    // events for many seconds — restart the staleness clock.
+    _noteRendererEvent();
     setProcessingState(BackendProcessingState.loading);
     try {
       await _ensureSession();
@@ -653,6 +709,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   Future<void> disposeRenderer() async {
     _disposing = true;
     _sessionLossGrace?.cancel();
+    _staleTicker?.cancel();
     if (_visualizer && !_handoffToVisualizer) {
       // Stop the off-screen transcode so it isn't left encoding after we switch
       // away. (LocalMediaServer is torn down by the handler on switch-to-local.)

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -158,6 +158,10 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     // suspend grace above, in case the SDK resumes it.
     _sessionSub ??= _sessions.currentSessionStream.listen((session) {
       if (_disposing || !_sessionStarted) return;
+      // The recovery loop owns the session state during its critical section:
+      // its own force-teardown pushes a null that must not be classified as a
+      // fresh loss (LAN is up by then — it would fire renderer-lost mid-fix).
+      if (_lossBusy) return;
       if (_sessions.hasConnectedSession) {
         // (Re)connected — a suspended session resumed. Cancel any pending
         // loss and re-arm one-shot detection for the next drop.
@@ -295,17 +299,25 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
           return false; // device hasn't reappeared — retry next window
         }
       }
+      _sessionStarted = false; // force _ensureSession to re-connect
       if (_sessions.currentSession != null && !_sessions.hasConnectedSession) {
-        // A stale SUSPENDED session lingers — startSessionWithDevice collides
-        // with it (round-7 smoke: every connect wait expired). End it
-        // gracefully (endSession does NOT stop the receiver, which keeps
-        // playing) so the fresh start below can cleanly JOIN the receiver.
-        appLog('[cast] re-attach: clearing the stale suspended session');
+        // A stale SUSPENDED session lingers, keeping its route selected —
+        // startSessionWithDevice collides with it and every connect wait
+        // expires (round-7 smoke). The graceful endSession() no-ops on a
+        // suspended session (round-8), so force it: the stop command rides
+        // the dead socket and never reaches the receiver, which keeps
+        // playing — the fresh start below then JOINs it. Wait for the
+        // teardown to actually settle before starting.
+        appLog('[cast] re-attach: force-clearing the stale suspended session');
         try {
-          await _sessions.endSession();
+          await _sessions.endSessionAndStopCasting();
+        } catch (_) {}
+        try {
+          await _sessions.currentSessionStream
+              .firstWhere((s) => s == null)
+              .timeout(const Duration(seconds: 3));
         } catch (_) {}
       }
-      _sessionStarted = false; // force _ensureSession to re-connect
       await _ensureSession();
       if (!_sessions.hasConnectedSession) {
         appLog('[cast] re-attach: session did not connect');

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -219,16 +219,18 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
 
   @protected
   @override
-  Future<void> loadIndex(int target,
+  Future<bool> loadIndex(int target,
       {required bool play, Duration startAt = Duration.zero}) async {
-    if (target < 0 || target >= items.length) return;
-    final gen = ++_loadGen; // this load owns the pipeline until a newer one starts
+    if (target < 0 || target >= items.length) return false;
+    final gen = ++_loadGen; // this load owns the pipeline until a newer load starts
     index = target;
     emitIndex(target);
     setProcessingState(BackendProcessingState.loading);
     try {
       await _ensureSession();
-      if (gen != _loadGen) return; // superseded by a newer load
+      // Superseded by a newer load: not a failure — the newer load owns the
+      // renderer now, so report success and let it drive the state.
+      if (gen != _loadGen) return true;
       _ensureListeners();
       // True only when this load actually served the visualizer (vs audio or
       // the audio fallback below) — drives the start position emitted after.
@@ -239,13 +241,13 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
           // possible, so startAt is ignored for the visualizer.
           final url =
               (await _resolveVisualizerUri(items[target], gen)).toString();
-          if (gen != _loadGen) return; // superseded during the warm-up
+          if (gen != _loadGen) return true; // superseded during the warm-up
           await _client.loadMedia(_visualizerMediaInfo(items[target], url),
               autoPlay: play);
           servedVisualizer = true;
           _visualizerFailures = 0; // recovered — a transient failure won't stick
         } catch (e) {
-          if (gen != _loadGen) return; // superseded, not a real failure
+          if (gen != _loadGen) return true; // superseded, not a real failure
           // Transcode/render failed — don't strand the cast on the phone; keep
           // the music on the TV as plain audio and tell the user. After a couple
           // of consecutive failures we stop re-attempting (avoids repeated waits).
@@ -258,17 +260,17 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
           CastManager().reportCastInfo(
               "Couldn't start the visualizer — casting audio to the TV");
           final url = (await _resolveUri(items[target])).toString();
-          if (gen != _loadGen) return;
+          if (gen != _loadGen) return true;
           await _client.loadMedia(_mediaInfo(items[target], url),
               autoPlay: play, playPosition: startAt);
         }
       } else {
         final url = (await _resolveUri(items[target])).toString();
-        if (gen != _loadGen) return;
+        if (gen != _loadGen) return true;
         await _client.loadMedia(_mediaInfo(items[target], url),
             autoPlay: play, playPosition: startAt);
       }
-      if (gen != _loadGen) return;
+      if (gen != _loadGen) return true;
       loadedIndex = target;
       playing = play;
       duration = items[target].duration;
@@ -277,8 +279,11 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       emitPos(position);
     } catch (e) {
       castLog('Chromecast load failed', error: e);
+      change();
+      return false;
     }
     change();
+    return true;
   }
 
   // ── Visualizer cast ──

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -144,8 +144,35 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
 
   void _noteRendererEvent() => _lastRendererEvent = DateTime.now();
 
+  // Real POSITION events specifically (status events don't move the bar).
+  // Drives both the optimistic extrapolation below and the post-adopt nudge.
+  DateTime _lastPositionEventAt = DateTime.now();
+  static const Duration _kExtrapolateAfter = Duration(seconds: 2);
+
+  // Optimistic progress while position events are starved: a sender-side
+  // blip stops the progress stream but the receiver KEEPS playing, so a
+  // frozen bar (then a jump at the next track) is wrong twice. While the
+  // last known state is actively playing, advance the position by the tick
+  // cadence; real events overwrite it the moment they resume. Clamped to the
+  // known duration so it can't run past the track end.
+  void _extrapolatePosition() {
+    if (!playing || processingState != BackendProcessingState.ready) return;
+    if (DateTime.now().difference(_lastPositionEventAt) < _kExtrapolateAfter) {
+      return;
+    }
+    final d = duration;
+    final next = position + const Duration(seconds: 1);
+    if (d != null && d > Duration.zero && next >= d) return;
+    position = next;
+    emitPos(position);
+    change();
+  }
+
   Future<void> _checkStale() async {
     if (_disposing || rendererLostEmitted) return;
+    // Runs even while recovery is live — the receiver is presumed playing
+    // through a sender-side loss, and the bar should say so.
+    _extrapolatePosition();
     if (_sessionLossGrace != null || _lossBusy) return; // recovery already live
     final loading = _loadingSince;
     if (loading != null &&
@@ -178,11 +205,14 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   }
 
   void _ensureListeners() {
+    // 1s cadence: drives the position extrapolation smoothly; the staleness
+    // and stuck-loading checks are just DateTime math per tick.
     _staleTicker ??=
-        Timer.periodic(const Duration(seconds: 5), (_) => _checkStale());
+        Timer.periodic(const Duration(seconds: 1), (_) => _checkStale());
     _statusSub ??= _client.mediaStatusStream.listen(_onStatus);
     _positionSub ??= _client.playerPositionStream.listen((pos) {
       _noteRendererEvent();
+      _lastPositionEventAt = DateTime.now();
       position = pos;
       emitPos(pos);
       change();
@@ -374,6 +404,24 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
       if (dead()) return false;
       final alive = fresh?.playerState == CastMediaPlayerState.playing ||
           fresh?.playerState == CastMediaPlayerState.buffering;
+      if (alive) {
+        // Adopted the still-playing receiver. The SDK's progress listener
+        // often stays quiet on a JOINED session until the next load, which
+        // froze the bar until the following track. If real position events
+        // don't resume shortly, nudge with a same-position seek — the round
+        // trip re-establishes the status/progress pipeline, and the target
+        // is the extrapolated live position, so the audible skip is ~0.
+        final before = _lastPositionEventAt;
+        await Future<void>.delayed(const Duration(milliseconds: 2500));
+        if (dead()) return true; // adopted; a successor owns any nudging
+        if (_lastPositionEventAt == before) {
+          appLog('[cast] adopted session is not reporting progress — '
+              'nudging with a same-position seek');
+          try {
+            await _client.seek(GoogleCastMediaSeekOption(position: position));
+          } catch (_) {}
+        }
+      }
       if (!alive) {
         if (_sessions.hasConnectedSession) {
           // The session claims connected but delivers nothing — a half-dead
@@ -551,6 +599,7 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     // A load (visualizer warm-up especially) legitimately produces no renderer
     // events for many seconds — restart the staleness and stuck-loading clocks.
     _noteRendererEvent();
+    _lastPositionEventAt = DateTime.now();
     _loadingSince = DateTime.now();
     setProcessingState(BackendProcessingState.loading);
     try {

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -37,9 +37,12 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
   final MediaCastDlnaApi _api;
   final DeviceUdn _udn;
 
-  bool _advancing = false; // guards against double-advance while a track loads
   bool _confirmedPlaying = false; // renderer reached PLAYING for the current track
   bool _reachedNearEnd = false; // position reached end-of-track while playing
+  // Furthest position seen while PLAYING for the current track. Some renderers
+  // reset position to 0 the moment they stop, so the STOPPED classification
+  // below reads this instead of the (already-overwritten) live position.
+  Duration _lastPlayingPosition = Duration.zero;
 
   Timer? _pollTimer;
   bool _polling = false;
@@ -104,6 +107,7 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
     final item = items[target];
     _confirmedPlaying = false;
     _reachedNearEnd = false;
+    _lastPlayingPosition = Duration.zero;
     setProcessingState(BackendProcessingState.loading);
     var ok = false;
     try {
@@ -250,8 +254,9 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
       switch (info.state) {
         case TransportState.playing:
           playing = true;
-          _advancing = false;
+          trackPlaying();
           _confirmedPlaying = true;
+          if (position > _lastPlayingPosition) _lastPlayingPosition = position;
           setProcessingState(BackendProcessingState.ready);
           break;
         case TransportState.paused:
@@ -283,22 +288,34 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
   }
 
   Future<void> _onRendererStopped() async {
-    // Only treat STOPPED as end-of-track if the track actually started
-    // (ignores the transient STOPPED during the load->play transition that
-    // otherwise skips a freshly-selected track) AND playback reached the end.
-    // Without these guards a just-loaded track skips after a few seconds.
-    if (_advancing || !_confirmedPlaying || !_reachedNearEnd) return;
-    _advancing = true;
-    final n = nextIndex(onComplete: true);
-    if (n != null) {
-      await loadIndex(n, play: true); // _advancing cleared when poll sees PLAYING
+    // Ignore the transient STOPPED during the load→play transition — without
+    // the _confirmedPlaying guard a freshly-selected track skips after a few
+    // seconds. (advancing additionally collapses the repeated STOPPED polls
+    // while the next track loads.)
+    if (advancing || !_confirmedPlaying) return;
+    final dur = duration;
+    // With no usable duration (missing metadata, or a renderer that reports
+    // 0), _reachedNearEnd can never latch — accept a stop after real playing
+    // progress as the track's natural end, or such queues halt after every
+    // single track.
+    final endedWithoutDuration = (dur == null || dur == Duration.zero) &&
+        _lastPlayingPosition >= const Duration(seconds: 5);
+    if (_reachedNearEnd || endedWithoutDuration) {
+      await advanceOnComplete();
     } else {
+      // Stopped well before the end: the renderer aborted (fetch/decode
+      // error). Walk on (bounded) instead of ignoring the stop forever with
+      // the published state stuck on 'playing'.
       playing = false;
-      _advancing = false;
-      setProcessingState(BackendProcessingState.completed);
-      _stopPolling();
+      await trackFailed(
+          'renderer stopped mid-track at ${_lastPlayingPosition.inSeconds}s');
     }
   }
+
+  // The advance walk settled (end of a non-repeating list, or it gave up and
+  // declared the renderer lost) — nothing is playing, so stop the 1 Hz poll.
+  @override
+  void onPlaybackSettled() => _stopPolling();
 
   @protected
   @override

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io' show File;
 
 import 'package:audio_service/audio_service.dart' show MediaItem;
 // Hide media_cast_dlna's own MediaItem — we use audio_service's MediaItem for
@@ -7,11 +6,11 @@ import 'package:audio_service/audio_service.dart' show MediaItem;
 import 'package:media_cast_dlna/media_cast_dlna.dart' hide MediaItem;
 import 'package:meta/meta.dart';
 
+import '../util/connectivity_probe.dart';
 import 'cast_art.dart';
 import 'cast_log.dart';
 import 'cast_origin.dart';
 import 'emulated_playlist_backend.dart';
-import 'local_media_server.dart';
 import 'playback_backend.dart';
 
 /// [PlaybackBackend] that plays through a DLNA renderer (TV / AV receiver /
@@ -59,38 +58,10 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
   int _pollFailures = 0;
   static const int _kMaxPollFailures = 4;
 
-  // ── Transport ──
-  // DLNA renderers fetch the URL themselves. A plain HTTP server id is handed
-  // over as-is; a local-only item (file-explorer track — id is a UUID) is served
-  // from the phone's LocalMediaServer; an iroh server's id is the phone-loopback
-  // tunnel URL the renderer can't reach, so it's relayed through the
-  // LocalMediaServer proxy (re-bound to the live tunnel).
-  Future<Uri> _resolveUri(MediaItem item) async {
-    final localPath = item.extras?['localPath'] as String?;
-    final isNetwork =
-        item.id.startsWith('http://') || item.id.startsWith('https://');
-    if (!isNetwork && localPath != null && File(localPath).existsSync()) {
-      await LocalMediaServer().ensureStarted();
-      return LocalMediaServer().registerFile(localPath);
-    }
-    final iroh = irohServerFor(item);
-    if (iroh != null) {
-      await LocalMediaServer().ensureStarted();
-      // A downloaded iroh track is already on disk — serve it from there (faster,
-      // and it skips the tunnel relay). Its id is a 127.0.0.1 loopback URL, so
-      // isNetwork is true and the disk branch above is bypassed; handle it here.
-      if (localPath != null && File(localPath).existsSync()) {
-        return LocalMediaServer().registerFile(localPath);
-      }
-      return irohProxyUri(iroh, item.id);
-    }
-    return Uri.parse(item.id);
-  }
-
   AudioMetadata _metaFor(MediaItem item) {
     // Full-res art (drop the compress= size param) — looks sharp on a TV; for an
     // iroh server it's relayed through the LAN proxy (LocalMediaServer already
-    // started by _resolveUri above) so the renderer can fetch it.
+    // started by resolveRendererUri) so the renderer can fetch it.
     final art = castArtUriFor(item);
     return AudioMetadata(
       title: item.title,
@@ -118,7 +89,7 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
     setProcessingState(BackendProcessingState.loading);
     var ok = false;
     try {
-      final uri = await _resolveUri(item);
+      final uri = await resolveRendererUri(item);
       await _api.setMediaUri(_udn, Url(value: uri.toString()), _metaFor(item));
       loadedIndex = target;
       duration = item.duration;
@@ -143,7 +114,8 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
   Future<void> play() async {
     if (index < 0) return;
     if (loadedIndex != index) {
-      await loadIndex(index, play: true);
+      final ok = await loadIndex(index, play: true);
+      if (!ok) await trackFailed('load failed', play: true);
       return;
     }
     try {
@@ -190,7 +162,11 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
   Future<void> seek(Duration position, {int? index, bool? play}) async {
     final target = index ?? this.index;
     if (target >= 0 && target != loadedIndex) {
-      await loadIndex(target, play: play ?? playing);
+      final intent = play ?? playing;
+      final ok = await loadIndex(target, play: intent);
+      // A failed user-driven load would otherwise strand the backend in
+      // 'loading' with no watchdog running (polling only starts on success).
+      if (!ok) await trackFailed('load failed', play: intent);
     }
     try {
       await _api.seek(_udn, TimePosition(seconds: position.inSeconds));
@@ -204,15 +180,19 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
   Future<void> seekToNext() async {
     final n = nextIndex();
     if (n != null) {
-      await loadIndex(n,
-          play: playing || processingState == BackendProcessingState.ready);
+      final intent =
+          playing || processingState == BackendProcessingState.ready;
+      final ok = await loadIndex(n, play: intent);
+      if (!ok) await trackFailed('load failed', play: intent);
     }
   }
 
   @override
   Future<void> seekToPrevious() async {
     if (index > 0) {
-      await loadIndex(index - 1, play: playing);
+      final intent = playing;
+      final ok = await loadIndex(index - 1, play: intent);
+      if (!ok) await trackFailed('load failed', play: intent);
     } else {
       await seek(Duration.zero);
     }
@@ -285,8 +265,9 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
       if (loading != null &&
           DateTime.now().difference(loading) > _kStuckLoadingAfter) {
         _loadingSince = null;
-        await trackFailed('renderer stuck loading for '
-            '${_kStuckLoadingAfter.inSeconds}s');
+        await trackFailed(
+            'renderer stuck loading for ${_kStuckLoadingAfter.inSeconds}s',
+            play: playing);
       }
       change();
     } catch (_) {
@@ -295,6 +276,16 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
       // fails every poll; after _kMaxPollFailures in a row, declare it lost so
       // the handler can fall back to local playback.
       if (!_disposed && ++_pollFailures >= _kMaxPollFailures) {
+        // The renderer pulls its stream from the server directly, so when the
+        // PHONE's own LAN is what dropped, the cast is usually still playing
+        // fine — hold instead of tearing a working cast down and falling back
+        // to a phone that is itself offline. Polls keep retrying; the first
+        // success resets the counter, and a threshold crossing once the LAN
+        // is back means the renderer is genuinely gone.
+        if (!await hasConnectivity(lanOnly: true)) {
+          _pollFailures = _kMaxPollFailures; // hold at the threshold
+          return;
+        }
         _stopPolling();
         emitRendererLost(
             'Lost connection to the cast device — back on this phone');
@@ -322,10 +313,15 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
     } else {
       // Stopped well before the end: the renderer aborted (fetch/decode
       // error). Walk on (bounded) instead of ignoring the stop forever with
-      // the published state stuck on 'playing'.
+      // the published state stuck on 'playing'. Known tradeoff: a stop issued
+      // from the renderer's OWN remote / another control point is
+      // indistinguishable from an abort and also walks — recovering the
+      // dead-server case is worth that rare misfire.
+      final wasPlaying = playing;
       playing = false;
       await trackFailed(
-          'renderer stopped mid-track at ${_lastPlayingPosition.inSeconds}s');
+          'renderer stopped mid-track at ${_lastPlayingPosition.inSeconds}s',
+          play: wasPlaying);
     }
   }
 

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -43,6 +43,12 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
   // reset position to 0 the moment they stop, so the STOPPED classification
   // below reads this instead of the (already-overwritten) live position.
   Duration _lastPlayingPosition = Duration.zero;
+  // A renderer stuck fetching media it can never get (dead iroh tunnel, dead
+  // server) answers every poll in TRANSITIONING forever — no poll failure, no
+  // stop. Track how long a load has gone without reaching playback; past the
+  // threshold the track is failed into the bounded walk.
+  DateTime? _loadingSince;
+  static const Duration _kStuckLoadingAfter = Duration(seconds: 30);
 
   Timer? _pollTimer;
   bool _polling = false;
@@ -108,6 +114,7 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
     _confirmedPlaying = false;
     _reachedNearEnd = false;
     _lastPlayingPosition = Duration.zero;
+    _loadingSince = DateTime.now();
     setProcessingState(BackendProcessingState.loading);
     var ok = false;
     try {
@@ -256,13 +263,16 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
           playing = true;
           trackPlaying();
           _confirmedPlaying = true;
+          _loadingSince = null;
           if (position > _lastPlayingPosition) _lastPlayingPosition = position;
           setProcessingState(BackendProcessingState.ready);
           break;
         case TransportState.paused:
           playing = false;
+          _loadingSince = null;
           break;
         case TransportState.transitioning:
+          _loadingSince ??= DateTime.now();
           setProcessingState(BackendProcessingState.buffering);
           break;
         case TransportState.stopped:
@@ -270,6 +280,13 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
           break;
         case TransportState.noMediaPresent:
           break;
+      }
+      final loading = _loadingSince;
+      if (loading != null &&
+          DateTime.now().difference(loading) > _kStuckLoadingAfter) {
+        _loadingSince = null;
+        await trackFailed('renderer stuck loading for '
+            '${_kStuckLoadingAfter.inSeconds}s');
       }
       change();
     } catch (_) {

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -97,14 +97,15 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
 
   @protected
   @override
-  Future<void> loadIndex(int target, {required bool play}) async {
-    if (target < 0 || target >= items.length) return;
+  Future<bool> loadIndex(int target, {required bool play}) async {
+    if (target < 0 || target >= items.length) return false;
     index = target;
     emitIndex(target);
     final item = items[target];
     _confirmedPlaying = false;
     _reachedNearEnd = false;
     setProcessingState(BackendProcessingState.loading);
+    var ok = false;
     try {
       final uri = await _resolveUri(item);
       await _api.setMediaUri(_udn, Url(value: uri.toString()), _metaFor(item));
@@ -119,10 +120,12 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
       }
       setProcessingState(BackendProcessingState.ready);
       _startPolling();
+      ok = true;
     } catch (e) {
       castLog('DLNA load failed', error: e);
     }
     change();
+    return ok;
   }
 
   @override

--- a/lib/media/emulated_playlist_backend.dart
+++ b/lib/media/emulated_playlist_backend.dart
@@ -168,6 +168,13 @@ abstract class EmulatedPlaylistBackend implements PlaybackBackend {
   // without this latch they would restart the walk mid-fallback.
   bool _lost = false;
 
+  /// True once the failure walk has declared this renderer lost — subclass
+  /// watchdogs gate on it so they stop re-reporting while the handler swaps
+  /// backends (the swap can take a while when the fallback's own load is
+  /// fighting a dead network).
+  @protected
+  bool get rendererLostEmitted => _lost;
+
   /// The renderer confirmed the current track is playing: clear the advance
   /// latch and reset the failure budget. Subclasses call this from their
   /// PLAYING state handler.

--- a/lib/media/emulated_playlist_backend.dart
+++ b/lib/media/emulated_playlist_backend.dart
@@ -6,6 +6,7 @@ import 'package:just_audio/just_audio.dart' show AndroidEqualizer;
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 
+import 'cast_log.dart';
 import 'playback_backend.dart';
 
 /// Shared base for the renderer backends (DLNA, Chromecast) that *emulate*
@@ -118,8 +119,13 @@ abstract class EmulatedPlaylistBackend implements PlaybackBackend {
   /// Push [index] to the renderer and start / queue playback. Called both by a
   /// backend's own transport and by [removeSourceAt] when the playing track is
   /// removed and the slot it left behind must be (re)loaded.
+  ///
+  /// Returns whether the track was successfully handed to the renderer (and
+  /// never throws). A `false` from an auto-advance feeds the bounded failure
+  /// walk in [_advance] — a dead load emits no renderer event, so nothing else
+  /// would move playback forward.
   @protected
-  Future<void> loadIndex(int index, {required bool play});
+  Future<bool> loadIndex(int index, {required bool play});
 
   /// Stop the renderer and settle the terminal (idle) state after the source
   /// list has been emptied (clearSources, or removing the last item). A hook
@@ -132,6 +138,86 @@ abstract class EmulatedPlaylistBackend implements PlaybackBackend {
   /// session). Called by [dispose] *before* the shared subjects are closed.
   @protected
   Future<void> disposeRenderer();
+
+  /// Called when an advance settles with nothing left to play (end of a
+  /// non-repeating list, or a failure walk that ran out of tracks). DLNA stops
+  /// its poll timer here; the Cast SDK pushes events, so Chromecast needs
+  /// nothing. Default: no-op.
+  @protected
+  void onPlaybackSettled() {}
+
+  // ── Failure-bounded auto-advance ──
+  /// Latched while an advance (natural end or failure skip) is loading the
+  /// next track, so duplicate end/error events for the same track boundary
+  /// can't double-advance. Cleared by [trackPlaying] when the renderer
+  /// confirms PLAYING — not when the load call returns, because renderers keep
+  /// re-reporting the OLD track's end until the new media is up — and by
+  /// [_advance] itself when a load fails, so a dead load can't wedge the latch
+  /// (the failure walk continues under its own budget instead).
+  @protected
+  bool advancing = false;
+
+  // Consecutive renderer-side track failures (load failed, receiver media
+  // error, premature stop). Reset when any track reaches confirmed playback.
+  int _trackFailures = 0;
+  static const int kMaxTrackFailures = 3;
+
+  /// The renderer confirmed the current track is playing: clear the advance
+  /// latch and reset the failure budget. Subclasses call this from their
+  /// PLAYING state handler.
+  @protected
+  void trackPlaying() {
+    advancing = false;
+    _trackFailures = 0;
+  }
+
+  /// Natural end of the current track — advance per shuffle/repeat, or settle
+  /// `completed` at the end of a non-repeating list.
+  @protected
+  Future<void> advanceOnComplete() => _advance(failedBecause: null, play: true);
+
+  /// The current track failed on the renderer (load error, receiver media
+  /// error, premature stop) — move on so the queue doesn't silently stop,
+  /// bounded by [kMaxTrackFailures]: after that many consecutive failures the
+  /// renderer is declared lost, which sends the handler's existing fallback
+  /// home to local playback at the same spot. [play] carries the play intent
+  /// through the walk (a failure while paused must not start audio).
+  @protected
+  Future<void> trackFailed(String reason, {bool play = true}) =>
+      _advance(failedBecause: reason, play: play);
+
+  Future<void> _advance(
+      {required String? failedBecause, required bool play}) async {
+    if (advancing) return;
+    if (items.isEmpty) return;
+    advancing = true;
+    if (failedBecause != null) {
+      castLog('cast track failed ($failedBecause) — moving on');
+      _trackFailures++;
+      if (_trackFailures >= kMaxTrackFailures) {
+        _trackFailures = 0;
+        advancing = false;
+        emitRendererLost(
+            "The cast device couldn't play these tracks — back on this phone");
+        return;
+      }
+    }
+    // onComplete:true so repeat-one retries its own track (bounded by the
+    // failure budget) rather than skipping a track the user asked to loop.
+    final n = nextIndex(onComplete: true);
+    if (n == null) {
+      playing = false;
+      advancing = false;
+      setProcessingState(BackendProcessingState.completed);
+      onPlaybackSettled();
+      return;
+    }
+    final ok = await loadIndex(n, play: play);
+    if (!ok) {
+      advancing = false;
+      await trackFailed('load failed', play: play);
+    }
+  }
 
   // ── Source list (mirrors just_audio's on-player playlist API) ──
   @override
@@ -186,7 +272,10 @@ abstract class EmulatedPlaylistBackend implements PlaybackBackend {
       if (_index >= _items.length) _index = _items.length - 1;
       _loadedIndex = -1;
       emitIndex(_index);
-      await loadIndex(_index, play: _playing);
+      final ok = await loadIndex(_index, play: _playing);
+      // A dead load emits no renderer event; walk on so playback isn't
+      // silently stranded on the removed track's empty slot.
+      if (!ok) await trackFailed('load after remove failed', play: _playing);
     }
   }
 

--- a/lib/media/emulated_playlist_backend.dart
+++ b/lib/media/emulated_playlist_backend.dart
@@ -112,6 +112,11 @@ abstract class EmulatedPlaylistBackend implements PlaybackBackend {
 
   @protected
   void emitRendererLost(String message) {
+    // One-shot at the single emit point: every loss path (failure walk, poll
+    // failures, session loss) funnels here, and the handler must see exactly
+    // one fallback trigger per backend life. Also quiesces the walk (_lost).
+    if (_lost) return;
+    _lost = true;
     if (!_rendererLost.isClosed) _rendererLost.add(message);
   }
 
@@ -199,38 +204,75 @@ abstract class EmulatedPlaylistBackend implements PlaybackBackend {
   Future<void> trackFailed(String reason, {bool play = true}) =>
       _advance(failedBecause: reason, play: play);
 
+  /// Delay between failure-walk strikes, so a transient outage at a track
+  /// boundary (e.g. the iroh tunnel supervisor's few-second reconnect, during
+  /// which loads fail instantly) can't burn the whole budget in milliseconds.
+  /// Overridable so unit tests don't sleep.
+  @protected
+  Duration failureWalkDelay = const Duration(seconds: 2);
+
+  // True while an _advance body is executing (its delay + load awaits). The
+  // `advancing` latch alone can't serve both roles: it is deliberately left
+  // held AFTER a successful load (until the renderer confirms PLAYING), and a
+  // failure event in that pending-confirm state must be allowed to release it
+  // — but a failure event while the walk body is actually running must not
+  // re-enter it.
+  bool _walkRunning = false;
+
   Future<void> _advance(
       {required String? failedBecause, required bool play}) async {
-    if (advancing || _lost) return;
+    if (_lost || _walkRunning) return;
+    if (advancing) {
+      // Duplicate end events for the same track boundary must not
+      // double-advance. A FAILURE event in the pending-confirm state is
+      // different: the walk's own freshly-loaded track failed at the renderer
+      // (loadIndex resolves when the load is handed over, before the renderer
+      // fetches the media) — swallowing it would wedge the walk forever, so
+      // release the latch and keep walking under the same budget.
+      if (failedBecause == null) return;
+      advancing = false;
+    }
     if (items.isEmpty) return;
+    _walkRunning = true;
     advancing = true;
-    if (failedBecause != null) {
-      castLog('cast track failed ($failedBecause) — moving on');
-      _trackFailures++;
-      if (_trackFailures >= kMaxTrackFailures) {
-        _trackFailures = 0;
-        advancing = false;
-        _lost = true;
-        onPlaybackSettled();
-        emitRendererLost(
-            "The cast device couldn't play these tracks — back on this phone");
-        return;
+    try {
+      var failure = failedBecause;
+      while (true) {
+        if (failure != null) {
+          castLog('cast track failed ($failure) — moving on');
+          _trackFailures++;
+          if (_trackFailures >= kMaxTrackFailures) {
+            _trackFailures = 0;
+            advancing = false;
+            onPlaybackSettled();
+            emitRendererLost(
+                "The cast device couldn't play these tracks — back on this phone");
+            return;
+          }
+          if (failureWalkDelay > Duration.zero) {
+            await Future<void>.delayed(failureWalkDelay);
+            if (_lost) {
+              advancing = false;
+              return;
+            }
+          }
+        }
+        // onComplete:true so repeat-one retries its own track (bounded by the
+        // failure budget) rather than skipping a track the user asked to loop.
+        final n = nextIndex(onComplete: true);
+        if (n == null) {
+          playing = false;
+          advancing = false;
+          setProcessingState(BackendProcessingState.completed);
+          onPlaybackSettled();
+          return;
+        }
+        final ok = await loadIndex(n, play: play);
+        if (ok) return; // latch stays held until the renderer confirms PLAYING
+        failure = 'load failed';
       }
-    }
-    // onComplete:true so repeat-one retries its own track (bounded by the
-    // failure budget) rather than skipping a track the user asked to loop.
-    final n = nextIndex(onComplete: true);
-    if (n == null) {
-      playing = false;
-      advancing = false;
-      setProcessingState(BackendProcessingState.completed);
-      onPlaybackSettled();
-      return;
-    }
-    final ok = await loadIndex(n, play: play);
-    if (!ok) {
-      advancing = false;
-      await trackFailed('load failed', play: play);
+    } finally {
+      _walkRunning = false;
     }
   }
 

--- a/lib/media/emulated_playlist_backend.dart
+++ b/lib/media/emulated_playlist_backend.dart
@@ -162,6 +162,12 @@ abstract class EmulatedPlaylistBackend implements PlaybackBackend {
   int _trackFailures = 0;
   static const int kMaxTrackFailures = 3;
 
+  // Set when the failure walk gives up and declares the renderer lost. The
+  // handler is about to dispose this backend; renderer events keep arriving
+  // until it does (DLNA polls still succeed, Cast still pushes status), and
+  // without this latch they would restart the walk mid-fallback.
+  bool _lost = false;
+
   /// The renderer confirmed the current track is playing: clear the advance
   /// latch and reset the failure budget. Subclasses call this from their
   /// PLAYING state handler.
@@ -188,7 +194,7 @@ abstract class EmulatedPlaylistBackend implements PlaybackBackend {
 
   Future<void> _advance(
       {required String? failedBecause, required bool play}) async {
-    if (advancing) return;
+    if (advancing || _lost) return;
     if (items.isEmpty) return;
     advancing = true;
     if (failedBecause != null) {
@@ -197,6 +203,8 @@ abstract class EmulatedPlaylistBackend implements PlaybackBackend {
       if (_trackFailures >= kMaxTrackFailures) {
         _trackFailures = 0;
         advancing = false;
+        _lost = true;
+        onPlaybackSettled();
         emitRendererLost(
             "The cast device couldn't play these tracks — back on this phone");
         return;

--- a/lib/media/local_media_server.dart
+++ b/lib/media/local_media_server.dart
@@ -330,12 +330,13 @@ class LocalMediaServer {
   // renderer (and the cast-failure fallback) treats it as a load error.
   Future<void> _proxyRequest(HttpRequest req, Uri upstream) async {
     final res = req.response;
+    HttpClientRequest? up; // tracked so a timed-out relay can abort its socket
     HttpClientResponse? upRes; // tracked so a failed relay can release the socket
     try {
       final client = _proxyClient ??=
           (HttpClient()..connectionTimeout = const Duration(seconds: 15));
       final method = req.method == 'HEAD' ? 'HEAD' : 'GET';
-      final up = await client.openUrl(method, upstream);
+      up = await client.openUrl(method, upstream);
       // Forward the byte range; ask for identity so Content-Length / Content-Range
       // stay exact (audio isn't gzipped, but be explicit rather than rely on it).
       final range = req.headers.value(HttpHeaders.rangeHeader);
@@ -376,6 +377,14 @@ class LocalMediaServer {
       await res.close();
     } catch (e) {
       castLog('LocalMediaServer proxy relay failed', error: e);
+      // A relay that never got response headers (first-byte timeout) leaves
+      // its request in flight on the shared keep-alive client — abort it, or
+      // each timed-out fetch strands a zombie connection to the dead tunnel.
+      if (upRes == null && up != null) {
+        try {
+          up.abort();
+        } catch (_) {}
+      }
       // Drain the half-read upstream so the reused keep-alive client doesn't pool
       // a dirty socket (e.g. the renderer aborted mid-stream on a seek).
       if (upRes != null) {

--- a/lib/media/local_media_server.dart
+++ b/lib/media/local_media_server.dart
@@ -341,7 +341,12 @@ class LocalMediaServer {
       final range = req.headers.value(HttpHeaders.rangeHeader);
       if (range != null) up.headers.set(HttpHeaders.rangeHeader, range);
       up.headers.set(HttpHeaders.acceptEncodingHeader, 'identity');
-      upRes = await up.close();
+      // Bound the wait for the upstream response headers: a tunnel that
+      // accepts the connection but never answers (supervisor mid-reconnect)
+      // would otherwise hang this relay and leave the renderer 'loading'
+      // forever. The timeout lands in the catch below → 502 → the renderer
+      // reports a media error and the cast failure walk takes over.
+      upRes = await up.close().timeout(const Duration(seconds: 12));
 
       res.statusCode = upRes.statusCode;
       // Fall back to a basename sniff when the upstream omits Content-Type: a DLNA

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -403,10 +403,12 @@ class ServerManager {
         // has no prior port — so a "changed-only" guard would skip exactly the
         // case that strands the saved queue. Only an actual (re)start reaches here
         // (the already-wired-up fast path returned above), and the rebuild no-ops
-        // when no URL actually changed. (Also reloads an active cast onto the fresh
-        // tunnel — see the no-drop note above.)
+        // when no URL actually changed. auto:true → skipped while casting: the
+        // cast backends re-resolve each track against the live tunnel at load
+        // time (irohProxyUri), and a mid-session reload clobbers the Cast SDK's
+        // own suspend/resume recovery.
         unawaited(MediaManager().audioHandler.customAction(
-            'rebuildTranscodeUrls', const {'upcomingOnly': false}));
+            'rebuildTranscodeUrls', const {'upcomingOnly': false, 'auto': true}));
       } catch (e) {
         s.tunnelPort = null;
         s.tunnelToken = null;

--- a/lib/util/connectivity_probe.dart
+++ b/lib/util/connectivity_probe.dart
@@ -1,0 +1,26 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+/// Best-effort "is a usable network up right now?" probe.
+///
+/// [lanOnly] restricts the answer to LAN-capable transports (Wi-Fi /
+/// ethernet). That is the right question for anything that must reach a
+/// device on the local network (a cast session, a renderer): when Wi-Fi
+/// blips, phones fail over to mobile data within seconds, so an any-network
+/// probe reports online while the LAN — and everything on it — is
+/// unreachable. Leave it false for internet streaming, where any transport
+/// serves.
+///
+/// Fails OPEN (a broken probe counts as online) so callers that loop while
+/// offline can never wait forever on a probe error.
+Future<bool> hasConnectivity({bool lanOnly = false}) async {
+  try {
+    final r = await Connectivity().checkConnectivity();
+    if (lanOnly) {
+      return r.contains(ConnectivityResult.wifi) ||
+          r.contains(ConnectivityResult.ethernet);
+    }
+    return r.any((c) => c != ConnectivityResult.none);
+  } catch (_) {
+    return true;
+  }
+}

--- a/lib/util/stream_url.dart
+++ b/lib/util/stream_url.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show mapEquals;
 import 'package:uuid/uuid.dart';
 
 import '../objects/server.dart';
@@ -44,6 +45,28 @@ String buildServerStreamUrl(Server server, String path) {
   if (tm.bitrate != null) sb.write('&bitrate=${tm.bitrate!}');
   sb.write(server.localTokenQuery);
   return sb.toString();
+}
+
+/// Whether two stream URLs point at the same stream. [buildServerStreamUrl]
+/// stamps a fresh cache-busting `app_uuid` on EVERY call, so a raw string
+/// compare sees every rebuild as a change — and rebuild paths would reload
+/// the whole queue (dumping the player's buffer, or clobbering an active
+/// cast) even when endpoint, port and token are identical. Lives here, next
+/// to the builder that mints the cache-buster it ignores.
+bool sameStreamUrl(String a, String b) {
+  if (a == b) return true;
+  final ua = Uri.tryParse(a);
+  final ub = Uri.tryParse(b);
+  if (ua == null || ub == null) return false;
+  if (ua.scheme != ub.scheme ||
+      ua.host != ub.host ||
+      ua.port != ub.port ||
+      ua.path != ub.path) {
+    return false;
+  }
+  final qa = Map.of(ua.queryParameters)..remove('app_uuid');
+  final qb = Map.of(ub.queryParameters)..remove('app_uuid');
+  return mapEquals(qa, qb);
 }
 
 /// Single source of truth for a server's album-art URL.

--- a/test/media/dlna_playback_backend_test.dart
+++ b/test/media/dlna_playback_backend_test.dart
@@ -1,0 +1,170 @@
+import 'package:audio_service/audio_service.dart' show MediaItem;
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/services.dart' show PlatformException;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_cast_dlna/media_cast_dlna.dart' hide MediaItem;
+import 'package:mstream_music/media/dlna_playback_backend.dart';
+
+/// Fake pigeon API: every method the backend touches is overridden, so no
+/// platform channel is ever hit. Poll responses are scripted through [polls]
+/// (the last entry repeats once the script runs out).
+class _FakeDlnaApi extends MediaCastDlnaApi {
+  final List<String> calls = [];
+  final List<PlaybackInfo> polls = [];
+  int pollCount = 0;
+  bool Function(String uri)? setMediaUriOk;
+
+  @override
+  Future<void> setMediaUri(
+      DeviceUdn deviceUdn, Url uri, MediaMetadata metadata) async {
+    calls.add('set:${uri.value}');
+    if (!(setMediaUriOk?.call(uri.value) ?? true)) {
+      throw PlatformException(code: 'timeout', message: 'SOAP timeout');
+    }
+  }
+
+  @override
+  Future<void> play(DeviceUdn deviceUdn) async => calls.add('play');
+
+  @override
+  Future<void> pause(DeviceUdn deviceUdn) async => calls.add('pause');
+
+  @override
+  Future<void> stop(DeviceUdn deviceUdn) async => calls.add('stop');
+
+  @override
+  Future<void> seek(DeviceUdn deviceUdn, TimePosition position) async {}
+
+  @override
+  Future<void> setVolume(DeviceUdn deviceUdn, VolumeLevel volume) async {}
+
+  @override
+  Future<PlaybackInfo> getPlaybackInfo(DeviceUdn deviceUdn) async {
+    final i = pollCount < polls.length ? pollCount : polls.length - 1;
+    pollCount++;
+    return polls[i];
+  }
+}
+
+PlaybackInfo _info(TransportState state, int posSec, int durSec) =>
+    PlaybackInfo(
+        state: state,
+        position: TimePosition(seconds: posSec),
+        duration: TimeDuration(seconds: durSec));
+
+MediaItem _track(int i, {Duration? duration}) => MediaItem(
+    id: 'http://server/media/$i.mp3', title: 'Track $i', duration: duration);
+
+void main() {
+  test('natural end (near-end latched) advances to the next track', () {
+    fakeAsync((fa) {
+      final api = _FakeDlnaApi();
+      final b = DlnaPlaybackBackend(udn: 'udn', api: api);
+      b.setSources(List.generate(3, (i) => _track(i)));
+      fa.flushMicrotasks();
+      b.play();
+      fa.flushMicrotasks();
+      expect(api.calls, ['set:http://server/media/0.mp3', 'play']);
+
+      api.polls.addAll([
+        _info(TransportState.playing, 100, 180),
+        _info(TransportState.playing, 176, 180), // near-end latch
+        _info(TransportState.stopped, 0, 180), // renderer stops at track end
+      ]);
+      fa.elapse(const Duration(seconds: 3));
+      fa.flushMicrotasks();
+      expect(api.calls, contains('set:http://server/media/1.mp3'));
+      expect(b.currentIndex, 1);
+    });
+  });
+
+  test('mid-track STOPPED is treated as a failure and walks on', () {
+    fakeAsync((fa) {
+      final api = _FakeDlnaApi();
+      final b = DlnaPlaybackBackend(udn: 'udn', api: api);
+      b.setSources(List.generate(3, (i) => _track(i)));
+      fa.flushMicrotasks();
+      b.play();
+      fa.flushMicrotasks();
+
+      api.polls.addAll([
+        _info(TransportState.playing, 60, 180), // confirmed, far from the end
+        _info(TransportState.stopped, 0, 180), // renderer aborted mid-track
+      ]);
+      fa.elapse(const Duration(seconds: 2));
+      fa.flushMicrotasks();
+      // Previously this wedged forever with state stuck on 'playing'.
+      expect(api.calls, contains('set:http://server/media/1.mp3'));
+      expect(b.currentIndex, 1);
+    });
+  });
+
+  test('unknown duration: a stop after real progress is a natural end', () {
+    fakeAsync((fa) {
+      final api = _FakeDlnaApi();
+      final b = DlnaPlaybackBackend(udn: 'udn', api: api);
+      b.setSources(List.generate(2, (i) => _track(i))); // no item duration
+      fa.flushMicrotasks();
+      b.play();
+      fa.flushMicrotasks();
+
+      api.polls.addAll([
+        _info(TransportState.playing, 30, 0), // renderer reports no duration
+        _info(TransportState.stopped, 0, 0),
+      ]);
+      fa.elapse(const Duration(seconds: 2));
+      fa.flushMicrotasks();
+      // Previously the near-end latch could never set → stopped after every track.
+      expect(api.calls, contains('set:http://server/media/1.mp3'));
+    });
+  });
+
+  test('transient STOPPED before playback is confirmed is ignored', () {
+    fakeAsync((fa) {
+      final api = _FakeDlnaApi();
+      final b = DlnaPlaybackBackend(udn: 'udn', api: api);
+      b.setSources(List.generate(2, (i) => _track(i)));
+      fa.flushMicrotasks();
+      b.play();
+      fa.flushMicrotasks();
+
+      api.polls.add(_info(TransportState.stopped, 0, 180)); // load transition
+      fa.elapse(const Duration(seconds: 3));
+      fa.flushMicrotasks();
+      expect(api.calls.where((c) => c.startsWith('set:')), hasLength(1));
+      expect(b.currentIndex, 0);
+    });
+  });
+
+  test(
+      'persistent load failures give up, declare the renderer lost and stop '
+      'polling', () {
+    fakeAsync((fa) {
+      final api = _FakeDlnaApi();
+      final b = DlnaPlaybackBackend(udn: 'udn', api: api);
+      final lost = <String>[];
+      b.rendererLostStream.listen(lost.add);
+      b.setSources(List.generate(6, (i) => _track(i)));
+      fa.flushMicrotasks();
+      b.play();
+      fa.flushMicrotasks();
+
+      // Track 0 plays, then every subsequent load times out at the renderer.
+      api.setMediaUriOk = (uri) => uri.contains('/0.mp3');
+      api.polls.addAll([
+        _info(TransportState.playing, 100, 180),
+        _info(TransportState.playing, 176, 180),
+        _info(TransportState.stopped, 0, 180), // natural end → advance fails
+      ]);
+      fa.elapse(const Duration(seconds: 3));
+      fa.flushMicrotasks();
+
+      expect(lost, hasLength(1));
+      // Walk attempted exactly kMaxTrackFailures loads before giving up.
+      expect(api.calls.where((c) => c.startsWith('set:')).length, 1 + 3);
+      final pollsAtLoss = api.pollCount;
+      fa.elapse(const Duration(seconds: 5));
+      expect(api.pollCount, pollsAtLoss); // polling quiesced
+    });
+  });
+}

--- a/test/media/dlna_playback_backend_test.dart
+++ b/test/media/dlna_playback_backend_test.dart
@@ -46,6 +46,14 @@ class _FakeDlnaApi extends MediaCastDlnaApi {
   }
 }
 
+/// DLNA backend with the failure-walk delay zeroed so fakeAsync tests don't
+/// have to elapse the inter-strike backoff.
+class _TestDlnaBackend extends DlnaPlaybackBackend {
+  _TestDlnaBackend({required super.udn, super.api}) {
+    failureWalkDelay = Duration.zero;
+  }
+}
+
 PlaybackInfo _info(TransportState state, int posSec, int durSec) =>
     PlaybackInfo(
         state: state,
@@ -59,7 +67,7 @@ void main() {
   test('natural end (near-end latched) advances to the next track', () {
     fakeAsync((fa) {
       final api = _FakeDlnaApi();
-      final b = DlnaPlaybackBackend(udn: 'udn', api: api);
+      final b = _TestDlnaBackend(udn: 'udn', api: api);
       b.setSources(List.generate(3, (i) => _track(i)));
       fa.flushMicrotasks();
       b.play();
@@ -81,7 +89,7 @@ void main() {
   test('mid-track STOPPED is treated as a failure and walks on', () {
     fakeAsync((fa) {
       final api = _FakeDlnaApi();
-      final b = DlnaPlaybackBackend(udn: 'udn', api: api);
+      final b = _TestDlnaBackend(udn: 'udn', api: api);
       b.setSources(List.generate(3, (i) => _track(i)));
       fa.flushMicrotasks();
       b.play();
@@ -102,7 +110,7 @@ void main() {
   test('unknown duration: a stop after real progress is a natural end', () {
     fakeAsync((fa) {
       final api = _FakeDlnaApi();
-      final b = DlnaPlaybackBackend(udn: 'udn', api: api);
+      final b = _TestDlnaBackend(udn: 'udn', api: api);
       b.setSources(List.generate(2, (i) => _track(i))); // no item duration
       fa.flushMicrotasks();
       b.play();
@@ -122,7 +130,7 @@ void main() {
   test('transient STOPPED before playback is confirmed is ignored', () {
     fakeAsync((fa) {
       final api = _FakeDlnaApi();
-      final b = DlnaPlaybackBackend(udn: 'udn', api: api);
+      final b = _TestDlnaBackend(udn: 'udn', api: api);
       b.setSources(List.generate(2, (i) => _track(i)));
       fa.flushMicrotasks();
       b.play();
@@ -141,7 +149,7 @@ void main() {
       'polling', () {
     fakeAsync((fa) {
       final api = _FakeDlnaApi();
-      final b = DlnaPlaybackBackend(udn: 'udn', api: api);
+      final b = _TestDlnaBackend(udn: 'udn', api: api);
       final lost = <String>[];
       b.rendererLostStream.listen(lost.add);
       b.setSources(List.generate(6, (i) => _track(i)));

--- a/test/media/emulated_playlist_backend_test.dart
+++ b/test/media/emulated_playlist_backend_test.dart
@@ -1,0 +1,182 @@
+import 'package:audio_service/audio_service.dart' show MediaItem;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/emulated_playlist_backend.dart';
+import 'package:mstream_music/media/playback_backend.dart';
+
+/// Scriptable stand-in for a renderer backend: loads succeed/fail per
+/// [loadResult], and the protected advance API is exposed for the tests.
+class _FakeBackend extends EmulatedPlaylistBackend {
+  final List<String> loads = [];
+  bool Function(int index)? loadResult;
+  int settledCalls = 0;
+
+  @override
+  Future<bool> loadIndex(int target, {required bool play}) async {
+    // Mirror the real backends: the logical index moves to the target before
+    // the renderer push is attempted; loadedIndex only on success.
+    index = target;
+    emitIndex(target);
+    loads.add('$target:${play ? 'play' : 'pause'}');
+    final ok = loadResult?.call(target) ?? true;
+    if (ok) loadedIndex = target;
+    return ok;
+  }
+
+  @override
+  Future<void> stopForEmptyList() async {}
+
+  @override
+  Future<void> disposeRenderer() async {}
+
+  @override
+  void onPlaybackSettled() {
+    settledCalls++;
+  }
+
+  // Public wrappers for the protected advance API.
+  Future<void> endOfTrack() => advanceOnComplete();
+  Future<void> failTrack(String reason, {bool play = true}) =>
+      trackFailed(reason, play: play);
+  void confirmPlaying() => trackPlaying();
+  bool get isAdvancing => advancing;
+
+  // Inert transport (not under test).
+  @override
+  Future<void> play() async {}
+  @override
+  Future<void> pause() async {}
+  @override
+  Future<void> stop() async {}
+  @override
+  Future<void> seek(Duration position, {int? index, bool? play}) async {}
+  @override
+  Future<void> seekToNext() async {}
+  @override
+  Future<void> seekToPrevious() async {}
+  @override
+  Future<void> setVolume(double volume) async {}
+}
+
+MediaItem _item(int i) => MediaItem(id: 'id-$i', title: 'Track $i');
+
+Future<_FakeBackend> _seeded(int count) async {
+  final b = _FakeBackend();
+  await b.setSources(List.generate(count, _item));
+  return b;
+}
+
+void main() {
+  group('advanceOnComplete', () {
+    test('advances to the next index and loads it playing', () async {
+      final b = await _seeded(3);
+      await b.endOfTrack();
+      expect(b.loads, ['1:play']);
+      expect(b.currentIndex, 1);
+    });
+
+    test('settles completed at the end of a non-repeating list', () async {
+      final b = await _seeded(3);
+      await b.loadIndex(2, play: true);
+      b.confirmPlaying();
+      b.loads.clear();
+      await b.endOfTrack();
+      expect(b.loads, isEmpty);
+      expect(b.processingState, BackendProcessingState.completed);
+      expect(b.playing, isFalse);
+      expect(b.settledCalls, 1);
+      expect(b.isAdvancing, isFalse);
+    });
+
+    test('wraps to 0 under repeat-all', () async {
+      final b = await _seeded(3);
+      await b.setRepeat(BackendRepeat.all);
+      await b.loadIndex(2, play: true);
+      b.confirmPlaying();
+      b.loads.clear();
+      await b.endOfTrack();
+      expect(b.loads, ['0:play']);
+    });
+
+    test('repeat-one reloads the same track', () async {
+      final b = await _seeded(3);
+      await b.setRepeat(BackendRepeat.one);
+      await b.loadIndex(1, play: true);
+      b.confirmPlaying();
+      b.loads.clear();
+      await b.endOfTrack();
+      expect(b.loads, ['1:play']);
+    });
+
+    test('duplicate end events while the latch is held advance once',
+        () async {
+      final b = await _seeded(5);
+      await b.endOfTrack(); // latches advancing (no PLAYING confirm yet)
+      await b.endOfTrack();
+      await b.endOfTrack();
+      expect(b.loads, ['1:play']);
+    });
+  });
+
+  group('trackFailed (bounded failure walk)', () {
+    test('a failed advance load walks on to the following track', () async {
+      final b = await _seeded(5);
+      b.loadResult = (i) => i != 1; // only index 1 is broken
+      await b.endOfTrack();
+      expect(b.loads, ['1:play', '2:play']);
+      expect(b.currentIndex, 2);
+    });
+
+    test(
+        'gives up after kMaxTrackFailures consecutive failures and '
+        'declares the renderer lost once', () async {
+      final b = await _seeded(10);
+      b.loadResult = (_) => false; // everything is broken
+      final lost = <String>[];
+      b.rendererLostStream.listen(lost.add);
+      await b.endOfTrack();
+      await Future<void>.delayed(Duration.zero); // let the stream deliver
+      expect(b.loads.length, EmulatedPlaylistBackend.kMaxTrackFailures);
+      expect(lost, hasLength(1));
+      expect(b.isAdvancing, isFalse); // no wedge: latch released
+    });
+
+    test('confirmed playback resets the failure budget', () async {
+      final b = await _seeded(10);
+      b.loadResult = (i) => i == 3; // two failures, then 3 loads fine
+      final lost = <String>[];
+      b.rendererLostStream.listen(lost.add);
+      await b.endOfTrack(); // 1 fails, 2 fails, 3 loads
+      b.confirmPlaying();
+      b.loadResult = (_) => false;
+      await b.endOfTrack(); // needs 3 FRESH failures to trip
+      await Future<void>.delayed(Duration.zero);
+      expect(lost, hasLength(1)); // not 2 — the first walk never tripped
+      expect(b.loads, ['1:play', '2:play', '3:play', '4:play', '5:play', '6:play']);
+    });
+
+    test('preserves a paused play intent through the walk', () async {
+      final b = await _seeded(5);
+      b.loadResult = (i) => i == 2;
+      await b.failTrack('renderer stopped', play: false);
+      expect(b.loads, ['1:pause', '2:pause']);
+    });
+
+    test('is a no-op on an empty list', () async {
+      final b = _FakeBackend();
+      await b.setSources(const []);
+      await b.failTrack('anything');
+      expect(b.loads, isEmpty);
+    });
+
+    test('a failed walk does not wedge later natural advances', () async {
+      final b = await _seeded(5);
+      b.loadResult = (_) => false;
+      await b.endOfTrack(); // trips renderer-lost, latch released
+      b.loadResult = null; // renderer healthy again
+      b.confirmPlaying();
+      b.loads.clear();
+      await b.endOfTrack();
+      expect(b.loads, hasLength(1)); // advances normally
+    });
+  });
+}

--- a/test/media/emulated_playlist_backend_test.dart
+++ b/test/media/emulated_playlist_backend_test.dart
@@ -6,6 +6,10 @@ import 'package:mstream_music/media/playback_backend.dart';
 /// Scriptable stand-in for a renderer backend: loads succeed/fail per
 /// [loadResult], and the protected advance API is exposed for the tests.
 class _FakeBackend extends EmulatedPlaylistBackend {
+  _FakeBackend() {
+    failureWalkDelay = Duration.zero; // tests must not sleep between strikes
+  }
+
   final List<String> loads = [];
   bool Function(int index)? loadResult;
   int settledCalls = 0;
@@ -114,6 +118,19 @@ void main() {
       await b.endOfTrack();
       await b.endOfTrack();
       expect(b.loads, ['1:play']);
+    });
+
+    test(
+        'a renderer failure of the walk-loaded track releases the latch and '
+        'keeps walking (loadIndex resolves before the renderer fetches)',
+        () async {
+      final b = await _seeded(5);
+      await b.endOfTrack(); // loads 1 successfully, latch held pending PLAYING
+      expect(b.loads, ['1:play']);
+      // The receiver then fails to FETCH track 1 (proxy 502 / dead tunnel):
+      // this arrives as a failure event while the latch is still held.
+      await b.failTrack('receiver reported a media error');
+      expect(b.loads, ['1:play', '2:play']); // walked on — no wedge
     });
   });
 

--- a/test/media/emulated_playlist_backend_test.dart
+++ b/test/media/emulated_playlist_backend_test.dart
@@ -168,15 +168,29 @@ void main() {
       expect(b.loads, isEmpty);
     });
 
-    test('a failed walk does not wedge later natural advances', () async {
+    test('a mid-walk failure does not wedge the following natural advance',
+        () async {
       final b = await _seeded(5);
-      b.loadResult = (_) => false;
-      await b.endOfTrack(); // trips renderer-lost, latch released
-      b.loadResult = null; // renderer healthy again
+      b.loadResult = (i) => i != 1; // one broken track, then healthy
+      await b.endOfTrack(); // 1 fails, 2 loads (latch held until PLAYING)
       b.confirmPlaying();
       b.loads.clear();
       await b.endOfTrack();
-      expect(b.loads, hasLength(1)); // advances normally
+      expect(b.loads, ['3:play']); // advances normally — no wedge
+    });
+
+    test(
+        'after renderer-lost the walk quiesces — straggler renderer events '
+        'cannot restart it while the handler swaps backends', () async {
+      final b = await _seeded(5);
+      b.loadResult = (_) => false;
+      await b.endOfTrack(); // trips renderer-lost
+      expect(b.settledCalls, 1); // quiesce hook fired (DLNA stops polling)
+      b.loadResult = null;
+      b.loads.clear();
+      await b.endOfTrack();
+      await b.failTrack('straggler poll');
+      expect(b.loads, isEmpty);
     });
   });
 }

--- a/test/media/same_stream_url_test.dart
+++ b/test/media/same_stream_url_test.dart
@@ -1,15 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mstream_music/media/audio_stuff.dart';
+import 'package:mstream_music/util/stream_url.dart';
 
 void main() {
-  group('AudioPlayerHandler.sameStreamUrl', () {
+  group('sameStreamUrl', () {
     // buildServerStreamUrl stamps a fresh app_uuid per call; the rebuild paths
     // must treat two URLs differing ONLY in that cache-buster as the same
     // stream, or every tunnel reconnect reloads the whole queue.
 
     test('identical except app_uuid → same', () {
       expect(
-        AudioPlayerHandler.sameStreamUrl(
+        sameStreamUrl(
           'http://127.0.0.1:41234/media/a/b.mp3?app_uuid=1111&token=t&__lt=x',
           'http://127.0.0.1:41234/media/a/b.mp3?app_uuid=2222&token=t&__lt=x',
         ),
@@ -19,7 +19,7 @@ void main() {
 
     test('different port (tunnel rotated) → different', () {
       expect(
-        AudioPlayerHandler.sameStreamUrl(
+        sameStreamUrl(
           'http://127.0.0.1:41234/media/a.mp3?app_uuid=1&token=t',
           'http://127.0.0.1:52345/media/a.mp3?app_uuid=2&token=t',
         ),
@@ -29,7 +29,7 @@ void main() {
 
     test('different token → different', () {
       expect(
-        AudioPlayerHandler.sameStreamUrl(
+        sameStreamUrl(
           'https://demo.mstream.io/media/a.mp3?app_uuid=1&token=old',
           'https://demo.mstream.io/media/a.mp3?app_uuid=2&token=new',
         ),
@@ -39,7 +39,7 @@ void main() {
 
     test('endpoint change (media → transcode) → different', () {
       expect(
-        AudioPlayerHandler.sameStreamUrl(
+        sameStreamUrl(
           'https://s/media/a.mp3?app_uuid=1&token=t',
           'https://s/transcode/a.mp3?app_uuid=2&token=t&codec=opus',
         ),
@@ -49,7 +49,7 @@ void main() {
 
     test('added transcode params → different', () {
       expect(
-        AudioPlayerHandler.sameStreamUrl(
+        sameStreamUrl(
           'https://s/transcode/a.mp3?app_uuid=1&token=t',
           'https://s/transcode/a.mp3?app_uuid=2&token=t&bitrate=192k',
         ),
@@ -59,13 +59,13 @@ void main() {
 
     test('exact same string → same (fast path)', () {
       const u = 'https://s/media/a.mp3?app_uuid=1&token=t';
-      expect(AudioPlayerHandler.sameStreamUrl(u, u), isTrue);
+      expect(sameStreamUrl(u, u), isTrue);
     });
 
     test('non-URL ids compare as plain strings', () {
-      expect(AudioPlayerHandler.sameStreamUrl('abc', 'abc'), isTrue);
+      expect(sameStreamUrl('abc', 'abc'), isTrue);
       // Uuid-style local ids parse as URIs with only a path — path differs.
-      expect(AudioPlayerHandler.sameStreamUrl('abc', 'def'), isFalse);
+      expect(sameStreamUrl('abc', 'def'), isFalse);
     });
   });
 }

--- a/test/media/same_stream_url_test.dart
+++ b/test/media/same_stream_url_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/audio_stuff.dart';
+
+void main() {
+  group('AudioPlayerHandler.sameStreamUrl', () {
+    // buildServerStreamUrl stamps a fresh app_uuid per call; the rebuild paths
+    // must treat two URLs differing ONLY in that cache-buster as the same
+    // stream, or every tunnel reconnect reloads the whole queue.
+
+    test('identical except app_uuid → same', () {
+      expect(
+        AudioPlayerHandler.sameStreamUrl(
+          'http://127.0.0.1:41234/media/a/b.mp3?app_uuid=1111&token=t&__lt=x',
+          'http://127.0.0.1:41234/media/a/b.mp3?app_uuid=2222&token=t&__lt=x',
+        ),
+        isTrue,
+      );
+    });
+
+    test('different port (tunnel rotated) → different', () {
+      expect(
+        AudioPlayerHandler.sameStreamUrl(
+          'http://127.0.0.1:41234/media/a.mp3?app_uuid=1&token=t',
+          'http://127.0.0.1:52345/media/a.mp3?app_uuid=2&token=t',
+        ),
+        isFalse,
+      );
+    });
+
+    test('different token → different', () {
+      expect(
+        AudioPlayerHandler.sameStreamUrl(
+          'https://demo.mstream.io/media/a.mp3?app_uuid=1&token=old',
+          'https://demo.mstream.io/media/a.mp3?app_uuid=2&token=new',
+        ),
+        isFalse,
+      );
+    });
+
+    test('endpoint change (media → transcode) → different', () {
+      expect(
+        AudioPlayerHandler.sameStreamUrl(
+          'https://s/media/a.mp3?app_uuid=1&token=t',
+          'https://s/transcode/a.mp3?app_uuid=2&token=t&codec=opus',
+        ),
+        isFalse,
+      );
+    });
+
+    test('added transcode params → different', () {
+      expect(
+        AudioPlayerHandler.sameStreamUrl(
+          'https://s/transcode/a.mp3?app_uuid=1&token=t',
+          'https://s/transcode/a.mp3?app_uuid=2&token=t&bitrate=192k',
+        ),
+        isFalse,
+      );
+    });
+
+    test('exact same string → same (fast path)', () {
+      const u = 'https://s/media/a.mp3?app_uuid=1&token=t';
+      expect(AudioPlayerHandler.sameStreamUrl(u, u), isTrue);
+    });
+
+    test('non-URL ids compare as plain strings', () {
+      expect(AudioPlayerHandler.sameStreamUrl('abc', 'abc'), isTrue);
+      // Uuid-style local ids parse as URIs with only a path — path differs.
+      expect(AudioPlayerHandler.sameStreamUrl('abc', 'def'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Fixes the five confirmed cast-path findings from the playback-stops review, plus **ten more defects found during a full on-device smoke campaign** (S25 + Chromecast-built-in TV, iroh + plain-HTTP servers). Every way a cast queue could silently stop, wedge on "playing," or die on a network blip.

## Part 1 — the review findings (commits 1–5)

1. **Base failure walk** (`EmulatedPlaylistBackend`): `loadIndex` reports success; `trackFailed` walks past a broken track, bounded (3 strikes → renderer-lost → the handler's existing fallback brings playback home at the same spot). The advance latch releases on a failed load (the old permanent-wedge mechanism) but holds until PLAYING on success; after give-up the walk quiesces.
2. **DLNA**: STOPPED classified (load-transition / natural end / mid-track failure); unknown-duration tracks advance on stop-after-progress (was: queue halted after every track); failed advances feed the walk.
3. **Chromecast**: receiver `idleReason: ERROR` feeds the walk (was: silently ignored, state stuck on "playing").
4. **Suspend grace**: transient session drops get a grace window instead of instant teardown.
5. **Cast→cast handoff**: switching devices or toggling visualizer cast no longer ends the session the successor is using; `_ensureSession` actually moves the session on a device change.

## Part 2 — what nine on-device smoke rounds added (commits 6–19)

- **URL-rebuild sabotage**: `buildServerStreamUrl` stamps a fresh cache-buster per call, so the tunnel-reconnect queue rebuild NEVER no-op'd — every reconnect force-reloaded the whole queue on the active backend (log-silent). `sameStreamUrl()` compares modulo `app_uuid`; auto rebuilds skip while casting (cast loads re-resolve per track).
- **Session-loss recovery, iterated to correctness**: on Android a Wi-Fi drop surfaces as session **END (null)**, not suspend → null-while-LAN-down gets the grace; the connectivity probe must be **LAN-specific** (phones fail over to mobile data in seconds, fooling an any-network probe); an ENDED session never auto-resumes, so the backend **actively re-attaches** — running discovery (MediaRouter routes only exist while discovery runs; the plugin's `selectRoute` silently no-ops without them), force-clearing the stale suspended session (`endSession()` no-ops on suspended sessions), then adopting the still-playing receiver or reloading at position.
- **Single-driver state machine**: watchdogs and session events only *arm* the recovery loop; one bounded actor makes all decisions (races between two drivers burned the retry budget in 12s). Every leg logs; the re-attach has a 30s hard timeout (a hanging plugin Future once froze the whole machine).
- **Silent session death**: a blip can kill the session with NO SDK event — a staleness watchdog (20s of event silence while playing) feeds the recovery, mirroring DLNA's poll-failure detection.
- **Stuck-loading detection** (both backends): a receiver fetching media it can never get keeps its status channel alive — loading/buffering >30s without playback fails the track into the walk. Plus **fail-fast** dead-tunnel resolution (`irohProxyUri` throws when the tunnel isn't serving → 3 strikes in milliseconds) and a **12s first-byte timeout** in the LAN proxy (hangs become 502s → receiver-error path).
- **Leak-proof fallbacks**: the handler's fallback paths swap control to the local backend before their (fallible) reload and dispose the remote backend in a `finally` — a reload fighting a dead server used to skip the dispose (leaked ticker + session listener) and could strand the handler on a dead backend.

## On-device verification (all passing)

| Scenario | Result |
|---|---|
| Visualizer cast; viz→audio handoff | session survives; encoder stops cleanly |
| Natural auto-advance ×6; end-of-queue settle | correct positions/diagnostics |
| TV powered off mid-cast | fallback at exact position (paused by design — receiver pauses before CEC death; hard losses auto-resume) |
| Wi-Fi blip mid-cast | **TV never stops; re-attached in 3.2s (~33s total incl. detection)** |
| iroh server killed mid-cast | 30s watchdog → 3 walk strikes in 6ms → fallback with toast |
| Casting downloaded tracks with server down | plays via LAN file server |
| Real-outage chaos (user-driven switches mid-outage) | bounded everywhere, no wedges, `remote start timed out (12s)` fallback validated |

Unit tests: 16 new (base walk incl. repeat modes/budget/latch/quiesce; DLNA end-to-end via fake pigeon API; `sameStreamUrl`). Full suite green, analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Part 3 — high-effort review hardening (final commit)

A 36-agent review over the finished branch (7 finder angles, adversarial verification) confirmed 4 correctness bugs and a set of accretion cleanups, all fixed:

- **Walk latch hole**: a renderer-side failure of the walk's own freshly-loaded track was swallowed by the advance latch (loadIndex resolves at hand-over, before the receiver fetches) — the exact silent wedge the walk exists to prevent. Failure events now release the pending-confirm latch; a 2s inter-strike delay stops fail-fast loads from burning the budget during a transient tunnel reconnect.
- **Orphan-proof re-attach**: the 30s timeout doesn't cancel the future and dispose can land mid-await — a generation counter makes superseded/disposed attempts inert at their next await.
- **Play intent honored everywhere**: a failure while paused no longer starts audio; user-driven loads (play/seek/next/prev) feed failures into the walk instead of stranding 'loading'.
- **Safer fallbacks**: reseed-before-swap restores correct stream replay while keeping disposals leak-proof in a finally; return-to-local re-derives queue URLs (the while-casting rebuild skip left stale tunnel ports in stored ids); art resolution can't fail a downloaded track's cast; DLNA holds its loss verdict while the phone's own LAN is down; online-only recovery episodes give up in 3 attempts, not 8; the LAN proxy aborts timed-out upstream requests.
- **Dedupe**: one loss latch, one arming helper, one quiet-session-end helper, one shared fallback reseed, one renderer URL resolver, one connectivity probe, `sameStreamUrl` beside the builder it compensates for; smoke-history comments rewritten as code constraints.

Post-review: 91 unit tests green, analyze clean. Known accepted tradeoffs (documented in code): an external stop from a DLNA renderer's own remote is indistinguishable from an abort and walks; the stuck-loading clocks stay per-backend (push vs poll drivers); the cast-to-cast handoff stays a concrete-type special case pending a generic backend hook.
