### PR TITLE
Audit batch 3: playback/cast robustness

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -888,7 +888,11 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
                   child: PopupMenuButton(
                       onSelected: (int selectedServerIndex) async {
                         if (selectedServerIndex > -1) {
-                          ServerManager()
+                          // Awaited (mirroring the add-server flow): the ping
+                          // below used to race the iroh tunnel bring-up inside
+                          // changeCurrentServer and reliably showed a spurious
+                          // "failed to connect" toast on every iroh switch.
+                          await ServerManager()
                               .changeCurrentServer(selectedServerIndex);
 
                           try {

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -716,11 +716,14 @@ class AudioPlayerHandler extends BaseAudioHandler
     // the load so the renderer auto-plays when its media is ready. Not routed
     // through _loadAtSpot — parking a local-playback spot on a switch TO a
     // renderer would be meaningless, and the local arm's own revive paths
-    // already cover the way back.
-    await next.setSources(
-        identical(next, _localBackend) ? _queueWithFreshUrls() : queue.value,
-        initialIndex: idx,
-        initialPosition: pos);
+    // already cover the way back. Clamped: a queue edit racing the switch can
+    // leave idx past the end, and an out-of-range initialIndex kills the load.
+    final items = identical(next, _localBackend)
+        ? _queueWithFreshUrls()
+        : queue.value;
+    await next.setSources(items,
+        initialIndex: items.isEmpty ? null : idx.clamp(0, items.length - 1),
+        initialPosition: items.isEmpty ? null : pos);
     _backendSubject.add(next);
     if (queue.value.isNotEmpty) {
       // Carry the play state into the load: a renderer then auto-plays when its
@@ -795,7 +798,10 @@ class AudioPlayerHandler extends BaseAudioHandler
     await _reseedLocalAfterCastLoss(
       pos: pos,
       idx: idx,
-      play: true,
+      // The LIVE intent, not a literal true: a pause landing during the
+      // 12s remote-start wait must win (the post-await doctrine every other
+      // revive path follows) — not blast audio on the phone anyway.
+      play: _playIntent,
       dispose: [
         if (!identical(failed, _localBackend)) failed,
         if (!identical(prev, _localBackend) && !identical(prev, failed)) prev,
@@ -2656,7 +2662,29 @@ class AudioPlayerHandler extends BaseAudioHandler
     return true;
   }
 
+  // True while an autoDJ() fetch is in flight — overlapping runs share the
+  // ignoreList (it only updates after the response), so two concurrent POSTs
+  // can queue the same track twice on a narrow pool (sonic-locked / genre
+  // filter / small library). The empty-queue start path provably overlaps:
+  // its first pick's index-0 emit satisfies the last-item check in the
+  // currentIndexStream listener while the explicit follow-up call runs.
+  bool _djInFlight = false;
+
+  /// Fetch and queue one Auto-DJ pick. Overlapping calls are dropped — safe,
+  /// because every trigger (the follow-up call, the next last-item index
+  /// emit) re-fires the top-up once the in-flight run lands.
   Future<void> autoDJ(
+      {bool autoPlay = false, bool incrementIndex = false}) async {
+    if (_djInFlight) return;
+    _djInFlight = true;
+    try {
+      await _autoDJPick(autoPlay: autoPlay, incrementIndex: incrementIndex);
+    } finally {
+      _djInFlight = false;
+    }
+  }
+
+  Future<void> _autoDJPick(
       {bool autoPlay = false, bool incrementIndex = false}) async {
     if (autoDJServer == null) return;
     // The lane this call belongs to — checked when each response lands.

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -461,9 +461,17 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
   /// [waitForTeardown], also wait (bounded) for the session stream to settle
   /// on null — starting a new session against a half-torn-down one collides
   /// and times out its connect wait.
+  ///
+  /// The SDK call itself is timeboxed: plugin calls against a broken session
+  /// can hang FOREVER (see the re-attach doctrine above), and this runs on
+  /// dispose — which the handler awaits on _switchChain, exactly when the
+  /// session is most likely broken. An unbounded hang there would wedge every
+  /// future cast switch and fallback until app restart.
   Future<void> _endSessionQuietly({bool waitForTeardown = false}) async {
     try {
-      await _sessions.endSessionAndStopCasting();
+      await _sessions
+          .endSessionAndStopCasting()
+          .timeout(const Duration(seconds: 10));
     } catch (_) {}
     if (!waitForTeardown) return;
     try {

--- a/lib/media/dlna_playback_backend.dart
+++ b/lib/media/dlna_playback_backend.dart
@@ -166,7 +166,14 @@ class DlnaPlaybackBackend extends EmulatedPlaylistBackend {
       final ok = await loadIndex(target, play: intent);
       // A failed user-driven load would otherwise strand the backend in
       // 'loading' with no watchdog running (polling only starts on success).
-      if (!ok) await trackFailed('load failed', play: intent);
+      // Return after the walk (mirroring the Chromecast seek): falling
+      // through yanked the SUBSTITUTE track the walk just loaded to the
+      // failed track's offset. The success path still falls through — DLNA's
+      // loadIndex has no startAt, so the position is applied below.
+      if (!ok) {
+        await trackFailed('load failed', play: intent);
+        return;
+      }
     }
     try {
       await _api.seek(_udn, TimePosition(seconds: position.inSeconds));

--- a/lib/media/local_media_server.dart
+++ b/lib/media/local_media_server.dart
@@ -1,8 +1,15 @@
 import 'dart:io';
 import 'dart:math' show Random;
 
+import 'package:meta/meta.dart';
+
 import 'cast_art.dart' show mimeForPath;
 import 'cast_log.dart';
+
+/// Outcome of parsing a Range header against a body of known length:
+/// serve [start]..[end] inclusive ([partial] → 206, else 200), or null for an
+/// unsatisfiable range (416).
+typedef ParsedRange = ({int start, int end, bool partial});
 
 /// On-device HTTP server that streams phone-local audio files to a cast
 /// renderer over the LAN.
@@ -25,7 +32,19 @@ class LocalMediaServer {
 
   HttpServer? _server;
   String? _host; // LAN IPv4 the renderer connects back to
-  final Random _rng = Random();
+  // Secure source: the token is doing security work (it's the only thing
+  // gating a LAN peer from a registered resource on an all-interfaces bind),
+  // and math.Random is a predictable time-seeded PRNG.
+  final Random _rng = _tokenRandom();
+
+  static Random _tokenRandom() {
+    try {
+      return Random.secure();
+    } catch (_) {
+      // No secure entropy source on this platform — degraded but functional.
+      return Random();
+    }
+  }
   final Map<String, String> _files = <String, String>{}; // token -> abs path
   final Map<String, String> _types = <String, String>{}; // token -> content type
   final Map<String, String> _dirs = <String, String>{}; // token -> directory
@@ -280,24 +299,17 @@ class LocalMediaServer {
         ..set(HttpHeaders.contentTypeHeader,
             contentType ?? mimeForPath(path));
 
-      // Parse a single byte range (renderers send `bytes=start-` or
-      // `bytes=start-end`); multi-range isn't used by media renderers.
-      var start = 0;
-      var end = length - 1;
-      final range = req.headers.value(HttpHeaders.rangeHeader);
-      if (range != null && range.startsWith('bytes=')) {
-        final spec = range.substring(6).split('-');
-        if (spec[0].isNotEmpty) start = int.tryParse(spec[0]) ?? 0;
-        if (spec.length > 1 && spec[1].isNotEmpty) {
-          end = int.tryParse(spec[1]) ?? end;
-        }
-        if (start < 0 || start >= length || start > end) {
-          res.statusCode = HttpStatus.requestedRangeNotSatisfiable;
-          res.headers.set(HttpHeaders.contentRangeHeader, 'bytes */$length');
-          await res.close();
-          return;
-        }
-        if (end > length - 1) end = length - 1;
+      final parsed =
+          parseRange(req.headers.value(HttpHeaders.rangeHeader), length);
+      if (parsed == null) {
+        res.statusCode = HttpStatus.requestedRangeNotSatisfiable;
+        res.headers.set(HttpHeaders.contentRangeHeader, 'bytes */$length');
+        await res.close();
+        return;
+      }
+      final start = parsed.start;
+      final end = parsed.end;
+      if (parsed.partial) {
         res.statusCode = HttpStatus.partialContent;
         res.headers
             .set(HttpHeaders.contentRangeHeader, 'bytes $start-$end/$length');
@@ -321,6 +333,40 @@ class LocalMediaServer {
         await res.close();
       } catch (_) {}
     }
+  }
+
+  /// Parse a single byte-range header against a body of [length] bytes.
+  /// Renderers send `bytes=start-`, `bytes=start-end`, and — as the standard
+  /// tail probe for end-of-file moov atoms / tags — the suffix form
+  /// `bytes=-N` (the LAST N bytes); multi-range isn't used by media renderers.
+  ///
+  /// Returns the inclusive window to serve (partial → 206), null for an
+  /// unsatisfiable range (416), and the whole body as a plain 200 when there
+  /// is no Range header or its syntax is invalid (RFC 9110: an unparseable
+  /// Range MUST be ignored). Pure; unit-tested.
+  @visibleForTesting
+  static ParsedRange? parseRange(String? range, int length) {
+    ParsedRange full() => (start: 0, end: length - 1, partial: false);
+    if (range == null || !range.startsWith('bytes=')) return full();
+    final spec = range.substring(6).split('-');
+    if (spec.length != 2) return full(); // malformed → ignore the header
+    final first = spec[0].isEmpty ? null : int.tryParse(spec[0]);
+    final second = spec[1].isEmpty ? null : int.tryParse(spec[1]);
+
+    if (spec[0].isEmpty) {
+      // Suffix form `bytes=-N`: the last N bytes — NOT 0..N. Serving the head
+      // here made tail probes (MP4 moov at end, ID3v1/APE tags) read the
+      // wrong bytes as a well-formed 206.
+      if (second == null) return full(); // `bytes=-` → ignore
+      if (second <= 0 || length <= 0) return null; // no bytes to serve → 416
+      final start = second >= length ? 0 : length - second;
+      return (start: start, end: length - 1, partial: true);
+    }
+
+    if (first == null) return full(); // `bytes=abc-…` → ignore
+    final end = second == null || second > length - 1 ? length - 1 : second;
+    if (first < 0 || first >= length || first > end) return null; // 416
+    return (start: first, end: end, partial: true);
   }
 
   // Relay a renderer's GET/HEAD to the [upstream] loopback URL, forwarding Range

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -272,6 +272,10 @@ class BrowserManager {
   }
 
   void goToNavScreen() {
+    // The stack this reset discards is the one any in-flight browse fetch
+    // would push onto — cancel them, or a late response (e.g. the OLD server's
+    // folder surviving a server switch) lands on top of the NEW home screen.
+    cancelLoading();
     _albumDetail.add(null);
     browserCache.clear();
     browserList.clear();

--- a/test/media/dlna_playback_backend_test.dart
+++ b/test/media/dlna_playback_backend_test.dart
@@ -33,7 +33,8 @@ class _FakeDlnaApi extends MediaCastDlnaApi {
   Future<void> stop(DeviceUdn deviceUdn) async => calls.add('stop');
 
   @override
-  Future<void> seek(DeviceUdn deviceUdn, TimePosition position) async {}
+  Future<void> seek(DeviceUdn deviceUdn, TimePosition position) async =>
+      calls.add('seek:${position.seconds}');
 
   @override
   Future<void> setVolume(DeviceUdn deviceUdn, VolumeLevel volume) async {}
@@ -173,6 +174,31 @@ void main() {
       final pollsAtLoss = api.pollCount;
       fa.elapse(const Duration(seconds: 5));
       expect(api.pollCount, pollsAtLoss); // polling quiesced
+    });
+  });
+
+  test('seek to a track whose load fails walks on WITHOUT seeking the substitute',
+      () {
+    fakeAsync((fa) {
+      final api = _FakeDlnaApi();
+      final b = _TestDlnaBackend(udn: 'udn', api: api);
+      b.setSources(List.generate(3, (i) => _track(i)));
+      fa.flushMicrotasks();
+      b.play();
+      fa.flushMicrotasks();
+
+      // A cast-handoff-style seek: jump to track 1 at 90s, but track 1
+      // refuses to load — the failure walk lands on track 2 instead.
+      api.setMediaUriOk = (uri) => !uri.contains('/1.mp3');
+      b.seek(const Duration(seconds: 90), index: 1);
+      fa.flushMicrotasks();
+
+      expect(api.calls, contains('set:http://server/media/2.mp3'));
+      // Regression: seek() used to fall through after the walk and yank the
+      // SUBSTITUTE track to the failed track's 90s offset (and report that
+      // position). The substitute must start from its own beginning.
+      expect(api.calls.where((c) => c.startsWith('seek:')), isEmpty);
+      expect(b.position, Duration.zero);
     });
   });
 }

--- a/test/media/local_media_server_test.dart
+++ b/test/media/local_media_server_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/local_media_server.dart';
+
+void main() {
+  // A 1000-byte body throughout; ranges are inclusive.
+  const len = 1000;
+
+  group('LocalMediaServer.parseRange', () {
+    test('no header → whole body as 200', () {
+      expect(LocalMediaServer.parseRange(null, len),
+          (start: 0, end: 999, partial: false));
+    });
+
+    test('bytes=start-end serves the window, end clamped to the body', () {
+      expect(LocalMediaServer.parseRange('bytes=0-499', len),
+          (start: 0, end: 499, partial: true));
+      expect(LocalMediaServer.parseRange('bytes=500-1999', len),
+          (start: 500, end: 999, partial: true));
+    });
+
+    test('bytes=start- serves to the end', () {
+      expect(LocalMediaServer.parseRange('bytes=900-', len),
+          (start: 900, end: 999, partial: true));
+    });
+
+    test('suffix bytes=-N serves the LAST N bytes (the tail-probe form)', () {
+      // Regression: this parsed as start=0/end=N and served the HEAD as a
+      // well-formed 206 — breaking renderers probing end-of-file moov atoms /
+      // ID3v1 tags.
+      expect(LocalMediaServer.parseRange('bytes=-500', len),
+          (start: 500, end: 999, partial: true));
+      expect(LocalMediaServer.parseRange('bytes=-1', len),
+          (start: 999, end: 999, partial: true));
+      // A suffix longer than the body serves the whole body as 206.
+      expect(LocalMediaServer.parseRange('bytes=-5000', len),
+          (start: 0, end: 999, partial: true));
+    });
+
+    test('unsatisfiable ranges → null (416)', () {
+      expect(LocalMediaServer.parseRange('bytes=1000-', len), isNull);
+      expect(LocalMediaServer.parseRange('bytes=1000-1999', len), isNull);
+      expect(LocalMediaServer.parseRange('bytes=500-100', len), isNull);
+      expect(LocalMediaServer.parseRange('bytes=-0', len), isNull);
+      // Empty body: any actual range is unsatisfiable.
+      expect(LocalMediaServer.parseRange('bytes=0-', 0), isNull);
+      expect(LocalMediaServer.parseRange('bytes=-10', 0), isNull);
+    });
+
+    test('invalid syntax is ignored → whole body as 200 (RFC 9110)', () {
+      expect(LocalMediaServer.parseRange('bytes=abc-def', len),
+          (start: 0, end: 999, partial: false));
+      expect(LocalMediaServer.parseRange('bytes=-', len),
+          (start: 0, end: 999, partial: false));
+      expect(LocalMediaServer.parseRange('bytes=5', len),
+          (start: 0, end: 999, partial: false));
+      expect(LocalMediaServer.parseRange('items=0-499', len),
+          (start: 0, end: 999, partial: false));
+    });
+  });
+}

--- a/test/singletons/browser_load_test.dart
+++ b/test/singletons/browser_load_test.dart
@@ -59,5 +59,18 @@ void main() {
     bm.beginLoading(); // non-cancelable mutation — no canceler registered
     expect(bm.cancelLoading(), isTrue);
     expect(cancelerFires, 1, reason: 'only the cancelable load is aborted');
+
+    // 6. A stack reset (server switch / removal / make-default all route
+    //    through goToNavScreen) cancels in-flight loads: without this, the OLD
+    //    server's late browse response pushed its rows onto the NEW server's
+    //    home screen. (No server configured in tests → it resets and returns.)
+    var resetCancelerFired = false;
+    final e = bm.beginLoading(onCancel: () => resetCancelerFired = true);
+    bm.goToNavScreen();
+    expect(resetCancelerFired, isTrue,
+        reason: 'the in-flight fetch must be aborted by the stack reset');
+    expect(bm.isLoadCancelled(e), isTrue,
+        reason: 'a late response must be dropped, not pushed');
+    expect(bm.isLoading, isFalse);
   });
 }


### PR DESCRIPTION
Fixes the playback-core robustness findings from the codebase audit — 5 medium-severity issues (#23, #24, #16, #14, #18 in the audit report) plus the adjacent one-line lows in the same files (#25–#29, minus the shuffle-semantics redesign).

> **Stacked PR** — based on `claude/audit-batch2-http` (#121). Merge order: #119 (high-severity) → #120 (batch 1) → #121 (batch 2) → this.

## Fixes

**Cast teardown can no longer wedge the switch chain.** `_endSessionQuietly` timeboxes the Cast SDK call (10s). The file's own comment documents that plugin calls against a broken session can hang forever — the re-attach path already had a 30s guard, but `disposeRenderer` (awaited on `_switchChain`, and invoked precisely when the session is broken) had none. One hang froze every future cast switch/fallback until app restart.

**Suffix Range requests serve the right bytes.** `LocalMediaServer` parsed `bytes=-N` (the last N bytes — the standard renderer tail-probe for end-of-file moov atoms / ID3v1 tags) as `0..N` and served the *head* of the file as a well-formed 206. Range parsing is now a pure, unit-tested `parseRange` that handles the suffix form, ignores invalid syntax per RFC 9110, and 416s only genuinely unsatisfiable ranges. Serving tokens are minted with `Random.secure()` (they gate LAN access on an all-interfaces bind).

**Auto DJ reentrancy.** `autoDJ()` drops overlapping runs (in-flight guard). Concurrent runs share the ignoreList — updated only after the response — so the empty-queue start path, which provably fires a third concurrent call via the index listener, could queue duplicate picks on a narrow pool.

**Server-switch races.** The app-bar switch awaits `changeCurrentServer` before its `throwErr` ping (mirroring the add-server flow) — switching to an iroh server used to reliably toast a spurious "Failed to connect" while racing the tunnel bring-up. And `goToNavScreen` now cancels in-flight browse loads, so a slow response from the *old* server can no longer push its rows onto the *new* server's home screen (tapping those rows mixed servers).

**The one-liners:** backend swaps/reseeds pass `initialIndex`/`initialPosition` so re-subscribed listeners replay the real spot instead of a spurious index-0 (now-playing flash + possible double DJ top-up); `skipToQueueItem` rejects `index == length`; DLNA `seek` returns after a failed load walk instead of yanking the substitute track to the failed track's offset; the cast-failure fallback resumes with the live `_playIntent` so a pause during the 12s start wait wins.

## Verification

- `flutter analyze` clean; **200 tests pass**, including new coverage: a thorough `parseRange` suite (suffix/open/unsatisfiable/invalid forms), a DLNA regression test that a failed seek-load walks on *without* seeking the substitute, and a browser-load test that a stack reset aborts in-flight fetches.
- iOS Simulator smoke (results in the session log): queue restore, playback, and a staged server-switch race against a deliberately stalling server.
- Needs a device pass for the cast paths (real Chromecast: teardown timeout, pause-during-start) and an iroh server for the tunnel-race toast — same list as the earlier audit branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
