### PR TITLE
fix(playback): auto-heal parked playback when the iroh tunnel reconnects

### DIFF
--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -16,6 +16,7 @@ import 'local_media_server.dart';
 import 'auto_browse.dart';
 import 'cast_log.dart';
 import 'cast_target.dart';
+import '../native/iroh_tunnel.dart';
 import '../objects/server.dart';
 import '../objects/metadata.dart';
 import '../singletons/auto_dj_manager.dart';
@@ -185,6 +186,18 @@ class AudioPlayerHandler extends BaseAudioHandler
     // (just_audio's error channel), NOT as errors on changeStream — recover the
     // iroh mid-stream-drop case from here.
     _backendSubject.switchMap((b) => b.errorStream).listen(_onPlaybackError);
+    // The iroh supervisor re-dials a dropped tunnel forever on the same
+    // loopback port, so a dead server coming back flips this status to
+    // connected without any app-side event: the phone's network never changed
+    // (the connectivity listener stays silent) and the error-time recovery
+    // timed out long ago. This transition is the only signal that playback
+    // parked by the outage can resume.
+    ServerManager().tunnelStatusStream.listen((status) {
+      final prev = _lastTunnelStatus;
+      _lastTunnelStatus = status;
+      if (prev == null || prev == IrohTunnelStatus.connected) return;
+      if (status == IrohTunnelStatus.connected) _onTunnelReconnected();
+    });
     // Stop the service when playback reaches the end of the queue.
     _backendSubject.switchMap((b) => b.processingStateStream).listen((state) {
       if (state == BackendProcessingState.completed) {
@@ -713,16 +726,93 @@ class AudioPlayerHandler extends BaseAudioHandler
     _httpRetries = 0;
     _recoveringPlayback = true;
     appLog('[play] connectivity back — resuming after network stall');
-    _switchChain = _switchChain.then((_) async {
-      if (queue.value.isEmpty || !identical(_backend, _localBackend)) return;
-      final pos = _localBackend.position;
-      final idx = _localBackend.currentIndex ?? 0;
-      await _localBackend.setSources(queue.value,
-          initialIndex: idx, initialPosition: pos);
-      if (_playIntent) unawaited(_localBackend.play());
-    }).catchError((Object e) {
+    _switchChain = _switchChain
+        .then((_) => _reseedLocalAtSpot())
+        .catchError((Object e) {
       castLog('network-regained resume failed', error: e);
     }).whenComplete(() => _recoveringPlayback = false);
+  }
+
+  /// Reload the local backend at its current spot, with every URL re-derived
+  /// against the live tunnel/transcode state, then resume if the user still
+  /// wants playback. The revive primitive for a parked player: once just_audio
+  /// goes idle (a playback error tears the platform player down) a bare play()
+  /// silently no-ops — only a re-seed brings audio back. _playIntent is read
+  /// AFTER the load on purpose: setSources is network-bound (seconds over a
+  /// just-reconnected tunnel) and a pause landing mid-load must win over the
+  /// recovery that scheduled us. Callers serialize on _switchChain and hold
+  /// _recoveringPlayback.
+  Future<void> _reseedLocalAtSpot() async {
+    if (!identical(_backend, _localBackend)) return;
+    final fresh = _queueWithFreshUrls();
+    if (fresh.isEmpty) return;
+    final pos = _localBackend.position;
+    final idx = (_localBackend.currentIndex ?? 0).clamp(0, fresh.length - 1);
+    // Load DIRECTLY at the spot (initialIndex/Position) so the now-playing UI
+    // doesn't flash track 0 on the reload.
+    await _localBackend.setSources(fresh,
+        initialIndex: idx, initialPosition: pos);
+    if (_playIntent) unawaited(_localBackend.play());
+  }
+
+  // Resume playback parked by an iroh server outage, fired on the tunnel's
+  // not-connected → connected transition (listener in _init). The supervisor
+  // heals a dropped tunnel in place — same loopback port — so the stored URLs
+  // still look current and _ensureActiveTunnel's rebuild-on-restart never
+  // runs; without this hook nothing reloads the player when the server
+  // returns. Only touches a player that is actually parked: local backend,
+  // idle without a deliberate stop, current track owned by the served server.
+  IrohTunnelStatus? _lastTunnelStatus;
+  // One-shot re-check for a connected edge that arrived while a transient
+  // guard blocked the heal. The status subject emits on change only, so a
+  // consumed edge never re-fires on its own — dropping it would park playback
+  // until the user taps play.
+  Timer? _tunnelHealRetry;
+  void _onTunnelReconnected() {
+    _tunnelHealRetry?.cancel();
+    _tunnelHealRetry = null;
+    if (!identical(_backend, _localBackend)) return;
+    if (_intentionalStop) return;
+    if (_recoveringPlayback || _skipPending) {
+      _rearmTunnelHeal();
+      return;
+    }
+    if (_localBackend.processingState != BackendProcessingState.idle) return;
+    final q = queue.value;
+    if (q.isEmpty) return;
+    final idx = _localBackend.currentIndex ?? 0;
+    final item = (idx >= 0 && idx < q.length) ? q[idx] : null;
+    final server = item == null ? null : _serverFor(item);
+    if (server == null || !server.isIroh) return;
+    if (!ServerManager().tunnelServes(server)) return;
+    // Shares the error-time recovery's per-server budget so a flapping tunnel
+    // (connected↔reconnecting) can't spin reloads against a dying server.
+    final now = DateTime.now();
+    final last = _lastRecoveryByServer[server.localname];
+    if (last != null && now.difference(last) < const Duration(seconds: 10)) {
+      _rearmTunnelHeal();
+      return;
+    }
+    _lastRecoveryByServer[server.localname] = now;
+    _recoveringPlayback = true;
+    appLog('[play] iroh tunnel back — resuming parked playback');
+    _switchChain = _switchChain.then((_) async {
+      // Re-check the park under the chain: something queued ahead of us (a
+      // backend switch, a user play) may already have revived the player.
+      if (_localBackend.processingState != BackendProcessingState.idle) return;
+      await _reseedLocalAtSpot();
+    }).catchError((Object e) {
+      castLog('tunnel-reconnect resume failed', error: e);
+    }).whenComplete(() => _recoveringPlayback = false);
+  }
+
+  // Check the parked state again once the blocking guard has had time to
+  // clear (the cooldown runs 10s; recoveries always finish). Terminates: a
+  // healed player fails the idle guard and a still-dead tunnel fails
+  // tunnelServes, and neither of those re-arms.
+  void _rearmTunnelHeal() {
+    _tunnelHealRetry =
+        Timer(const Duration(seconds: 11), _onTunnelReconnected);
   }
 
   // Heuristic: does this error look like a clearly bad/unplayable source (skip
@@ -789,13 +879,21 @@ class AudioPlayerHandler extends BaseAudioHandler
     await _initialized.future;
     _intentionalStop = false;
     queue.add(items.toList());
-    await _backend.setSources(items);
-    final int i = index.clamp(0, items.length - 1);
-    // play: false → load paused at the saved spot (don't blast audio on open).
-    await _backend.seek(position, index: i, play: false);
-    _repeatMode = repeat;
-    await _backend.setRepeat(_backendRepeat(repeat));
-    if (shuffle) await _backend.setShuffleEnabled(true);
+    // Serialized on _switchChain: the re-seed paths (reload-on-play, tunnel
+    // heal) chain their loads there, and an un-serialized restore load racing
+    // one of them makes the two setSources abort each other ("Loading
+    // interrupted"), losing the saved spot.
+    final done = _switchChain.then((_) async {
+      await _backend.setSources(items);
+      final int i = index.clamp(0, items.length - 1);
+      // play: false → load paused at the saved spot (don't blast audio on open).
+      await _backend.seek(position, index: i, play: false);
+      _repeatMode = repeat;
+      await _backend.setRepeat(_backendRepeat(repeat));
+      if (shuffle) await _backend.setShuffleEnabled(true);
+    });
+    _switchChain = done.catchError((_) {});
+    await done;
     _emitCurrentMediaItem();
     _broadcastState();
   }
@@ -816,11 +914,40 @@ class AudioPlayerHandler extends BaseAudioHandler
   // re-seed resumes PAUSED rather than autoplaying on open.
   bool _playIntent = false;
 
+  /// Whether play() must re-seed the local player instead of issuing a bare
+  /// backend.play(): just_audio parked idle (a playback error tears the
+  /// platform player down) with tracks still queued, so a bare play() would
+  /// silently no-op. Never while a recovery is in flight — it re-seeds itself
+  /// and reads the play intent when it does. Pure; unit-tested.
+  static bool shouldReseedOnPlay({
+    required bool onLocalBackend,
+    required BackendProcessingState processingState,
+    required bool queueEmpty,
+    required bool recovering,
+  }) =>
+      onLocalBackend &&
+      processingState == BackendProcessingState.idle &&
+      !queueEmpty &&
+      !recovering;
+
   @override
   Future<void> play() {
     appLog('[play] play');
     _playIntent = true;
     _intentionalStop = false;
+    if (shouldReseedOnPlay(
+        onLocalBackend: identical(_backend, _localBackend),
+        processingState: _backend.processingState,
+        queueEmpty: queue.value.isEmpty,
+        recovering: _recoveringPlayback)) {
+      appLog('[play] play on an idle player — re-seeding sources');
+      _recoveringPlayback = true;
+      _switchChain = _switchChain
+          .then((_) => _reseedLocalAtSpot())
+          .catchError((Object e) => castLog('re-seed on play failed', error: e))
+          .whenComplete(() => _recoveringPlayback = false);
+      return _switchChain;
+    }
     return _backend.play();
   }
 

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -407,8 +407,16 @@ class ServerManager {
         // cast backends re-resolve each track against the live tunnel at load
         // time (irohProxyUri), and a mid-session reload clobbers the Cast SDK's
         // own suspend/resume recovery.
-        unawaited(MediaManager().audioHandler.customAction(
-            'rebuildTranscodeUrls', const {'upcomingOnly': false, 'auto': true}));
+        unawaited(MediaManager()
+            .audioHandler
+            .customAction('rebuildTranscodeUrls',
+                const {'upcomingOnly': false, 'auto': true})
+            .catchError((Object e) {
+          // A concurrent serialized load (restore, re-seed) can interrupt this
+          // reload ("Loading interrupted") — benign, the newer load already
+          // carries the fresh tunnel URLs; just don't let it hit the zone.
+          appLog('[iroh] auto URL rebuild after tunnel bind failed: $e');
+        }));
       } catch (e) {
         s.tunnelPort = null;
         s.tunnelToken = null;

--- a/test/media/reseed_on_play_test.dart
+++ b/test/media/reseed_on_play_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/audio_stuff.dart';
+import 'package:mstream_music/media/playback_backend.dart';
+
+void main() {
+  group('AudioPlayerHandler.shouldReseedOnPlay', () {
+    // A bare backend.play() is a silent no-op once just_audio has parked idle
+    // (a playback error tears the platform player down), so play() must
+    // re-seed the sources instead — but ONLY then: re-seeding a live player
+    // on every tap would hiccup normal resume.
+
+    test('idle local player with queued tracks → re-seed', () {
+      expect(
+        AudioPlayerHandler.shouldReseedOnPlay(
+            onLocalBackend: true,
+            processingState: BackendProcessingState.idle,
+            queueEmpty: false,
+            recovering: false),
+        isTrue,
+      );
+    });
+
+    test('cast backend → never (renderer owns its own load state)', () {
+      expect(
+        AudioPlayerHandler.shouldReseedOnPlay(
+            onLocalBackend: false,
+            processingState: BackendProcessingState.idle,
+            queueEmpty: false,
+            recovering: false),
+        isFalse,
+      );
+    });
+
+    test('empty queue → nothing to re-seed', () {
+      expect(
+        AudioPlayerHandler.shouldReseedOnPlay(
+            onLocalBackend: true,
+            processingState: BackendProcessingState.idle,
+            queueEmpty: true,
+            recovering: false),
+        isFalse,
+      );
+    });
+
+    test('recovery in flight → defer to it (it reads the play intent)', () {
+      expect(
+        AudioPlayerHandler.shouldReseedOnPlay(
+            onLocalBackend: true,
+            processingState: BackendProcessingState.idle,
+            queueEmpty: false,
+            recovering: true),
+        isFalse,
+      );
+    });
+
+    test('any non-idle state → bare play', () {
+      for (final state in BackendProcessingState.values) {
+        if (state == BackendProcessingState.idle) continue;
+        expect(
+          AudioPlayerHandler.shouldReseedOnPlay(
+              onLocalBackend: true,
+              processingState: state,
+              queueEmpty: false,
+              recovering: false),
+          isFalse,
+          reason: '$state must not trigger a re-seed',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Observed on-device while smoke-testing #95: play an iroh track, background the app, kill the server. The player errors and parks (the service correctly survives in `ERROR` since #95) — but when the server comes back, **playback never resumes**:

- The Rust tunnel supervisor re-dials forever on the **same loopback port**, so the tunnel heals in place. No app-side event fires: the phone's network never changed (connectivity listener silent), the error-time recovery (`_recoverIrohPlayback`) gave up when `awaitTunnelReady` timed out, and `_ensureActiveTunnel`'s rebuild-on-restart never runs for an in-place reconnect.
- Even a manual **pause→play didn't recover**: a bare `play()` is a silent no-op once just_audio has gone idle after an error — only a re-seed (`setSources` + load at the spot) revives it.

## Fix

One shared revive primitive, `_reseedLocalAtSpot()`: rebuild URLs against the live tunnel/transcode state (`_queueWithFreshUrls`), load directly at the current index/position, resume on **live** `_playIntent` (read *after* the network-bound load, so a pause landing mid-reload wins).

1. **Tunnel-reconnect self-heal** — the handler listens to `tunnelStatusStream`; on a not-connected→connected edge it re-seeds a parked player (local backend, idle, not an intentional stop, current track owned by the served iroh server). Reuses the error recovery's per-server 10s budget; a blocked edge re-arms a one-shot 11s re-check, because the change-only status subject never re-emits a consumed edge — dropping it would park background playback until a manual tap.
2. **Reload-on-play safety net** — `play()` re-seeds instead of no-op'ing when the local player reads idle with tracks queued (decision in pure, unit-tested `shouldReseedOnPlay`). Manual recovery for any dead-source park, iroh or HTTP.
3. `onNetworkRegained` now reuses the same primitive (bonus: picks up fresh URLs, previously reloaded stale `queue.value`).
4. `restoreQueue`'s load is serialized on `_switchChain` so the new re-seed paths can't race the launch restore into "Loading interrupted"; the unawaited auto URL rebuild after a tunnel bind catches that interruption instead of leaking it to the zone.

The media notification returns on its own once the heal publishes `loading → ready` (the chip only aged out because the player sat in `ERROR` forever).

An adversarial multi-agent review ran over the diff before opening; confirmed findings (frozen play-intent across the load, one-shot edge consumed by the cooldown, restore race, zone leak) are all fixed above. Cast paths are untouched — every new path checks the backend is local.

## Testing

- `flutter analyze` clean (pre-existing baseline only); 100/100 tests pass (5 new for `shouldReseedOnPlay`).
- On-device (pending): iroh track → background → kill server → wait past the ERROR park → restart server → expect auto-resume at position within ~30s (supervisor backoff) + notification back; plus manual pause→play revive and normal play/pause/cast regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)