### PR TITLE
Quick Connect: title + clearer section headers

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -353,7 +353,7 @@
   "settingsAccentColorSubtitle": "Die Hervorhebungsfarbe, die in der gesamten App verwendet wird.",
   "accentThemeDefault": "Theme-Standard",
   "accentCustom": "Benutzerdefiniert",
-  "lanOnYourNetwork": "In deinem Netzwerk",
+  "lanOnYourNetwork": "Server in deinem lokalen Netzwerk",
   "lanSearching": "Suche nach Servern…",
   "lanRefresh": "Aktualisieren",
   "lanServerVersion": "mStream v{version}",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -866,7 +866,7 @@
   "settingsAccentColorSubtitle": "The highlight color used across the app.",
   "accentThemeDefault": "Theme default",
   "accentCustom": "Custom",
-  "lanOnYourNetwork": "On your network",
+  "lanOnYourNetwork": "Servers on your local network",
   "lanSearching": "Searching for servers…",
   "lanRefresh": "Refresh",
   "lanServerVersion": "mStream v{version}",
@@ -969,11 +969,19 @@
   },
   "irohConnectHeader": "Connect peer-to-peer",
   "@irohConnectHeader": {
-    "description": "Header of the iroh tab on the add-server form."
+    "description": "Title at the top of the Quick Connect tab."
   },
-  "irohConnectBody": "Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.",
+  "irohPairingHeader": "Connect with a pairing code",
+  "@irohPairingHeader": {
+    "description": "Header of the manual pairing-code section on the Quick Connect tab."
+  },
+  "irohConnectBody": "Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.",
   "@irohConnectBody": {
-    "description": "Explainer under the iroh tab header on the add-server form."
+    "description": "Explainer under the Quick Connect tab title."
+  },
+  "irohPairingBody": "Enable Remote Access on the server, then paste its pairing code or scan the QR.",
+  "@irohPairingBody": {
+    "description": "Explainer under the pairing-code section header on the Quick Connect tab."
   },
   "irohOneServerLimit": "Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.",
   "@irohOneServerLimit": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -353,7 +353,7 @@
   "settingsAccentColorSubtitle": "El color de resalte que se usa en toda la aplicación.",
   "accentThemeDefault": "Predeterminado del tema",
   "accentCustom": "Personalizado",
-  "lanOnYourNetwork": "En tu red",
+  "lanOnYourNetwork": "Servidores en tu red local",
   "lanSearching": "Buscando servidores…",
   "lanRefresh": "Actualizar",
   "lanServerVersion": "mStream v{version}",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -353,7 +353,7 @@
   "settingsAccentColorSubtitle": "La couleur de mise en évidence utilisée dans toute l'application.",
   "accentThemeDefault": "Par défaut du thème",
   "accentCustom": "Personnalisé",
-  "lanOnYourNetwork": "Sur votre réseau",
+  "lanOnYourNetwork": "Serveurs sur votre réseau local",
   "lanSearching": "Recherche de serveurs…",
   "lanRefresh": "Actualiser",
   "lanServerVersion": "mStream v{version}",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -353,7 +353,7 @@
   "settingsAccentColorSubtitle": "Il colore di evidenziazione usato in tutta l'app.",
   "accentThemeDefault": "Predefinito del tema",
   "accentCustom": "Personalizzato",
-  "lanOnYourNetwork": "Sulla tua rete",
+  "lanOnYourNetwork": "Server sulla tua rete locale",
   "lanSearching": "Ricerca server…",
   "lanRefresh": "Aggiorna",
   "lanServerVersion": "mStream v{version}",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -353,7 +353,7 @@
   "settingsAccentColorSubtitle": "アプリ全体で使用される強調表示の色。",
   "accentThemeDefault": "テーマの既定",
   "accentCustom": "カスタム",
