### PR TITLE
feat(playback): hold a WifiLock while audio streams over the network

### DIFF
--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io' show File;
 
 import 'package:audio_service/audio_service.dart';
 import 'package:audio_session/audio_session.dart'
@@ -8,6 +9,7 @@ import 'package:just_audio/just_audio.dart';
 import 'package:mstream_music/main.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:http/http.dart' as http;
+import 'package:wifi_lock_shim/wifi_lock_shim.dart';
 import 'playback_backend.dart';
 import 'local_playback_backend.dart';
 import 'dlna_playback_backend.dart';
@@ -292,6 +294,10 @@ class AudioPlayerHandler extends BaseAudioHandler
       return;
     }
     if (identical(next, _backend)) return;
+    // A visualizer cast makes the phone the renderer's byte origin (on-device
+    // HLS transcode served by LocalMediaServer) — the WifiLock heuristics need
+    // to know, and the backend itself doesn't expose it.
+    _castVisualizer = !target.isLocal && visualizer;
     await _switchBackend(next);
   }
 
@@ -1323,7 +1329,83 @@ class AudioPlayerHandler extends BaseAudioHandler
   }
 
   /// Broadcasts the current state to all clients.
+  /// Whether the Android WifiLock should be held: the phone is actively
+  /// moving audio bytes over the network. Either the local player is playing
+  /// a network source, or a cast renderer is being fed FROM the phone (iroh
+  /// LAN relay, local-file serve, visualizer HLS — LocalMediaServer moves
+  /// every byte, so radio power-save starves the TV just the same; a
+  /// plain-HTTP cast streams renderer-direct and doesn't need it). Never for
+  /// on-disk files and never while paused, stopped, or parked — a silent
+  /// player holding a full-power Wi-Fi lock for hours is a battery bug, and
+  /// the tunnel heal works without it. Pure; unit-tested.
+  static bool shouldHoldWifiLock({
+    required bool playing,
+    required bool onLocalBackend,
+    required BackendProcessingState processingState,
+    required bool itemIsNetworkSource,
+    required bool castRelaysViaPhone,
+  }) {
+    if (!playing) return false;
+    if (castRelaysViaPhone) return true;
+    return onLocalBackend &&
+        itemIsNetworkSource &&
+        processingState != BackendProcessingState.idle &&
+        processingState != BackendProcessingState.completed;
+  }
+
+  // Whether the LOCAL backend actually pulls [item] over the network. Mirrors
+  // LocalPlaybackBackend._uriFor: a downloaded track plays from disk only
+  // while its file still exists — gone (SD ejected, folder cleared) it falls
+  // back to streaming the id, which needs the lock like any other stream.
+  static bool _streamsFromNetwork(MediaItem item) {
+    if (!item.id.startsWith('http://') && !item.id.startsWith('https://')) {
+      return false;
+    }
+    final localPath = item.extras?['localPath'] as String?;
+    return localPath == null || !File(localPath).existsSync();
+  }
+
+  // Whether a cast renderer fetches [item] FROM THE PHONE rather than from a
+  // server. Mirrors resolveRendererUri (cast_origin.dart): a local-only file
+  // is served by LocalMediaServer, an iroh track is relayed through its proxy
+  // (or disk-served); only a plain-HTTP server track goes renderer-direct.
+  bool _phoneIsCastOrigin(MediaItem item) {
+    final localPath = item.extras?['localPath'] as String?;
+    final isNetwork =
+        item.id.startsWith('http://') || item.id.startsWith('https://');
+    if (!isNetwork && localPath != null && File(localPath).existsSync()) {
+      return true;
+    }
+    return _serverFor(item)?.isIroh ?? false;
+  }
+
+  // True while the active cast backend streams the on-device visualizer: the
+  // phone transcodes and serves the HLS itself, so it is the renderer's byte
+  // origin regardless of where the track's audio came from. Set on every cast
+  // switch; only consulted while a cast backend is active.
+  bool _castVisualizer = false;
+
+  // Re-evaluated on every state broadcast (play/pause, track change, backend
+  // swap, processing-state moves all land there); the shim dedupes, so only
+  // actual transitions cross the platform channel.
+  void _updateWifiLock() {
+    final q = queue.value;
+    final idx = _backend.currentIndex ?? 0;
+    final item = (idx >= 0 && idx < q.length) ? q[idx] : null;
+    final onLocal = identical(_backend, _localBackend);
+    unawaited(WifiLockShim.setHeld(shouldHoldWifiLock(
+      playing: _backend.playing,
+      onLocalBackend: onLocal,
+      processingState: _backend.processingState,
+      itemIsNetworkSource: item != null && _streamsFromNetwork(item),
+      castRelaysViaPhone: !onLocal &&
+          item != null &&
+          (_castVisualizer || _phoneIsCastOrigin(item)),
+    )));
+  }
+
   void _broadcastState() {
+    _updateWifiLock();
     final playing = _backend.playing;
     final AudioServiceShuffleMode shuffle = _backend.shuffleEnabled == true
         ? AudioServiceShuffleMode.all

--- a/packages/wifi_lock_shim/android/build.gradle.kts
+++ b/packages/wifi_lock_shim/android/build.gradle.kts
@@ -1,0 +1,60 @@
+group = "music.mstream.wifi_lock_shim"
+version = "0.1.0"
+
+buildscript {
+    val kotlinVersion = "2.3.20"
+    val agpVersion = "9.0.1"
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("com.android.tools.build:gradle:$agpVersion")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id("com.android.library")
+}
+
+// AGP 9 compiles Kotlin itself; older AGP needs the standalone plugin
+// (mirrors how audio_session 0.2.4 builds under both toolchains).
+val agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toInt()
+if (agpMajor < 9) {
+    apply(plugin = "org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "music.mstream.wifi_lock_shim"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 24
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    sourceSets {
+        getByName("main") {
+            java.srcDirs("src/main/kotlin")
+        }
+    }
+}
+
+project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java) {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}

--- a/packages/wifi_lock_shim/android/gradle.properties
+++ b/packages/wifi_lock_shim/android/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true

--- a/packages/wifi_lock_shim/android/settings.gradle.kts
+++ b/packages/wifi_lock_shim/android/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "wifi_lock_shim"

--- a/packages/wifi_lock_shim/android/src/main/AndroidManifest.xml
+++ b/packages/wifi_lock_shim/android/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- WifiLock.acquire() requires WAKE_LOCK. The app already declares it
+         (audio_service needs it too); declared here as well so the plugin is
+         self-contained under manifest merging. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+</manifest>

--- a/packages/wifi_lock_shim/android/src/main/kotlin/music/mstream/wifi_lock_shim/WifiLockShimPlugin.kt
+++ b/packages/wifi_lock_shim/android/src/main/kotlin/music/mstream/wifi_lock_shim/WifiLockShimPlugin.kt
@@ -1,0 +1,65 @@
+package music.mstream.wifi_lock_shim
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Holds an Android WifiLock while the Dart side says audio is streaming.
+ *
+ * One method: setHeld(bool). The lock is created from the application
+ * context, so it works with no activity alive (background playback), and is
+ * released defensively when the engine detaches so a killed engine can never
+ * strand it.
+ */
+class WifiLockShimPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
+    private var channel: MethodChannel? = null
+    private var lock: WifiManager.WifiLock? = null
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        val wifi = binding.applicationContext
+            .getSystemService(Context.WIFI_SERVICE) as? WifiManager
+        // WIFI_MODE_FULL_HIGH_PERF is what ExoPlayer's WAKE_MODE_NETWORK
+        // holds, and it is the strongest option the platform offers anywhere:
+        // - API <= 33: works as intended — keeps the radio out of power-save
+        //   with the screen off. This covers the fleet the "playback stops"
+        //   reports came from (Galaxy S20 FE caps at Android 13).
+        // - API 34+: the OS silently converts the acquire into a
+        //   WIFI_MODE_FULL_LOW_LATENCY lock (WifiManager.java, android-34),
+        //   which is only active while the app is FOREGROUND with the SCREEN
+        //   ON — i.e. inert for screen-off streaming. No public API restores
+        //   the old behavior there; the lock is harmless but ineffective, and
+        //   modern Android relies on the FGS media exemption instead. Keep
+        //   that in mind before blaming this shim for a stall on 14+.
+        @Suppress("DEPRECATION")
+        lock = wifi?.createWifiLock(
+            WifiManager.WIFI_MODE_FULL_HIGH_PERF, "mstream:streaming"
+        )?.apply { setReferenceCounted(false) }
+        channel = MethodChannel(binding.binaryMessenger, "mstream/wifi_lock")
+        channel?.setMethodCallHandler(this)
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel?.setMethodCallHandler(null)
+        channel = null
+        lock?.takeIf { it.isHeld }?.release()
+        lock = null
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "setHeld" -> {
+                val want = call.arguments as? Boolean ?: false
+                val l = lock
+                if (l != null) {
+                    if (want && !l.isHeld) l.acquire()
+                    else if (!want && l.isHeld) l.release()
+                }
+                result.success(l?.isHeld ?: false)
+            }
+            else -> result.notImplemented()
+        }
+    }
+}

