### PR TITLE
feat(playback): survive process death via Android media resumption

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,8 +59,12 @@
     <!-- allowBackup=false: servers.json holds credentials (JWT, password, and the
          iroh pairing code's connect secret), so keep it out of adb / cloud backups
          where another process could exfiltrate it. -->
+    <!-- MainApplication (not the Flutter default ${applicationName}):
+         process-wide native init (IrohNative/ndk_context) that must also run
+         on HEADLESS service binds — media-resumption chip, Bluetooth media
+         key, Android Auto — where MainActivity never exists. -->
     <application
-        android:name="${applicationName}"
+        android:name=".MainApplication"
         android:label="mStream Music"
         android:allowBackup="false"
         android:usesCleartextTraffic="true"

--- a/android/app/src/main/kotlin/com/example/mstream_music/MainApplication.kt
+++ b/android/app/src/main/kotlin/com/example/mstream_music/MainApplication.kt
@@ -1,0 +1,23 @@
+package com.example.mstream_music
+
+import android.app.Application
+
+// Process-wide native init. Runs on EVERY process start — including the
+// HEADLESS service binds (media-resumption chip, Bluetooth media key, Android
+// Auto) where MainActivity never exists. IrohNative used to be initialized
+// only from MainActivity.configureFlutterEngine, so a headless boot had no
+// working tunnel: ndk_context panicked ("android context was not
+// initialized"), every iroh stream URL failed, and a saved iroh queue could
+// not resume. MainActivity keeps its own (idempotent) call as a belt.
+class MainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        // Guarded so a missing/unloadable .so never blocks boot — the feature
+        // just stays unavailable (mirrors MainActivity).
+        try {
+            IrohNative.ensureInit(this)
+        } catch (e: Throwable) {
+            android.util.Log.w("IrohNative", "iroh native init failed: ${e.message}")
+        }
+    }
+}

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -23,6 +23,7 @@ import '../singletons/auto_dj_manager.dart';
 import '../singletons/cast_manager.dart';
 import '../singletons/app_messenger.dart';
 import '../singletons/log_manager.dart';
+import '../singletons/queue_store.dart';
 import '../singletons/settings.dart';
 import '../singletons/server_list.dart';
 import '../util/camelot.dart';
@@ -930,11 +931,49 @@ class AudioPlayerHandler extends BaseAudioHandler
       !queueEmpty &&
       !recovering;
 
+  // Completes when the launch queue restore has settled — restored, nothing
+  // to restore (feature off / no snapshot / empty), or failed. Signalled by
+  // QueueStore.init(); play() awaits it on a cold boot so a transport command
+  // that beats the restore doesn't no-op on an empty player.
+  final Completer<void> _restoreSettled = Completer<void>();
+  Future<void> get queueRestoreSettled => _restoreSettled.future;
+  void markQueueRestoreSettled() {
+    if (!_restoreSettled.isCompleted) _restoreSettled.complete();
+  }
+
+  // Cold-boot resume race: a PLAY from the media-resumption chip, Bluetooth,
+  // or Android Auto can reach a headless-booted service before QueueStore has
+  // restored the saved queue — a bare play on an empty player silently no-ops
+  // (the reseed net needs a non-empty queue). Trigger the restore ourselves
+  // (both calls are idempotent; on a headless boot no widget may ever run
+  // main.dart's initState trigger) and wait for it to settle. Bounded: the
+  // settle can legitimately take tens of seconds (loadServerList dials an
+  // iroh tunnel first), but a wedged startup must not hold the transport
+  // forever.
+  Future<void> _awaitQueueRestore() {
+    unawaited(ServerManager()
+        .ensureLoaded()
+        .then((_) => QueueStore().init())
+        .catchError((Object e) => appLog('[play] restore trigger failed: $e')));
+    return queueRestoreSettled.timeout(const Duration(seconds: 60),
+        onTimeout: () =>
+            appLog('[play] queue restore never settled — playing as-is'));
+  }
+
   @override
