### PR TITLE
Audit batch 1: serialized persistence + slider write storms

### DIFF
--- a/lib/screens/auto_dj.dart
+++ b/lib/screens/auto_dj.dart
@@ -53,6 +53,13 @@ class _AutoDJScreenState extends State<AutoDJScreen> {
 
   final TextEditingController _keywordCtrl = TextEditingController();
 
+  // In-flight slider drag values. The sliders update these (cheap, local)
+  // per drag tick and commit to AutoDJManager only in onChangeEnd — the
+  // manager setter does a _notify() plus a full auto_dj.json rewrite, which
+  // used to run on EVERY tick of a drag (up to ~50 writes per gesture).
+  double? _sonicDrag;
+  int? _bpmDrag;
+
   @override
   void initState() {
     super.initState();
@@ -312,7 +319,7 @@ class _AutoDJScreenState extends State<AutoDJScreen> {
                 Spacer(),
                 Text(
                   l.autoDjSonicStrictnessValue(
-                      (mgr.sonicMinSimilarity * 100).round()),
+                      ((_sonicDrag ?? mgr.sonicMinSimilarity) * 100).round()),
                   style: TextStyle(
                     color: VelvetColors.primary,
                     fontSize: 13,
@@ -330,11 +337,17 @@ class _AutoDJScreenState extends State<AutoDJScreen> {
               // Raw cosine threshold; the useful band in practice —
               // webapp's slider covers the same perceptual range.
               child: Slider(
-                value: mgr.sonicMinSimilarity.clamp(0.30, 0.80),
+                value: (_sonicDrag ?? mgr.sonicMinSimilarity).clamp(0.30, 0.80),
                 min: 0.30,
                 max: 0.80,
                 divisions: 50,
-                onChanged: (v) => mgr.setSonicMinSimilarity(v),
+                // Track the drag locally; persist once on release (the EQ
+                // screen's pattern) instead of a notify+file-write per tick.
+                onChanged: (v) => setState(() => _sonicDrag = v),
+                onChangeEnd: (v) async {
+                  await mgr.setSonicMinSimilarity(v);
+                  if (mounted) setState(() => _sonicDrag = null);
+                },
               ),
             ),
             // What the DJ does from a standing start. The old row here was a
@@ -458,7 +471,7 @@ class _AutoDJScreenState extends State<AutoDJScreen> {
                 ),
                 Spacer(),
                 Text(
-                  l.autoDjBpmTolerance(mgr.bpmTolerance),
+                  l.autoDjBpmTolerance(_bpmDrag ?? mgr.bpmTolerance),
                   style: TextStyle(
                     color: VelvetColors.primary,
                     fontSize: 13,
@@ -474,11 +487,17 @@ class _AutoDJScreenState extends State<AutoDJScreen> {
                 overlayColor: VelvetColors.primaryDim,
               ),
               child: Slider(
-                value: mgr.bpmTolerance.toDouble().clamp(1.0, 20.0),
+                value: (_bpmDrag ?? mgr.bpmTolerance).toDouble().clamp(1.0, 20.0),
                 min: 1,
                 max: 20,
                 divisions: 19,
-                onChanged: (v) => mgr.setBpmTolerance(v.round()),
+                // Local during the drag, persisted once on release — see
+                // _sonicDrag.
+                onChanged: (v) => setState(() => _bpmDrag = v.round()),
+                onChangeEnd: (v) async {
+                  await mgr.setBpmTolerance(v.round());
+                  if (mounted) setState(() => _bpmDrag = null);
+                },
               ),
             ),
           ],

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -28,6 +28,13 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
+  // In-flight letter-strip slider drag value. Updated locally per drag tick;
+  // committed via setLetterStripThreshold only in onChangeEnd — the setter
+  // rewrites all of settings.json AND re-emits the whole browser list per
+  // call, which used to run on every tick of a drag.
+  int? _letterStripDrag;
+
+
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
@@ -477,7 +484,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       ),
                     ),
                     Text(
-                      '${SettingsManager().letterStripThreshold}',
+                      '${_letterStripDrag ?? SettingsManager().letterStripThreshold}',
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w700,
@@ -499,18 +506,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     overlayColor: VelvetColors.primaryDim,
                   ),
                   child: Slider(
-                    value: SettingsManager()
-                        .letterStripThreshold
-                        .toDouble()
-                        .clamp(0.0, 100.0),
+                    value:
+                        (_letterStripDrag ?? SettingsManager().letterStripThreshold)
+                            .toDouble()
+                            .clamp(0.0, 100.0),
                     min: 0,
                     max: 100,
                     divisions: 20,
-                    onChanged: (v) async {
-                      setState(() {});
-                      await SettingsManager()
-                          .setLetterStripThreshold(v.round());
-                      setState(() {});
+                    // Local during the drag; committed once on release — the
+                    // setter rewrites settings.json and re-emits the entire
+                    // browser list, so it must not run per tick.
+                    onChanged: (v) =>
+                        setState(() => _letterStripDrag = v.round()),
+                    onChangeEnd: (v) async {
+                      await SettingsManager().setLetterStripThreshold(v.round());
+                      if (mounted) setState(() => _letterStripDrag = null);
                     },
                   ),
                 ),

--- a/lib/singletons/auto_dj_manager.dart
+++ b/lib/singletons/auto_dj_manager.dart
@@ -17,6 +17,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../objects/server.dart';
+import '../util/write_chain.dart';
 
 /// Which paths feed random-songs' `similarTo` when sonic mode is on — a
 /// pure client-side policy (the server statelessly averages whatever
@@ -262,7 +263,11 @@ class AutoDJManager {
     return v.clamp(durationFloorSec, durationCeilSec);
   }
 
-  Future<void> _save() async {
+  // Serialized so overlapping saves can't interleave truncate+writes on
+  // auto_dj.json (load() silently resets every setting on a corrupt file).
+  final WriteChain _writeChain = WriteChain();
+
+  Future<void> _save() => _writeChain.run(() async {
     final f = await _file;
     await f.writeAsString(jsonEncode({
       // Held only until the migration runs; see the field declarations.
@@ -289,7 +294,7 @@ class AutoDJManager {
       'maxDurationSec': maxDurationSec,
       'allowUnknownDuration': allowUnknownDuration,
     }));
-  }
+  });
 
   /// Remember which server Auto DJ is running on (null = off). Called from the
   /// audio handler's setAutoDJ, so every path that toggles the DJ — the queue

--- a/lib/singletons/auto_download_ledger.dart
+++ b/lib/singletons/auto_download_ledger.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:path_provider/path_provider.dart';
 
 import '../objects/auto_download_entry.dart';
+import '../util/write_chain.dart';
 import 'log_manager.dart';
 
 /// Persistent, ordered record of auto-downloaded tracks (keep-queue-offline),
@@ -103,13 +104,18 @@ class AutoDownloadLedger {
           int cap, bool Function(String server, String path) isProtected) =>
       selectEvictions(_entries, cap, isProtected: isProtected);
 
-  Future<void> _persist() async {
-    try {
-      final f = await _file();
-      await f.writeAsString(
-          jsonEncode(_entries.map((e) => e.toJson()).toList()));
-    } catch (e) {
-      appLog('[auto-dl] ledger persist failed: $e');
-    }
-  }
+  // Serialized: two downloads completing near-simultaneously (routine during
+  // a keep-queue-offline sweep or "Download all") both run record→_persist;
+  // without the chain their truncate+writes interleave on auto_downloads.json.
+  final WriteChain _writeChain = WriteChain();
+
+  Future<void> _persist() => _writeChain.run(() async {
+        try {
+          final f = await _file();
+          await f.writeAsString(
+              jsonEncode(_entries.map((e) => e.toJson()).toList()));
+        } catch (e) {
+          appLog('[auto-dl] ledger persist failed: $e');
+        }
+      });
 }

--- a/lib/singletons/playlists.dart
+++ b/lib/singletons/playlists.dart
@@ -16,6 +16,7 @@ import 'package:rxdart/rxdart.dart';
 
 import '../objects/playlist.dart';
 import '../singletons/media.dart';
+import '../util/write_chain.dart';
 
 class PlaylistManager {
   PlaylistManager._privateConstructor();
@@ -52,10 +53,15 @@ class PlaylistManager {
     }
   }
 
-  Future<void> _save() async {
-    final f = await _file;
-    await f.writeAsString(jsonEncode(playlists.map((p) => p.toJson()).toList()));
-  }
+  // Serialized so rapid successive edits (create + add-song, bulk removes)
+  // can't interleave truncate+writes on playlists.json.
+  final WriteChain _writeChain = WriteChain();
+
+  Future<void> _save() => _writeChain.run(() async {
+        final f = await _file;
+        await f
+            .writeAsString(jsonEncode(playlists.map((p) => p.toJson()).toList()));
+      });
 
   Future<Playlist> create(String name) async {
     final p = Playlist(name: name, entries: []);

--- a/lib/singletons/queue_store.dart
+++ b/lib/singletons/queue_store.dart
@@ -8,6 +8,7 @@ import 'package:uuid/uuid.dart';
 
 import '../objects/server.dart';
 import '../util/stream_url.dart';
+import '../util/write_chain.dart';
 import 'media.dart';
 import 'server_list.dart';
 import 'log_manager.dart';
@@ -45,6 +46,20 @@ class QueueStore {
   Timer? _debounceTimer;
   Timer? _ticker;
   final List<StreamSubscription> _subs = [];
+
+  // Serializes the snapshot writes AND deletes so they can't interleave a
+  // truncate+write on queue.json (a delete racing a checkpoint write is the
+  // same hazard).
+  final WriteChain _writeChain = WriteChain();
+
+  // Encoded 'items' array of the last snapshot, invalidated on every queue
+  // emission. The items are the whole queue — by far the largest part of the
+  // file and unchanged between most checkpoints (the 10s position ticker), so
+  // the checkpoint splices a fresh header onto this instead of re-serializing
+  // every item each time. Every queue content change re-emits the handler's
+  // queue subject (including the mutate-in-place `queue.value..add(x)` sites),
+  // so emission-invalidation is sound.
+  String? _itemsJsonCache;
 
   Future<File> get _file async {
     final dir = await getApplicationDocumentsDirectory();
@@ -196,8 +211,12 @@ class QueueStore {
 
   void _attachListeners() {
     final handler = MediaManager().audioHandler;
-    // Queue edits (add / remove / reorder / clear) and track changes.
-    _subs.add(handler.queue.listen((_) => _schedule()));
+    // Queue edits (add / remove / reorder / clear) and track changes. A queue
+    // emission means the items may have changed — drop the cached encoding.
+    _subs.add(handler.queue.listen((_) {
+      _itemsJsonCache = null;
+      _schedule();
+    }));
     _subs.add(handler.mediaItem.listen((_) => _schedule()));
     // Periodic position checkpoint while actually playing.
     _ticker = Timer.periodic(_tick, (_) {
@@ -236,7 +255,9 @@ class QueueStore {
       final file = await _file;
       if (!SettingsManager().resumeQueue) {
         // Feature disabled — drop any saved queue so it can't be restored.
-        if (await file.exists()) await file.delete();
+        await _writeChain.run(() async {
+          if (await file.exists()) await file.delete();
+        });
         return;
       }
       final handler = MediaManager().audioHandler;
@@ -248,7 +269,11 @@ class QueueStore {
         // whiffed — transient server-list read failure, no resolvable items —
         // would destroy the very snapshot the resumption chip serves, turning
         // a recoverable hiccup into permanent loss.
-        if (_hadQueue && await file.exists()) await file.delete();
+        if (_hadQueue) {
+          await _writeChain.run(() async {
+            if (await file.exists()) await file.delete();
+          });
+        }
         return;
       }
       _hadQueue = true;
@@ -264,18 +289,39 @@ class QueueStore {
       final int? durMs = spot != null
           ? (idx < queue.length ? queue[idx].duration?.inMilliseconds : null)
           : handler.mediaItem.value?.duration?.inMilliseconds;
-      final snapshot = <String, dynamic>{
-        'version': _schemaVersion,
-        'index': idx,
-        'positionMs': clampResumePositionMs(pos.inMilliseconds, durMs),
-        'shuffle': state.shuffleMode == AudioServiceShuffleMode.all,
-        'repeat': _repeatName(state.repeatMode),
-        'items': queue.map(itemToJson).toList(),
-      };
-      await file.writeAsString(jsonEncode(snapshot));
+      final itemsJson =
+          _itemsJsonCache ??= jsonEncode(queue.map(itemToJson).toList());
+      final content = snapshotJson(
+        index: idx,
+        positionMs: clampResumePositionMs(pos.inMilliseconds, durMs),
+        shuffle: state.shuffleMode == AudioServiceShuffleMode.all,
+        repeat: _repeatName(state.repeatMode),
+        itemsJson: itemsJson,
+      );
+      await _writeChain.run(() => file.writeAsString(content));
     } catch (e) {
       appLog('[queue] save failed: $e');
     }
+  }
+
+  /// Assemble the snapshot by splicing the pre-encoded items array into the
+  /// encoded header — see [_itemsJsonCache] for why the array is cached.
+  /// Pure; unit-tested to stay byte-identical with a full jsonEncode.
+  static String snapshotJson({
+    required int index,
+    required int positionMs,
+    required bool shuffle,
+    required String repeat,
+    required String itemsJson,
+  }) {
+    final header = jsonEncode({
+      'version': _schemaVersion,
+      'index': index,
+      'positionMs': positionMs,
+      'shuffle': shuffle,
+      'repeat': repeat,
+    });
+    return '${header.substring(0, header.length - 1)},"items":$itemsJson}';
   }
 
   // ── (de)serialization — pure & static so they're unit-testable ──

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -10,6 +10,7 @@ import './log_manager.dart';
 import '../build_variant.dart';
 import '../util/insecure_tls_channel.dart';
 import '../util/server_version.dart';
+import '../util/write_chain.dart';
 import '../native/iroh_tunnel.dart';
 import '../media/cast_target.dart';
 import 'cast_manager.dart';
@@ -49,22 +50,16 @@ class ServerManager {
     return File('$path/servers.json');
   }
 
-  // Serializes writes through a single chain so overlapping truncate+writes
-  // can't corrupt servers.json — notably the parallel getServerPaths() pings
-  // fired at startup (loadServerList), which can each trigger a
-  // capability-change write at the same moment.
-  Future<void> _writeChain = Future.value();
+  // Serializes writes so overlapping truncate+writes can't corrupt
+  // servers.json — notably the parallel getServerPaths() pings fired at
+  // startup (loadServerList), which can each trigger a capability-change
+  // write at the same moment.
+  final WriteChain _writeChain = WriteChain();
 
-  Future<void> writeServerFile() {
-    final write = _writeChain.then((_) async {
-      final file = await _serverFile;
-      await file.writeAsString(jsonEncode(serverList));
-    });
-    // The baton swallows errors so one failed write can't block later writes;
-    // the caller still sees this write's own error via [write].
-    _writeChain = write.catchError((_) {});
-    return write;
-  }
+  Future<void> writeServerFile() => _writeChain.run(() async {
+        final file = await _serverFile;
+        await file.writeAsString(jsonEncode(serverList));
+      });
 
   Future<List> readServerManager() async {
     try {

--- a/lib/singletons/settings.dart
+++ b/lib/singletons/settings.dart
@@ -8,6 +8,7 @@ import 'package:rxdart/rxdart.dart';
 
 import '../objects/player_layout.dart';
 import '../theme/velvet_theme.dart';
+import '../util/write_chain.dart';
 import 'transcode.dart';
 
 /// How tapping a song in the browser should behave. The default
@@ -519,7 +520,11 @@ class SettingsManager {
     return {...current, c};
   }
 
-  Future<void> _save() async {
+  // Serialized so overlapping saves (e.g. two toggles in quick succession)
+  // can't interleave truncate+writes on settings.json — see WriteChain.
+  final WriteChain _writeChain = WriteChain();
+
+  Future<void> _save() => _writeChain.run(() async {
     final f = await _file;
     await f.writeAsString(jsonEncode({
       'transcode': TranscodeManager().transcodeOn,
@@ -558,7 +563,7 @@ class SettingsManager {
       'castVisualizerQuality': castVisualizerQuality.name,
       'language': language,
     }));
-  }
+  });
 
   Future<void> setTranscode(bool v) async {
     TranscodeManager().transcodeOn = v;

--- a/lib/util/write_chain.dart
+++ b/lib/util/write_chain.dart
@@ -1,0 +1,23 @@
+/// Serializes writes to a single file through one chain so overlapping
+/// truncate+write cycles can't interleave and corrupt it.
+///
+/// This is the servers.json pattern (ServerManager's write chain), extracted
+/// so the other persistence files — settings.json, auto_dj.json,
+/// playlists.json, queue.json, auto_downloads.json — get the same guarantee.
+/// Their loads all swallow a corrupt file (by design: startup must not block),
+/// which makes silent interleaved-write corruption a silent settings/data
+/// reset; serializing the writes removes the hazard at the source.
+class WriteChain {
+  Future<void> _chain = Future.value();
+
+  /// Run [action] after every previously queued action has settled.
+  ///
+  /// The returned future completes (or errors) with [action]'s own outcome;
+  /// the internal baton swallows errors so one failed write can't block
+  /// every write that comes after it.
+  Future<void> run(Future<void> Function() action) {
+    final next = _chain.then((_) => action());
+    _chain = next.catchError((_) {});
+    return next;
+  }
+}

--- a/test/singletons/queue_store_test.dart
+++ b/test/singletons/queue_store_test.dart
@@ -243,4 +243,71 @@ void main() {
       expect(item!.title, 'Second');
     });
   });
+
+  group('QueueStore.snapshotJson', () {
+    // The checkpoint path splices a cached pre-encoded items array into a
+    // freshly encoded header — the result must stay byte-identical to a full
+    // jsonEncode of the equivalent snapshot map, or restore/peek would drift.
+    test('splice is byte-identical to a full jsonEncode', () {
+      final items = [
+        QueueStore.itemToJson(MediaItem(
+          id: 'http://host/media/a',
+          title: 'A "quoted" title', // exercise JSON escaping
+          duration: const Duration(milliseconds: 91000),
+          extras: {'server': 's1', 'path': '/music/a.mp3'},
+        )),
+        QueueStore.itemToJson(
+            MediaItem(id: 'local-1', title: 'B', extras: {'localPath': '/x'})),
+      ];
+
+      final spliced = QueueStore.snapshotJson(
+        index: 1,
+        positionMs: 4200,
+        shuffle: true,
+        repeat: 'one',
+        itemsJson: jsonEncode(items),
+      );
+      final full = jsonEncode({
+        'version': 1,
+        'index': 1,
+        'positionMs': 4200,
+        'shuffle': true,
+        'repeat': 'one',
+        'items': items,
+      });
+
+      expect(spliced, full);
+    });
+
+    test('splice output feeds the restore-side readers', () {
+      final items = [
+        {
+          'title': 'Only',
+          'extras': {'server': 's1', 'path': '/a', 'artUrl': 'http://h/a.jpg'},
+        },
+      ];
+      final decoded = jsonDecode(QueueStore.snapshotJson(
+        index: 0,
+        positionMs: 0,
+        shuffle: false,
+        repeat: 'none',
+        itemsJson: jsonEncode(items),
+      ));
+      final entry = QueueStore.currentEntryFromSnapshot(decoded);
+      expect(entry, isNotNull);
+      expect(QueueStore.resumeItemFromSnapshot(entry)!.title, 'Only');
+    });
+
+    test('empty items array splices cleanly', () {
+      final decoded = jsonDecode(QueueStore.snapshotJson(
+        index: 0,
+        positionMs: 0,
+        shuffle: false,
+        repeat: 'all',
+        itemsJson: '[]',
+      ));
+      expect(decoded['items'], isEmpty);
+      expect(decoded['version'], 1);
+    });
+  });
 }

--- a/test/util/write_chain_test.dart
+++ b/test/util/write_chain_test.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/util/write_chain.dart';
+
+void main() {
+  group('WriteChain', () {
+    test('serializes overlapping actions in submission order', () async {
+      final chain = WriteChain();
+      final log = <String>[];
+      final gate = Completer<void>();
+
+      // First action blocks until released; the rest are queued behind it.
+      final f1 = chain.run(() async {
+        log.add('a:start');
+        await gate.future;
+        log.add('a:end');
+      });
+      final f2 = chain.run(() async => log.add('b'));
+      final f3 = chain.run(() async => log.add('c'));
+
+      // Nothing after the first can run while it is in flight — this is the
+      // interleaved truncate+write hazard the chain exists to prevent.
+      await Future<void>.delayed(Duration.zero);
+      expect(log, ['a:start']);
+
+      gate.complete();
+      await Future.wait([f1, f2, f3]);
+      expect(log, ['a:start', 'a:end', 'b', 'c']);
+    });
+
+    test('a failed action does not block later actions', () async {
+      final chain = WriteChain();
+      final log = <String>[];
+
+      final failing = chain.run(() async => throw StateError('disk full'));
+      final after = chain.run(() async => log.add('after'));
+
+      await expectLater(failing, throwsStateError);
+      await after;
+      expect(log, ['after']);
+    });
+
+    test('each caller sees its own action outcome', () async {
+      final chain = WriteChain();
+      final ok = chain.run(() async {});
+      final bad = chain.run(() async => throw StateError('nope'));
+      final okAgain = chain.run(() async {});
+
+      await expectLater(ok, completes);
+      await expectLater(bad, throwsStateError);
+      await expectLater(okAgain, completes);
+    });
+  });
+}


### PR DESCRIPTION
Batch 1 of the audit's medium-severity findings: the unserialized-persistence family (#44, #15, #17 in the audit report) and the per-drag-tick write storms (#9, #43), plus the queue checkpoint re-encode (#42).

> **Stacked PR** — based on `claude/fix-audit-high-severity` (#119). Merge order: #119 → this → batch 2 → #118.

## Fixes

**Serialized writes for every app-state file.** The servers.json write chain (added after a real corruption hazard) is extracted into a shared `WriteChain` and applied to settings.json, auto_dj.json, playlists.json, auto_downloads.json, and queue.json — including queue.json's deletes, since a delete racing a checkpoint write is the same truncate hazard. Every one of these loads silently swallows a corrupt file by design, so an interleaved write meant a silent settings/data reset.

**Sliders persist on release, not per tick.** The settings letter-strip slider and the Auto DJ sonic-strictness + BPM sliders committed through their manager setters on every drag tick — a full file rewrite per tick, plus (letter-strip) a whole browser-list re-emit and (Auto DJ) a whole-screen notify, up to ~50× per gesture. They now track the drag in local widget state and persist once in `onChangeEnd` — the pattern the EQ screen already documents.

**Queue checkpoints stop re-serializing every item.** The 10s position ticker re-encoded the entire queue each tick. The encoded items array is now cached (invalidated on queue emissions — every mutation site re-emits the subject, including the mutate-in-place sites) and checkpoints splice a fresh header onto it via `QueueStore.snapshotJson`, unit-tested byte-identical to the previous full encode.

## Verification

- `flutter analyze` clean; full suite passes with new tests: WriteChain ordering/error-isolation/error-surfacing, snapshot splice equivalence + restore-reader compatibility.
- iOS Simulator smoke with measured write counts: dragging the letter-strip slider end-to-end produced **exactly one** settings.json write (at release, final value persisted) where the old code wrote per crossed division; same for the BPM slider. A queue checkpoint through the spliced writer produced a byte-valid snapshot that restored correctly across relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)