--- a/packages/wifi_lock_shim/lib/wifi_lock_shim.dart
+++ b/packages/wifi_lock_shim/lib/wifi_lock_shim.dart
@@ -1,0 +1,32 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/services.dart';
+
+/// Android WifiLock shim — the Wi-Fi half of ExoPlayer's WAKE_MODE_NETWORK,
+/// which just_audio doesn't expose. audio_service already holds the CPU half
+/// (a partial wake lock); without this, screen-off Wi-Fi power-save can
+/// throttle the radio mid-stream and stall playback.
+///
+/// Effective on API <= 33 (the fleet the stall reports came from). On 34+ the
+/// OS converts the lock to screen-on-only LOW_LATENCY — harmless but inert
+/// for screen-off streaming; see the platform-side comment.
+class WifiLockShim {
+  static const MethodChannel _channel = MethodChannel('mstream/wifi_lock');
+
+  static bool _held = false;
+
+  /// Acquire ([want] true) or release the lock. Deduped — repeat calls with
+  /// the same value never cross the platform channel, so this is cheap to
+  /// call from every state broadcast — and fail-open: a platform error can
+  /// never block playback (worst case is pre-shim behavior, and an engine
+  /// detach releases a stranded lock natively). No-op off Android.
+  static Future<void> setHeld(bool want) async {
+    if (!Platform.isAndroid || want == _held) return;
+    _held = want;
+    try {
+      await _channel.invokeMethod<bool>('setHeld', want);
+    } catch (_) {
+      // Fail open (see doc comment).
+    }
+  }
+}

