### PR TITLE
Audit high-severity fixes: TLS scoping, cast play-after-stop, stale JWT

### DIFF
--- a/android/app/src/full/kotlin/com/example/mstream_music/InsecureTls.kt
+++ b/android/app/src/full/kotlin/com/example/mstream_music/InsecureTls.kt
@@ -2,39 +2,59 @@ package com.example.mstream_music
 
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodChannel
+import java.net.Socket
+import java.security.KeyStore
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509ExtendedTrustManager
 import javax.net.ssl.X509TrustManager
 
 // FULL (sideload) flavor ONLY.
 //
 // just_audio streams through ExoPlayer, which uses the native
 // HttpsURLConnection TLS stack — NOT Dart's HttpClient — so a Dart-side
-// badCertificateCallback can't make self-signed *streaming* work. This installs
-// a trust-all default SSLSocketFactory + hostname verifier so ExoPlayer will
-// stream from a server with a self-signed cert.
+// badCertificateCallback can't make self-signed *streaming* work. The only
+// hook into that stack is the process-default SSLSocketFactory / hostname
+// verifier, but swapping in a blanket trust-all there would also disable
+// validation for every OTHER host (other servers with valid certs, and
+// background_downloader transfers, which use the same stack).
 //
-// It's OFF unless the user enables "Allow self-signed" for a server: the Dart
-// side toggles it via the `mstream/insecure_tls` channel. It is deliberately
-// absent from the `play` source set — a trust-all X509TrustManager in the
-// binary trips Google Play's unsafe-TLS scan even when unused, which is the
-// whole reason this lives behind the flavor split.
+// So the swap installs a DELEGATING trust manager + verifier scoped to the
+// hosts the user explicitly opted into via "Allow self-signed" (synced from
+// the Dart side over the `mstream/insecure_tls` channel): those hosts skip
+// validation, every other host is handed to the untouched platform trust
+// manager / verifier. Handshakes with no resolvable peer host fail closed
+// (platform validation). With no opted-in hosts the platform defaults are
+// restored untouched.
+//
+// This is deliberately absent from the `play` source set — a non-validating
+// X509TrustManager in the binary trips Google Play's unsafe-TLS scan even
+// when unused, which is the whole reason this lives behind the flavor split.
 object InsecureTls {
     private var originalFactory: SSLSocketFactory? = null
     private var originalVerifier: HostnameVerifier? = null
-    private var enabled = false
+    private var installed = false
+
+    // Hosts (lowercased) whose self-signed certs the user accepted. Read from
+    // TLS handshake threads, replaced wholesale from the channel handler.
+    @Volatile
+    private var allowedHosts: Set<String> = emptySet()
 
     fun register(messenger: BinaryMessenger) {
         MethodChannel(messenger, "mstream/insecure_tls")
             .setMethodCallHandler { call, result ->
                 when (call.method) {
-                    "setEnabled" -> {
-                        setEnabled(call.argument<Boolean>("enabled") == true)
+                    "setAllowedHosts" -> {
+                        setAllowedHosts(
+                            call.argument<List<String>>("hosts") ?: emptyList())
                         result.success(null)
                     }
                     else -> result.notImplemented()
@@ -42,33 +62,105 @@ object InsecureTls {
             }
     }
 
-    @Synchronized
-    private fun setEnabled(on: Boolean) {
-        if (on == enabled) return
-        if (on) {
-            if (originalFactory == null) {
-                originalFactory = HttpsURLConnection.getDefaultSSLSocketFactory()
-                originalVerifier = HttpsURLConnection.getDefaultHostnameVerifier()
+    private fun isAllowed(host: String?): Boolean =
+        host != null && allowedHosts.contains(host.lowercase())
+
+    // The untouched platform trust manager — every host NOT opted in is
+    // validated by exactly what the system would have used.
+    private val platformTrustManager: X509TrustManager by lazy {
+        val tmf =
+            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        tmf.init(null as KeyStore?)
+        tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+    }
+
+    // Accepts any chain for opted-in hosts; delegates everything else to the
+    // platform trust manager. The host comes from the in-flight handshake
+    // (socket / engine peer host); overloads with no host context validate
+    // normally, so unknown callers fail closed rather than open.
+    private val scopedTrustManager: X509ExtendedTrustManager by lazy {
+        object : X509ExtendedTrustManager() {
+            private val ext get() = platformTrustManager as? X509ExtendedTrustManager
+
+            override fun checkServerTrusted(
+                chain: Array<X509Certificate>?, authType: String?, socket: Socket?
+            ) {
+                if (isAllowed((socket as? SSLSocket)?.handshakeSession?.peerHost)) return
+                ext?.checkServerTrusted(chain, authType, socket)
+                    ?: platformTrustManager.checkServerTrusted(chain, authType)
             }
-            val trustAll = arrayOf<TrustManager>(object : X509TrustManager {
-                override fun checkClientTrusted(c: Array<X509Certificate>?, a: String?) {}
-                override fun checkServerTrusted(c: Array<X509Certificate>?, a: String?) {}
-                override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
-            })
-            val ctx = SSLContext.getInstance("TLS")
-            ctx.init(null, trustAll, SecureRandom())
-            HttpsURLConnection.setDefaultSSLSocketFactory(ctx.socketFactory)
-            HttpsURLConnection.setDefaultHostnameVerifier(HostnameVerifier { _, _ -> true })
-        } else {
-            originalFactory?.let { HttpsURLConnection.setDefaultSSLSocketFactory(it) }
-            originalVerifier?.let { HttpsURLConnection.setDefaultHostnameVerifier(it) }
+
+            override fun checkServerTrusted(
+                chain: Array<X509Certificate>?, authType: String?, engine: SSLEngine?
+            ) {
+                if (isAllowed(engine?.peerHost)) return
+                ext?.checkServerTrusted(chain, authType, engine)
+                    ?: platformTrustManager.checkServerTrusted(chain, authType)
+            }
+
+            override fun checkServerTrusted(
+                chain: Array<X509Certificate>?, authType: String?
+            ) {
+                platformTrustManager.checkServerTrusted(chain, authType)
+            }
+
+            override fun checkClientTrusted(
+                chain: Array<X509Certificate>?, authType: String?, socket: Socket?
+            ) {
+                ext?.checkClientTrusted(chain, authType, socket)
+                    ?: platformTrustManager.checkClientTrusted(chain, authType)
+            }
+
+            override fun checkClientTrusted(
+                chain: Array<X509Certificate>?, authType: String?, engine: SSLEngine?
+            ) {
+                ext?.checkClientTrusted(chain, authType, engine)
+                    ?: platformTrustManager.checkClientTrusted(chain, authType)
+            }
+
+            override fun checkClientTrusted(
+                chain: Array<X509Certificate>?, authType: String?
+            ) {
+                platformTrustManager.checkClientTrusted(chain, authType)
+            }
+
+            override fun getAcceptedIssuers(): Array<X509Certificate> =
+                platformTrustManager.acceptedIssuers
         }
-        enabled = on
+    }
+
+    @Synchronized
+    private fun setAllowedHosts(hosts: List<String>) {
+        allowedHosts = hosts.map { it.lowercase() }.toSet()
+        if (allowedHosts.isEmpty()) {
+            // Nothing opted in — put the platform defaults back untouched.
+            if (installed) {
+                originalFactory?.let { HttpsURLConnection.setDefaultSSLSocketFactory(it) }
+                originalVerifier?.let { HttpsURLConnection.setDefaultHostnameVerifier(it) }
+                installed = false
+            }
+            return
+        }
+        if (installed) return // delegators already in place; the new set is live
+
+        originalFactory = HttpsURLConnection.getDefaultSSLSocketFactory()
+        originalVerifier = HttpsURLConnection.getDefaultHostnameVerifier()
+
+        val ctx = SSLContext.getInstance("TLS")
+        ctx.init(null, arrayOf<TrustManager>(scopedTrustManager), SecureRandom())
+        HttpsURLConnection.setDefaultSSLSocketFactory(ctx.socketFactory)
+
+        val fallback = originalVerifier
+        HttpsURLConnection.setDefaultHostnameVerifier(
+            HostnameVerifier { hostname, session ->
+                isAllowed(hostname) || (fallback?.verify(hostname, session) ?: false)
+            })
+        installed = true
     }
 
     // ── Album-art ContentProvider TLS ──
     // The art provider runs headless on the Android Auto cold-bind, where
-    // MainActivity never installed the global trust-all swap above, so it can't
+    // MainActivity never installed the delegating swap above, so it can't
     // rely on it. applyArtTls trusts a SINGLE provider connection so a
     // self-signed server's browse art loads; the provider calls it only for
     // hosts the user marked "allow self-signed", so valid-cert servers (and the

--- a/integration_test/helpers/test_helpers.dart
+++ b/integration_test/helpers/test_helpers.dart
@@ -69,9 +69,18 @@ class MockServer {
   static Future<MockServer> start(
     Map<String, MockRoute> routes, {
     MockRoute? defaultHandler,
+    // When set, the server binds TLS with this context (self-signed test
+    // cert) and the url is https:// — used to exercise the native
+    // per-host TLS bypass (ExoPlayer streams via the platform stack, which
+    // is exactly what a plain-HTTP mock can never reach).
+    SecurityContext? securityContext,
   }) async {
-    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-    final url = 'http://127.0.0.1:${server.port}';
+    final server = securityContext == null
+        ? await HttpServer.bind(InternetAddress.loopbackIPv4, 0)
+        : await HttpServer.bindSecure(
+            InternetAddress.loopbackIPv4, 0, securityContext);
+    final scheme = securityContext == null ? 'http' : 'https';
+    final url = '$scheme://127.0.0.1:${server.port}';
 
     final allRoutes = <String, MockRoute>{
       '/api/v1/ping': (_) => {

--- a/integration_test/server_edit_jwt_test.dart
+++ b/integration_test/server_edit_jwt_test.dart
@@ -1,0 +1,121 @@
+// Editing a server persists the freshly obtained JWT (PR #119).
+//
+// The edit flow's checkServer() logs in and threads the new token into
+// saveServer(lol, res['token']), but the shouldUpdate branch used to ignore
+// the jwt parameter entirely — after an edit the app kept sending the old,
+// dead token on every request, and nothing re-logs-in on a 401.
+//
+// Two contracts:
+//   1. Auth path (ping non-200 → login runs): the token from the login
+//      response replaces the stored one.
+//   2. No-login path (ping 200 → public/no-auth save): the stored token is
+//      KEPT — an empty jwt means no login ran, and clobbering it would break
+//      iroh servers whose pairing-time JWT never comes from this flow.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:material_ui/material_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mstream_music/l10n/app_localizations.dart';
+import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/screens/add_server.dart';
+import 'package:mstream_music/singletons/server_list.dart';
+
+import 'helpers/test_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  MockServer? mock;
+  String? lastLoginPassword;
+
+  setUp(() async {
+    await resetAppState();
+    lastLoginPassword = null;
+  });
+
+  tearDown(() async {
+    await mock?.close();
+    mock = null;
+  });
+
+  Future<void> pumpEditScreen(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const Scaffold(body: SizedBox()),
+    ));
+    await tester.pumpAndSettle();
+    // Pushed (not home:) so saveServer's Navigator.pop has a route to pop.
+    tester
+        .state<NavigatorState>(find.byType(Navigator))
+        .push(MaterialPageRoute(
+            builder: (_) => const EditServerScreen(editThisServer: 0)));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> waitFor(bool Function() cond, String what,
+      {Duration timeout = const Duration(seconds: 15)}) async {
+    final deadline = DateTime.now().add(timeout);
+    while (!cond()) {
+      if (DateTime.now().isAfter(deadline)) fail('timed out waiting for $what');
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+  }
+
+  testWidgets('edit + login replaces the stored JWT', (tester) async {
+    mock = await MockServer.start({
+      // Non-200 ping forces checkServer down the login path.
+      '/api/v1/ping': (req) => null,
+      '/api/v1/auth/login': (HttpRequest req) async {
+        final body = await utf8.decoder.bind(req).join();
+        lastLoginPassword = Uri.splitQueryString(body)['password'];
+        return {'token': 'tok-FRESH'};
+      },
+    });
+    ServerManager()
+        .serverList
+        .add(Server(mock!.url, 'user', 'pw-old', 'tok-OLD', 'edit-target'));
+
+    await pumpEditScreen(tester);
+    await tester.tap(find.text('Save'));
+    // Real network round-trip — poll the singleton rather than pumpAndSettle
+    // (the login + save run behind awaits the widget tree doesn't surface).
+    await tester.runAsync(() => waitFor(
+        () => ServerManager().byLocalname('edit-target')?.jwt == 'tok-FRESH',
+        'the fresh token to be stored'));
+
+    expect(ServerManager().byLocalname('edit-target')!.jwt, 'tok-FRESH',
+        reason: 'the edit used to keep sending the old, dead token');
+    expect(lastLoginPassword, 'pw-old',
+        reason: 'login must run with the form credentials');
+  });
+
+  testWidgets('edit via the no-auth ping path keeps the stored JWT',
+      (tester) async {
+    // Default harness /ping answers 200 → saveServer(lol) runs with jwt ''.
+    mock = await MockServer.start({});
+    ServerManager()
+        .serverList
+        .add(Server(mock!.url, 'user', 'pw-old', 'tok-KEEP', 'edit-target'));
+
+    await pumpEditScreen(tester);
+    await tester.tap(find.text('Save'));
+    // The save pops the pushed route when it completes. Pump-poll (not
+    // runAsync): the pop only shows up in the tree once frames are pumped.
+    final deadline = DateTime.now().add(const Duration(seconds: 15));
+    while (tester.any(find.byType(EditServerScreen))) {
+      if (DateTime.now().isAfter(deadline)) {
+        fail('timed out waiting for the edit screen to pop after saving');
+      }
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
+    expect(ServerManager().byLocalname('edit-target')!.jwt, 'tok-KEEP',
+        reason: 'no login ran, so the stored token must survive '
+            '(iroh pairing tokens come from outside this flow)');
+  });
+}

--- a/integration_test/tls_scoping_test.dart
+++ b/integration_test/tls_scoping_test.dart
@@ -1,0 +1,172 @@
+// The native per-host TLS bypass, end-to-end (PR #119) — ANDROID ONLY,
+// and meaningful only on the FULL flavor (run with `--flavor full`): the
+// InsecureTls bridge is absent from the play source set by design.
+//
+// just_audio's ExoPlayer streams through the platform HttpsURLConnection
+// stack, so a Dart-side badCertificateCallback can't cover it — the fix
+// under test installs a DELEGATING trust manager scoped to the hosts the
+// user opted into. These two phases pin both halves of that contract
+// against a real TLS handshake with a self-signed in-process server:
+//
+//   1. Host opted in  → ExoPlayer streams and playback reaches ready and
+//      advances (the bypass works, per host).
+//   2. Host NOT opted in (set emptied → platform defaults restored) →
+//      the handshake fails and playback never reaches ready (validation
+//      is back; the old blanket trust-all would have kept playing).
+//
+// The server host is the IP literal 127.0.0.1 on purpose: LAN self-signed
+// servers are typically configured by IP, and the Kotlin resolves the peer
+// host from the connection (no SNI for IP literals) — this proves that
+// path works.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/singletons/media.dart';
+import 'package:mstream_music/singletons/server_list.dart';
+import 'package:mstream_music/util/stream_url.dart';
+
+import 'helpers/test_helpers.dart';
+
+// Self-signed 2048-bit RSA cert, CN=127.0.0.1, SAN IP:127.0.0.1 +
+// DNS:localhost, valid to 2036. Generated with openssl for this test only —
+// the platform trust store must reject it (that IS phase 2's assertion).
+const String _certPem = '''
+-----BEGIN CERTIFICATE-----
+MIICyTCCAbGgAwIBAgIJALxEOWbYx7/iMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV
+BAMMCTEyNy4wLjAuMTAeFw0yNjA5MDExMjA5MjFaFw0zNjA4MjkxMjA5MjFaMBQx
+EjAQBgNVBAMMCTEyNy4wLjAuMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAJze9qIjWZwgrGemh5eGeoBPC9V/qu0yY3YWUDFUsmW3I6yj/KUm07xudzMu
+zorFzes7/gtXJjHzMWLqzTMJH94/9MmLLZEWpetXcd/eGEZgMLqriRkdLEz0ANmD
+igx21Gq7O+gQVgeZynlta2BW+lstP6yzjPhv8fa9RURo9HDbRQTzvk6QUjF3r6Bj
+DKuNEi1Dy3HvVrS4AzDsVs/TNZ0G7j03RwV6msy1UT5zNvgxG9aIrEPhdUKldt9o
+MBGT4uJBGiUtKqs4oh3vUq8euX2oX5SwxZIsUIgU39oUrLwtM4x4ha0QXvg9kaY8
+/cMt5p/YQ5EjnEFpjC5Can/eZTECAwEAAaMeMBwwGgYDVR0RBBMwEYcEfwAAAYIJ
+bG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQB0v+XqjKnBWpnOYImYRHmOE50k
+BM3TtJBa0kNQulPFmvIZlrRxNvGNYlB2k3epdz9bYmm6Kzb6KRnmbu7k+izXOBwU
+ll16Bcw2lNcWCQiRL1Jg1vWE69xxZq45+bHbJVNSSnmiu6/xfy5Iesii60G8OBva
+DvfJIxQGLhg30oTJaJ9+p372d0AAjuoTvwS4kw+6uHXqsXycjSaopIUj1lVAXcp/
+jn1JfHjtt8ZLSqLSv5uU91x2foboGx5l3hi1//Vj2yFg1s37yzxFAduP3SGrRM5P
+RsRzNDcW5QCvsaBw9pgBsG3WaKF6va0THFMT4yKfqjU6mOoL4nOOHZMdjXZp
+-----END CERTIFICATE-----
+''';
+
+const String _keyPem = '''
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCc3vaiI1mcIKxn
+poeXhnqATwvVf6rtMmN2FlAxVLJltyOso/ylJtO8bnczLs6Kxc3rO/4LVyYx8zFi
+6s0zCR/eP/TJiy2RFqXrV3Hf3hhGYDC6q4kZHSxM9ADZg4oMdtRquzvoEFYHmcp5
+bWtgVvpbLT+ss4z4b/H2vUVEaPRw20UE875OkFIxd6+gYwyrjRItQ8tx71a0uAMw
+7FbP0zWdBu49N0cFeprMtVE+czb4MRvWiKxD4XVCpXbfaDARk+LiQRolLSqrOKId
+71KvHrl9qF+UsMWSLFCIFN/aFKy8LTOMeIWtEF74PZGmPP3DLeaf2EORI5xBaYwu
+Qmp/3mUxAgMBAAECggEAb1vL4v+LLkz3dkD+Qi+BqLH0aaPOd8FsX7ipRsukNJaU
+aYqj3603Y61bSucwUcznR9T3m59LCuxjo5+g+VjB2ai3IZd+Sl+0euNBgDUOMG86
+SFla4owWFa6lJ8O77OsyEW5GsY9fMtgWpqppLiOwZ6cwa22uZfI55vknQc/rrmyt
+BqyWWjCY4KQYqYV3qzlimskGrzTHSymIzjpJK86NA1VGpyX/b7/6DdonlKIWj+Tm
+2Jin8CDLLQCrS/c37v7ORW/O7aQ/tKpBgBvm+Udl3fj8gy6BF6PdB3ykgeA88UDC
+2Q7xiH0cV6QwSdk1svSoyomn9k1fjj3mlsPHewHHTQKBgQDIsjB3UfgC0TVk8VGP
+ALazbsqaGgoxjDZRyS6jYlWUAY02OZLQ5LylYMCmMgvnpTSfXuwTe8daFeQbtNHq
+MRxhdyS96YCutn4f2b3uxvGDCnPQgU/QmluNPuj2KUBQFQLYu0BkCH+ERZPgXfhb
+ze78NDoMjuJlWLDROwBfQF2b9wKBgQDIGTI3Vp/JrTxY4gAL4phxtIsL2NNDp34I
+rbv58v9oKQYvZcG12DLA6/wfMxxtvMiD2sRLpvHH8Vrg56ZeaA8lb0gHAACDaZxT
+bP+XPX5EGDVuX1v7Ir3vQAcmT4WhhYHhIe7v9mXUeGMHHjVkjY6pXIWTpW8iilUB
+sE4e9EkuFwKBgBQ8Y0akrS0bixayfla8668L7MG8/mogiRmV/23Z7GcQAP0GsRb+
++UZzivk28pxYvAWVvJf6Uw9yRZ3FjaTfbs0lBj9f2+nB3NW5Tr1UseVUmHjdkP6n
+kbOcNEEdx65LcA4KU2PCt5jOqypkTzZyfTZQzcmWXp15Y9q06ESyaL3hAoGBAMb0
+3oxNckVqHYXW+OrYXHE6bcLSzYUIZfWlITHunmtn1wGLsObpV9WhDqfK/ypRuiH4
+hJMgJGmEnrLfQfm+h8jV9A0ZwGjpuojs6NntR73XQFFFOcTkD2xzAmjiSuGGSNSc
+E+K+4RM4vGYYcEhRxBa7qwlaRb1XRByQu6xlgtnzAoGBAI7XsnOj24IAJB19W0/n
+NHfH2hcg0qocvBckqRAbgvhiYSlbEbpunyS99BCUK20ZyJ1YrCKiGFP1qMK3WJfu
+ItNS+jfzkf9OLVhEwJqEwk8vLPTRkKklV8kg2q80teiURPCkIfZxSAwUU4nCzz3l
+Bz2V8ENlMhrWkMCNlcPYnQBR
+-----END PRIVATE KEY-----
+''';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await MediaManager().start();
+  });
+
+  testWidgets('native TLS bypass is scoped to opted-in hosts',
+      (WidgetTester tester) async {
+    if (!Platform.isAndroid) {
+      markTestSkipped('native InsecureTls bridge is Android-only');
+      return;
+    }
+    await resetAppState();
+
+    final ctx = SecurityContext()
+      ..useCertificateChainBytes(utf8.encode(_certPem))
+      ..usePrivateKeyBytes(utf8.encode(_keyPem));
+    final mock = await MockServer.start(
+      const {},
+      // Every non-API path is a stream URL — serve a wav long enough that
+      // playback can't complete mid-assertion.
+      defaultHandler: (_) => buildSilentWav(seconds: 60),
+      securityContext: ctx,
+    );
+    addTearDown(mock.close);
+
+    final handler = MediaManager().audioHandler;
+    final srv = Server(mock.url, null, null, null, 'tls-test-server')
+      ..allowSelfSigned = true;
+    ServerManager().serverList.add(srv);
+    addTearDown(() async {
+      ServerManager().serverList.remove(srv);
+      ServerManager().syncInsecureTls();
+      await handler.customAction('clearPlaylist');
+    });
+
+    Future<void> queueAndPlay() async {
+      await handler.customAction('clearPlaylist');
+      await handler.addQueueItem(MediaItem(
+        id: buildServerStreamUrl(srv, '/demo/tone.wav'),
+        title: 'TLS probe',
+        extras: {'server': srv.localname, 'path': '/demo/tone.wav'},
+      ));
+      await handler.play();
+    }
+
+    bool readyAndPlaying() {
+      final s = handler.playbackState.value;
+      return s.playing &&
+          s.processingState == AudioProcessingState.ready &&
+          s.position > const Duration(milliseconds: 300);
+    }
+
+    // ── Phase 1: host opted in → the stream plays over the bypass. ──
+    ServerManager().syncInsecureTls();
+    await queueAndPlay();
+    final okDeadline = DateTime.now().add(const Duration(seconds: 25));
+    while (!readyAndPlaying()) {
+      if (DateTime.now().isAfter(okDeadline)) {
+        fail('opted-in self-signed host never reached playing/ready — the '
+            'per-host bypass is not letting ExoPlayer stream');
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    }
+
+    // ── Phase 2: opt-out → platform validation is back and blocks it. ──
+    await handler.customAction('clearPlaylist');
+    srv.allowSelfSigned = false;
+    ServerManager().syncInsecureTls();
+    // Let the channel round-trip land before the next handshake.
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    await queueAndPlay();
+    final failWindow = DateTime.now().add(const Duration(seconds: 10));
+    while (DateTime.now().isBefore(failWindow)) {
+      expect(readyAndPlaying(), isFalse,
+          reason: 'with the host no longer opted in, the self-signed '
+              'handshake must fail — reaching ready means validation is '
+              'still bypassed (the old process-wide trust-all behavior)');
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+    }
+  });
+}

--- a/lib/media/chromecast_playback_backend.dart
+++ b/lib/media/chromecast_playback_backend.dart
@@ -808,6 +808,11 @@ class ChromecastPlaybackBackend extends EmulatedPlaylistBackend {
     try {
       await _client.stop();
     } catch (_) {}
+    // _client.stop() unloads the receiver's media session, so the loaded track
+    // is gone on the renderer side. Without resetting loadedIndex, the next
+    // play() takes the fast path and issues a bare _client.play() against a
+    // session-less receiver — a swallowed no-op reported as "playing".
+    loadedIndex = -1;
     playing = false;
     setProcessingState(BackendProcessingState.idle);
     change();

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -830,6 +830,11 @@ class MyCustomFormState extends State<MyCustomForm> {
       s.storageMode = _storageMode;
       s.allowSelfSigned = _allowSelfSigned;
       s.storageBasePath = basePath;
+      // checkServer just logged in with the (possibly edited) credentials —
+      // keep the fresh token, or every later request would still send the old
+      // one (nothing else re-logs-in on a 401). Empty jwt means no login ran
+      // (no-auth ping path / direct iroh save): keep the stored token.
+      if (jwt.isNotEmpty) s.jwt = jwt;
       ServerManager()
           .editServer(widget.editThisServer!, _urlCtrl.text, username, password);
       await ServerManager().getServerPaths(s);

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -940,11 +940,20 @@ class ServerManager {
     return false;
   }
 
-  /// Enable the native trust-all TLS bridge (ExoPlayer streaming) iff some
-  /// server opted into self-signed. No-op on the Play build. Call whenever the
-  /// server list changes.
+  /// Sync the native per-host TLS bypass (ExoPlayer streaming) to the hosts of
+  /// servers that opted into self-signed — only those hosts skip validation;
+  /// everything else keeps platform TLS. No-op on the Play build. Call whenever
+  /// the server list changes.
   void syncInsecureTls() {
-    InsecureTlsChannel.setEnabled(serverList.any((s) => s.allowSelfSigned));
+    final hosts = <String>{};
+    for (final s in serverList) {
+      if (!s.allowSelfSigned) continue;
+      try {
+        final host = Uri.parse(s.url).host;
+        if (host.isNotEmpty) hosts.add(host);
+      } catch (_) {}
+    }
+    InsecureTlsChannel.setAllowedHosts(hosts);
   }
 
   /// Like [byLocalname] but throws when no server matches — for legacy callers

--- a/lib/util/insecure_tls_channel.dart
+++ b/lib/util/insecure_tls_channel.dart
@@ -2,20 +2,25 @@ import 'package:flutter/services.dart';
 
 import '../build_variant.dart';
 
-/// Toggles the native trust-all TLS bridge (full flavor only) so just_audio's
+/// Syncs the native per-host TLS bypass (full flavor only) so just_audio's
 /// ExoPlayer can stream from a self-signed server. The Dart `http` API path is
 /// handled separately by SelfSignedHttpOverrides — ExoPlayer uses the native TLS
 /// stack, which Dart can't reach into.
+///
+/// Only the hosts passed here skip validation on the native side; every other
+/// host keeps full platform TLS validation (mirroring the per-host scoping of
+/// SelfSignedHttpOverrides). An empty list restores the platform defaults.
 ///
 /// No-op on the Play build (the channel isn't registered there); errors are
 /// swallowed so a missing handler never breaks startup.
 class InsecureTlsChannel {
   static const MethodChannel _channel = MethodChannel('mstream/insecure_tls');
 
-  static Future<void> setEnabled(bool enabled) async {
+  static Future<void> setAllowedHosts(Iterable<String> hosts) async {
     if (isPlayBuild) return;
     try {
-      await _channel.invokeMethod('setEnabled', {'enabled': enabled});
+      await _channel
+          .invokeMethod('setAllowedHosts', {'hosts': hosts.toList()});
     } catch (_) {
       // No handler (Play build / non-Android / tests) — streaming self-signed
       // is simply unavailable; API self-signed still works via HttpOverrides.

--- a/test/media/chromecast_stop_test.dart
+++ b/test/media/chromecast_stop_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/chromecast_playback_backend.dart';
+import 'package:mstream_music/media/playback_backend.dart';
+
+/// Exposes the protected playlist bookkeeping so the test can seed the
+/// "track loaded on the receiver" state without a live Cast session. The
+/// plugin's channel calls throw MissingPluginException here, which stop()
+/// swallows — exactly like a broken session in production.
+class _TestableCast extends ChromecastPlaybackBackend {
+  _TestableCast() : super(deviceId: 'test-device');
+
+  void seedLoaded(int i) {
+    index = i;
+    loadedIndex = i;
+    playing = true;
+  }
+
+  int get exposedLoadedIndex => loadedIndex;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ChromecastPlaybackBackend.stop', () {
+    // Regression: stop() unloads the receiver's media session but used to keep
+    // loadedIndex, so the next play() fast-pathed into a bare _client.play()
+    // against a session-less receiver and reported "playing" over silence.
+    test('resets loadedIndex so the next play() must reload', () async {
+      final b = _TestableCast();
+      b.seedLoaded(0);
+      expect(b.exposedLoadedIndex, 0, reason: 'seeded as loaded');
+
+      await b.stop();
+
+      expect(b.exposedLoadedIndex, -1,
+          reason: 'stop() unloaded the receiver session; loadedIndex must not '
+              'claim a track is still loaded');
+      expect(b.playing, isFalse);
+      expect(b.processingState, BackendProcessingState.idle);
+    });
+  });
+}

--- a/test/media/chromecast_stop_test.dart
+++ b/test/media/chromecast_stop_test.dart
@@ -16,6 +16,20 @@ class _TestableCast extends ChromecastPlaybackBackend {
   }
 
   int get exposedLoadedIndex => loadedIndex;
+
+  // Records reloads instead of talking to the plugin, so the play-after-stop
+  // test can assert the ROUTE play() took: the fixed path calls loadIndex
+  // (reloading the receiver), the broken fast path never did.
+  final List<({int index, bool play})> loadCalls = [];
+
+  @override
+  Future<bool> loadIndex(int target,
+      {required bool play, Duration startAt = Duration.zero}) async {
+    loadCalls.add((index: target, play: play));
+    loadedIndex = target;
+    if (play) playing = true;
+    return true;
+  }
 }
 
 void main() {
@@ -37,6 +51,23 @@ void main() {
               'claim a track is still loaded');
       expect(b.playing, isFalse);
       expect(b.processingState, BackendProcessingState.idle);
+    });
+
+    // The other half of the contract: with loadedIndex reset, the next play()
+    // must ROUTE THROUGH loadIndex (reloading the track on the receiver). The
+    // broken fast path issued a bare _client.play() against the unloaded
+    // session — a swallowed no-op reported as "playing" — and never reloaded.
+    test('play() after stop() reloads via loadIndex', () async {
+      final b = _TestableCast();
+      b.seedLoaded(0);
+      await b.stop();
+
+      await b.play();
+
+      expect(b.loadCalls, [(index: 0, play: true)],
+          reason: 'a session-less receiver needs a fresh LOAD, not a bare '
+              'play()');
+      expect(b.playing, isTrue);
     });
   });
 }

--- a/test/singletons/insecure_tls_sync_test.dart
+++ b/test/singletons/insecure_tls_sync_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/singletons/server_list.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('mstream/insecure_tls');
+  final calls = <MethodCall>[];
+
+  Server server(String url, {bool selfSigned = false}) {
+    final s = Server(url, 'user', 'pw', 'jwt', 'local-$url');
+    s.allowSelfSigned = selfSigned;
+    return s;
+  }
+
+  setUp(() {
+    calls.clear();
+    ServerManager().serverList.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+  });
+
+  tearDown(() {
+    ServerManager().serverList.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  group('ServerManager.syncInsecureTls', () {
+    test('sends only the hosts of servers that opted into self-signed',
+        () async {
+      ServerManager().serverList.addAll([
+        server('https://valid.example.com'), // no opt-in → must NOT be sent
+        server('https://Self1.Example.com:8443', selfSigned: true),
+        server('https://192.168.1.7:3000', selfSigned: true),
+        server('iroh://abcdef0123'), // iroh, no opt-in
+      ]);
+
+      ServerManager().syncInsecureTls();
+      await pumpEventQueue();
+
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'setAllowedHosts');
+      final hosts =
+          (calls.single.arguments['hosts'] as List).cast<String>().toSet();
+      // Uri.parse lowercases the host; the valid-cert and iroh servers are
+      // excluded — this is the per-host scoping the fix is about.
+      expect(hosts, {'self1.example.com', '192.168.1.7'});
+    });
+
+    test('duplicate hosts are sent once', () async {
+      ServerManager().serverList.addAll([
+        server('https://nas.local:8443', selfSigned: true),
+        server('https://nas.local:9443', selfSigned: true),
+      ]);
+
+      ServerManager().syncInsecureTls();
+      await pumpEventQueue();
+
+      expect(
+          (calls.single.arguments['hosts'] as List).cast<String>(),
+          ['nas.local']);
+    });
+
+    test('no opted-in servers → empty host list (restores platform TLS)',
+        () async {
+      ServerManager().serverList.add(server('https://valid.example.com'));
+
+      ServerManager().syncInsecureTls();
+      await pumpEventQueue();
+
+      expect(calls.single.method, 'setAllowedHosts');
+      expect(calls.single.arguments['hosts'], isEmpty);
+    });
+
+    test('missing native handler is swallowed (Play build / iOS / tests)',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null); // no handler registered
+      ServerManager()
+          .serverList
+          .add(server('https://nas.local', selfSigned: true));
+
+      // Must not throw even though the channel has no handler.
+      ServerManager().syncInsecureTls();
+      await pumpEventQueue();
+    });
+  });
+}


### PR DESCRIPTION
Fixes the three high-severity findings from the full codebase audit (52 verified findings; report in the audit session). **Base of the audit-fix stack** — merge order: this (#119) → #120 (batch 1) → #121 (batch 2) → #118 (batch 3).

## Fixes

**Self-signed TLS opt-in no longer disables validation process-wide.** The full flavor's `InsecureTls` bridge was toggled by a boolean: once ANY server had `allowSelfSigned`, it swapped the process-default `SSLSocketFactory`/`HostnameVerifier` to trust-all — every `HttpsURLConnection` user (ExoPlayer streams from other valid-cert servers, all `background_downloader` transfers) lost cert AND hostname validation. The Dart side now syncs the actual opted-in host set, and the native side installs a delegating `X509ExtendedTrustManager` + verifier: opted-in hosts skip validation exactly as before; every other host is handed to the untouched platform trust manager; no-host-context handshakes fail closed; an empty set restores platform defaults. The per-connection `applyArtTls` path is unchanged (already caller-scoped).

**Play after stop while casting no longer wedges in "playing".** `ChromecastPlaybackBackend.stop()` unloads the receiver's media session but kept `loadedIndex`, so the next `play()` fast-pathed into a bare `_client.play()` against a session-less receiver — a swallowed no-op reported as playing. The queue naturally completing while casting hit this automatically. `stop()` now resets `loadedIndex` so `play()` reloads. (DLNA deliberately unchanged: its status poller self-corrects.)

**Editing a server persists the freshly obtained JWT.** The edit flow logged in and then discarded the new token (`editServer` only updates url/username/password; there is no 401-relogin path anywhere), so after a password change every request kept sending the dead token until the server was deleted and re-added. The edit branch now stores the token when a login actually ran — guarded on non-empty so the no-auth ping path and the direct iroh save can't clobber a pairing-time JWT.

## Verification

- `flutter analyze` clean; full test suite passes, including new unit tests for the TLS host-set sync (exact hosts, dedup, empty-set restore, missing-handler swallow) and the Chromecast `stop()` state reset.
- JWT fix verified end-to-end in the iOS Simulator against a fake mStream server that invalidates old tokens on password rotation: post-edit requests carried the fresh token, persisted across app relaunch.
- **Not yet verified: the Kotlin side.** No Android SDK on the dev Mac — `InsecureTls.kt` is hand-verified against API 24+ signatures (minSdk 26) but needs an Android build, plus an on-device check that self-signed streaming still works while a valid-cert server keeps validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