-  "lanOnYourNetwork": "ネットワーク上のサーバー",
+  "lanOnYourNetwork": "ローカルネットワーク上のサーバー",
   "lanSearching": "サーバーを検索中…",
   "lanRefresh": "更新",
   "lanServerVersion": "mStream v{version}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2325,7 +2325,7 @@ abstract class AppLocalizations {
   /// No description provided for @lanOnYourNetwork.
   ///
   /// In en, this message translates to:
-  /// **'On your network'**
+  /// **'Servers on your local network'**
   String get lanOnYourNetwork;
 
   /// No description provided for @lanSearching.
@@ -2604,17 +2604,29 @@ abstract class AppLocalizations {
   /// **'Quick Connect'**
   String get addServerTabQuickConnect;
 
-  /// Header of the iroh tab on the add-server form.
+  /// Title at the top of the Quick Connect tab.
   ///
   /// In en, this message translates to:
   /// **'Connect peer-to-peer'**
   String get irohConnectHeader;
 
-  /// Explainer under the iroh tab header on the add-server form.
+  /// Header of the manual pairing-code section on the Quick Connect tab.
   ///
   /// In en, this message translates to:
-  /// **'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.'**
+  /// **'Connect with a pairing code'**
+  String get irohPairingHeader;
+
+  /// Explainer under the Quick Connect tab title.
+  ///
+  /// In en, this message translates to:
+  /// **'Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.'**
   String get irohConnectBody;
+
+  /// Explainer under the pairing-code section header on the Quick Connect tab.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable Remote Access on the server, then paste its pairing code or scan the QR.'**
+  String get irohPairingBody;
 
   /// Shown on the iroh add-server tab when an iroh server already exists (only one is allowed).
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1340,7 +1340,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get accentCustom => 'Benutzerdefiniert';
 
   @override
-  String get lanOnYourNetwork => 'In deinem Netzwerk';
+  String get lanOnYourNetwork => 'Server in deinem lokalen Netzwerk';
 
   @override
   String get lanSearching => 'Suche nach Servern…';
@@ -1505,8 +1505,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override
+  String get irohPairingHeader => 'Connect with a pairing code';
+
+  @override
   String get irohConnectBody =>
-      'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
+      'Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.';
+
+  @override
+  String get irohPairingBody =>
+      'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
   String get irohOneServerLimit =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1322,7 +1322,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get accentCustom => 'Custom';
 
   @override
-  String get lanOnYourNetwork => 'On your network';
+  String get lanOnYourNetwork => 'Servers on your local network';
 
   @override
   String get lanSearching => 'Searching for servers…';
@@ -1486,8 +1486,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override
+  String get irohPairingHeader => 'Connect with a pairing code';
+
+  @override
   String get irohConnectBody =>
-      'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
+      'Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.';
+
+  @override
+  String get irohPairingBody =>
+      'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
   String get irohOneServerLimit =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1338,7 +1338,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get accentCustom => 'Personalizado';
 
   @override
-  String get lanOnYourNetwork => 'En tu red';
+  String get lanOnYourNetwork => 'Servidores en tu red local';
 
   @override
   String get lanSearching => 'Buscando servidores…';
@@ -1503,8 +1503,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override
+  String get irohPairingHeader => 'Connect with a pairing code';
+
+  @override
   String get irohConnectBody =>
-      'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
+      'Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.';
+
+  @override
+  String get irohPairingBody =>
+      'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
   String get irohOneServerLimit =>

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1336,7 +1336,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get accentCustom => 'Personnalisé';
 
   @override
-  String get lanOnYourNetwork => 'Sur votre réseau';
+  String get lanOnYourNetwork => 'Serveurs sur votre réseau local';
 
   @override
   String get lanSearching => 'Recherche de serveurs…';
@@ -1503,8 +1503,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override
+  String get irohPairingHeader => 'Connect with a pairing code';
+
+  @override
   String get irohConnectBody =>
-      'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
+      'Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.';
+
+  @override
+  String get irohPairingBody =>
+      'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
   String get irohOneServerLimit =>

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1338,7 +1338,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get accentCustom => 'Personalizzato';
 
   @override
-  String get lanOnYourNetwork => 'Sulla tua rete';
+  String get lanOnYourNetwork => 'Server sulla tua rete locale';
 
   @override
   String get lanSearching => 'Ricerca server…';
@@ -1504,8 +1504,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override
+  String get irohPairingHeader => 'Connect with a pairing code';
+
+  @override
   String get irohConnectBody =>
-      'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
+      'Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.';
+
+  @override
+  String get irohPairingBody =>
+      'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
   String get irohOneServerLimit =>

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1282,7 +1282,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get accentCustom => 'カスタム';
 
   @override
-  String get lanOnYourNetwork => 'ネットワーク上のサーバー';
+  String get lanOnYourNetwork => 'ローカルネットワーク上のサーバー';
 
   @override
   String get lanSearching => 'サーバーを検索中…';
@@ -1442,8 +1442,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override
+  String get irohPairingHeader => 'Connect with a pairing code';
+
+  @override
   String get irohConnectBody =>
-      'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
+      'Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.';
+
+  @override
+  String get irohPairingBody =>
+      'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
   String get irohOneServerLimit =>

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1356,7 +1356,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get accentCustom => 'Niestandardowy';
 
   @override
-  String get lanOnYourNetwork => 'W twojej sieci';
+  String get lanOnYourNetwork => 'Serwery w twojej sieci lokalnej';
 
   @override
   String get lanSearching => 'Wyszukiwanie serwerów…';
@@ -1520,8 +1520,15 @@ class AppLocalizationsPl extends AppLocalizations {
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override
+  String get irohPairingHeader => 'Connect with a pairing code';
+
+  @override
   String get irohConnectBody =>
-      'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
+      'Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.';
+
+  @override
+  String get irohPairingBody =>
+      'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
   String get irohOneServerLimit =>

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1334,7 +1334,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get accentCustom => 'Personalizado';
 
   @override
-  String get lanOnYourNetwork => 'Na sua rede';
+  String get lanOnYourNetwork => 'Servidores na sua rede local';
 
   @override
   String get lanSearching => 'Procurando servidores…';
@@ -1500,8 +1500,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override
+  String get irohPairingHeader => 'Connect with a pairing code';
+
+  @override
   String get irohConnectBody =>
-      'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
+      'Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.';
+
+  @override
+  String get irohPairingBody =>
+      'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
   String get irohOneServerLimit =>

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1360,7 +1360,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get accentCustom => 'Свой';
 
   @override
-  String get lanOnYourNetwork => 'В вашей сети';
+  String get lanOnYourNetwork => 'Серверы в вашей локальной сети';
 
   @override
   String get lanSearching => 'Поиск серверов…';
@@ -1524,8 +1524,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override
+  String get irohPairingHeader => 'Connect with a pairing code';
+
+  @override
   String get irohConnectBody =>
-      'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
+      'Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.';
+
+  @override
+  String get irohPairingBody =>
+      'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
   String get irohOneServerLimit =>

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1256,7 +1256,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get accentCustom => '自定义';
 
   @override
-  String get lanOnYourNetwork => '你的网络中';
+  String get lanOnYourNetwork => '本地网络中的服务器';
 
   @override
   String get lanSearching => '正在搜索服务器…';
@@ -1412,8 +1412,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get irohConnectHeader => 'Connect peer-to-peer';
 
   @override
+  String get irohPairingHeader => 'Connect with a pairing code';
+
+  @override
   String get irohConnectBody =>
-      'Reach your server from anywhere — no port-forwarding or public IP. Enable Remote Access on the server, then paste its pairing code or scan the QR.';
+      'Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.';
+
+  @override
+  String get irohPairingBody =>
+      'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
   String get irohOneServerLimit =>

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -353,7 +353,7 @@
   "settingsAccentColorSubtitle": "Kolor wyróżnienia używany w całej aplikacji.",
   "accentThemeDefault": "Domyślny motywu",
   "accentCustom": "Niestandardowy",
-  "lanOnYourNetwork": "W twojej sieci",
+  "lanOnYourNetwork": "Serwery w twojej sieci lokalnej",
   "lanSearching": "Wyszukiwanie serwerów…",
   "lanRefresh": "Odśwież",
   "lanServerVersion": "mStream v{version}",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -353,7 +353,7 @@
   "settingsAccentColorSubtitle": "A cor de destaque usada em todo o aplicativo.",
   "accentThemeDefault": "Padrão do tema",
   "accentCustom": "Personalizado",
-  "lanOnYourNetwork": "Na sua rede",
+  "lanOnYourNetwork": "Servidores na sua rede local",
   "lanSearching": "Procurando servidores…",
   "lanRefresh": "Atualizar",
   "lanServerVersion": "mStream v{version}",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -353,7 +353,7 @@
   "settingsAccentColorSubtitle": "Цвет выделения, используемый во всём приложении.",
   "accentThemeDefault": "Из темы",
   "accentCustom": "Свой",
-  "lanOnYourNetwork": "В вашей сети",
+  "lanOnYourNetwork": "Серверы в вашей локальной сети",
   "lanSearching": "Поиск серверов…",
   "lanRefresh": "Обновить",
   "lanServerVersion": "mStream v{version}",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -353,7 +353,7 @@
   "settingsAccentColorSubtitle": "整个应用中使用的高亮颜色。",
   "accentThemeDefault": "主题默认",
   "accentCustom": "自定义",
-  "lanOnYourNetwork": "你的网络中",
+  "lanOnYourNetwork": "本地网络中的服务器",
   "lanSearching": "正在搜索服务器…",
   "lanRefresh": "刷新",
   "lanServerVersion": "mStream v{version}",

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -1843,10 +1843,9 @@ class MyCustomFormState extends State<MyCustomForm> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            // Servers found on the LAN (mDNS). Tapping one bootstraps an iroh
-            // connection over the network; the manual paste/scan below is the
-            // fallback (and the only path away from home).
-            _discoveredSection(),
+            // Tab title + the p2p pitch: everything below connects
+            // peer-to-peer, whether via a discovered LAN server or a manually
+            // entered pairing code.
             Text(l.irohConnectHeader,
                 style: TextStyle(
                     color: VelvetColors.textPrimary,
@@ -1855,6 +1854,21 @@ class MyCustomFormState extends State<MyCustomForm> {
             SizedBox(height: 6),
             Text(
               l.irohConnectBody,
+              style: TextStyle(color: VelvetColors.textSecondary, fontSize: 13),
+            ),
+            SizedBox(height: 16),
+            // Servers found on the LAN (mDNS). Tapping one bootstraps an iroh
+            // connection over the network; the manual paste/scan below is the
+            // fallback (and the only path away from home).
+            _discoveredSection(),
+            Text(l.irohPairingHeader,
+                style: TextStyle(
+                    color: VelvetColors.textPrimary,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700)),
+            SizedBox(height: 6),
+            Text(
+              l.irohPairingBody,
               style: TextStyle(color: VelvetColors.textSecondary, fontSize: 13),
             ),
             SizedBox(height: 16),


### PR DESCRIPTION
Requested copy/layout tweak on the Quick Connect tab:

- **'Connect peer-to-peer'** moves to the top of the tab as its title, with the pitch line under it ('Reach your server from anywhere — no port-forwarding, DNS, or public IP needed.')
- **'Servers on your local network'** replaces 'On your network' (updated in all 10 locales)
- **'Connect with a pairing code'** heads the manual section, keeping the Remote Access / paste / scan instructions

Deployed to the S25 and verified visually — screenshot in the session. 126/126 tests, analyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)