--- a/packages/wifi_lock_shim/pubspec.yaml
+++ b/packages/wifi_lock_shim/pubspec.yaml
@@ -1,0 +1,23 @@
+name: wifi_lock_shim
+description: >-
+  In-repo Android WifiLock shim — the Wi-Fi half of ExoPlayer's
+  WAKE_MODE_NETWORK, which just_audio doesn't expose. Kept as a path plugin
+  (not a MainActivity channel) so it auto-registers on every FlutterEngine,
+  including the headless one Android Auto / media-resumption cold-binds boot.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.3.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: music.mstream.wifi_lock_shim
+        pluginClass: WifiLockShimPlugin

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -937,6 +937,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  wifi_lock_shim:
+    dependency: "direct main"
+    description:
+      path: "packages/wifi_lock_shim"
+      relative: true
+    source: path
+    version: "0.1.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,11 @@ dependencies:
   # Package name (applicationId) lookup so the album-art ContentProvider
   # authority always matches the manifest, regardless of --dart-define flags.
   package_info_plus: ^10.2.0
+  # In-repo Android WifiLock shim (the Wi-Fi half of ExoPlayer's
+  # WAKE_MODE_NETWORK, which just_audio doesn't expose) — held while audio
+  # actually streams so screen-off Wi-Fi power-save can't stall playback.
+  wifi_lock_shim:
+    path: packages/wifi_lock_shim
 dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:

