### PR TITLE
feat: show an iroh server's pairing code as a QR from Manage Servers

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1019,6 +1019,18 @@
   "@irohPairingCodeHint": {
     "description": "Hint text inside the iroh pairing-code field."
   },
+  "irohShowPairingCode": "Show pairing code",
+  "@irohShowPairingCode": {
+    "description": "Server ⋮ menu action that displays the stored iroh pairing code as a QR."
+  },
+  "irohQrBody": "Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.",
+  "@irohQrBody": {
+    "description": "Body text of the pairing-code QR sheet."
+  },
+  "irohQrCaution": "Anyone with this code can connect to your server.",
+  "@irohQrCaution": {
+    "description": "Caution line under the pairing QR — the code is a credential."
+  },
   "irohScanQr": "Scan QR",
   "@irohScanQr": {
     "description": "Button that opens the camera to scan an iroh pairing QR code."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2682,6 +2682,24 @@ abstract class AppLocalizations {
   /// **'Paste the code from the server Remote Access panel'**
   String get irohPairingCodeHint;
 
+  /// Server ⋮ menu action that displays the stored iroh pairing code as a QR.
+  ///
+  /// In en, this message translates to:
+  /// **'Show pairing code'**
+  String get irohShowPairingCode;
+
+  /// Body text of the pairing-code QR sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.'**
+  String get irohQrBody;
+
+  /// Caution line under the pairing QR — the code is a credential.
+  ///
+  /// In en, this message translates to:
+  /// **'Anyone with this code can connect to your server.'**
+  String get irohQrCaution;
+
   /// Button that opens the camera to scan an iroh pairing QR code.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1548,6 +1548,17 @@ class AppLocalizationsDe extends AppLocalizations {
       'Paste the code from the server Remote Access panel';
 
   @override
+  String get irohShowPairingCode => 'Show pairing code';
+
+  @override
+  String get irohQrBody =>
+      'Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.';
+
+  @override
+  String get irohQrCaution =>
+      'Anyone with this code can connect to your server.';
+
+  @override
   String get irohScanQr => 'Scan QR';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1529,6 +1529,17 @@ class AppLocalizationsEn extends AppLocalizations {
       'Paste the code from the server Remote Access panel';
 
   @override
+  String get irohShowPairingCode => 'Show pairing code';
+
+  @override
+  String get irohQrBody =>
+      'Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.';
+
+  @override
+  String get irohQrCaution =>
+      'Anyone with this code can connect to your server.';
+
+  @override
   String get irohScanQr => 'Scan QR';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1546,6 +1546,17 @@ class AppLocalizationsEs extends AppLocalizations {
       'Paste the code from the server Remote Access panel';
 
   @override
+  String get irohShowPairingCode => 'Show pairing code';
+
+  @override
+  String get irohQrBody =>
+      'Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.';
+
+  @override
+  String get irohQrCaution =>
+      'Anyone with this code can connect to your server.';
+
+  @override
   String get irohScanQr => 'Scan QR';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1546,6 +1546,17 @@ class AppLocalizationsFr extends AppLocalizations {
       'Paste the code from the server Remote Access panel';
 
   @override
+  String get irohShowPairingCode => 'Show pairing code';
+
+  @override
+  String get irohQrBody =>
+      'Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.';
+
+  @override
+  String get irohQrCaution =>
+      'Anyone with this code can connect to your server.';
+
+  @override
   String get irohScanQr => 'Scan QR';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1547,6 +1547,17 @@ class AppLocalizationsIt extends AppLocalizations {
       'Paste the code from the server Remote Access panel';
 
   @override
+  String get irohShowPairingCode => 'Show pairing code';
+
+  @override
+  String get irohQrBody =>
+      'Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.';
+
+  @override
+  String get irohQrCaution =>
+      'Anyone with this code can connect to your server.';
+
+  @override
   String get irohScanQr => 'Scan QR';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1485,6 +1485,17 @@ class AppLocalizationsJa extends AppLocalizations {
       'Paste the code from the server Remote Access panel';
 
   @override
+  String get irohShowPairingCode => 'Show pairing code';
+
+  @override
+  String get irohQrBody =>
+      'Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.';
+
+  @override
+  String get irohQrCaution =>
+      'Anyone with this code can connect to your server.';
+
+  @override
   String get irohScanQr => 'Scan QR';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1563,6 +1563,17 @@ class AppLocalizationsPl extends AppLocalizations {
       'Paste the code from the server Remote Access panel';
 
   @override
+  String get irohShowPairingCode => 'Show pairing code';
+
+  @override
+  String get irohQrBody =>
+      'Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.';
+
+  @override
+  String get irohQrCaution =>
+      'Anyone with this code can connect to your server.';
+
+  @override
   String get irohScanQr => 'Scan QR';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1543,6 +1543,17 @@ class AppLocalizationsPt extends AppLocalizations {
       'Paste the code from the server Remote Access panel';
 
   @override
+  String get irohShowPairingCode => 'Show pairing code';
+
+  @override
+  String get irohQrBody =>
+      'Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.';
+
+  @override
+  String get irohQrCaution =>
+      'Anyone with this code can connect to your server.';
+
+  @override
   String get irohScanQr => 'Scan QR';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1567,6 +1567,17 @@ class AppLocalizationsRu extends AppLocalizations {
       'Paste the code from the server Remote Access panel';
 
   @override
+  String get irohShowPairingCode => 'Show pairing code';
+
+  @override
+  String get irohQrBody =>
+      'Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.';
+
+  @override
+  String get irohQrCaution =>
+      'Anyone with this code can connect to your server.';
+
+  @override
   String get irohScanQr => 'Scan QR';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1455,6 +1455,17 @@ class AppLocalizationsZh extends AppLocalizations {
       'Paste the code from the server Remote Access panel';
 
   @override
+  String get irohShowPairingCode => 'Show pairing code';
+
+  @override
+  String get irohQrBody =>
+      'Scan with the mStream app on another device to connect it to this server, or copy the code and paste it there.';
+
+  @override
+  String get irohQrCaution =>
+      'Anyone with this code can connect to your server.';
+
+  @override
   String get irohScanQr => 'Scan QR';
 
   @override

--- a/lib/screens/manage_server.dart
+++ b/lib/screens/manage_server.dart
@@ -8,6 +8,7 @@ import '../singletons/server_list.dart';
 import '../native/iroh_tunnel.dart';
 import '../singletons/log_manager.dart';
 import '../theme/velvet_theme.dart';
+import '../widgets/iroh_pairing_qr_sheet.dart';
 import 'add_server.dart';
 
 class ManageServersScreen extends StatelessWidget {
@@ -84,9 +85,11 @@ class ManageServersScreen extends StatelessWidget {
     );
   }
 
-  // The per-row ⋮ overflow menu (Make Default / Info / Edit / Delete).
+  // The per-row ⋮ overflow menu (Make Default / Info / Pairing code / Edit /
+  // Delete).
   Widget _overflowMenu(BuildContext context, int index) {
     final l = AppLocalizations.of(context);
+    final Server server = ServerManager().serverList[index];
     return PopupMenuButton<String>(
       icon: Icon(Icons.more_vert, color: VelvetColors.textSecondary),
       color: VelvetColors.surface,
@@ -102,6 +105,9 @@ class ManageServersScreen extends StatelessWidget {
           case 'info':
             _showServerInfo(context, index);
             break;
+          case 'pairingCode':
+            showIrohPairingQrSheet(context, server.irohPairingCode!);
+            break;
           case 'delete':
             _showDeleteDialog(context, index);
             break;
@@ -112,6 +118,9 @@ class ManageServersScreen extends StatelessWidget {
         if (index != 0)
           _menuItem('default', Icons.arrow_upward_rounded, l.makeDefault),
         _menuItem('info', Icons.info_outline, l.info),
+        // Re-share this iroh server's pairing QR so another device can pair.
+        if (server.isIroh && server.irohPairingCode != null)
+          _menuItem('pairingCode', Icons.qr_code_2, l.irohShowPairingCode),
         _menuItem('edit', Icons.edit_outlined, l.edit),
         _menuItem('delete', Icons.delete_outline, l.delete,
             color: VelvetColors.error),

--- a/lib/widgets/iroh_pairing_qr_sheet.dart
+++ b/lib/widgets/iroh_pairing_qr_sheet.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+import '../l10n/app_localizations.dart';
+import '../theme/velvet_theme.dart';
+
+/// Shows an iroh server's stored composite pairing code as a scannable QR
+/// (plus copy-to-clipboard), so another device can pair without opening the
+/// server's Remote Access panel. Renders the same string the panel's QR
+/// encodes; it's a credential, so the sheet carries a caution line.
+Future<void> showIrohPairingQrSheet(BuildContext context, String code) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: VelvetColors.surface,
+    builder: (_) => _IrohPairingQrSheet(code: code),
+  );
+}
+
+class _IrohPairingQrSheet extends StatelessWidget {
+  const _IrohPairingQrSheet({required this.code});
+
+  final String code;
+
+  void _copy(BuildContext context) {
+    Clipboard.setData(ClipboardData(text: code));
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(AppLocalizations.of(context).copiedToClipboard)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    // Pairing codes are long (ticket + secret), so the QR is dense — keep it
+    // large, but inside the sheet width on narrow phones.
+    final double qrSize =
+        (MediaQuery.of(context).size.width - 104).clamp(160.0, 280.0);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(l.irohPairingCodeLabel,
+                style: TextStyle(
+                    color: VelvetColors.textPrimary,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700)),
+            const SizedBox(height: 6),
+            Text(
+              l.irohQrBody,
+              style: TextStyle(color: VelvetColors.textSecondary, fontSize: 13),
+            ),
+            const SizedBox(height: 14),
+            Center(
+              // White field so the QR scans against the dark theme.
+              child: Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius:
+                      BorderRadius.circular(VelvetColors.radiusSmall),
+                ),
+                child: QrImageView(
+                  data: code,
+                  size: qrSize,
+                  backgroundColor: Colors.white,
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              l.irohQrCaution,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: VelvetColors.warning, fontSize: 12),
+            ),
+            const SizedBox(height: 14),
+            OutlinedButton.icon(
+              style: OutlinedButton.styleFrom(
+                foregroundColor: VelvetColors.textPrimary,
+                side: BorderSide(color: VelvetColors.border2),
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                    borderRadius:
+                        BorderRadius.circular(VelvetColors.radiusSmall)),
+              ),
+              icon: const Icon(Icons.content_copy, size: 18),
+              label: Text(l.copy),
+              onPressed: () => _copy(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -739,6 +739,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  qr_flutter:
+    dependency: "direct main"
+    description:
+      name: qr_flutter
+      sha256: "5095f0fc6e3f71d08adef8feccc8cea4f12eec18a2e31c2e8d82cb6019f4b097"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   record_use:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,9 @@ dependencies:
   # QR scanning for iroh pairing codes (CameraX/ML Kit). Replaces the
   # long-removed flutter_barcode_scanner.
   mobile_scanner: ^7.2.0
+  # QR rendering (pure Dart) — shows an iroh server's stored pairing code so
+  # another device can scan it without opening the server admin panel.
+  qr_flutter: ^4.1.0
   # Network-change signal that kicks the iroh tunnel's reconnect — iroh can't
   # self-detect interface changes (Wi-Fi<->cellular) on Android.
   connectivity_plus: ^7.2.0


### PR DESCRIPTION
## What

Adds a **Show pairing code** action to the per-server ⋮ menu in Manage Servers (iroh servers only). It opens a bottom sheet rendering the stored composite pairing code (`mstr1:` envelope) as a QR on a white field, with a caution line (the code is a credential) and a Copy button for devices that paste instead of scan.

Use case: pair a new device (another phone, or the desktop app via copy/paste) by scanning the phone's screen, without opening the server's Remote Access panel. Works fully offline — `Server.irohPairingCode` stores the exact string the admin panel's QR encodes, and it stays valid until the connect secret is rotated.

## Changes

- `qr_flutter` dependency (pure Dart — no native libs, safe for both flavors and desktop)
- new `widgets/iroh_pairing_qr_sheet.dart`
- `Show pairing code` menu entry in `manage_server.dart`, gated on `isIroh` + non-null code
- 3 new l10n strings (English; other locales fall back per convention)

## Verification

- `flutter analyze` clean (only pre-existing infos), all 137 tests pass
- On-device smoke test (full-flavor debug build, Samsung over wireless adb):
  - iroh server row shows the new menu item; HTTP server row does not
  - sheet renders QR + caution + Copy; Copy writes the clipboard (system toast)
  - decoded the QR from an actual device screenshot with zxing: yields the exact `mstr1:…` pairing code (286 chars) — full render→scan round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)