### PR TITLE
feat: Sonic path builder — standalone journey setup with browse-to-pick endpoints

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -440,5 +440,16 @@
   "pathEndSong": "Zielsong",
   "pathLength": "Länge",
   "pathRegenerate": "Neu generieren",
-  "pathSaveAsPlaylist": "Als Playlist speichern"
+  "pathSaveAsPlaylist": "Als Playlist speichern",
+  "pathSetupHint": "Wähle einen Start- und einen Zielsong — die Reise dazwischen füllt sich von selbst.",
+  "pathNotSet": "Nicht gewählt",
+  "pathUsePlaying": "Laufenden Song verwenden",
+  "pathSearchSong": "Suchen",
+  "pathBrowseLibrary": "Bibliothek durchsuchen",
+  "pathBuild": "Reise erstellen",
+  "pathStartOver": "Neu beginnen",
+  "pathPickBannerStart": "Startsong wählen — tippe irgendwo in der Bibliothek auf einen Titel",
+  "pathPickBannerEnd": "Zielsong wählen — tippe irgendwo in der Bibliothek auf einen Titel",
+  "pathNothingPlaying": "Es läuft gerade nichts",
+  "pathPickOnServer": "Wähle einen Titel auf {server}"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1379,5 +1379,54 @@
   "pathSaveAsPlaylist": "Save as playlist",
   "@pathSaveAsPlaylist": {
     "description": "Tooltip/toast name of the action saving the generated path as a server playlist."
+  },
+  "pathSetupHint": "Pick a start and an end song — the journey between them fills itself.",
+  "@pathSetupHint": {
+    "description": "Explainer line at the top of the sonic path setup stage."
+  },
+  "pathNotSet": "Not set",
+  "@pathNotSet": {
+    "description": "Placeholder in an empty endpoint card before a song is chosen."
+  },
+  "pathUsePlaying": "Use playing song",
+  "@pathUsePlaying": {
+    "description": "Endpoint-card button that fills the card with the currently playing track."
+  },
+  "pathSearchSong": "Search",
+  "@pathSearchSong": {
+    "description": "Endpoint-card button that opens the song search sheet."
+  },
+  "pathBrowseLibrary": "Browse library",
+  "@pathBrowseLibrary": {
+    "description": "Endpoint-card button that arms browse-to-pick: the user browses the library and the next tapped track fills the card."
+  },
+  "pathBuild": "Build the journey",
+  "@pathBuild": {
+    "description": "Primary setup-stage button that fetches the path between the two chosen endpoints."
+  },
+  "pathStartOver": "Start over",
+  "@pathStartOver": {
+    "description": "Results-stage action that clears the journey and endpoints and returns to a pristine setup stage."
+  },
+  "pathPickBannerStart": "Pick the start song — tap a track anywhere in the library",
+  "@pathPickBannerStart": {
+    "description": "Home-browser banner while browse-to-pick is armed for the start endpoint."
+  },
+  "pathPickBannerEnd": "Pick the end song — tap a track anywhere in the library",
+  "@pathPickBannerEnd": {
+    "description": "Home-browser banner while browse-to-pick is armed for the end endpoint."
+  },
+  "pathNothingPlaying": "Nothing is playing",
+  "@pathNothingPlaying": {
+    "description": "Toast when Use-playing-song is tapped with an empty player."
+  },
+  "pathPickOnServer": "Pick a track on {server}",
+  "@pathPickOnServer": {
+    "description": "Toast when a browse-to-pick tap lands on a local file or another server's track; names the server the pick must come from.",
+    "placeholders": {
+      "server": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -440,5 +440,16 @@
   "pathEndSong": "Canción final",
   "pathLength": "Longitud",
   "pathRegenerate": "Regenerar",
-  "pathSaveAsPlaylist": "Guardar como lista"
+  "pathSaveAsPlaylist": "Guardar como lista",
+  "pathSetupHint": "Elige una canción de inicio y una de destino — el viaje entre ellas se completa solo.",
+  "pathNotSet": "Sin elegir",
+  "pathUsePlaying": "Usar la canción actual",
+  "pathSearchSong": "Buscar",
+  "pathBrowseLibrary": "Explorar biblioteca",
+  "pathBuild": "Crear el viaje",
+  "pathStartOver": "Empezar de nuevo",
+  "pathPickBannerStart": "Elige la canción de inicio — toca una pista en cualquier parte de la biblioteca",
+  "pathPickBannerEnd": "Elige la canción de destino — toca una pista en cualquier parte de la biblioteca",
+  "pathNothingPlaying": "No se está reproduciendo nada",
+  "pathPickOnServer": "Elige una pista en {server}"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -440,5 +440,16 @@
   "pathEndSong": "Chanson d'arrivée",
   "pathLength": "Longueur",
   "pathRegenerate": "Régénérer",
-  "pathSaveAsPlaylist": "Enregistrer comme playlist"
+  "pathSaveAsPlaylist": "Enregistrer comme playlist",
+  "pathSetupHint": "Choisis un morceau de départ et un d'arrivée — le voyage entre les deux se remplit tout seul.",
+  "pathNotSet": "Non défini",
+  "pathUsePlaying": "Utiliser le morceau en cours",
+  "pathSearchSong": "Rechercher",
+  "pathBrowseLibrary": "Parcourir la bibliothèque",
+  "pathBuild": "Créer le voyage",
+  "pathStartOver": "Recommencer",
+  "pathPickBannerStart": "Choisis le morceau de départ — touche une piste n'importe où dans la bibliothèque",
+  "pathPickBannerEnd": "Choisis le morceau d'arrivée — touche une piste n'importe où dans la bibliothèque",
+  "pathNothingPlaying": "Aucune lecture en cours",
+  "pathPickOnServer": "Choisis une piste sur {server}"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -440,5 +440,16 @@
   "pathEndSong": "Brano finale",
   "pathLength": "Lunghezza",
   "pathRegenerate": "Rigenera",
-  "pathSaveAsPlaylist": "Salva come playlist"
+  "pathSaveAsPlaylist": "Salva come playlist",
+  "pathSetupHint": "Scegli un brano di partenza e uno di arrivo — il viaggio tra i due si riempie da solo.",
+  "pathNotSet": "Non impostato",
+  "pathUsePlaying": "Usa il brano in riproduzione",
+  "pathSearchSong": "Cerca",
+  "pathBrowseLibrary": "Sfoglia la libreria",
+  "pathBuild": "Crea il viaggio",
+  "pathStartOver": "Ricomincia",
+  "pathPickBannerStart": "Scegli il brano di partenza — tocca una traccia ovunque nella libreria",
+  "pathPickBannerEnd": "Scegli il brano di arrivo — tocca una traccia ovunque nella libreria",
+  "pathNothingPlaying": "Nessuna riproduzione in corso",
+  "pathPickOnServer": "Scegli una traccia su {server}"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -440,5 +440,16 @@
   "pathEndSong": "終了曲",
   "pathLength": "長さ",
   "pathRegenerate": "再生成",
-  "pathSaveAsPlaylist": "プレイリストとして保存"
+  "pathSaveAsPlaylist": "プレイリストとして保存",
+  "pathSetupHint": "開始曲と目的曲を選ぶと、その間の旅路が自動で埋まります。",
+  "pathNotSet": "未設定",
+  "pathUsePlaying": "再生中の曲を使う",
+  "pathSearchSong": "検索",
+  "pathBrowseLibrary": "ライブラリを見る",
+  "pathBuild": "旅路を作成",
+  "pathStartOver": "最初からやり直す",
+  "pathPickBannerStart": "開始曲を選択 — ライブラリ内の好きな曲をタップ",
+  "pathPickBannerEnd": "目的曲を選択 — ライブラリ内の好きな曲をタップ",
+  "pathNothingPlaying": "再生中の曲がありません",
+  "pathPickOnServer": "{server} の曲を選んでください"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3209,6 +3209,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Save as playlist'**
   String get pathSaveAsPlaylist;
+
+  /// Explainer line at the top of the sonic path setup stage.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick a start and an end song — the journey between them fills itself.'**
+  String get pathSetupHint;
+
+  /// Placeholder in an empty endpoint card before a song is chosen.
+  ///
+  /// In en, this message translates to:
+  /// **'Not set'**
+  String get pathNotSet;
+
+  /// Endpoint-card button that fills the card with the currently playing track.
+  ///
+  /// In en, this message translates to:
+  /// **'Use playing song'**
+  String get pathUsePlaying;
+
+  /// Endpoint-card button that opens the song search sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get pathSearchSong;
+
+  /// Endpoint-card button that arms browse-to-pick: the user browses the library and the next tapped track fills the card.
+  ///
+  /// In en, this message translates to:
+  /// **'Browse library'**
+  String get pathBrowseLibrary;
+
+  /// Primary setup-stage button that fetches the path between the two chosen endpoints.
+  ///
+  /// In en, this message translates to:
+  /// **'Build the journey'**
+  String get pathBuild;
+
+  /// Results-stage action that clears the journey and endpoints and returns to a pristine setup stage.
+  ///
+  /// In en, this message translates to:
+  /// **'Start over'**
+  String get pathStartOver;
+
+  /// Home-browser banner while browse-to-pick is armed for the start endpoint.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick the start song — tap a track anywhere in the library'**
+  String get pathPickBannerStart;
+
+  /// Home-browser banner while browse-to-pick is armed for the end endpoint.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick the end song — tap a track anywhere in the library'**
+  String get pathPickBannerEnd;
+
+  /// Toast when Use-playing-song is tapped with an empty player.
+  ///
+  /// In en, this message translates to:
+  /// **'Nothing is playing'**
+  String get pathNothingPlaying;
+
+  /// Toast when a browse-to-pick tap lands on a local file or another server's track; names the server the pick must come from.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick a track on {server}'**
+  String pathPickOnServer(String server);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1849,4 +1849,42 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get pathSaveAsPlaylist => 'Als Playlist speichern';
+
+  @override
+  String get pathSetupHint =>
+      'Wähle einen Start- und einen Zielsong — die Reise dazwischen füllt sich von selbst.';
+
+  @override
+  String get pathNotSet => 'Nicht gewählt';
+
+  @override
+  String get pathUsePlaying => 'Laufenden Song verwenden';
+
+  @override
+  String get pathSearchSong => 'Suchen';
+
+  @override
+  String get pathBrowseLibrary => 'Bibliothek durchsuchen';
+
+  @override
+  String get pathBuild => 'Reise erstellen';
+
+  @override
+  String get pathStartOver => 'Neu beginnen';
+
+  @override
+  String get pathPickBannerStart =>
+      'Startsong wählen — tippe irgendwo in der Bibliothek auf einen Titel';
+
+  @override
+  String get pathPickBannerEnd =>
+      'Zielsong wählen — tippe irgendwo in der Bibliothek auf einen Titel';
+
+  @override
+  String get pathNothingPlaying => 'Es läuft gerade nichts';
+
+  @override
+  String pathPickOnServer(String server) {
+    return 'Wähle einen Titel auf $server';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1826,4 +1826,42 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get pathSaveAsPlaylist => 'Save as playlist';
+
+  @override
+  String get pathSetupHint =>
+      'Pick a start and an end song — the journey between them fills itself.';
+
+  @override
+  String get pathNotSet => 'Not set';
+
+  @override
+  String get pathUsePlaying => 'Use playing song';
+
+  @override
+  String get pathSearchSong => 'Search';
+
+  @override
+  String get pathBrowseLibrary => 'Browse library';
+
+  @override
+  String get pathBuild => 'Build the journey';
+
+  @override
+  String get pathStartOver => 'Start over';
+
+  @override
+  String get pathPickBannerStart =>
+      'Pick the start song — tap a track anywhere in the library';
+
+  @override
+  String get pathPickBannerEnd =>
+      'Pick the end song — tap a track anywhere in the library';
+
+  @override
+  String get pathNothingPlaying => 'Nothing is playing';
+
+  @override
+  String pathPickOnServer(String server) {
+    return 'Pick a track on $server';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1847,4 +1847,42 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get pathSaveAsPlaylist => 'Guardar como lista';
+
+  @override
+  String get pathSetupHint =>
+      'Elige una canción de inicio y una de destino — el viaje entre ellas se completa solo.';
+
+  @override
+  String get pathNotSet => 'Sin elegir';
+
+  @override
+  String get pathUsePlaying => 'Usar la canción actual';
+
+  @override
+  String get pathSearchSong => 'Buscar';
+
+  @override
+  String get pathBrowseLibrary => 'Explorar biblioteca';
+
+  @override
+  String get pathBuild => 'Crear el viaje';
+
+  @override
+  String get pathStartOver => 'Empezar de nuevo';
+
+  @override
+  String get pathPickBannerStart =>
+      'Elige la canción de inicio — toca una pista en cualquier parte de la biblioteca';
+
+  @override
+  String get pathPickBannerEnd =>
+      'Elige la canción de destino — toca una pista en cualquier parte de la biblioteca';
+
+  @override
+  String get pathNothingPlaying => 'No se está reproduciendo nada';
+
+  @override
+  String pathPickOnServer(String server) {
+    return 'Elige una pista en $server';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1846,4 +1846,42 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get pathSaveAsPlaylist => 'Enregistrer comme playlist';
+
+  @override
+  String get pathSetupHint =>
+      'Choisis un morceau de départ et un d\'arrivée — le voyage entre les deux se remplit tout seul.';
+
+  @override
+  String get pathNotSet => 'Non défini';
+
+  @override
+  String get pathUsePlaying => 'Utiliser le morceau en cours';
+
+  @override
+  String get pathSearchSong => 'Rechercher';
+
+  @override
+  String get pathBrowseLibrary => 'Parcourir la bibliothèque';
+
+  @override
+  String get pathBuild => 'Créer le voyage';
+
+  @override
+  String get pathStartOver => 'Recommencer';
+
+  @override
+  String get pathPickBannerStart =>
+      'Choisis le morceau de départ — touche une piste n\'importe où dans la bibliothèque';
+
+  @override
+  String get pathPickBannerEnd =>
+      'Choisis le morceau d\'arrivée — touche une piste n\'importe où dans la bibliothèque';
+
+  @override
+  String get pathNothingPlaying => 'Aucune lecture en cours';
+
+  @override
+  String pathPickOnServer(String server) {
+    return 'Choisis une piste sur $server';
+  }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1847,4 +1847,42 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get pathSaveAsPlaylist => 'Salva come playlist';
+
+  @override
+  String get pathSetupHint =>
+      'Scegli un brano di partenza e uno di arrivo — il viaggio tra i due si riempie da solo.';
+
+  @override
+  String get pathNotSet => 'Non impostato';
+
+  @override
+  String get pathUsePlaying => 'Usa il brano in riproduzione';
+
+  @override
+  String get pathSearchSong => 'Cerca';
+
+  @override
+  String get pathBrowseLibrary => 'Sfoglia la libreria';
+
+  @override
+  String get pathBuild => 'Crea il viaggio';
+
+  @override
+  String get pathStartOver => 'Ricomincia';
+
+  @override
+  String get pathPickBannerStart =>
+      'Scegli il brano di partenza — tocca una traccia ovunque nella libreria';
+
+  @override
+  String get pathPickBannerEnd =>
+      'Scegli il brano di arrivo — tocca una traccia ovunque nella libreria';
+
+  @override
+  String get pathNothingPlaying => 'Nessuna riproduzione in corso';
+
+  @override
+  String pathPickOnServer(String server) {
+    return 'Scegli una traccia su $server';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1776,4 +1776,39 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get pathSaveAsPlaylist => 'プレイリストとして保存';
+
+  @override
+  String get pathSetupHint => '開始曲と目的曲を選ぶと、その間の旅路が自動で埋まります。';
+
+  @override
+  String get pathNotSet => '未設定';
+
+  @override
+  String get pathUsePlaying => '再生中の曲を使う';
+
+  @override
+  String get pathSearchSong => '検索';
+
+  @override
+  String get pathBrowseLibrary => 'ライブラリを見る';
+
+  @override
+  String get pathBuild => '旅路を作成';
+
+  @override
+  String get pathStartOver => '最初からやり直す';
+
+  @override
+  String get pathPickBannerStart => '開始曲を選択 — ライブラリ内の好きな曲をタップ';
+
+  @override
+  String get pathPickBannerEnd => '目的曲を選択 — ライブラリ内の好きな曲をタップ';
+
+  @override
+  String get pathNothingPlaying => '再生中の曲がありません';
+
+  @override
+  String pathPickOnServer(String server) {
+    return '$server の曲を選んでください';
+  }
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1861,4 +1861,42 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get pathSaveAsPlaylist => 'Zapisz jako playlistę';
+
+  @override
+  String get pathSetupHint =>
+      'Wybierz utwór początkowy i docelowy — podróż między nimi wypełni się sama.';
+
+  @override
+  String get pathNotSet => 'Nie wybrano';
+
+  @override
+  String get pathUsePlaying => 'Użyj odtwarzanego utworu';
+
+  @override
+  String get pathSearchSong => 'Szukaj';
+
+  @override
+  String get pathBrowseLibrary => 'Przeglądaj bibliotekę';
+
+  @override
+  String get pathBuild => 'Utwórz podróż';
+
+  @override
+  String get pathStartOver => 'Zacznij od nowa';
+
+  @override
+  String get pathPickBannerStart =>
+      'Wybierz utwór początkowy — stuknij dowolny utwór w bibliotece';
+
+  @override
+  String get pathPickBannerEnd =>
+      'Wybierz utwór docelowy — stuknij dowolny utwór w bibliotece';
+
+  @override
+  String get pathNothingPlaying => 'Nic nie jest odtwarzane';
+
+  @override
+  String pathPickOnServer(String server) {
+    return 'Wybierz utwór na $server';
+  }
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1844,4 +1844,42 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get pathSaveAsPlaylist => 'Salvar como playlist';
+
+  @override
+  String get pathSetupHint =>
+      'Escolha uma música de início e uma de destino — a jornada entre elas se preenche sozinha.';
+
+  @override
+  String get pathNotSet => 'Não definido';
+
+  @override
+  String get pathUsePlaying => 'Usar a música em reprodução';
+
+  @override
+  String get pathSearchSong => 'Buscar';
+
+  @override
+  String get pathBrowseLibrary => 'Explorar biblioteca';
+
+  @override
+  String get pathBuild => 'Criar a jornada';
+
+  @override
+  String get pathStartOver => 'Começar de novo';
+
+  @override
+  String get pathPickBannerStart =>
+      'Escolha a música de início — toque em uma faixa em qualquer lugar da biblioteca';
+
+  @override
+  String get pathPickBannerEnd =>
+      'Escolha a música de destino — toque em uma faixa em qualquer lugar da biblioteca';
+
+  @override
+  String get pathNothingPlaying => 'Nada está tocando';
+
+  @override
+  String pathPickOnServer(String server) {
+    return 'Escolha uma faixa em $server';
+  }
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1864,4 +1864,42 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get pathSaveAsPlaylist => 'Сохранить как плейлист';
+
+  @override
+  String get pathSetupHint =>
+      'Выберите начальный и конечный трек — путь между ними заполнится сам.';
+
+  @override
+  String get pathNotSet => 'Не выбрано';
+
+  @override
+  String get pathUsePlaying => 'Текущий трек';
+
+  @override
+  String get pathSearchSong => 'Поиск';
+
+  @override
+  String get pathBrowseLibrary => 'Обзор библиотеки';
+
+  @override
+  String get pathBuild => 'Построить путь';
+
+  @override
+  String get pathStartOver => 'Начать заново';
+
+  @override
+  String get pathPickBannerStart =>
+      'Выберите начальный трек — коснитесь любого трека в библиотеке';
+
+  @override
+  String get pathPickBannerEnd =>
+      'Выберите конечный трек — коснитесь любого трека в библиотеке';
+
+  @override
+  String get pathNothingPlaying => 'Сейчас ничего не играет';
+
+  @override
+  String pathPickOnServer(String server) {
+    return 'Выберите трек на $server';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1738,4 +1738,39 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get pathSaveAsPlaylist => '保存为播放列表';
+
+  @override
+  String get pathSetupHint => '选择起点和终点歌曲——两者之间的旅程会自动填充。';
+
+  @override
+  String get pathNotSet => '未设置';
+
+  @override
+  String get pathUsePlaying => '使用正在播放的歌曲';
+
+  @override
+  String get pathSearchSong => '搜索';
+
+  @override
+  String get pathBrowseLibrary => '浏览曲库';
+
+  @override
+  String get pathBuild => '生成旅程';
+
+  @override
+  String get pathStartOver => '重新开始';
+
+  @override
+  String get pathPickBannerStart => '选择起点歌曲——在曲库中点按任意曲目';
+
+  @override
+  String get pathPickBannerEnd => '选择终点歌曲——在曲库中点按任意曲目';
+
+  @override
+  String get pathNothingPlaying => '当前没有播放内容';
+
+  @override
+  String pathPickOnServer(String server) {
+    return '请选择 $server 上的曲目';
+  }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -440,5 +440,16 @@
   "pathEndSong": "Utwór końcowy",
   "pathLength": "Długość",
   "pathRegenerate": "Wygeneruj ponownie",
-  "pathSaveAsPlaylist": "Zapisz jako playlistę"
+  "pathSaveAsPlaylist": "Zapisz jako playlistę",
+  "pathSetupHint": "Wybierz utwór początkowy i docelowy — podróż między nimi wypełni się sama.",
+  "pathNotSet": "Nie wybrano",
+  "pathUsePlaying": "Użyj odtwarzanego utworu",
+  "pathSearchSong": "Szukaj",
+  "pathBrowseLibrary": "Przeglądaj bibliotekę",
+  "pathBuild": "Utwórz podróż",
+  "pathStartOver": "Zacznij od nowa",
+  "pathPickBannerStart": "Wybierz utwór początkowy — stuknij dowolny utwór w bibliotece",
+  "pathPickBannerEnd": "Wybierz utwór docelowy — stuknij dowolny utwór w bibliotece",
+  "pathNothingPlaying": "Nic nie jest odtwarzane",
+  "pathPickOnServer": "Wybierz utwór na {server}"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -440,5 +440,16 @@
   "pathEndSong": "Música final",
   "pathLength": "Comprimento",
   "pathRegenerate": "Gerar novamente",
-  "pathSaveAsPlaylist": "Salvar como playlist"
+  "pathSaveAsPlaylist": "Salvar como playlist",
+  "pathSetupHint": "Escolha uma música de início e uma de destino — a jornada entre elas se preenche sozinha.",
+  "pathNotSet": "Não definido",
+  "pathUsePlaying": "Usar a música em reprodução",
+  "pathSearchSong": "Buscar",
+  "pathBrowseLibrary": "Explorar biblioteca",
+  "pathBuild": "Criar a jornada",
+  "pathStartOver": "Começar de novo",
+  "pathPickBannerStart": "Escolha a música de início — toque em uma faixa em qualquer lugar da biblioteca",
+  "pathPickBannerEnd": "Escolha a música de destino — toque em uma faixa em qualquer lugar da biblioteca",
+  "pathNothingPlaying": "Nada está tocando",
+  "pathPickOnServer": "Escolha uma faixa em {server}"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -440,5 +440,16 @@
   "pathEndSong": "Конечная песня",
   "pathLength": "Длина",
   "pathRegenerate": "Пересоздать",
-  "pathSaveAsPlaylist": "Сохранить как плейлист"
+  "pathSaveAsPlaylist": "Сохранить как плейлист",
+  "pathSetupHint": "Выберите начальный и конечный трек — путь между ними заполнится сам.",
+  "pathNotSet": "Не выбрано",
+  "pathUsePlaying": "Текущий трек",
+  "pathSearchSong": "Поиск",
+  "pathBrowseLibrary": "Обзор библиотеки",
+  "pathBuild": "Построить путь",
+  "pathStartOver": "Начать заново",
+  "pathPickBannerStart": "Выберите начальный трек — коснитесь любого трека в библиотеке",
+  "pathPickBannerEnd": "Выберите конечный трек — коснитесь любого трека в библиотеке",
+  "pathNothingPlaying": "Сейчас ничего не играет",
+  "pathPickOnServer": "Выберите трек на {server}"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -440,5 +440,16 @@
   "pathEndSong": "结束歌曲",
   "pathLength": "长度",
   "pathRegenerate": "重新生成",
-  "pathSaveAsPlaylist": "保存为播放列表"
+  "pathSaveAsPlaylist": "保存为播放列表",
+  "pathSetupHint": "选择起点和终点歌曲——两者之间的旅程会自动填充。",
+  "pathNotSet": "未设置",
+  "pathUsePlaying": "使用正在播放的歌曲",
+  "pathSearchSong": "搜索",
+  "pathBrowseLibrary": "浏览曲库",
+  "pathBuild": "生成旅程",
+  "pathStartOver": "重新开始",
+  "pathPickBannerStart": "选择起点歌曲——在曲库中点按任意曲目",
+  "pathPickBannerEnd": "选择终点歌曲——在曲库中点按任意曲目",
+  "pathNothingPlaying": "当前没有播放内容",
+  "pathPickOnServer": "请选择 {server} 上的曲目"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,9 @@ import 'singletons/migration_manager.dart';
 import 'screens/add_server.dart';
 import 'screens/manage_server.dart';
 import 'screens/settings_screen.dart';
+import 'screens/sonic_path_screen.dart';
+import 'singletons/sonic_path_state.dart';
+import 'singletons/track_capture.dart';
 import 'screens/diagnostics_screen.dart';
 import 'screens/transcode_screen.dart';
 import 'screens/share_playlist_dialog.dart';
@@ -393,6 +396,36 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
     );
   }
 
+  // Browse-to-pick strip for the sonic path setup — visible while a
+  // TrackCapture request is armed: the next library track tapped fills the
+  // endpoint card. Cancel returns to the (state-preserving) path screen.
+  Widget _captureBanner() {
+    return ValueListenableBuilder<TrackCaptureRequest?>(
+      valueListenable: TrackCapture.active,
+      builder: (context, req, _) {
+        if (req == null) return const SizedBox.shrink();
+        final l = AppLocalizations.of(context);
+        return _bannerStrip(
+          Icons.route,
+          VelvetColors.primary,
+          req.isStart ? l.pathPickBannerStart : l.pathPickBannerEnd,
+          action: TextButton(
+            onPressed: () {
+              TrackCapture.cancel();
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (context) => const SonicPathScreen()),
+              );
+            },
+            child: Text(l.cancel,
+                style: TextStyle(color: VelvetColors.primary)),
+          ),
+        );
+      },
+    );
+  }
+
   // Thin banner above the tabs showing a background storage move's progress
   // (and resumed moves after an app restart). Hidden when none is running.
   Widget _migrationBanner() {
@@ -674,6 +707,7 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
       body: Column(children: [
         _migrationBanner(),
         _tunnelBanner(),
+        _captureBanner(),
         Expanded(
           child: Padding(
             padding: EdgeInsets.only(
@@ -792,6 +826,33 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
             Navigator.push(
               context,
               MaterialPageRoute(builder: (context) => AutoDJScreen()),
+            );
+          },
+        ),
+        // Sonic path — the journey builder between two tracks. Rendered only
+        // when the current server's ping advertised the route (mStream
+        // #762); the StreamBuilder keeps the tile honest across server
+        // switches.
+        StreamBuilder<Server?>(
+          stream: ServerManager().currentServerStream,
+          initialData: ServerManager().currentServer,
+          builder: (context, snap) {
+            final s = snap.data;
+            if (s == null || s.discoveryPathAvailable != true) {
+              return const SizedBox.shrink();
+            }
+            return ListTile(
+              leading: Icon(Icons.route),
+              title: Text(l.pathScreenTitle),
+              onTap: () {
+                Navigator.of(context).pop();
+                SonicPathState().beginSetup(s);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => const SonicPathScreen()),
+                );
+              },
             );
           },
         ),

--- a/lib/screens/album_detail_view.dart
+++ b/lib/screens/album_detail_view.dart
@@ -16,10 +16,12 @@ import 'package:rxdart/rxdart.dart';
 import '../l10n/app_localizations.dart';
 import '../objects/display_item.dart';
 import '../screens/discover_screen.dart';
+import '../screens/sonic_path_screen.dart';
 import '../singletons/api.dart';
 import '../singletons/browser_list.dart';
 import '../singletons/media.dart';
 import '../singletons/settings.dart';
+import '../singletons/track_capture.dart';
 import '../theme/velvet_theme.dart';
 import '../util/ambient_color.dart';
 import '../util/media_format.dart';
@@ -177,10 +179,24 @@ class _AlbumDetailViewState extends State<AlbumDetailView> {
   }
 
   // Row tap: defer to the shared TapBehavior setting (the same one the file
-  // browser uses). A pure add-to-queue shows a confirmation toast.
+  // browser uses). A pure add-to-queue shows a confirmation toast. An armed
+  // sonic-path pick eats the tap first — nothing may queue mid-pick.
   Future<void> _onRowTap(int index) async {
     final songs = _songs;
-    if (songs == null) return;
+    if (songs == null || index < 0 || index >= songs.length) return;
+    switch (TrackCapture.tryCapture(songs[index])) {
+      case CaptureResult.captured:
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => const SonicPathScreen()),
+        );
+        return;
+      case CaptureResult.rejected:
+        showCaptureRejectedToast(context);
+        return;
+      case CaptureResult.pass:
+        break;
+    }
     if (await handleTrackTap(songs, index)) _toast();
   }
 

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -17,9 +17,11 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import '../widgets/track_actions_sheet.dart';
 
 import '../singletons/media.dart';
+import '../singletons/track_capture.dart';
 import '../util/queue_actions.dart';
 
 import 'add_server.dart';
+import 'sonic_path_screen.dart';
 
 class Browser extends StatefulWidget {
   const Browser({super.key});
@@ -135,6 +137,9 @@ class _BrowserState extends State<Browser> {
     }
 
     if (browserList[index].type == 'file') {
+      // An armed sonic-path pick eats the tap BEFORE tap-behavior dispatch
+      // — nothing may queue (or play-from-here) mid-pick.
+      if (_captureTap(browserList[index], context)) return;
       if (SettingsManager().tapBehavior == TapBehavior.playFromHere) {
         _playFromHere(browserList, index);
       } else {
@@ -150,12 +155,34 @@ class _BrowserState extends State<Browser> {
     }
 
     if (browserList[index].type == 'localFile') {
+      // Local files can't seed the server's index — an armed pick rejects
+      // them (toast) instead of queueing.
+      if (_captureTap(browserList[index], context)) return;
       if (SettingsManager().tapBehavior == TapBehavior.playFromHere) {
         _playFromHere(browserList, index);
       } else {
         addLocalFile(browserList[index]);
       }
       return;
+    }
+  }
+
+  /// True when an armed TrackCapture consumed the tap: a captured pick
+  /// returns to the sonic path screen (its state already holds the song),
+  /// a rejected one toasts and stays armed.
+  bool _captureTap(DisplayItem item, BuildContext context) {
+    switch (TrackCapture.tryCapture(item)) {
+      case CaptureResult.captured:
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => const SonicPathScreen()),
+        );
+        return true;
+      case CaptureResult.rejected:
+        showCaptureRejectedToast(context);
+        return true;
+      case CaptureResult.pass:
+        return false;
     }
   }
 

--- a/lib/screens/discover_screen.dart
+++ b/lib/screens/discover_screen.dart
@@ -14,8 +14,10 @@ import '../singletons/auto_dj_manager.dart';
 import '../singletons/media.dart';
 import '../singletons/server_list.dart';
 import '../singletons/settings.dart';
+import '../singletons/sonic_path_state.dart';
 import '../theme/velvet_theme.dart';
 import '../util/queue_actions.dart';
+import '../util/stream_url.dart';
 import '../widgets/song_picker_sheet.dart';
 import 'sonic_path_screen.dart';
 
@@ -459,16 +461,19 @@ class _DiscoverScreenState extends State<DiscoverScreen> {
     );
     final destPath = dest?.data;
     if (dest == null || destPath == null || !mounted) return;
-    Navigator.of(context).push(MaterialPageRoute(
-      builder: (_) => SonicPathScreen(
-        server: server,
-        startPath: path,
-        startTitle: _seedTitle,
-        startArtist: _seedArtist,
-        endPath: destPath,
-        endTitle: dest.metadata?.title ?? destPath.split('/').last,
-        endArtist: dest.metadata?.artist,
+    final destArt = dest.altAlbumArt ?? dest.metadata?.albumArt;
+    SonicPathState().beginJourney(
+      server,
+      SonicPathEndpoint(path, title: _seedTitle, artist: _seedArtist),
+      SonicPathEndpoint(
+        destPath,
+        title: dest.metadata?.title ?? destPath.split('/').last,
+        artist: dest.metadata?.artist,
+        artUrl: destArt == null ? null : buildAlbumArtUrl(server, destArt),
       ),
+    );
+    Navigator.of(context).push(MaterialPageRoute(
+      builder: (_) => const SonicPathScreen(autoBuild: true),
     ));
   }
 

--- a/lib/screens/sonic_path_screen.dart
+++ b/lib/screens/sonic_path_screen.dart
@@ -5,65 +5,49 @@ import '../objects/discovery.dart';
 import '../objects/display_item.dart';
 import '../objects/server.dart';
 import '../singletons/api.dart';
+import '../singletons/media.dart';
+import '../singletons/sonic_path_state.dart';
+import '../singletons/track_capture.dart';
 import '../theme/velvet_theme.dart';
 import '../util/queue_actions.dart';
+import '../util/stream_url.dart';
 import '../widgets/playlist_picker_sheet.dart';
 import '../widgets/song_picker_sheet.dart';
 import 'discover_screen.dart' show MatchMeter;
 
 /// Sonic path — the ordered "journey" between two tracks
 /// (POST /api/v1/discovery/local/path, mStream #762+): waypoints along the
-/// arc between the seeds' embeddings, snapped to real library tracks. A
-/// preview-first screen: the user sees the whole arc (start → rows → end)
-/// before committing, then Play (replaces the queue), Queue all (appends)
-/// or Save as playlist. The launch args only seed the first fetch — both
-/// endpoints are editable in place (chip tap → repick → rebuild) and the
-/// length slider stays local until Regenerate, so the current list is
-/// never yanked away mid-look (webapp parity).
+/// arc between the seeds' embeddings, snapped to real library tracks.
+///
+/// Two stages, webapp parity (alpha/m.js SONICPATH). Setup: a Start and an
+/// End card — filled from the playing track, the search sheet, or by
+/// browsing the library (TrackCapture) — plus the length slider and Build.
+/// Results: the preview arc (seed rows accented, waypoints wearing match
+/// meters) with Play / Queue all / Save as playlist pinned below, endpoints
+/// editable in place, and Start over back to a pristine setup. All setup
+/// state lives in [SonicPathState] because browse-to-pick tears this route
+/// down and re-pushes it after the captured tap.
 class SonicPathScreen extends StatefulWidget {
-  final Server server;
-  final String startPath;
-  final String? startTitle;
-  final String? startArtist;
-  final String endPath;
-  final String? endTitle;
-  final String? endArtist;
+  /// True on the Discover "Play a path to…" flow: the state's endpoints are
+  /// complete, skip setup and build immediately. Every other entry (drawer,
+  /// capture round-trip) opens on the setup stage.
+  final bool autoBuild;
 
-  const SonicPathScreen({
-    super.key,
-    required this.server,
-    required this.startPath,
-    this.startTitle,
-    this.startArtist,
-    required this.endPath,
-    this.endTitle,
-    this.endArtist,
-  });
+  const SonicPathScreen({super.key, this.autoBuild = false});
 
   @override
   State<SonicPathScreen> createState() => _SonicPathScreenState();
 }
 
 class _SonicPathScreenState extends State<SonicPathScreen> {
-  bool _loading = true;
+  SonicPathState get _s => SonicPathState();
+  Server get _server => _s.server!;
+
+  bool _showResults = false;
+  bool _loading = false;
   bool _failed = false;
   DiscoveryPath? _path;
   List<DisplayItem> _rows = const [];
-
-  // Editable endpoints, seeded from the launch args. Kept as plain state so
-  // a repick (or a not-analyzed dead end) can be fixed without backing out
-  // to the Discover screen.
-  late String _startPath = widget.startPath;
-  late String? _startTitle = widget.startTitle;
-  late String? _startArtist = widget.startArtist;
-  late String _endPath = widget.endPath;
-  late String? _endTitle = widget.endTitle;
-  late String? _endArtist = widget.endArtist;
-
-  /// Requested total rows including both seeds (server default 14, valid
-  /// 4..32). Slider moves are local; only Regenerate (or an endpoint
-  /// change) refetches with it.
-  int _length = 14;
 
   // Repick/Regenerate can overlap an in-flight fetch; last request wins.
   int _reqId = 0;
@@ -71,18 +55,25 @@ class _SonicPathScreenState extends State<SonicPathScreen> {
   @override
   void initState() {
     super.initState();
-    _load();
+    // A stale armed pick (drawer re-entry over a live banner) would capture
+    // the next browse tap after this screen closes again — drop it.
+    TrackCapture.cancel();
+    if (widget.autoBuild && _s.ready) {
+      _showResults = true;
+      _load();
+    }
   }
 
   Future<void> _load() async {
+    if (!_s.ready) return;
     final rid = ++_reqId;
     setState(() {
       _loading = true;
       _failed = false;
     });
     final r = await ApiManager().fetchDiscoveryPath(
-        widget.server, _startPath, _endPath,
-        length: _length);
+        _server, _s.start!.path, _s.end!.path,
+        length: _s.length);
     if (!mounted || rid != _reqId) return;
     setState(() {
       _loading = false;
@@ -94,34 +85,55 @@ class _SonicPathScreenState extends State<SonicPathScreen> {
       _path = r.data;
       final results = r.data!.results;
       _rows = results.map((t) {
-        final row = DisplayItem(widget.server, t.filepath, 'file',
-            '/${t.filepath}', null, null);
+        final row =
+            DisplayItem(_server, t.filepath, 'file', '/${t.filepath}', null, null);
         row.metadata = t.metadata;
         return row;
       }).toList();
-      // The chips show whatever the picker knew; the seed rows carry the
+      // The cards show whatever the picker knew; the seed rows carry the
       // server's own metadata — backfill so a filename-titled pick heals.
       if (results.isNotEmpty) {
         final start = results.first.metadata;
         if ((start?.title ?? '').trim().isNotEmpty) {
-          _startTitle = start!.title;
-          _startArtist = start.artist ?? _startArtist;
+          _s.start!.title = start!.title;
+          _s.start!.artist = start.artist ?? _s.start!.artist;
         }
         if (results.length > 1) {
           final end = results.last.metadata;
           if ((end?.title ?? '').trim().isNotEmpty) {
-            _endTitle = end!.title;
-            _endArtist = end.artist ?? _endArtist;
+            _s.end!.title = end!.title;
+            _s.end!.artist = end.artist ?? _s.end!.artist;
           }
         }
       }
     });
   }
 
-  /// Chip tap → shared song picker → endpoint swap. An endpoint change
-  /// rebuilds immediately (unlike length, which waits for Regenerate) —
-  /// the old journey is wrong the moment its anchor moved.
-  Future<void> _repick({required bool isStart}) async {
+  SonicPathEndpoint _endpointFromItem(DisplayItem item) {
+    final art = item.altAlbumArt ?? item.metadata?.albumArt;
+    return SonicPathEndpoint(
+      item.data!,
+      title: item.metadata?.title ?? item.name.split('/').last,
+      artist: item.metadata?.artist,
+      artUrl: art == null ? null : buildAlbumArtUrl(_server, art),
+    );
+  }
+
+  void _setEndpoint(bool isStart, SonicPathEndpoint? ep) {
+    setState(() {
+      if (isStart) {
+        _s.start = ep;
+      } else {
+        _s.end = ep;
+      }
+    });
+  }
+
+  /// Search-sheet pick — the setup cards' Search button and the results
+  /// stage's chip tap. An endpoint change in results rebuilds immediately
+  /// (unlike length, which waits for Regenerate) — the old journey is wrong
+  /// the moment its anchor moved.
+  Future<void> _pickViaSearch({required bool isStart}) async {
     final l = AppLocalizations.of(context);
     final pick = await showModalBottomSheet<DisplayItem>(
       context: context,
@@ -131,25 +143,91 @@ class _SonicPathScreenState extends State<SonicPathScreen> {
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
       builder: (_) => SongPickerSheet(
-        server: widget.server,
+        server: _server,
         title: isStart ? l.pathStartSong : l.pathEndSong,
       ),
     );
-    final path = pick?.data;
-    if (pick == null || path == null || !mounted) return;
-    setState(() {
-      final title = pick.metadata?.title ?? path.split('/').last;
-      if (isStart) {
-        _startPath = path;
-        _startTitle = title;
-        _startArtist = pick.metadata?.artist;
-      } else {
-        _endPath = path;
-        _endTitle = title;
-        _endArtist = pick.metadata?.artist;
-      }
-    });
+    if (pick == null || pick.data == null || !mounted) return;
+    _setEndpoint(isStart, _endpointFromItem(pick));
+    if (_showResults) _load();
+  }
+
+  /// Browse-to-pick: arm the capture and drop back to the home browser —
+  /// the banner up there carries the instructions, and the tap site
+  /// re-pushes this screen once a track lands (state survives in
+  /// [SonicPathState], so the card is filled on return).
+  void _pickViaBrowse({required bool isStart}) {
+    final server = _server;
+    TrackCapture.arm(TrackCaptureRequest(
+      server: server,
+      isStart: isStart,
+      onPicked: (item) {
+        // Runs after this State is disposed — write the singleton only.
+        final art = item.altAlbumArt ?? item.metadata?.albumArt;
+        final ep = SonicPathEndpoint(
+          item.data!,
+          title: item.metadata?.title ?? item.name.split('/').last,
+          artist: item.metadata?.artist,
+          artUrl: art == null ? null : buildAlbumArtUrl(server, art),
+        );
+        if (isStart) {
+          SonicPathState().start = ep;
+        } else {
+          SonicPathState().end = ep;
+        }
+      },
+    ));
+    Navigator.of(context).pop();
+  }
+
+  void _usePlaying({required bool isStart}) {
+    final l = AppLocalizations.of(context);
+    final item = MediaManager().audioHandler.mediaItem.value;
+    final extras = item?.extras;
+    final path = extras?['path'] as String?;
+    if (item == null || path == null) {
+      _snack(l.pathNothingPlaying);
+      return;
+    }
+    // Local-only items carry no server; other servers can't seed this one's
+    // index. Same guard the webapp applies to federated tracks.
+    if (extras?['server'] != _server.localname) {
+      _snack(l.pathPickOnServer(_server.localname));
+      return;
+    }
+    _setEndpoint(
+        isStart,
+        SonicPathEndpoint(path,
+            title: item.title,
+            artist: item.artist,
+            artUrl: extras?['artUrl'] as String?));
+  }
+
+  void _build() {
+    if (!_s.ready) return;
+    setState(() => _showResults = true);
     _load();
+  }
+
+  /// Start over — drop the journey and the endpoints, back to a pristine
+  /// setup on the same server (webapp parity).
+  void _startOver() {
+    _reqId++; // orphan any in-flight fetch
+    _s.reset();
+    setState(() {
+      _showResults = false;
+      _loading = false;
+      _failed = false;
+      _path = null;
+      _rows = const [];
+    });
+  }
+
+  void _snack(String text) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(text),
+      behavior: SnackBarBehavior.floating,
+    ));
   }
 
   Future<void> _play() async {
@@ -185,17 +263,17 @@ class _SonicPathScreenState extends State<SonicPathScreen> {
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
-      builder: (_) => PlaylistPickerSheet(server: widget.server),
+      builder: (_) => PlaylistPickerSheet(server: _server),
     );
     final playlist = name?.trim();
     if (playlist == null || playlist.isEmpty || !mounted) return;
     try {
-      await ApiManager().savePlaylist(widget.server, playlist,
-          [for (final t in path.results) t.filepath]);
+      await ApiManager().savePlaylist(
+          _server, playlist, [for (final t in path.results) t.filepath]);
       // Keep pickers fresh before the next ping refreshes the server's
       // playlist list.
-      if (!widget.server.playlists.contains(playlist)) {
-        widget.server.playlists.add(playlist);
+      if (!_server.playlists.contains(playlist)) {
+        _server.playlists.add(playlist);
       }
       messenger.showSnackBar(SnackBar(
         content: Text(l.addedToPlaylist(playlist)),
@@ -212,8 +290,13 @@ class _SonicPathScreenState extends State<SonicPathScreen> {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
+    // Every entry point binds the server before pushing; a bare push (hot
+    // reload edge) has nothing to build against.
+    if (_s.server == null) {
+      return Scaffold(backgroundColor: VelvetColors.bg);
+    }
     final path = _path;
-    final hasRows = path != null && path.results.isNotEmpty;
+    final hasRows = _showResults && path != null && path.results.isNotEmpty;
 
     return Scaffold(
       backgroundColor: VelvetColors.bg,
@@ -232,17 +315,27 @@ class _SonicPathScreenState extends State<SonicPathScreen> {
             fontWeight: FontWeight.w600,
           ),
         ),
-      ),
-      // Endpoint chips + length controls stay visible in every body state:
-      // a failed or not-analyzed journey is fixed by editing them, not by
-      // leaving the screen.
-      body: Column(
-        children: [
-          _endpointsRow(l),
-          _lengthRow(l),
-          Expanded(child: _body(l)),
+        actions: [
+          if (_showResults)
+            IconButton(
+              icon: const Icon(Icons.restart_alt, size: 22),
+              tooltip: l.pathStartOver,
+              onPressed: _startOver,
+            ),
         ],
       ),
+      body: _showResults
+          // Endpoint chips + length controls stay visible in every result
+          // state: a failed or not-analyzed journey is fixed by editing
+          // them, not by leaving the screen.
+          ? Column(
+              children: [
+                _endpointsRow(l),
+                _lengthRow(l, withRegen: true),
+                Expanded(child: _resultsBody(l)),
+              ],
+            )
+          : _setupBody(l),
       // Play / Queue all / Save — pinned so the arc scrolls under them.
       bottomNavigationBar: hasRows
           ? SafeArea(
@@ -296,6 +389,191 @@ class _SonicPathScreenState extends State<SonicPathScreen> {
     );
   }
 
+  // ── setup stage ──
+
+  Widget _setupBody(AppLocalizations l) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+      children: [
+        Text(
+          l.pathSetupHint,
+          style: TextStyle(color: VelvetColors.textSecondary, fontSize: 13),
+        ),
+        const SizedBox(height: 14),
+        _setupCard(l, isStart: true),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6),
+          child:
+              Icon(Icons.south, size: 18, color: VelvetColors.textSecondary),
+        ),
+        _setupCard(l, isStart: false),
+        const SizedBox(height: 6),
+        _lengthRow(l, withRegen: false, inset: false),
+        const SizedBox(height: 10),
+        FilledButton.icon(
+          icon: const Icon(Icons.route, size: 20),
+          label: Text(l.pathBuild),
+          style: FilledButton.styleFrom(
+            backgroundColor: VelvetColors.primary,
+            foregroundColor: VelvetColors.bg,
+            disabledBackgroundColor: VelvetColors.raised,
+            disabledForegroundColor: VelvetColors.textSecondary,
+            padding: const EdgeInsets.symmetric(vertical: 14),
+          ),
+          onPressed: _s.ready ? _build : null,
+        ),
+      ],
+    );
+  }
+
+  Widget _setupCard(AppLocalizations l, {required bool isStart}) {
+    final ep = isStart ? _s.start : _s.end;
+    return Material(
+      color: VelvetColors.raised,
+      borderRadius: BorderRadius.circular(VelvetColors.radiusLarge),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(14, 12, 8, 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  isStart ? Icons.trip_origin : Icons.flag,
+                  size: 16,
+                  color: VelvetColors.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  isStart ? l.pathStartSong : l.pathEndSong,
+                  style: TextStyle(
+                    color: VelvetColors.textSecondary,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: 0.4,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            if (ep == null) ...[
+              Padding(
+                padding: const EdgeInsets.only(bottom: 10, right: 6),
+                child: Text(
+                  l.pathNotSet,
+                  style: TextStyle(
+                      color: VelvetColors.textSecondary,
+                      fontSize: 13,
+                      fontStyle: FontStyle.italic),
+                ),
+              ),
+              // A filled card hides these — a settled decision (webapp
+              // parity); the ✕ below reopens it.
+              Padding(
+                padding: const EdgeInsets.only(right: 6),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    _cardButton(Icons.play_circle_outline, l.pathUsePlaying,
+                        () => _usePlaying(isStart: isStart)),
+                    _cardButton(Icons.search, l.pathSearchSong,
+                        () => _pickViaSearch(isStart: isStart)),
+                    _cardButton(Icons.library_music_outlined,
+                        l.pathBrowseLibrary,
+                        () => _pickViaBrowse(isStart: isStart)),
+                  ],
+                ),
+              ),
+            ] else
+              Row(
+                children: [
+                  _endpointArt(ep),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          (ep.title?.trim().isNotEmpty ?? false)
+                              ? ep.title!
+                              : ep.path.split('/').last,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: VelvetColors.textPrimary,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        if (ep.artist?.trim().isNotEmpty ?? false)
+                          Text(
+                            ep.artist!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                                color: VelvetColors.textSecondary,
+                                fontSize: 12),
+                          ),
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close, size: 18),
+                    color: VelvetColors.textSecondary,
+                    onPressed: () => _setEndpoint(isStart, null),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _cardButton(IconData icon, String label, VoidCallback onPressed) {
+    return OutlinedButton.icon(
+      icon: Icon(icon, size: 16),
+      label: Text(label, style: const TextStyle(fontSize: 12)),
+      style: OutlinedButton.styleFrom(
+        foregroundColor: VelvetColors.primary,
+        side: BorderSide(color: VelvetColors.border2),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      ),
+      onPressed: onPressed,
+    );
+  }
+
+  Widget _endpointArt(SonicPathEndpoint ep) {
+    final radius = BorderRadius.circular(VelvetColors.radiusSmall);
+    if (ep.artUrl != null) {
+      return ClipRRect(
+        borderRadius: radius,
+        child: Image.network(
+          ep.artUrl!,
+          width: 44,
+          height: 44,
+          fit: BoxFit.cover,
+          errorBuilder: (_, _, _) => _artPlaceholder(radius),
+        ),
+      );
+    }
+    return _artPlaceholder(radius);
+  }
+
+  Widget _artPlaceholder(BorderRadius radius) => Container(
+        width: 44,
+        height: 44,
+        decoration:
+            BoxDecoration(color: VelvetColors.surface, borderRadius: radius),
+        child: Icon(Icons.music_note,
+            size: 20, color: VelvetColors.textSecondary),
+      );
+
+  // ── results stage ──
+
   Widget _endpointsRow(AppLocalizations l) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
@@ -314,15 +592,16 @@ class _SonicPathScreenState extends State<SonicPathScreen> {
   }
 
   Widget _endpointChip(AppLocalizations l, {required bool isStart}) {
-    final title = (isStart ? _startTitle : _endTitle)?.trim();
-    final artist = (isStart ? _startArtist : _endArtist)?.trim();
-    final fallback = (isStart ? _startPath : _endPath).split('/').last;
+    final ep = isStart ? _s.start : _s.end;
+    final title = ep?.title?.trim();
+    final artist = ep?.artist?.trim();
+    final fallback = ep?.path.split('/').last ?? '';
     return Material(
       color: VelvetColors.raised,
       borderRadius: BorderRadius.circular(VelvetColors.radiusLarge),
       child: InkWell(
         borderRadius: BorderRadius.circular(VelvetColors.radiusLarge),
-        onTap: () => _repick(isStart: isStart),
+        onTap: () => _pickViaSearch(isStart: isStart),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
           child: Row(
@@ -368,9 +647,12 @@ class _SonicPathScreenState extends State<SonicPathScreen> {
     );
   }
 
-  Widget _lengthRow(AppLocalizations l) {
+  Widget _lengthRow(AppLocalizations l,
+      {required bool withRegen, bool inset = true}) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 0, 4, 0),
+      padding: inset
+          ? const EdgeInsets.fromLTRB(16, 0, 4, 0)
+          : EdgeInsets.zero,
       child: Row(
         children: [
           Text(
@@ -379,18 +661,18 @@ class _SonicPathScreenState extends State<SonicPathScreen> {
           ),
           Expanded(
             child: Slider(
-              value: _length.toDouble().clamp(4.0, 32.0),
+              value: _s.length.toDouble().clamp(4.0, 32.0),
               min: 4,
               max: 32,
               divisions: 28,
-              label: '$_length',
-              onChanged: (v) => setState(() => _length = v.round()),
+              label: '${_s.length}',
+              onChanged: (v) => setState(() => _s.length = v.round()),
             ),
           ),
           SizedBox(
             width: 22,
             child: Text(
-              '$_length',
+              '${_s.length}',
               textAlign: TextAlign.end,
               style: TextStyle(
                 color: VelvetColors.textPrimary,
@@ -399,18 +681,19 @@ class _SonicPathScreenState extends State<SonicPathScreen> {
               ),
             ),
           ),
-          IconButton(
-            icon: const Icon(Icons.refresh, size: 20),
-            color: VelvetColors.primary,
-            tooltip: l.pathRegenerate,
-            onPressed: _loading ? null : _load,
-          ),
+          if (withRegen)
+            IconButton(
+              icon: const Icon(Icons.refresh, size: 20),
+              color: VelvetColors.primary,
+              tooltip: l.pathRegenerate,
+              onPressed: _loading ? null : _load,
+            ),
         ],
       ),
     );
   }
 
-  Widget _body(AppLocalizations l) {
+  Widget _resultsBody(AppLocalizations l) {
     if (_loading) {
       return Center(
         child: SizedBox(

--- a/lib/singletons/sonic_path_state.dart
+++ b/lib/singletons/sonic_path_state.dart
@@ -1,0 +1,60 @@
+import '../objects/server.dart';
+
+/// One end of the journey. [artUrl] is a ready-to-load album-art URL when
+/// the pick carried one (setup-card thumbnail); title/artist may be null
+/// until a built path's seed rows backfill them from the server's metadata.
+class SonicPathEndpoint {
+  String path;
+  String? title;
+  String? artist;
+  String? artUrl;
+
+  SonicPathEndpoint(this.path, {this.title, this.artist, this.artUrl});
+}
+
+/// Module-level state for the sonic path builder — the mobile analog of the
+/// webapp's SONICPATH object. It must outlive the screen: "Browse library"
+/// picking pops the route (the file browser is the home scaffold's body,
+/// not a route) and re-pushes it after the captured tap, and Start over
+/// returns to a setup view that still shows the last-picked endpoints.
+class SonicPathState {
+  SonicPathState._();
+  static final SonicPathState _instance = SonicPathState._();
+  factory SonicPathState() => _instance;
+
+  /// The server both endpoints must belong to; set on every entry.
+  Server? server;
+  SonicPathEndpoint? start;
+  SonicPathEndpoint? end;
+
+  /// Requested total rows including both seeds (server clamps 4..32).
+  int length = 14;
+
+  bool get ready => server != null && start != null && end != null;
+
+  /// Drawer entry: bind to [s], keeping any endpoints already picked there
+  /// (re-entry continuity) — a server switch invalidates them.
+  void beginSetup(Server s) {
+    if (!identical(server, s)) {
+      start = null;
+      end = null;
+      length = 14;
+    }
+    server = s;
+  }
+
+  /// Discover entry: both ends known up front (seed → destination).
+  void beginJourney(Server s, SonicPathEndpoint from, SonicPathEndpoint to) {
+    server = s;
+    start = from;
+    end = to;
+    length = 14;
+  }
+
+  /// Start over — pristine setup on the same server.
+  void reset() {
+    start = null;
+    end = null;
+    length = 14;
+  }
+}

--- a/lib/singletons/track_capture.dart
+++ b/lib/singletons/track_capture.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../l10n/app_localizations.dart';
+import '../objects/display_item.dart';
+import '../objects/server.dart';
+
+/// Outcome of a tap while capture may be armed: [pass] — not armed, run the
+/// normal tap handling; [captured] — consumed, the pick landed; [rejected]
+/// — consumed, but the row can't seed the path (wrong server / local file).
+enum CaptureResult { pass, captured, rejected }
+
+/// One armed "pick a song from the library" request (the webapp's
+/// songCapture): which server the pick must come from, which endpoint card
+/// it fills (drives the banner copy), and where the picked row goes.
+class TrackCaptureRequest {
+  final Server server;
+  final bool isStart;
+  final void Function(DisplayItem) onPicked;
+
+  TrackCaptureRequest(
+      {required this.server, required this.isStart, required this.onPicked});
+}
+
+/// App-wide browse-to-pick mode. Armed by the sonic path setup cards;
+/// checked at the top of the browser / album-detail tap handlers BEFORE
+/// tap-behavior dispatch, so a pick can never queue (or play-from-here)
+/// the tapped track. [active] doubles as the home banner's listenable.
+class TrackCapture {
+  TrackCapture._();
+
+  static final ValueNotifier<TrackCaptureRequest?> active =
+      ValueNotifier(null);
+
+  static void arm(TrackCaptureRequest req) => active.value = req;
+
+  static void cancel() => active.value = null;
+
+  /// Runs the armed request against a tapped row. Only a server track on
+  /// the request's server is captured; the request stays armed on a
+  /// rejection so the user can keep browsing to a valid row.
+  static CaptureResult tryCapture(DisplayItem item) {
+    final req = active.value;
+    if (req == null) return CaptureResult.pass;
+    if (item.type != 'file' ||
+        item.data == null ||
+        item.server?.localname != req.server.localname) {
+      return CaptureResult.rejected;
+    }
+    active.value = null;
+    req.onPicked(item);
+    return CaptureResult.captured;
+  }
+}
+
+/// Shared toast for a rejected capture tap — names the server the pick has
+/// to come from (local files and other servers can't seed the path).
+void showCaptureRejectedToast(BuildContext context) {
+  final req = TrackCapture.active.value;
+  if (req == null) return;
+  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+    content: Text(
+        AppLocalizations.of(context).pathPickOnServer(req.server.localname)),
+    behavior: SnackBarBehavior.floating,
+  ));
+}

--- a/test/singletons/sonic_path_test.dart
+++ b/test/singletons/sonic_path_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/objects/display_item.dart';
+import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/singletons/sonic_path_state.dart';
+import 'package:mstream_music/singletons/track_capture.dart';
+
+Server _server(String name) => Server('http://$name', null, null, null, name);
+
+DisplayItem _file(Server? s, String path, {String type = 'file'}) =>
+    DisplayItem(s, path.split('/').last, type, path, null, null);
+
+void main() {
+  final a = _server('alpha');
+  final b = _server('beta');
+
+  setUp(() {
+    // Both are process-wide singletons — start every test pristine.
+    SonicPathState()
+      ..server = null
+      ..reset();
+    TrackCapture.cancel();
+  });
+
+  group('SonicPathState', () {
+    test('beginSetup on a new server clears endpoints and length', () {
+      final s = SonicPathState();
+      s.beginJourney(a, SonicPathEndpoint('/x.mp3'), SonicPathEndpoint('/y.mp3'));
+      s.length = 22;
+      s.beginSetup(b);
+      expect(s.server, same(b));
+      expect(s.start, isNull);
+      expect(s.end, isNull);
+      expect(s.length, 14);
+    });
+
+    test('beginSetup on the same server keeps picked endpoints', () {
+      final s = SonicPathState();
+      s.beginSetup(a);
+      s.start = SonicPathEndpoint('/x.mp3', title: 'X');
+      s.length = 8;
+      s.beginSetup(a);
+      expect(s.start?.title, 'X');
+      expect(s.end, isNull);
+      expect(s.length, 8);
+    });
+
+    test('beginJourney sets both ends and resets length', () {
+      final s = SonicPathState();
+      s.length = 30;
+      s.beginJourney(a, SonicPathEndpoint('/x.mp3'), SonicPathEndpoint('/y.mp3'));
+      expect(s.ready, isTrue);
+      expect(s.length, 14);
+    });
+
+    test('reset clears endpoints + length but keeps the server', () {
+      final s = SonicPathState();
+      s.beginJourney(a, SonicPathEndpoint('/x.mp3'), SonicPathEndpoint('/y.mp3'));
+      s.length = 20;
+      s.reset();
+      expect(s.server, same(a));
+      expect(s.start, isNull);
+      expect(s.end, isNull);
+      expect(s.length, 14);
+      expect(s.ready, isFalse);
+    });
+
+    test('ready only once server and both endpoints are set', () {
+      final s = SonicPathState();
+      expect(s.ready, isFalse);
+      s.beginSetup(a);
+      expect(s.ready, isFalse);
+      s.start = SonicPathEndpoint('/x.mp3');
+      expect(s.ready, isFalse);
+      s.end = SonicPathEndpoint('/y.mp3');
+      expect(s.ready, isTrue);
+    });
+  });
+
+  group('TrackCapture.tryCapture', () {
+    test('passes when nothing is armed', () {
+      expect(TrackCapture.tryCapture(_file(a, '/x.mp3')), CaptureResult.pass);
+    });
+
+    test('captures a matching-server track, delivers it, and disarms', () {
+      DisplayItem? picked;
+      TrackCapture.arm(TrackCaptureRequest(
+          server: a, isStart: true, onPicked: (i) => picked = i));
+      final item = _file(a, '/music/x.mp3');
+      expect(TrackCapture.tryCapture(item), CaptureResult.captured);
+      expect(picked, same(item));
+      expect(TrackCapture.active.value, isNull);
+      // Disarmed — the next tap runs the normal handling.
+      expect(TrackCapture.tryCapture(item), CaptureResult.pass);
+    });
+
+    test('rejects another server\'s track and stays armed', () {
+      TrackCapture.arm(TrackCaptureRequest(
+          server: a, isStart: false, onPicked: (_) => fail('must not pick')));
+      expect(TrackCapture.tryCapture(_file(b, '/x.mp3')),
+          CaptureResult.rejected);
+      expect(TrackCapture.active.value, isNotNull);
+    });
+
+    test('rejects local files and rows without a path, then still captures',
+        () {
+      DisplayItem? picked;
+      TrackCapture.arm(TrackCaptureRequest(
+          server: a, isStart: true, onPicked: (i) => picked = i));
+      expect(TrackCapture.tryCapture(_file(a, '/x.mp3', type: 'localFile')),
+          CaptureResult.rejected);
+      expect(TrackCapture.tryCapture(_file(null, '/x.mp3')),
+          CaptureResult.rejected);
+      final noPath = DisplayItem(a, 'x', 'file', null, null, null);
+      expect(TrackCapture.tryCapture(noPath), CaptureResult.rejected);
+      // A valid row after the rejections still lands.
+      final item = _file(a, '/music/ok.mp3');
+      expect(TrackCapture.tryCapture(item), CaptureResult.captured);
+      expect(picked, same(item));
+    });
+
+    test('cancel disarms without picking', () {
+      TrackCapture.arm(TrackCaptureRequest(
+          server: a, isStart: true, onPicked: (_) => fail('must not pick')));
+      TrackCapture.cancel();
+      expect(TrackCapture.active.value, isNull);
+      expect(TrackCapture.tryCapture(_file(a, '/x.mp3')), CaptureResult.pass);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Ports the webapp's **sonic path journey builder** (`webapp/alpha/m.js` `SONICPATH`) to mobile. PR #114 shipped the *results* stage (the journey preview); this adds everything upstream of it: a standalone entry that doesn't need a Discover seed, a **setup stage** with freely-choosable Start/End endpoints, and the webapp's signature **browse-to-pick** flow.

### Setup stage

`SonicPathScreen` is now two-stage. Setup: a hint line, a **Start** and an **End** card stacked with a ↓ between (webapp layout), the length slider, and a ready-gated **Build the journey** button. An empty card offers three fills:
- **Use playing song** — grabs the current track; guarded (nothing playing / a local file / another server's track → toast, the webapp's federated-track guard generalized to multi-server)
- **Search** — the existing `SongPickerSheet` (debounced search + random dice)
- **Browse library** — the webapp's capture flow, below

A filled card shows art + title/artist + ✕ and hides the buttons ("a settled decision"). Results gains a **Start over** app-bar action → pristine setup on the same server. The Discover "Play a path to…" flow is unchanged from the user's side: it lands straight in results (`autoBuild`) with endpoints editable in place, as shipped.

### Browse-to-pick (`TrackCapture`)

The webapp's `songCapture`: **Browse library** arms a capture request and drops back to the home browser — a banner strip (same idiom as the migration/tunnel strips) says which endpoint is being picked, with **Cancel** returning to the screen. The next **server-track tap** in the file browser or album detail fills the card and re-pushes the path screen; the check runs **before tap-behavior dispatch**, so a pick can never queue or play-from-here. Local files and other servers' tracks toast ("Pick a track on ⟨server⟩") and stay armed. Because the browser is the home scaffold's body (not a route), setup state lives in a `SonicPathState` singleton that survives the round trip — also what makes Start over and re-entry continuity work.

### Drawer entry

**Sonic path** tile between Auto DJ and Share Playlist — the webapp's side-nav placement — rendered only when the current server's ping advertised `discoveryPath` (mStream #762), tracking server switches via `currentServerStream`.

## Implementation notes

- `lib/singletons/sonic_path_state.dart` — endpoints (path/title/artist/artUrl), length, binding server; `beginSetup` (drawer; keeps same-server picks), `beginJourney` (Discover), `reset` (Start over)
- `lib/singletons/track_capture.dart` — `ValueNotifier`-armed request + pure `tryCapture` → `pass | captured | rejected`; intercepts in `browser.dart` (`file` + `localFile` branches) and `album_detail_view.dart`'s row tap
- Seed-row metadata backfill now heals the singleton's endpoints (filename-titled picks fix themselves after a build), as before
- 11 new l10n keys, translated in all 10 locales

## Testing

- `flutter analyze` — at pre-existing baseline (18 infos, all pre-dating the branch)
- `flutter test` — **176/176** (adds 10 unit tests: `SonicPathState` begin/reset/ready semantics; `tryCapture` pass/capture/reject/disarm, wrong-server + localFile + pathless rejections, re-capture after reject)
- **On-device (S25, debug full flavor, discovery-enabled iroh server) — full flow verified:** drawer tile appears (gated on `discoveryPath`); setup stage renders; **Use playing song** fills Start with art; **Browse library** arms the banner over the home browser; a browsed file tap **captures** (filled the End card from a `3-1 Remixes` track), survives an app lock/unlock via the singleton, and **Build** produced a correct journey (Gold Rush → DnB descent → destination); **Start over** returns to a pristine setup; **Discover → "Play a path to…" → Random song** still autoBuilds into results (regression pass). Zero crashes across the session (single PID, clean logcat).
- Not device-exercised (unit-tested only): the wrong-server and local-file rejection toasts — the test phone has a single server configured.
- Note for posterity: an earlier "End card came back unset" observation was a red herring — the phone was dozing mid-run and `screencap` served a stale pre-capture framebuffer; the live singleton had the captured track all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)