--- a/test/media/wifi_lock_test.dart
+++ b/test/media/wifi_lock_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/audio_stuff.dart';
+import 'package:mstream_music/media/playback_backend.dart';
+
+void main() {
+  group('AudioPlayerHandler.shouldHoldWifiLock', () {
+    // The lock is the Wi-Fi half of ExoPlayer's WAKE_MODE_NETWORK: held ONLY
+    // while the phone actively moves audio bytes over the network. Holding it
+    // any longer (paused, parked, on-disk files) is a battery bug; holding it
+    // any less re-opens the screen-off power-save stall this exists to
+    // prevent.
+
+    test('local player streaming a network source → hold', () {
+      for (final state in [
+        BackendProcessingState.loading,
+        BackendProcessingState.buffering,
+        BackendProcessingState.ready,
+      ]) {
+        expect(
+          AudioPlayerHandler.shouldHoldWifiLock(
+              playing: true,
+              onLocalBackend: true,
+              processingState: state,
+              itemIsNetworkSource: true,
+              castRelaysViaPhone: false),
+          isTrue,
+          reason: 'playing a network source in $state must hold the lock',
+        );
+      }
+    });
+
+    test('paused → release, regardless of everything else', () {
+      expect(
+        AudioPlayerHandler.shouldHoldWifiLock(
+            playing: false,
+            onLocalBackend: true,
+            processingState: BackendProcessingState.ready,
+            itemIsNetworkSource: true,
+            castRelaysViaPhone: false),
+        isFalse,
+      );
+      expect(
+        AudioPlayerHandler.shouldHoldWifiLock(
+            playing: false,
+            onLocalBackend: false,
+            processingState: BackendProcessingState.ready,
+            itemIsNetworkSource: true,
+            castRelaysViaPhone: true),
+        isFalse,
+        reason: 'a paused cast relay moves no bytes',
+      );
+    });
+
+    test('on-disk file → never (no network to keep awake)', () {
+      expect(
+        AudioPlayerHandler.shouldHoldWifiLock(
+            playing: true,
+            onLocalBackend: true,
+            processingState: BackendProcessingState.ready,
+            itemIsNetworkSource: false,
+            castRelaysViaPhone: false),
+        isFalse,
+      );
+    });
+
+    test('parked (idle) or completed → release even with play still set', () {
+      for (final state in [
+        BackendProcessingState.idle,
+        BackendProcessingState.completed,
+      ]) {
+        expect(
+          AudioPlayerHandler.shouldHoldWifiLock(
+              playing: true,
+              onLocalBackend: true,
+              processingState: state,
+              itemIsNetworkSource: true,
+              castRelaysViaPhone: false),
+          isFalse,
+          reason: '$state moves no bytes — holding would drain battery',
+        );
+      }
+    });
+
+    test('cast fed from the phone (iroh relay / local file / viz HLS) → hold',
+        () {
+      // itemIsNetworkSource false here mirrors the local-file cast: the item
+      // plays from disk, but the PHONE is still the renderer's byte origin.
+      expect(
+        AudioPlayerHandler.shouldHoldWifiLock(
+            playing: true,
+            onLocalBackend: false,
+            processingState: BackendProcessingState.ready,
+            itemIsNetworkSource: false,
+            castRelaysViaPhone: true),
+        isTrue,
+      );
+    });
+
+    test('casting a plain HTTP track (renderer streams direct) → release', () {
+      expect(
+        AudioPlayerHandler.shouldHoldWifiLock(
+            playing: true,
+            onLocalBackend: false,
+            processingState: BackendProcessingState.ready,
+            itemIsNetworkSource: true,
+            castRelaysViaPhone: false),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

The prevention half of the reliability effort: everything in v0.30.1 *recovers* from a stalled stream; this stops the stall from happening. With the screen off, Wi-Fi power-save can throttle the radio mid-stream. ExoPlayer apps (Spotify et al.) avoid it via `setWakeMode(WAKE_MODE_NETWORK)` — a CPU WakeLock + WifiLock held while playing — but just_audio doesn't expose that API, and audio_service only holds the CPU half. This adds the missing Wi-Fi half.

## How

- **Native**: in-repo path plugin `packages/wifi_lock_shim` (~60 lines Kotlin, one `setHeld(bool)` method). A path plugin rather than a MainActivity channel so it auto-registers on **every** FlutterEngine — including the headless one Android Auto / media-resumption cold-binds boot, where an activity-registered channel would be dead. App-context lock, reference counting off (idempotent), released defensively on engine detach. Gradle mirrors audio_session 0.2.4 (already proven under this AGP 9.0.1 / Kotlin 2.3.20 toolchain).
- **Dart**: pure `shouldHoldWifiLock()` evaluated from `_broadcastState()` (fires on every play/pause/track/backend/state transition), deduped in the shim so only actual changes cross the platform channel. Fail-open, `Platform.isAndroid`-guarded.

**Held** only while the phone actively moves audio bytes over the network:
- local backend playing/buffering a network source — including a downloaded track whose file went missing (the backend silently falls back to streaming; mirrored with the same `existsSync` check), and
- a cast renderer fed **from the phone**: iroh LAN relay, local-file serve, or visualizer HLS (mirrors `resolveRendererUri`'s branching).

**Released** when paused, stopped, error-parked, playing from disk, or casting a plain-HTTP track (renderer fetches direct). A parked player never holds the lock — that would be a battery bug, and the v0.30.1 tunnel heal works without it.

## Honest coverage note

`WIFI_MODE_FULL_HIGH_PERF` (what `WAKE_MODE_NETWORK` holds) works as intended through **API 33** — which covers the Galaxy S20 FE fleet the "playback stops" reports came from (caps at Android 13). On **API 34+** the OS silently converts the acquire to `WIFI_MODE_FULL_LOW_LATENCY`, which is only active foreground-with-screen-on — i.e. inert for screen-off streaming, and no public API does better there (modern Android leans on the FGS media exemption instead). Verified against SDK sources; documented in the code so a future "still stalls on Android 15" report doesn't get misattributed to this shim.

An adversarial multi-agent review ran over the diff; its three confirmed findings (phone-origin casts beyond iroh not holding the lock, the missing-file streaming fallback classified as local, and the wrong API 34+ platform claim) are all fixed in this PR.

## Testing

- `flutter analyze` clean (pre-existing baseline only); 106/106 tests pass (6 new for `shouldHoldWifiLock`).
- Debug APK builds under the AGP 9 toolchain.
- On-device (pending): `adb shell dumpsys wifi` should show the `mstream:streaming` lock appear on play, vanish on pause/stop/disk playback, and hold while casting an iroh track; then a 30+ min screen-off streaming soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)