-  Future<void> play() {
+  Future<void> play() async {
     appLog('[play] play');
     _playIntent = true;
     _intentionalStop = false;
+    if (queue.value.isEmpty && !_restoreSettled.isCompleted) {
+      await _awaitQueueRestore();
+      // The wait can run tens of seconds — a pause/stop that arrived during
+      // it must win, not be overridden by this stale play when the restored
+      // queue comes up. (pause() and stop() both clear _playIntent.)
+      if (!_playIntent) return;
+      // The restore parks paused at the saved spot; fall through so the bare
+      // play (or the reseed net, if the restore load failed) resumes it.
+    }
     if (shouldReseedOnPlay(
         onLocalBackend: identical(_backend, _localBackend),
         processingState: _backend.processingState,

--- a/lib/media/auto_browse.dart
+++ b/lib/media/auto_browse.dart
@@ -18,6 +18,7 @@
 //      mirrors the same endpoints + parsing and returns plain DisplayItems
 //      (so playback can reuse queue_actions.playFromHere unchanged).
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:audio_service/audio_service.dart';
@@ -31,6 +32,7 @@ import '../objects/metadata.dart';
 import '../objects/server.dart';
 import '../singletons/log_manager.dart';
 import '../singletons/media.dart';
+import '../singletons/queue_store.dart';
 import '../singletons/server_list.dart';
 import '../util/queue_actions.dart';
 import '../util/stream_url.dart';
@@ -140,19 +142,23 @@ class AutoBrowse {
   /// server / network failure it returns a single non-playable notice row.
   static Future<List<MediaItem>> children(String parentMediaId) async {
     try {
-      await ServerManager().ensureLoaded();
-      final Server? server = ServerManager().currentServer;
-      if (server == null) {
-        return [
-          _notice('Open mStream on your phone',
-              'Add a server there to browse it here'),
-        ];
-      }
-
-      // Android 11 playback resumption requests the 'recent' root: surface the
-      // now-playing item (when the queue is warm) as a playable 'resume' entry.
+      // Android 11+ playback resumption requests the 'recent' root: surface
+      // the last-played item as a playable 'resume' entry. Answered BEFORE
+      // the ensureLoaded await below — on a cold headless bind the system
+      // asks within moments, and loadServerList can legitimately spend
+      // 30-45s dialing an iroh tunnel; nothing here needs a server (the live
+      // mediaItem and the snapshot peek are both server-free, and a
+      // local-files queue has no server at all). The restore chain is kicked
+      // in the background (both calls idempotent) so the subsequent tap
+      // finds the queue warm.
       if (parentMediaId == AudioService.recentRootId) {
-        final cur = MediaManager().audioHandler.mediaItem.value;
+        unawaited(ServerManager()
+            .ensureLoaded()
+            .then((_) => QueueStore().init())
+            .catchError(
+                (Object e) => appLog('[auto] restore kick failed: $e')));
+        final cur = MediaManager().audioHandler.mediaItem.value ??
+            await QueueStore().peekResumeItem();
         if (cur == null) return const [];
         final art = cur.extras?['artUrl'];
         return [
@@ -164,6 +170,21 @@ class AutoBrowse {
             artUri: art is String ? Uri.parse(_artContentUri(art)) : null,
             playable: true,
           ),
+        ];
+      }
+
+      await ServerManager().ensureLoaded();
+      // A browse bind may be the process's only entry point (media-resumption
+      // chip, Android Auto cold start — no widget ever builds, so main.dart's
+      // initState trigger never runs). Kick the queue restore here so a
+      // following play/'resume' finds the queue warm. Idempotent + guarded.
+      unawaited(QueueStore().init());
+
+      final Server? server = ServerManager().currentServer;
+      if (server == null) {
+        return [
+          _notice('Open mStream on your phone',
+              'Add a server there to browse it here'),
         ];
       }
 
@@ -316,9 +337,14 @@ class AutoBrowse {
       final qp = u.queryParameters;
       final handler = MediaManager().audioHandler;
 
-      // Resume the restored queue (no-op if there's nothing to resume).
+      // Resume the saved queue. handler.play() gates itself on the launch
+      // restore settling (cold headless bind: the tap can beat QueueStore),
+      // and no-ops safely when there's nothing to resume. Fire-and-forget:
+      // just_audio's play() future completes only when playback later
+      // pauses/stops, so awaiting it here would hang this callback.
       if (u.host == 'resume') {
-        if (handler.queue.value.isNotEmpty) await handler.play();
+        unawaited(handler.play().catchError(
+            (Object e) => appLog('[auto] resume play failed: $e')));
         return;
       }
 

--- a/lib/singletons/queue_store.dart
+++ b/lib/singletons/queue_store.dart
@@ -39,6 +39,9 @@ class QueueStore {
 
   bool _restoring = false;
   bool _started = false;
+  // True once the live queue has been non-empty this session — gates the
+  // empty-queue snapshot delete in saveNow (see there).
+  bool _hadQueue = false;
   Timer? _debounceTimer;
   Timer? _ticker;
   final List<StreamSubscription> _subs = [];
@@ -60,8 +63,13 @@ class QueueStore {
     } catch (e) {
       // A corrupt / incompatible file must never block startup.
       appLog('[queue] restore failed: $e');
+    } finally {
+      _restoring = false;
+      // Settled either way (restored / nothing to restore / failed) — a
+      // cold-boot transport command gates on this, and an error here must
+      // release it, not wedge play forever.
+      MediaManager().audioHandler.markQueueRestoreSettled();
     }
-    _restoring = false;
     _attachListeners();
   }
 
@@ -88,23 +96,66 @@ class QueueStore {
   /// instead of a dead loopback port (the default stays the selected server).
   /// Cheap: reads + parses the file but builds no MediaItems.
   Future<String?> peekResumeServer() async {
+    final entry = await _peekCurrentEntry();
+    if (entry == null) return null;
+    final extras = entry['extras'];
+    return (extras is Map) ? extras['server'] as String? : null;
+  }
+
+  /// The saved queue's current item as DISPLAY metadata (title/artist/album/
+  /// artUrl) for the Android 11+ playback-resumption chip. Served straight
+  /// from the snapshot so a cold headless bind can answer the system's
+  /// recent-root query before — and without — the full restore. No server
+  /// resolution, no URL rebuild: the id is display-only (playback goes through
+  /// the browse tree's 'resume' command), and an iroh artUrl may carry a dead
+  /// loopback port, in which case the chip just renders without artwork.
+  Future<MediaItem?> peekResumeItem() async {
+    return resumeItemFromSnapshot(await _peekCurrentEntry());
+  }
+
+  // Read + parse the snapshot down to its current-index item entry. Null when
+  // the feature is off or the file is missing/incompatible/corrupt — never
+  // throws (startup and the resumption chip both ride on this).
+  Future<Map<String, dynamic>?> _peekCurrentEntry() async {
     if (!SettingsManager().resumeQueue) return null;
     try {
       final file = await _file;
       if (!await file.exists()) return null;
-      final dynamic raw = jsonDecode(await file.readAsString());
-      if (raw is! Map || raw['version'] != _schemaVersion) return null;
-      final dynamic items = raw['items'];
-      if (items is! List || items.isEmpty) return null;
-      int index = (raw['index'] is int) ? raw['index'] as int : 0;
-      if (index < 0 || index >= items.length) index = 0;
-      final entry = items[index];
-      if (entry is! Map) return null;
-      final extras = entry['extras'];
-      return (extras is Map) ? extras['server'] as String? : null;
+      return currentEntryFromSnapshot(jsonDecode(await file.readAsString()));
     } catch (_) {
-      return null; // a corrupt/unreadable file must never block startup
+      return null;
     }
+  }
+
+  /// The snapshot's current-index item entry (index clamped like restore
+  /// does), or null when the shape is wrong. Pure; unit-tested.
+  static Map<String, dynamic>? currentEntryFromSnapshot(dynamic raw) {
+    if (raw is! Map || raw['version'] != _schemaVersion) return null;
+    final dynamic items = raw['items'];
+    if (items is! List || items.isEmpty) return null;
+    int index = (raw['index'] is int) ? raw['index'] as int : 0;
+    if (index < 0 || index >= items.length) index = 0;
+    final entry = items[index];
+    return entry is Map ? Map<String, dynamic>.from(entry) : null;
+  }
+
+  /// Build the resumption-chip [MediaItem] from a saved item entry. Display
+  /// fields only — see [peekResumeItem]. Pure; unit-tested.
+  static MediaItem? resumeItemFromSnapshot(Map<String, dynamic>? entry) {
+    if (entry == null) return null;
+    final extras = entry['extras'];
+    final artUrl = (extras is Map) ? extras['artUrl'] : null;
+    final title = (entry['title'] as String?) ??
+        ((extras is Map) ? (extras['path'] as String?) : null)?.split('/').last;
+    if (title == null || title.isEmpty) return null;
+    return MediaItem(
+      id: 'resume-peek', // display-only; never handed to a backend
+      title: title,
+      artist: entry['artist'] as String?,
+      album: entry['album'] as String?,
+      playable: true,
+      extras: {if (artUrl is String) 'artUrl': artUrl},
+    );
   }
 
   Future<void> _restore() async {
@@ -191,9 +242,16 @@ class QueueStore {
       final handler = MediaManager().audioHandler;
       final queue = handler.queue.value;
       if (queue.isEmpty) {
-        if (await file.exists()) await file.delete();
+        // Delete only after a queue actually existed this session (a real,
+        // user-visible clear). Without the guard, the listener attach right
+        // after init REPLAYS the current (empty) queue, so a restore that
+        // whiffed — transient server-list read failure, no resolvable items —
+        // would destroy the very snapshot the resumption chip serves, turning
+        // a recoverable hiccup into permanent loss.
+        if (_hadQueue && await file.exists()) await file.delete();
         return;
       }
+      _hadQueue = true;
       final state = handler.playbackState.value;
       final snapshot = <String, dynamic>{
         'version': _schemaVersion,

--- a/test/singletons/queue_store_test.dart
+++ b/test/singletons/queue_store_test.dart
@@ -163,4 +163,84 @@ void main() {
       expect(QueueStore.clampResumePositionMs(0, 240000), 0);
     });
   });
+
+  group('QueueStore snapshot peeks (resumption chip)', () {
+    Map<String, dynamic> snapshot({int index = 1, int version = 1}) => {
+          'version': version,
+          'index': index,
+          'positionMs': 1000,
+          'shuffle': false,
+          'repeat': 'none',
+          'items': [
+            {
+              'title': 'First',
+              'extras': {'server': 's1', 'path': '/a.mp3'},
+            },
+            {
+              'title': 'Second',
+              'artist': 'Artist',
+              'album': 'Album',
+              'extras': {
+                'server': 's1',
+                'path': '/b.mp3',
+                'artUrl': 'http://host/album-art/b.jpg',
+              },
+            },
+          ],
+        };
+
+    test('currentEntryFromSnapshot returns the saved-index entry', () {
+      final entry = QueueStore.currentEntryFromSnapshot(snapshot());
+      expect(entry, isNotNull);
+      expect(entry!['title'], 'Second');
+    });
+
+    test('out-of-range index clamps to the first item (like restore)', () {
+      expect(QueueStore.currentEntryFromSnapshot(snapshot(index: 7))!['title'],
+          'First');
+      expect(QueueStore.currentEntryFromSnapshot(snapshot(index: -2))!['title'],
+          'First');
+    });
+
+    test('wrong schema version / shape / empty items -> null', () {
+      expect(QueueStore.currentEntryFromSnapshot(snapshot(version: 2)), isNull);
+      expect(QueueStore.currentEntryFromSnapshot('junk'), isNull);
+      expect(QueueStore.currentEntryFromSnapshot(null), isNull);
+      expect(
+          QueueStore.currentEntryFromSnapshot(
+              {'version': 1, 'index': 0, 'items': <dynamic>[]}),
+          isNull);
+    });
+
+    test('resumeItemFromSnapshot builds display metadata + carries artUrl', () {
+      final item = QueueStore.resumeItemFromSnapshot(
+          QueueStore.currentEntryFromSnapshot(snapshot()));
+      expect(item, isNotNull);
+      expect(item!.title, 'Second');
+      expect(item.artist, 'Artist');
+      expect(item.album, 'Album');
+      expect(item.playable, isTrue);
+      expect(item.extras!['artUrl'], 'http://host/album-art/b.jpg');
+    });
+
+    test('missing title falls back to the path basename', () {
+      final item = QueueStore.resumeItemFromSnapshot({
+        'extras': {'path': '/music/deep/track.flac'},
+      });
+      expect(item, isNotNull);
+      expect(item!.title, 'track.flac');
+    });
+
+    test('no title and no path -> null (nothing worth a chip)', () {
+      expect(QueueStore.resumeItemFromSnapshot({'extras': {}}), isNull);
+      expect(QueueStore.resumeItemFromSnapshot(null), isNull);
+    });
+
+    test('the peeked item survives a JSON text round-trip of the snapshot', () {
+      final raw = jsonDecode(jsonEncode(snapshot()));
+      final item = QueueStore.resumeItemFromSnapshot(
+          QueueStore.currentEntryFromSnapshot(raw));
+      expect(item!.title, 'Second');
+    });
+  });
 }


### PR DESCRIPTION
## What

The recovery of last resort in the reliability series: #94–#98 keep playback alive *while the process lives*; this makes an actual OS kill recoverable with one tap from Android's media-resumption chip (Quick Settings / shade, Android 11+), or a Bluetooth PLAY — instead of "find and reopen the app."

## Background

The plumbing has existed since Android Auto (v0.28.0): audio_service already answers the system's `EXTRA_RECENT` bind, and `auto_browse` already serves a playable "resume" entry. But on a **cold headless boot** (the only case that matters — the process just died) both halves raced the queue restore and lost:

1. **Recent-root race** — the reply served only the live `mediaItem` (null until QueueStore restores) *and* sat behind `ensureLoaded()`'s iroh tunnel dial (30–45s on a cold bind). System UI asks within moments; it got nothing, so no chip.
2. **Play-tap race** — a PLAY reaching the handler before the restore finished was a bare no-op on an empty player (the #97 reseed net needs a non-empty queue). This is the same defect as the audit's "Bluetooth play answered before restore" finding — fixed together.

## How

- **Chip content**: the `recent` root is answered **before** the `ensureLoaded` await, falling back to display metadata peeked straight from the persisted snapshot (`QueueStore.peekResumeItem()` — pure parse of queue.json, no server resolution, no network; unit-tested statics). The restore chain is kicked in the background. The branch also moved above the no-server notice (a local-files queue has no server, and resuming needs none).
- **Play gate**: `AudioPlayerHandler.play()` on an empty queue with the restore unsettled now (a) self-triggers `ensureLoaded → QueueStore.init` — headless boots never run main.dart's `initState` trigger — and (b) awaits a restore-settled completer (signalled from `QueueStore.init`'s `finally`: restored / nothing to restore / failed all settle it), bounded at 60s. After the wait it falls through to the existing bare-play/reseed logic, and a pause/stop that landed *during* the wait wins over the stale play.

Hardened from the adversarial review (2 lenses, 13 findings, 3 confirmed + 1 nit — all fixed):
- The chip reply no longer waits behind the tunnel dial (the original sin of my first cut).
- A pause/stop during the restore wait is honored (`_playIntent` re-check).
- An empty-queue save deletes the snapshot **only after a queue actually existed this session** — the listener attach replays the empty queue after a whiffed restore (e.g. transient server-list read failure), which used to destroy the very snapshot the chip depends on. Pre-existing bug, feature-critical now.
- The Auto resume tap no longer awaits `play()`'s never-completing future.

## Testing

- `flutter analyze` clean (baseline only); 107/107 tests pass (7 new: snapshot peek parsing, index clamping, corrupt-shape handling).
- On-device (next): kill the process, send `KEYCODE_MEDIA_PLAY` → expect headless boot → restore → resume at position; plus chip presence in the shade after death, and normal-launch regressions.
- Chip persistence after process death is ultimately at the OS/OEM's discretion (One UI has its own media-panel behavior) — this PR makes the app answer correctly whenever the system asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)