### PR TITLE
Cap auto-downloads (keep-queue-offline) with FIFO eviction

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -881,6 +881,30 @@
   "settingsOfflineQueueSubtitle": "Automatically download queued tracks to this device so playback survives losing the connection.",
   "settingsOfflineQueueWifiOnly": "Download on Wi-Fi only",
   "settingsOfflineQueueWifiOnlySubtitle": "Wait for Wi-Fi before downloading queued tracks.",
+  "settingsAutoDownloadCap": "Auto-download limit",
+  "@settingsAutoDownloadCap": {
+    "description": "Title of the keep-queue-offline retention-cap setting."
+  },
+  "settingsAutoDownloadCapSubtitle": "Keep the newest this many auto-downloads; older ones no longer in your queue are removed.",
+  "@settingsAutoDownloadCapSubtitle": {
+    "description": "Subtitle when a finite auto-download cap is set."
+  },
+  "settingsAutoDownloadCapSubtitleUnlimited": "Keep every auto-downloaded track (no limit).",
+  "@settingsAutoDownloadCapSubtitleUnlimited": {
+    "description": "Subtitle when the auto-download cap is unlimited (0)."
+  },
+  "settingsAutoDownloadCapUnlimited": "Unlimited",
+  "@settingsAutoDownloadCapUnlimited": {
+    "description": "Shown as the auto-download cap value when there's no limit."
+  },
+  "settingsAutoDownloadCapField": "Number of tracks",
+  "@settingsAutoDownloadCapField": {
+    "description": "Text field label in the auto-download limit dialog."
+  },
+  "settingsAutoDownloadCapDialogBody": "Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren't in your queue are deleted. Set to 0 to keep everything.",
+  "@settingsAutoDownloadCapDialogBody": {
+    "description": "Explainer in the auto-download limit dialog."
+  },
   "downloadWaitingWifi": "Waiting for Wi-Fi",
   "settingsRatingHalf": "Half-star ratings",
   "settingsRatingHalfSubtitle": "Rate songs in half-star steps (long-press a star).",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2400,6 +2400,42 @@ abstract class AppLocalizations {
   /// **'Wait for Wi-Fi before downloading queued tracks.'**
   String get settingsOfflineQueueWifiOnlySubtitle;
 
+  /// Title of the keep-queue-offline retention-cap setting.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto-download limit'**
+  String get settingsAutoDownloadCap;
+
+  /// Subtitle when a finite auto-download cap is set.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep the newest this many auto-downloads; older ones no longer in your queue are removed.'**
+  String get settingsAutoDownloadCapSubtitle;
+
+  /// Subtitle when the auto-download cap is unlimited (0).
+  ///
+  /// In en, this message translates to:
+  /// **'Keep every auto-downloaded track (no limit).'**
+  String get settingsAutoDownloadCapSubtitleUnlimited;
+
+  /// Shown as the auto-download cap value when there's no limit.
+  ///
+  /// In en, this message translates to:
+  /// **'Unlimited'**
+  String get settingsAutoDownloadCapUnlimited;
+
+  /// Text field label in the auto-download limit dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'Number of tracks'**
+  String get settingsAutoDownloadCapField;
+
+  /// Explainer in the auto-download limit dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren\'t in your queue are deleted. Set to 0 to keep everything.'**
+  String get settingsAutoDownloadCapDialogBody;
+
   /// No description provided for @downloadWaitingWifi.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1388,6 +1388,27 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wartet mit dem Herunterladen von Titeln in der Warteschlange auf eine WLAN-Verbindung.';
 
   @override
+  String get settingsAutoDownloadCap => 'Auto-download limit';
+
+  @override
+  String get settingsAutoDownloadCapSubtitle =>
+      'Keep the newest this many auto-downloads; older ones no longer in your queue are removed.';
+
+  @override
+  String get settingsAutoDownloadCapSubtitleUnlimited =>
+      'Keep every auto-downloaded track (no limit).';
+
+  @override
+  String get settingsAutoDownloadCapUnlimited => 'Unlimited';
+
+  @override
+  String get settingsAutoDownloadCapField => 'Number of tracks';
+
+  @override
+  String get settingsAutoDownloadCapDialogBody =>
+      'Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren\'t in your queue are deleted. Set to 0 to keep everything.';
+
+  @override
   String get downloadWaitingWifi => 'Wartet auf WLAN';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1369,6 +1369,27 @@ class AppLocalizationsEn extends AppLocalizations {
       'Wait for Wi-Fi before downloading queued tracks.';
 
   @override
+  String get settingsAutoDownloadCap => 'Auto-download limit';
+
+  @override
+  String get settingsAutoDownloadCapSubtitle =>
+      'Keep the newest this many auto-downloads; older ones no longer in your queue are removed.';
+
+  @override
+  String get settingsAutoDownloadCapSubtitleUnlimited =>
+      'Keep every auto-downloaded track (no limit).';
+
+  @override
+  String get settingsAutoDownloadCapUnlimited => 'Unlimited';
+
+  @override
+  String get settingsAutoDownloadCapField => 'Number of tracks';
+
+  @override
+  String get settingsAutoDownloadCapDialogBody =>
+      'Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren\'t in your queue are deleted. Set to 0 to keep everything.';
+
+  @override
   String get downloadWaitingWifi => 'Waiting for Wi-Fi';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1386,6 +1386,27 @@ class AppLocalizationsEs extends AppLocalizations {
       'Espera a tener Wi-Fi antes de descargar las pistas de la cola.';
 
   @override
+  String get settingsAutoDownloadCap => 'Auto-download limit';
+
+  @override
+  String get settingsAutoDownloadCapSubtitle =>
+      'Keep the newest this many auto-downloads; older ones no longer in your queue are removed.';
+
+  @override
+  String get settingsAutoDownloadCapSubtitleUnlimited =>
+      'Keep every auto-downloaded track (no limit).';
+
+  @override
+  String get settingsAutoDownloadCapUnlimited => 'Unlimited';
+
+  @override
+  String get settingsAutoDownloadCapField => 'Number of tracks';
+
+  @override
+  String get settingsAutoDownloadCapDialogBody =>
+      'Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren\'t in your queue are deleted. Set to 0 to keep everything.';
+
+  @override
   String get downloadWaitingWifi => 'Esperando Wi-Fi';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1385,6 +1385,27 @@ class AppLocalizationsFr extends AppLocalizations {
       'Attend une connexion Wi-Fi avant de télécharger les pistes de la file d\'attente.';
 
   @override
+  String get settingsAutoDownloadCap => 'Auto-download limit';
+
+  @override
+  String get settingsAutoDownloadCapSubtitle =>
+      'Keep the newest this many auto-downloads; older ones no longer in your queue are removed.';
+
+  @override
+  String get settingsAutoDownloadCapSubtitleUnlimited =>
+      'Keep every auto-downloaded track (no limit).';
+
+  @override
+  String get settingsAutoDownloadCapUnlimited => 'Unlimited';
+
+  @override
+  String get settingsAutoDownloadCapField => 'Number of tracks';
+
+  @override
+  String get settingsAutoDownloadCapDialogBody =>
+      'Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren\'t in your queue are deleted. Set to 0 to keep everything.';
+
+  @override
   String get downloadWaitingWifi => 'En attente du Wi-Fi';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1386,6 +1386,27 @@ class AppLocalizationsIt extends AppLocalizations {
       'Attende una connessione Wi-Fi prima di scaricare i brani in coda.';
 
   @override
+  String get settingsAutoDownloadCap => 'Auto-download limit';
+
+  @override
+  String get settingsAutoDownloadCapSubtitle =>
+      'Keep the newest this many auto-downloads; older ones no longer in your queue are removed.';
+
+  @override
+  String get settingsAutoDownloadCapSubtitleUnlimited =>
+      'Keep every auto-downloaded track (no limit).';
+
+  @override
+  String get settingsAutoDownloadCapUnlimited => 'Unlimited';
+
+  @override
+  String get settingsAutoDownloadCapField => 'Number of tracks';
+
+  @override
+  String get settingsAutoDownloadCapDialogBody =>
+      'Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren\'t in your queue are deleted. Set to 0 to keep everything.';
+
+  @override
   String get downloadWaitingWifi => 'In attesa del Wi-Fi';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1328,6 +1328,27 @@ class AppLocalizationsJa extends AppLocalizations {
       'キュー内の曲のダウンロードをWi-Fi接続まで待機します。';
 
   @override
+  String get settingsAutoDownloadCap => 'Auto-download limit';
+
+  @override
+  String get settingsAutoDownloadCapSubtitle =>
+      'Keep the newest this many auto-downloads; older ones no longer in your queue are removed.';
+
+  @override
+  String get settingsAutoDownloadCapSubtitleUnlimited =>
+      'Keep every auto-downloaded track (no limit).';
+
+  @override
+  String get settingsAutoDownloadCapUnlimited => 'Unlimited';
+
+  @override
+  String get settingsAutoDownloadCapField => 'Number of tracks';
+
+  @override
+  String get settingsAutoDownloadCapDialogBody =>
+      'Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren\'t in your queue are deleted. Set to 0 to keep everything.';
+
+  @override
   String get downloadWaitingWifi => 'Wi-Fi接続を待機中';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1403,6 +1403,27 @@ class AppLocalizationsPl extends AppLocalizations {
       'Czeka na połączenie Wi-Fi przed pobraniem utworów z kolejki.';
 
   @override
+  String get settingsAutoDownloadCap => 'Auto-download limit';
+
+  @override
+  String get settingsAutoDownloadCapSubtitle =>
+      'Keep the newest this many auto-downloads; older ones no longer in your queue are removed.';
+
+  @override
+  String get settingsAutoDownloadCapSubtitleUnlimited =>
+      'Keep every auto-downloaded track (no limit).';
+
+  @override
+  String get settingsAutoDownloadCapUnlimited => 'Unlimited';
+
+  @override
+  String get settingsAutoDownloadCapField => 'Number of tracks';
+
+  @override
+  String get settingsAutoDownloadCapDialogBody =>
+      'Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren\'t in your queue are deleted. Set to 0 to keep everything.';
+
+  @override
   String get downloadWaitingWifi => 'Oczekiwanie na Wi-Fi';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1382,6 +1382,27 @@ class AppLocalizationsPt extends AppLocalizations {
       'Aguarda uma conexão Wi-Fi antes de baixar as faixas da fila.';
 
   @override
+  String get settingsAutoDownloadCap => 'Auto-download limit';
+
+  @override
+  String get settingsAutoDownloadCapSubtitle =>
+      'Keep the newest this many auto-downloads; older ones no longer in your queue are removed.';
+
+  @override
+  String get settingsAutoDownloadCapSubtitleUnlimited =>
+      'Keep every auto-downloaded track (no limit).';
+
+  @override
+  String get settingsAutoDownloadCapUnlimited => 'Unlimited';
+
+  @override
+  String get settingsAutoDownloadCapField => 'Number of tracks';
+
+  @override
+  String get settingsAutoDownloadCapDialogBody =>
+      'Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren\'t in your queue are deleted. Set to 0 to keep everything.';
+
+  @override
   String get downloadWaitingWifi => 'Aguardando Wi-Fi';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1407,6 +1407,27 @@ class AppLocalizationsRu extends AppLocalizations {
       'Ожидает подключения к Wi-Fi перед загрузкой треков из очереди.';
 
   @override
+  String get settingsAutoDownloadCap => 'Auto-download limit';
+
+  @override
+  String get settingsAutoDownloadCapSubtitle =>
+      'Keep the newest this many auto-downloads; older ones no longer in your queue are removed.';
+
+  @override
+  String get settingsAutoDownloadCapSubtitleUnlimited =>
+      'Keep every auto-downloaded track (no limit).';
+
+  @override
+  String get settingsAutoDownloadCapUnlimited => 'Unlimited';
+
+  @override
+  String get settingsAutoDownloadCapField => 'Number of tracks';
+
+  @override
+  String get settingsAutoDownloadCapDialogBody =>
+      'Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren\'t in your queue are deleted. Set to 0 to keep everything.';
+
+  @override
   String get downloadWaitingWifi => 'Ожидание Wi-Fi';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1300,6 +1300,27 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsOfflineQueueWifiOnlySubtitle => '等待连接 Wi-Fi 后再下载队列中的曲目。';
 
   @override
+  String get settingsAutoDownloadCap => 'Auto-download limit';
+
+  @override
+  String get settingsAutoDownloadCapSubtitle =>
+      'Keep the newest this many auto-downloads; older ones no longer in your queue are removed.';
+
+  @override
+  String get settingsAutoDownloadCapSubtitleUnlimited =>
+      'Keep every auto-downloaded track (no limit).';
+
+  @override
+  String get settingsAutoDownloadCapUnlimited => 'Unlimited';
+
+  @override
+  String get settingsAutoDownloadCapField => 'Number of tracks';
+
+  @override
+  String get settingsAutoDownloadCapDialogBody =>
+      'Automatically downloaded tracks kept for offline play. When you go over, the oldest ones that aren\'t in your queue are deleted. Set to 0 to keep everything.';
+
+  @override
   String get downloadWaitingWifi => '等待 Wi-Fi';
 
   @override

--- a/lib/objects/auto_download_entry.dart
+++ b/lib/objects/auto_download_entry.dart
@@ -1,0 +1,26 @@
+/// One track kept on disk by the keep-queue-offline auto-downloader, tracked so
+/// the cap can evict the oldest when the total grows past the user's limit.
+///
+/// Separate from user-initiated downloads ON PURPOSE: eviction must never touch
+/// a file the user asked for explicitly. A manual download of the same track
+/// removes it from the ledger (manual wins permanently), and downloads that
+/// predate this feature are never recorded — so they're grandfathered as
+/// manual and can't be evicted.
+class AutoDownloadEntry {
+  final String server; // server localname
+  final String path; // data path on that server
+  final String localPath; // absolute file on disk
+
+  AutoDownloadEntry(this.server, this.path, this.localPath);
+
+  String get key => server + path;
+
+  Map<String, dynamic> toJson() =>
+      {'server': server, 'path': path, 'localPath': localPath};
+
+  static AutoDownloadEntry? fromJson(Map<String, dynamic> j) {
+    final s = j['server'], p = j['path'], lp = j['localPath'];
+    if (s is! String || p is! String || lp is! String) return null;
+    return AutoDownloadEntry(s, p, lp);
+  }
+}

--- a/lib/objects/download_tracker.dart
+++ b/lib/objects/download_tracker.dart
@@ -26,6 +26,10 @@ class DownloadTracker {
   // Times this download has been re-resolved onto a fresh iroh tunnel URL; bounds
   // the re-enqueue so a repeatedly-rotating tunnel / dead source can't loop.
   int reResolves = 0;
+  // True when the keep-queue-offline sweep started this download (not a user
+  // tap). Only auto-downloads are recorded in the AutoDownloadLedger and are
+  // eligible for cap eviction; manual downloads are never evicted.
+  bool auto = false;
 
   DownloadTracker(this.serverUrl, this.filePath);
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async' show unawaited;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show FilteringTextInputFormatter;
 import 'package:permission_handler/permission_handler.dart';
 
 import '../l10n/app_localizations.dart';
@@ -252,6 +253,29 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     setState(() {});
                   },
             activeThumbColor: VelvetColors.primary,
+          ),
+          ListTile(
+            enabled: SettingsManager().offlineQueue,
+            title: Text(l.settingsAutoDownloadCap),
+            subtitle: Text(
+              _autoDownloadCapSubtitle(l, SettingsManager().autoDownloadCap),
+              style: TextStyle(
+                  color: VelvetColors.textSecondary, fontSize: 12),
+            ),
+            trailing: Text(
+              SettingsManager().autoDownloadCap <= 0
+                  ? l.settingsAutoDownloadCapUnlimited
+                  : '${SettingsManager().autoDownloadCap}',
+              style: TextStyle(
+                  color: SettingsManager().offlineQueue
+                      ? VelvetColors.primary
+                      : VelvetColors.textTertiary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600),
+            ),
+            onTap: !SettingsManager().offlineQueue
+                ? null
+                : () => _editAutoDownloadCap(l),
           ),
           SwitchListTile(
             title: Text(l.settingsRatingHalf),
@@ -680,6 +704,66 @@ class _SettingsScreenState extends State<SettingsScreen> {
       case TapBehavior.appendAndJump:
         return l.tapSubtitleAppendAndJump;
     }
+  }
+
+  String _autoDownloadCapSubtitle(AppLocalizations l, int cap) =>
+      cap <= 0 ? l.settingsAutoDownloadCapSubtitleUnlimited : l.settingsAutoDownloadCapSubtitle;
+
+  // Prompt for the auto-download retention limit. 0 (or empty) = unlimited.
+  // Applying a lower value evicts down to it immediately — a deliberate,
+  // user-initiated moment, the only place besides a fresh auto-download where
+  // eviction is allowed to run.
+  Future<void> _editAutoDownloadCap(AppLocalizations l) async {
+    final current = SettingsManager().autoDownloadCap;
+    final ctrl = TextEditingController(text: current <= 0 ? '' : '$current');
+    final result = await showDialog<int>(
+      context: context,
+      builder: (dctx) => AlertDialog(
+        backgroundColor: VelvetColors.surface,
+        title: Text(l.settingsAutoDownloadCap,
+            style: TextStyle(color: VelvetColors.textPrimary)),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(l.settingsAutoDownloadCapDialogBody,
+                style: TextStyle(
+                    color: VelvetColors.textSecondary, fontSize: 13)),
+            SizedBox(height: 16),
+            TextField(
+              controller: ctrl,
+              autofocus: true,
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              style: TextStyle(color: VelvetColors.textPrimary),
+              decoration: InputDecoration(
+                labelText: l.settingsAutoDownloadCapField,
+                hintText: l.settingsAutoDownloadCapUnlimited,
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.of(dctx).pop(),
+              child: Text(l.cancel,
+                  style: TextStyle(color: VelvetColors.textSecondary))),
+          TextButton(
+              onPressed: () {
+                final v = int.tryParse(ctrl.text.trim()) ?? 0;
+                Navigator.of(dctx).pop(v < 0 ? 0 : v);
+              },
+              child: Text(l.save)),
+        ],
+      ),
+    );
+    ctrl.dispose();
+    if (result == null) return;
+    final lowered = result != 0 &&
+        (current == 0 || result < current); // 0 = unlimited (never lower)
+    await SettingsManager().setAutoDownloadCap(result);
+    if (lowered) unawaited(DownloadManager().enforceAutoDownloadCap());
+    if (mounted) setState(() {});
   }
 
   Widget _sectionHeader(String label) {

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -275,7 +275,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
             onTap: !SettingsManager().offlineQueue
                 ? null
-                : () => _editAutoDownloadCap(l),
+                : () => _editAutoDownloadCap(),
           ),
           SwitchListTile(
             title: Text(l.settingsRatingHalf),
@@ -713,51 +713,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   // Applying a lower value evicts down to it immediately — a deliberate,
   // user-initiated moment, the only place besides a fresh auto-download where
   // eviction is allowed to run.
-  Future<void> _editAutoDownloadCap(AppLocalizations l) async {
+  Future<void> _editAutoDownloadCap() async {
     final current = SettingsManager().autoDownloadCap;
-    final ctrl = TextEditingController(text: current <= 0 ? '' : '$current');
     final result = await showDialog<int>(
       context: context,
-      builder: (dctx) => AlertDialog(
-        backgroundColor: VelvetColors.surface,
-        title: Text(l.settingsAutoDownloadCap,
-            style: TextStyle(color: VelvetColors.textPrimary)),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(l.settingsAutoDownloadCapDialogBody,
-                style: TextStyle(
-                    color: VelvetColors.textSecondary, fontSize: 13)),
-            SizedBox(height: 16),
-            TextField(
-              controller: ctrl,
-              autofocus: true,
-              keyboardType: TextInputType.number,
-              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-              style: TextStyle(color: VelvetColors.textPrimary),
-              decoration: InputDecoration(
-                labelText: l.settingsAutoDownloadCapField,
-                hintText: l.settingsAutoDownloadCapUnlimited,
-              ),
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-              onPressed: () => Navigator.of(dctx).pop(),
-              child: Text(l.cancel,
-                  style: TextStyle(color: VelvetColors.textSecondary))),
-          TextButton(
-              onPressed: () {
-                final v = int.tryParse(ctrl.text.trim()) ?? 0;
-                Navigator.of(dctx).pop(v < 0 ? 0 : v);
-              },
-              child: Text(l.save)),
-        ],
-      ),
+      builder: (_) => _AutoDownloadCapDialog(current: current),
     );
-    ctrl.dispose();
     if (result == null) return;
     final lowered = result != 0 &&
         (current == 0 || result < current); // 0 = unlimited (never lower)
@@ -778,6 +739,72 @@ class _SettingsScreenState extends State<SettingsScreen> {
           letterSpacing: 1.6,
         ),
       ),
+    );
+  }
+}
+
+// Number prompt for the auto-download retention limit; pops with the parsed
+// value (empty or 0 = unlimited), null on cancel. Stateful for the same reason
+// as add_server's _NewFolderDialog: the controller must outlive the dialog's
+// exit animation.
+class _AutoDownloadCapDialog extends StatefulWidget {
+  final int current;
+  const _AutoDownloadCapDialog({required this.current});
+
+  @override
+  State<_AutoDownloadCapDialog> createState() => _AutoDownloadCapDialogState();
+}
+
+class _AutoDownloadCapDialogState extends State<_AutoDownloadCapDialog> {
+  late final _ctrl = TextEditingController(
+      text: widget.current <= 0 ? '' : '${widget.current}');
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return AlertDialog(
+      backgroundColor: VelvetColors.surface,
+      title: Text(l.settingsAutoDownloadCap,
+          style: TextStyle(color: VelvetColors.textPrimary)),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(l.settingsAutoDownloadCapDialogBody,
+              style:
+                  TextStyle(color: VelvetColors.textSecondary, fontSize: 13)),
+          SizedBox(height: 16),
+          TextField(
+            controller: _ctrl,
+            autofocus: true,
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            style: TextStyle(color: VelvetColors.textPrimary),
+            decoration: InputDecoration(
+              labelText: l.settingsAutoDownloadCapField,
+              hintText: l.settingsAutoDownloadCapUnlimited,
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(l.cancel,
+                style: TextStyle(color: VelvetColors.textSecondary))),
+        TextButton(
+            onPressed: () {
+              final v = int.tryParse(_ctrl.text.trim()) ?? 0;
+              Navigator.of(context).pop(v < 0 ? 0 : v);
+            },
+            child: Text(l.save)),
+      ],
     );
   }
 }

--- a/lib/singletons/auto_download_ledger.dart
+++ b/lib/singletons/auto_download_ledger.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+import '../objects/auto_download_entry.dart';
+import 'log_manager.dart';
+
+/// Persistent, ordered record of auto-downloaded tracks (keep-queue-offline),
+/// so the auto-download cap can evict the oldest orphans once the total grows
+/// past the user's limit. Ordered oldest-first (newest appended), mirroring the
+/// single-JSON-file approach of QueueStore / servers.json.
+///
+/// Only the sweep records here; manual downloads never do and actively forget a
+/// track they touch, so an evictable entry is always something the app chose to
+/// cache on the user's behalf — never a file they asked for.
+class AutoDownloadLedger {
+  static final AutoDownloadLedger _instance = AutoDownloadLedger._();
+  factory AutoDownloadLedger() => _instance;
+  AutoDownloadLedger._();
+
+  // Oldest first, newest last — the FIFO eviction order.
+  final List<AutoDownloadEntry> _entries = [];
+  bool _loaded = false;
+
+  Future<File> _file() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/auto_downloads.json');
+  }
+
+  /// Read the ledger from disk once. Idempotent; safe to call on every entry
+  /// point that needs it.
+  Future<void> load() async {
+    if (_loaded) return;
+    _loaded = true;
+    try {
+      final f = await _file();
+      if (!await f.exists()) return;
+      final raw = jsonDecode(await f.readAsString());
+      if (raw is List) {
+        for (final e in raw) {
+          if (e is Map) {
+            final entry =
+                AutoDownloadEntry.fromJson(Map<String, dynamic>.from(e));
+            if (entry != null) _entries.add(entry);
+          }
+        }
+      }
+    } catch (e) {
+      appLog('[auto-dl] ledger load failed: $e');
+    }
+  }
+
+  int get length => _entries.length;
+
+  /// Record an auto-download completion. Re-recording a tracked track moves it
+  /// to newest (and updates its localPath after a storage-location change), so
+  /// a re-download doesn't make an old entry look freshly cached.
+  Future<void> record(String server, String path, String localPath) async {
+    await load();
+    _entries.removeWhere((e) => e.server == server && e.path == path);
+    _entries.add(AutoDownloadEntry(server, path, localPath));
+    await _persist();
+  }
+
+  /// Drop a track from the ledger without deleting its file — used when the
+  /// user downloads it manually (manual wins) and when the cap evicts it.
+  /// Returns whether anything was removed.
+  Future<bool> forget(String server, String path) async {
+    await load();
+    final before = _entries.length;
+    _entries.removeWhere((e) => e.server == server && e.path == path);
+    if (_entries.length == before) return false;
+    await _persist();
+    return true;
+  }
+
+  /// Oldest-first entries to evict so the total count drops to [cap], skipping
+  /// any the current queue still needs. Pure over its inputs (unit-tested):
+  /// - `cap <= 0` keeps everything (unlimited).
+  /// - protected entries (in the queue, incl. the playing track) are never
+  ///   selected, even if that leaves the total above the cap — the queue must
+  ///   stay fully offline-available; the cap only bounds the extra cache.
+  static List<AutoDownloadEntry> selectEvictions(
+      List<AutoDownloadEntry> entries, int cap,
+      {required bool Function(String server, String path) isProtected}) {
+    if (cap <= 0) return const [];
+    var over = entries.length - cap;
+    if (over <= 0) return const [];
+    final out = <AutoDownloadEntry>[];
+    for (final e in entries) {
+      // oldest first
+      if (over <= 0) break;
+      if (isProtected(e.server, e.path)) continue;
+      out.add(e);
+      over--;
+    }
+    return out;
+  }
+
+  List<AutoDownloadEntry> evictionsFor(
+          int cap, bool Function(String server, String path) isProtected) =>
+      selectEvictions(_entries, cap, isProtected: isProtected);
+
+  Future<void> _persist() async {
+    try {
+      final f = await _file();
+      await f.writeAsString(
+          jsonEncode(_entries.map((e) => e.toJson()).toList()));
+    } catch (e) {
+      appLog('[auto-dl] ledger persist failed: $e');
+    }
+  }
+}

--- a/lib/singletons/auto_download_ledger.dart
+++ b/lib/singletons/auto_download_ledger.dart
@@ -21,7 +21,7 @@ class AutoDownloadLedger {
 
   // Oldest first, newest last — the FIFO eviction order.
   final List<AutoDownloadEntry> _entries = [];
-  bool _loaded = false;
+  Future<void>? _loading;
 
   Future<File> _file() async {
     final dir = await getApplicationDocumentsDirectory();
@@ -29,10 +29,11 @@ class AutoDownloadLedger {
   }
 
   /// Read the ledger from disk once. Idempotent; safe to call on every entry
-  /// point that needs it.
-  Future<void> load() async {
-    if (_loaded) return;
-    _loaded = true;
+  /// point that needs it — concurrent callers await the same in-flight read
+  /// instead of proceeding against a half-loaded list.
+  Future<void> load() => _loading ??= _load();
+
+  Future<void> _load() async {
     try {
       final f = await _file();
       if (!await f.exists()) return;

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -10,6 +10,7 @@ import 'package:mstream_music/singletons/app_messenger.dart';
 import 'package:mstream_music/singletons/migration_manager.dart';
 import 'package:mstream_music/singletons/log_manager.dart';
 import 'package:mstream_music/singletons/settings.dart';
+import 'package:mstream_music/singletons/auto_download_ledger.dart';
 import 'package:mstream_music/l10n/app_localizations.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:background_downloader/background_downloader.dart';
@@ -55,6 +56,8 @@ class DownloadManager {
     // single stream, so the old flutter_downloader background-isolate /
     // SendPort plumbing is no longer needed.
     _updatesSub = FileDownloader().updates.listen(_onUpdate);
+    // Load the auto-download ledger before any sweep records into it.
+    await AutoDownloadLedger().load();
     // Rehydrate tasks that survived a process death in WorkManager (a
     // Wi-Fi-held keep-queue-offline transfer routinely does). Without this a
     // relaunch sweep re-enqueues DUPLICATES of every held task — the guards
@@ -77,7 +80,11 @@ class DownloadManager {
           ..serverName = key.substring(0, slash)
           ..dataPath = key.substring(slash)
           ..localPath = '${t.directory}/${t.filename}'
-          ..requiresWiFi = t.requiresWiFi;
+          ..requiresWiFi = t.requiresWiFi
+          // A Wi-Fi-held survivor is a keep-queue-offline transfer — manual
+          // downloads never set requiresWiFi — so recovering its auto flag from
+          // that can't mislabel a user download as evictable.
+          ..auto = t.requiresWiFi;
       }
       if (downloadMap.isNotEmpty) _downloadStream.add(downloadMap);
     } catch (e) {
@@ -107,6 +114,15 @@ class DownloadManager {
               dt.dataPath != null) {
             MediaManager().audioHandler.onTrackDownloaded(
                 dt.serverName!, dt.dataPath!, dt.localPath!);
+            // Record auto-downloads in the ledger and enforce the cap. Only
+            // here (a fresh auto-download landing, i.e. online) — never on
+            // startup or a connectivity change, so waking up offline can't
+            // trigger a sweep that deletes what you're about to play.
+            if (dt.auto) {
+              await AutoDownloadLedger()
+                  .record(dt.serverName!, dt.dataPath!, dt.localPath!);
+              await _enforceAutoDownloadCap();
+            }
           }
           break;
         case TaskStatus.failed:
@@ -229,6 +245,8 @@ class DownloadManager {
         referenceItem: dt.referenceDisplayItem,
         reResolves: dt.reResolves + 1,
         requiresWiFi: dt.requiresWiFi,
+        auto: dt.auto, // keep it evictable across a tunnel re-resolve
+
         // This path already avoids toasts (see caller); a re-enqueue that
         // ultimately fails lands in the throttled terminal-failure warn.
         quiet: true);
@@ -332,8 +350,48 @@ class DownloadManager {
     for (final m in autoDownloadCandidates(items, _autoAttempted,
         fileExists: (p) => File(p).existsSync())) {
       await downloadOneFile(m.id, m.extras!['server'], m.extras!['path'],
-          requiresWiFi: wifiOnly, quiet: true);
+          requiresWiFi: wifiOnly, auto: true, quiet: true);
     }
+  }
+
+  /// Delete auto-downloads over the user's cap, oldest orphans first. Runs
+  /// after a fresh auto-download lands and when the user lowers the cap — both
+  /// deliberate, online-ish moments; never from startup or a connectivity
+  /// change. Tracks still in the queue (incl. the playing one) are protected,
+  /// so the queue stays fully offline-available and only the extra cache is
+  /// trimmed. cap 0 = keep everything.
+  Future<void> enforceAutoDownloadCap() => _enforceAutoDownloadCap();
+
+  Future<void> _enforceAutoDownloadCap() async {
+    final cap = SettingsManager().autoDownloadCap;
+    if (cap <= 0) return;
+    // Protected = anything in the current queue, keyed serverName+path (the
+    // same key the ledger and the queue's extras share).
+    final queued = <String>{};
+    for (final m in MediaManager().audioHandler.queue.value) {
+      final s = m.extras?['server'], p = m.extras?['path'];
+      if (s is String && p is String) queued.add(s + p);
+    }
+    final victims =
+        AutoDownloadLedger().evictionsFor(cap, (s, p) => queued.contains(s + p));
+    if (victims.isEmpty) return;
+    for (final v in victims) {
+      try {
+        final f = File(v.localPath);
+        if (f.existsSync()) f.deleteSync();
+      } catch (e) {
+        appLog('[auto-dl] evict delete failed: $e');
+      }
+      // Drop the once-per-session sweep guard so the track can auto-download
+      // again if it later re-enters the queue, and drop it from the ledger.
+      _autoAttempted.remove(v.key);
+      await AutoDownloadLedger().forget(v.server, v.path);
+    }
+    appLog('[auto-dl] evicted ${victims.length} over cap $cap');
+    // The "downloaded" badge is file-existence derived; refresh any visible
+    // rows so a deleted orphan stops claiming a local copy. Evicted tracks are
+    // never in the queue, so no queue source needs reversing.
+    unawaited(BrowserManager().refreshAllDownloadStatus());
   }
 
   /// Re-sweep the current queue immediately — used when the user flips the
@@ -369,11 +427,31 @@ class DownloadManager {
       {DisplayItem? referenceItem,
       int reResolves = 0,
       bool requiresWiFi = false,
+      // The keep-queue-offline sweep passes true: the download is tracked in
+      // the ledger and eligible for cap eviction. A user-initiated download
+      // (false) instead FORGETS the track from the ledger — an explicit
+      // download promotes it to manual permanently, so the cap never deletes it.
+      bool auto = false,
       // Suppress the per-call snackbars — the keep-queue-offline sweep passes
       // true (nothing user-initiated, and a whole-queue sweep can hit the
       // same error dozens of times); manual downloads keep their feedback.
       bool quiet = false}) async {
     String downloadDirectory = serverName + filepath;
+
+    // Manual wins: an explicit download of a track removes it from the auto
+    // ledger so it can never be evicted (forget is a cheap no-op when it isn't
+    // tracked). Done up front so it applies whether or not the file already
+    // exists below. Also demote any in-flight auto-download of the same track,
+    // so when it completes it records as manual (i.e. isn't re-added to the
+    // ledger) instead of racing the forget.
+    if (!auto) {
+      unawaited(AutoDownloadLedger().forget(serverName, filepath));
+      for (final t in downloadMap.values) {
+        if (t.serverName == serverName && t.dataPath == filepath) {
+          t.auto = false;
+        }
+      }
+    }
 
     // The originating server may have been removed while this track lingered
     // in the queue — lookupServer is a bare firstWhere that would throw.
@@ -466,7 +544,8 @@ class DownloadManager {
             ..dataPath = filepath
             ..localPath = downloadTo
             ..requiresWiFi = requiresWiFi
-            ..reResolves = reResolves;
+            ..reResolves = reResolves
+            ..auto = auto;
       _downloadStream.add(downloadMap);
 
       await FileDownloader().enqueue(task);

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -297,7 +297,7 @@ class SettingsManager {
       resumeQueue = m['resumeQueue'] ?? true;
       offlineQueue = m['offlineQueue'] ?? false;
       offlineQueueWifiOnly = m['offlineQueueWifiOnly'] ?? true;
-      // Clamp: a corrupt/negative stored value falls back to "keep everything"
+      // A corrupt/negative stored value falls back to the default (50)
       // rather than evicting unpredictably.
       final cap = m['autoDownloadCap'];
       autoDownloadCap = (cap is int && cap >= 0) ? cap : 50;

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -177,6 +177,11 @@ class SettingsManager {
   // (background_downloader holds them until it's available).
   bool offlineQueue = false;
   bool offlineQueueWifiOnly = true;
+  // Cap on how many auto-downloaded (keep-queue-offline) tracks to retain. When
+  // the total grows past this, the oldest orphans (auto-downloads no longer in
+  // the queue) are deleted, newest kept. 0 = keep everything. Only auto-
+  // downloads count; user-initiated downloads are never evicted. Default 50.
+  int autoDownloadCap = 50;
   // Whether in-app diagnostic logging is captured (see LogManager) so users can
   // view / copy / share logs from the Diagnostics screen. On by default.
   bool diagnosticsLogging = true;
@@ -292,6 +297,10 @@ class SettingsManager {
       resumeQueue = m['resumeQueue'] ?? true;
       offlineQueue = m['offlineQueue'] ?? false;
       offlineQueueWifiOnly = m['offlineQueueWifiOnly'] ?? true;
+      // Clamp: a corrupt/negative stored value falls back to "keep everything"
+      // rather than evicting unpredictably.
+      final cap = m['autoDownloadCap'];
+      autoDownloadCap = (cap is int && cap >= 0) ? cap : 50;
       diagnosticsLogging = m['diagnosticsLogging'] ?? true;
       verboseLogging = m['verboseLogging'] ?? false;
       final rawGains = m['eqBandGains'];
@@ -475,6 +484,7 @@ class SettingsManager {
       'resumeQueue': resumeQueue,
       'offlineQueue': offlineQueue,
       'offlineQueueWifiOnly': offlineQueueWifiOnly,
+      'autoDownloadCap': autoDownloadCap,
       'diagnosticsLogging': diagnosticsLogging,
       'verboseLogging': verboseLogging,
       'eqBandGains': eqBandGains,
@@ -598,6 +608,11 @@ class SettingsManager {
     await _save();
   }
 
+  Future<void> setAutoDownloadCap(int v) async {
+    autoDownloadCap = v < 0 ? 0 : v;
+    await _save();
+  }
+
   Future<void> setDiagnosticsLogging(bool v) async {
     diagnosticsLogging = v;
     await _save();
@@ -676,6 +691,7 @@ class SettingsManager {
     resumeQueue = true;
     offlineQueue = false;
     offlineQueueWifiOnly = true;
+    autoDownloadCap = 50;
     diagnosticsLogging = true;
     verboseLogging = false;
     eqBandGains = const [];

--- a/test/singletons/auto_download_cap_test.dart
+++ b/test/singletons/auto_download_cap_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/objects/auto_download_entry.dart';
+import 'package:mstream_music/singletons/auto_download_ledger.dart';
+
+void main() {
+  // Oldest-first list (newest appended), mirroring the ledger's storage order.
+  List<AutoDownloadEntry> entries(int n) => [
+        for (var i = 0; i < n; i++) AutoDownloadEntry('s', '/t$i.mp3', '/dl/t$i.mp3'),
+      ];
+
+  bool protectNone(String s, String p) => false;
+
+  group('AutoDownloadLedger.selectEvictions', () {
+    test('cap 0 keeps everything (unlimited)', () {
+      final picked = AutoDownloadLedger.selectEvictions(entries(100), 0,
+          isProtected: protectNone);
+      expect(picked, isEmpty);
+    });
+
+    test('under and at the cap evict nothing', () {
+      expect(
+          AutoDownloadLedger.selectEvictions(entries(3), 5,
+              isProtected: protectNone),
+          isEmpty);
+      expect(
+          AutoDownloadLedger.selectEvictions(entries(5), 5,
+              isProtected: protectNone),
+          isEmpty);
+    });
+
+    test('over the cap evicts the oldest first, exactly enough', () {
+      final picked = AutoDownloadLedger.selectEvictions(entries(8), 5,
+          isProtected: protectNone);
+      expect(picked.length, 3);
+      // Oldest three (t0, t1, t2) go; t3..t7 stay.
+      expect(picked.map((e) => e.path), ['/t0.mp3', '/t1.mp3', '/t2.mp3']);
+    });
+
+    test('protected (in-queue) entries are never evicted, even past the cap',
+        () {
+      // t0 and t1 are the oldest but sit in the queue: eviction must skip them
+      // and take the next-oldest unprotected ones instead.
+      final protectedKeys = {'s/t0.mp3', 's/t1.mp3'};
+      final picked = AutoDownloadLedger.selectEvictions(entries(8), 5,
+          isProtected: (s, p) => protectedKeys.contains(s + p));
+      expect(picked.length, 3);
+      expect(picked.map((e) => e.path), ['/t2.mp3', '/t3.mp3', '/t4.mp3']);
+    });
+
+    test('leaves total above cap when too many are protected', () {
+      // 6 entries, cap 3, but 5 are protected — only 1 is evictable, so the
+      // total can only drop to 5. The queue stays fully offline-available.
+      final protectedKeys = {
+        's/t0.mp3',
+        's/t1.mp3',
+        's/t2.mp3',
+        's/t3.mp3',
+        's/t4.mp3'
+      };
+      final picked = AutoDownloadLedger.selectEvictions(entries(6), 3,
+          isProtected: (s, p) => protectedKeys.contains(s + p));
+      expect(picked.map((e) => e.path), ['/t5.mp3']);
+    });
+  });
+}


### PR DESCRIPTION
Bounds the on-disk growth of the **keep-queue-offline** auto-downloader, per the design we discussed.

## Behavior
- **New setting — "Auto-download limit"** (default **50**, **0 = unlimited**), a tile under keep-queue-offline in Settings with a number dialog. Gated/disabled when keep-queue-offline is off.
- **Separate tracking.** Auto-downloads are recorded in a persistent ledger (`auto_downloads.json`); user-initiated downloads are not. A manual download of a track **forgets** it from the ledger (manual wins permanently, including demoting an in-flight auto-download so its completion doesn't re-record it). Anything already on disk when this ships is **grandfathered as manual** — never evicted.
- **FIFO eviction of orphans.** When the total exceeds the cap, the oldest auto-downloads **that are no longer in the queue** are deleted, newest kept.
- **Queue-aware & safe.** Tracks still in the queue — including the playing one — are **protected** and never deleted, so the queue stays fully offline-available; only the extra cache is trimmed. If the queue itself exceeds the cap, all orphans go and the total simply stays at the queue size (honest, no silent under-download).
- **When it runs.** Only on a **fresh auto-download completing** (i.e. online) or when the **user lowers the cap** — never on startup or a connectivity change, so waking up offline can't delete what's about to play.

## Un-download
Evicted tracks are never in the queue, so there's no queue source to reverse-patch. The "downloaded" badge is file-existence-derived, so deleting the file + the existing browser recheck clears it.

## Tests
Cap-selection is a pure function with unit tests: oldest-first, protected-skipping, unlimited (0), under/at cap, and the over-protected case (total stays above cap when too many are queued). Full suite green (131), analyzer clean.

## Verification status
On-device UI smoke is **pending** — the phone dropped its wireless-debug connection mid-session. Logic is unit-test-covered; I'll deploy and smoke the Settings dialog + a real eviction once the phone's reconnected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
