### PR TITLE
Audit batch 2: HTTP layer — timeouts, shared client, off-isolate decode, batch enqueue

### DIFF
--- a/integration_test/batch_add_test.dart
+++ b/integration_test/batch_add_test.dart
@@ -1,0 +1,77 @@
+// Batch add ("Add all") onto an empty queue (PR #121 follow-up).
+//
+// The regression this pins: addQueueItems onto a fresh IDLE player let
+// just_audio's idle stub land the current index on the LAST row, so the
+// now-playing surfaces showed the final track and a later play() re-seeded
+// there too ("added a folder, and it opened on the last song"). The batch
+// add must park the queue on track 1, and playback must start there.
+
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mstream_music/singletons/media.dart';
+
+import 'helpers/test_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await MediaManager().start();
+  });
+
+  Future<void> waitFor(bool Function() cond, String what,
+      {Duration timeout = const Duration(seconds: 20)}) async {
+    final deadline = DateTime.now().add(timeout);
+    while (!cond()) {
+      if (DateTime.now().isAfter(deadline)) fail('timed out waiting for $what');
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+  }
+
+  testWidgets('batch add onto an empty queue opens and plays from track 1',
+      (WidgetTester tester) async {
+    await resetAppState();
+    final mock = await MockServer.start(
+      const {},
+      defaultHandler: (_) => buildSilentWav(seconds: 60),
+    );
+    addTearDown(mock.close);
+
+    final handler = MediaManager().audioHandler;
+    await handler.customAction('clearPlaylist');
+
+    final items = [
+      for (var i = 1; i <= 5; i++)
+        MediaItem(
+          id: '${mock.url}/media/demo/track_$i.wav',
+          title: 'Track $i',
+          extras: {'server': 'batch-test', 'path': 'demo/track_$i.wav'},
+        ),
+    ];
+    await handler.addQueueItems(items);
+
+    expect(handler.queue.value.length, 5);
+    // The parked spot must present TRACK 1 as now-playing, not wherever the
+    // idle stub's post-append emission landed (observed: the last row).
+    await waitFor(() => handler.mediaItem.valueOrNull?.title == 'Track 1',
+        'now-playing to settle on the first track');
+
+    // And play() must start there — the idle re-seed reads the same spot.
+    await handler.play();
+    // Generous: the iOS simulator's AVPlayer probes each source serially
+    // before ready — well over the Android emulator's near-instant start.
+    await waitFor(
+        () =>
+            handler.playbackState.value.processingState ==
+                AudioProcessingState.ready &&
+            handler.playbackState.value.playing &&
+            handler.playbackState.value.queueIndex == 0,
+        'playback to start on track 1',
+        timeout: const Duration(seconds: 90));
+    expect(handler.mediaItem.valueOrNull?.title, 'Track 1');
+
+    await handler.customAction('clearPlaylist');
+  });
+}

--- a/integration_test/batch_add_test.dart
+++ b/integration_test/batch_add_test.dart
@@ -6,6 +6,8 @@
 // there too ("added a folder, and it opened on the last song"). The batch
 // add must park the queue on track 1, and playback must start there.
 
+import 'dart:async';
+
 import 'package:audio_service/audio_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -58,18 +60,20 @@ void main() {
     await waitFor(() => handler.mediaItem.valueOrNull?.title == 'Track 1',
         'now-playing to settle on the first track');
 
-    // And play() must start there — the idle re-seed reads the same spot.
-    await handler.play();
-    // Generous: the iOS simulator's AVPlayer probes each source serially
-    // before ready — well over the Android emulator's near-instant start.
+    // And play must start there. NOT awaited: on iOS the batch add primes
+    // the player (non-idle), so play() takes the bare backend.play() branch —
+    // and just_audio's play() future resolves only when playback ENDS.
+    // Awaiting it here serialized the test behind five full tracks of audio
+    // while the poll below never got a turn (Android stays idle → the
+    // re-seed branch returns immediately, which is why only the simulator
+    // hit this). Production callers fire play() from taps without awaiting.
+    unawaited(handler.play());
     await waitFor(
         () =>
-            handler.playbackState.value.processingState ==
-                AudioProcessingState.ready &&
             handler.playbackState.value.playing &&
-            handler.playbackState.value.queueIndex == 0,
+            handler.mediaItem.valueOrNull?.title == 'Track 1',
         'playback to start on track 1',
-        timeout: const Duration(seconds: 90));
+        timeout: const Duration(seconds: 45));
     expect(handler.mediaItem.valueOrNull?.title, 'Track 1');
 
     await handler.customAction('clearPlaylist');

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -238,7 +238,8 @@ class AudioPlayerHandler extends BaseAudioHandler
       if (shouldTopUpAutoDJ(
           index: index,
           queueLength: queue.value.length,
-          state: _backend.processingState)) {
+          state: _backend.processingState,
+          inFailureWalk: _skipPending || _failedSkips > 0)) {
         autoDJ();
       }
       if (index != null && index >= 0 && index < queue.value.length) {
@@ -1708,17 +1709,31 @@ class AudioPlayerHandler extends BaseAudioHandler
   /// playback session keeps both legitimate triggers: advancing INTO the
   /// last track (ready), and the queue finishing on it (completed — the
   /// infinite-play top-up). The idle arm/empty-queue starts don't come
-  /// through here at all; setAutoDJ drives those explicitly. Pure;
+  /// through here at all; setAutoDJ drives those explicitly.
+  ///
+  /// [inFailureWalk] suppresses the top-up while the failed-track skip walk
+  /// is live (_skipPending, or a non-zero skip budget). Without it the walk
+  /// and the DJ feed each other unboundedly when streams are broken but the
+  /// random-songs API is fine (transcode down, media mount lost): each skip
+  /// lands on the last row with a non-idle (loading) state → pick appended →
+  /// pick fails → skip — and BOTH of the walk's exits chase the growing
+  /// queue: `_failedSkips >= q.length` never catches up (each cycle
+  /// increments both by one), and seekToNext never reaches the end because a
+  /// fresh pick is always ahead. Starved of picks, the walk terminates
+  /// through its own end-of-queue outage-vs-bad-source logic, and any track
+  /// reaching `ready` clears the budget and re-enables the DJ. Pure;
   /// unit-tested.
   static bool shouldTopUpAutoDJ({
     required int? index,
     required int queueLength,
     required BackendProcessingState state,
+    required bool inFailureWalk,
   }) =>
       index != null &&
       queueLength > 0 &&
       index == queueLength - 1 &&
-      state != BackendProcessingState.idle;
+      state != BackendProcessingState.idle &&
+      !inFailureWalk;
 
   /// Whether play() must re-seed the local player instead of issuing a bare
   /// backend.play(): just_audio parked idle (a playback error tears the

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -235,7 +235,10 @@ class AudioPlayerHandler extends BaseAudioHandler
       // otherwise dragging the playing track to the last slot would append a
       // spurious Auto-DJ track.
       if (_reordering || _rebuilding || _restoring) return;
-      if (index == queue.value.length - 1) {
+      if (shouldTopUpAutoDJ(
+          index: index,
+          queueLength: queue.value.length,
+          state: _backend.processingState)) {
         autoDJ();
       }
       if (index != null && index >= 0 && index < queue.value.length) {
@@ -1677,6 +1680,30 @@ class AudioPlayerHandler extends BaseAudioHandler
   // the backend's `playing` to false). A recovery uses this so a launch-time
   // re-seed resumes PAUSED rather than autoplaying on open.
   bool _playIntent = false;
+
+  /// Whether a currentIndex emission landing on the LAST queue row should
+  /// fire the Auto-DJ top-up.
+  ///
+  /// The index alone is not enough: an IDLE player's stub emissions also land
+  /// there without any playback behind them — a batch "Add all" onto a
+  /// fresh-boot player emitted the last index, the DJ appended a pick, the
+  /// idle player emitted the NEW last index, and the loop appended eleven
+  /// picks in nine seconds while the now-playing surface flashed through
+  /// them (the "skipping every few seconds" report). Requiring a real
+  /// playback session keeps both legitimate triggers: advancing INTO the
+  /// last track (ready), and the queue finishing on it (completed — the
+  /// infinite-play top-up). The idle arm/empty-queue starts don't come
+  /// through here at all; setAutoDJ drives those explicitly. Pure;
+  /// unit-tested.
+  static bool shouldTopUpAutoDJ({
+    required int? index,
+    required int queueLength,
+    required BackendProcessingState state,
+  }) =>
+      index != null &&
+      queueLength > 0 &&
+      index == queueLength - 1 &&
+      state != BackendProcessingState.idle;
 
   /// Whether play() must re-seed the local player instead of issuing a bare
   /// backend.play(): just_audio parked idle (a playback error tears the

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -1660,6 +1660,19 @@ class AudioPlayerHandler extends BaseAudioHandler
     appLog('[queue] add: ${mediaItem.title} (now ${queue.value.length})');
   }
 
+  @override
+  Future<void> addQueueItems(List<MediaItem> mediaItems) async {
+    if (mediaItems.isEmpty) return;
+    // ONE queue emission + ONE backend call for the whole batch. Appending a
+    // big folder per-item re-ran every whole-queue listener (iroh scan,
+    // keep-queue-offline sweep) and a platform round-trip per track — O(N²)
+    // work that stalled the UI on large "Add all"s.
+    queue.add(queue.value..addAll(mediaItems));
+    await _backend.addSources(mediaItems);
+    appLog('[queue] add ${mediaItems.length} tracks '
+        '(now ${queue.value.length})');
+  }
+
   // The user's intended play state, tracked across just_audio errors (which flip
   // the backend's `playing` to false). A recovery uses this so a launch-time
   // re-seed resumes PAUSED rather than autoplaying on open.

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -1666,11 +1666,26 @@ class AudioPlayerHandler extends BaseAudioHandler
   @override
   Future<void> addQueueItems(List<MediaItem> mediaItems) async {
     if (mediaItems.isEmpty) return;
+    final wasEmpty = queue.value.isEmpty;
     // ONE queue emission + ONE backend call for the whole batch. Appending a
     // big folder per-item re-ran every whole-queue listener (iroh scan,
     // keep-queue-offline sweep) and a platform round-trip per track — O(N²)
     // work that stalled the UI on large "Add all"s.
     queue.add(queue.value..addAll(mediaItems));
+    // Batch-adding onto an empty IDLE player: park now-playing on track 1
+    // before the backend append. just_audio's idle stub emits an index for
+    // the appended batch — observed landing on the LAST row — and without a
+    // parked spot the now-playing surfaces and a later play()'s re-seed both
+    // follow it ("added a folder, and it opened on the last song"). The spot
+    // is the existing failed-restore machinery: read first by
+    // _emitCurrentMediaItem and _reviveSpot, overwritten by an explicit tap
+    // (skipToQueueItem's idle park — playFromHere's jump still wins), and
+    // cleared when a real load reaches ready. Parked BEFORE addSources so
+    // the stub emission's own now-playing emit already reads it.
+    if (wasEmpty &&
+        _backend.processingState == BackendProcessingState.idle) {
+      _restoreSpot = (index: 0, position: Duration.zero);
+    }
     await _backend.addSources(mediaItems);
     appLog('[queue] add ${mediaItems.length} tracks '
         '(now ${queue.value.length})');

--- a/lib/media/emulated_playlist_backend.dart
+++ b/lib/media/emulated_playlist_backend.dart
@@ -309,6 +309,17 @@ abstract class EmulatedPlaylistBackend implements PlaybackBackend {
   }
 
   @override
+  Future<void> addSources(List<MediaItem> items) async {
+    if (items.isEmpty) return;
+    _items.addAll(items);
+    if (_index == -1) {
+      _index = 0;
+      emitIndex(0);
+      setProcessingState(BackendProcessingState.ready);
+    }
+  }
+
+  @override
   Future<void> removeSourceAt(int index) async {
     if (index < 0 || index >= _items.length) return;
     _items.removeAt(index);

--- a/lib/media/local_playback_backend.dart
+++ b/lib/media/local_playback_backend.dart
@@ -75,6 +75,10 @@ class LocalPlaybackBackend implements PlaybackBackend {
   Future<void> addSource(MediaItem item) =>
       _player.addAudioSource(AudioSource.uri(_uriFor(item)));
 
+  @override
+  Future<void> addSources(List<MediaItem> items) => _player
+      .addAudioSources([for (final i in items) AudioSource.uri(_uriFor(i))]);
+
   // Play the offline copy when it's actually on disk; otherwise stream
   // (item.id is the server URL). Re-checking existence means a file moved or
   // deleted after the item was built (mid-migration, SD removed) falls back to

--- a/lib/media/playback_backend.dart
+++ b/lib/media/playback_backend.dart
@@ -38,6 +38,11 @@ abstract class PlaybackBackend {
   Future<void> setSources(List<MediaItem> items,
       {int? initialIndex, Duration? initialPosition});
   Future<void> addSource(MediaItem item);
+
+  /// Append [items] as ONE batch — same semantics as calling [addSource] for
+  /// each in order, but a single platform/renderer call, so a bulk enqueue
+  /// ("Add all" on a folder) doesn't pay a round-trip per track.
+  Future<void> addSources(List<MediaItem> items);
   Future<void> removeSourceAt(int index);
 
   /// Move the source at [from] to [to] (the post-removal target index, matching

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -632,7 +632,7 @@ class _BrowserState extends State<Browser> {
                     label: l.addAll,
                     onPressed: (context) {
                       ApiManager().getRecursiveFiles(b[i].data!,
-                          useThisServer: b[i].server);
+                          useThisServer: b[i].server!);
                     })
               ],
             ),
@@ -818,8 +818,10 @@ class _BrowserState extends State<Browser> {
                   style: TextStyle(color: VelvetColors.textPrimary)),
               onTap: () {
                 Navigator.of(sheetCtx).pop();
+                // A browsed folder row always carries its server; the
+                // parameter went non-null in the recursive-files hardening.
                 ApiManager().getRecursiveFiles(item.data!,
-                    useThisServer: item.server);
+                    useThisServer: item.server!);
               },
             ),
             const SizedBox(height: 8),

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -237,10 +237,19 @@ class ApiManager {
               title: e.toString().split("/").last,
               extras: {'server': useThisServer.localname, 'path': e.toString()}),
       ];
+      if (items.isEmpty) return;
+      final handler = MediaManager().audioHandler;
+      final wasEmpty = handler.queue.value.isEmpty;
       // One batch append: a single queue emission + one backend call, instead
       // of N of each (every per-item add re-ran the whole-queue listeners —
       // iroh scan + offline sweep — making a big "Add all" O(N²)).
-      await MediaManager().audioHandler.addQueueItems(items);
+      await handler.addQueueItems(items);
+      // "Add all" onto an EMPTY queue starts playing from the first track —
+      // the same contract addRowsToQueue documents (a first add from a fresh
+      // state shouldn't require a separate play press). addQueueItems parked
+      // the spot on track 1, so the idle re-seed opens there rather than on
+      // the idle stub's landing row.
+      if (wasEmpty) await handler.play();
     } catch (err) {
       appLog('[api] getRecursiveFiles failed: $err');
     }

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -11,6 +11,7 @@ import '../objects/display_item.dart';
 import '../objects/lyrics.dart';
 import '../objects/metadata.dart';
 import 'media.dart';
+import '../util/decode_json.dart';
 import '../util/media_format.dart';
 import '../util/stream_url.dart';
 import '../theme/velvet_theme.dart';
@@ -26,6 +27,22 @@ class ApiManager {
   static final ApiManager _instance = ApiManager._privateConstructor();
   factory ApiManager() {
     return _instance;
+  }
+
+  // One keep-alive client for the direct (non-browse) calls — ratings,
+  // metadata / lyrics / discovery / search fetches fire in bursts (queue
+  // enrichment posts one per track, the Discover screen 3-4 per seed), and
+  // the top-level http.* functions create and close a Client per call, paying
+  // a fresh TCP+TLS handshake every time. makeServerCall deliberately keeps
+  // its per-request Client: closing that one is what makes Back-cancel
+  // actually abort a browse fetch.
+  http.Client _direct = http.Client();
+
+  /// Drop pooled connections. Called when the server list changes so sockets
+  /// to a removed or re-credentialed server don't linger.
+  void resetDirectClient() {
+    _direct.close();
+    _direct = http.Client();
   }
 
   /// POST /api/v1/db/genres — returns the server's distinct genre
@@ -45,14 +62,16 @@ class ApiManager {
       body['ignoreVPaths'] = ignoreVPaths;
     }
 
-    final response = await http.post(
-      server.apiUri('/api/v1/db/genres'),
-      body: jsonEncode(body),
-      headers: {
-        'Content-Type': 'application/json',
-        'x-access-token': server.jwt ?? '',
-      },
-    );
+    final response = await _direct
+        .post(
+          server.apiUri('/api/v1/db/genres'),
+          body: jsonEncode(body),
+          headers: {
+            'Content-Type': 'application/json',
+            'x-access-token': server.jwt ?? '',
+          },
+        )
+        .timeout(const Duration(seconds: 15));
     if (response.statusCode > 299) {
       throw Exception('Failed to fetch genres (HTTP ${response.statusCode})');
     }
@@ -72,14 +91,16 @@ class ApiManager {
     final body = <String, dynamic>{'playlist': filepaths};
     if (expiresInDays != null) body['time'] = expiresInDays;
 
-    final response = await http.post(
-      uri,
-      body: json.encode(body),
-      headers: {
-        'Content-Type': 'application/json',
-        'x-access-token': server.jwt ?? '',
-      },
-    );
+    final response = await _direct
+        .post(
+          uri,
+          body: json.encode(body),
+          headers: {
+            'Content-Type': 'application/json',
+            'x-access-token': server.jwt ?? '',
+          },
+        )
+        .timeout(const Duration(seconds: 15));
 
     if (response.statusCode > 299) {
       throw Exception('Share failed (HTTP ${response.statusCode})');
@@ -104,8 +125,9 @@ class ApiManager {
     final uri = Uri.parse('${server.effectiveBaseUrl}/api/v1/lyrics'
         '?path=$encodedPath${server.localTokenQuery}');
 
-    final response =
-        await http.get(uri, headers: {'x-access-token': server.jwt ?? ''});
+    final response = await _direct
+        .get(uri, headers: {'x-access-token': server.jwt ?? ''})
+        .timeout(const Duration(seconds: 15));
     if (response.statusCode == 404) return null; // no lyrics for this track
     if (response.statusCode > 299) {
       throw Exception('Lyrics fetch failed (HTTP ${response.statusCode})');
@@ -148,9 +170,11 @@ class ApiManager {
       final bool isIroh = server.isIroh;
       try {
         // For iroh, bound the request so a wedged tunnel fails fast instead of
-        // hanging the global loading bar.
-        response =
-            isIroh ? await send().timeout(const Duration(seconds: 20)) : await send();
+        // hanging the global loading bar. HTTP gets a generous bound too — a
+        // black-holed server (wrong LAN IP, firewalled port) used to hang the
+        // bar for the OS TCP timeout, minutes. Back-cancel still aborts sooner.
+        response = await send()
+            .timeout(Duration(seconds: isIroh ? 20 : 30));
       } catch (e) {
         // An iroh connection error usually means the tunnel is mid-drop; give the
         // self-healing tunnel a moment to recover, then retry once. (Skip on a
@@ -185,7 +209,9 @@ class ApiManager {
         throw Exception('Navigation cancelled');
       }
 
-      return jsonDecode(response.body);
+      // Whole-library payloads (artists / albums / playlist loads / recursive
+      // listings) run multi-MB — decode those off the UI isolate.
+      return decodeJsonBody(response.body);
     } finally {
       client.close();
       BrowserManager().endLoading(loadToken);
@@ -193,31 +219,31 @@ class ApiManager {
   }
 
   Future<void> getRecursiveFiles(String directory,
-      {Server? useThisServer}) async {
-    dynamic res;
+      {required Server useThisServer}) async {
     try {
-      res = await makeServerCall(useThisServer,
+      final res = await makeServerCall(useThisServer,
           '/api/v1/file-explorer/recursive', {"directory": directory}, 'POST');
-    } catch (err) {
-      // TODO: Handle Errors
-      appLog('[api] getRecursiveFiles failed: $err');
-      return;
-    }
 
-    res.forEach((e) {
-      // Same transcode-aware stream URL as the rest of the app (honors the
-      // /transcode endpoint + codec/bitrate when transcoding is on).
-      final String streamUrl =
-          buildServerStreamUrl(useThisServer!, e.toString());
-      // The recursive endpoint returns bare paths (no metadata), so these items
-      // carry only server + path — no rating / fidelity / tags. They populate
-      // if the same track is later reached via a metadata-bearing browse.
-      MediaItem lol = MediaItem(
-          id: streamUrl,
-          title: e.split("/").last,
-          extras: {'server': useThisServer.localname, 'path': e});
-      MediaManager().audioHandler.addQueueItem(lol);
-    });
+      final items = <MediaItem>[
+        for (final e in res as List)
+          // Same transcode-aware stream URL as the rest of the app (honors the
+          // /transcode endpoint + codec/bitrate when transcoding is on). The
+          // recursive endpoint returns bare paths (no metadata), so these items
+          // carry only server + path — no rating / fidelity / tags. They
+          // populate if the same track is later reached via a metadata-bearing
+          // browse.
+          MediaItem(
+              id: buildServerStreamUrl(useThisServer, e.toString()),
+              title: e.toString().split("/").last,
+              extras: {'server': useThisServer.localname, 'path': e.toString()}),
+      ];
+      // One batch append: a single queue emission + one backend call, instead
+      // of N of each (every per-item add re-ran the whole-queue listeners —
+      // iroh scan + offline sweep — making a big "Add all" O(N²)).
+      await MediaManager().audioHandler.addQueueItems(items);
+    } catch (err) {
+      appLog('[api] getRecursiveFiles failed: $err');
+    }
   }
 
   // Builds 'playlist' DisplayItems from a getall response.
@@ -231,33 +257,33 @@ class ApiManager {
   }
 
   Future<void> getPlaylists({Server? useThisServer}) async {
-    dynamic res;
+    // Parsing runs INSIDE the try (here and in the other browse fetches): a
+    // response-shape surprise (error object with a 2xx, older server) used to
+    // throw NoSuchMethodError past the guard and abort the browse silently.
     try {
-      res = await makeServerCall(
+      final res = await makeServerCall(
           useThisServer, '/api/v1/playlist/getall', {}, 'GET');
+
+      BrowserManager().setBrowserLabel('Playlists');
+      BrowserManager().addListToStack(_playlistItems(res, useThisServer));
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getPlaylists failed: $err');
-      return;
     }
-
-    BrowserManager().setBrowserLabel('Playlists');
-    BrowserManager().addListToStack(_playlistItems(res, useThisServer));
   }
 
   /// Re-fetches playlists and replaces the current view in place (no new
   /// back-stack frame) — used after a create / rename so the list updates
   /// without pushing a navigation entry.
   Future<void> refreshPlaylists() async {
-    dynamic res;
     try {
-      res = await makeServerCall(null, '/api/v1/playlist/getall', {}, 'GET');
+      final res =
+          await makeServerCall(null, '/api/v1/playlist/getall', {}, 'GET');
+      BrowserManager()
+          .replaceTop(_playlistItems(res, ServerManager().currentServer));
     } catch (err) {
       appLog('[api] refreshPlaylists failed: $err');
-      return;
     }
-    BrowserManager()
-        .replaceTop(_playlistItems(res, ServerManager().currentServer));
   }
 
   /// Creates an empty playlist (POST /playlist/new). Throws on failure (e.g. the
@@ -474,42 +500,41 @@ class ApiManager {
   }
 
   Future<void> getAlbums({Server? useThisServer}) async {
-    dynamic res;
     try {
-      res = await makeServerCall(useThisServer, '/api/v1/db/albums', {}, 'GET');
+      final res =
+          await makeServerCall(useThisServer, '/api/v1/db/albums', {}, 'GET');
+
+      BrowserManager().setBrowserLabel('Albums');
+
+      List<DisplayItem> newList = [];
+      res['albums'].forEach((e) {
+        // Newer servers include `album_artist`; fold it into the subtitle as
+        // "Artist · Year" for the browse card/list. Older servers omit it, so
+        // the subtitle gracefully falls back to just the year.
+        final artist = (e['album_artist'] ?? e['albumArtist'] ?? e['artist'])
+            ?.toString()
+            .trim();
+        final year = e['year']?.toString().trim();
+        final subtitle = [
+          if (artist != null && artist.isNotEmpty) artist,
+          if (year != null && year.isNotEmpty) year,
+        ].join(' · ');
+        DisplayItem newItem = DisplayItem(
+            useThisServer,
+            e['name'],
+            'album',
+            e['name'],
+            Icon(Icons.album, color: VelvetColors.textSecondary),
+            subtitle);
+        newItem.altAlbumArt = e['album_art_file'];
+        newList.add(newItem);
+      });
+
+      BrowserManager().addListToStack(newList, alphabetical: true);
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getAlbums failed: $err');
-      return;
     }
-
-    BrowserManager().setBrowserLabel('Albums');
-
-    List<DisplayItem> newList = [];
-    res['albums'].forEach((e) {
-      // Newer servers include `album_artist`; fold it into the subtitle as
-      // "Artist · Year" for the browse card/list. Older servers omit it, so the
-      // subtitle gracefully falls back to just the year.
-      final artist = (e['album_artist'] ?? e['albumArtist'] ?? e['artist'])
-          ?.toString()
-          .trim();
-      final year = e['year']?.toString().trim();
-      final subtitle = [
-        if (artist != null && artist.isNotEmpty) artist,
-        if (year != null && year.isNotEmpty) year,
-      ].join(' · ');
-      DisplayItem newItem = DisplayItem(
-          useThisServer,
-          e['name'],
-          'album',
-          e['name'],
-          Icon(Icons.album, color: VelvetColors.textSecondary),
-          subtitle);
-      newItem.altAlbumArt = e['album_art_file'];
-      newList.add(newItem);
-    });
-
-    BrowserManager().addListToStack(newList, alphabetical: true);
   }
 
   /// Fetches an album's songs as a list of `file` DisplayItems WITHOUT touching
@@ -553,66 +578,63 @@ class ApiManager {
   }
 
   Future<void> getRecentlyAdded({Server? useThisServer}) async {
-    dynamic res;
     try {
-      res = await makeServerCall(
+      final res = await makeServerCall(
           useThisServer, '/api/v1/db/recent/added', {'limit': 100}, 'POST');
+
+      BrowserManager().setBrowserLabel('Recent');
+
+      List<DisplayItem> newList = [];
+      res.forEach((e) {
+        MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
+
+        DisplayItem newItem = DisplayItem(
+            useThisServer,
+            e['filepath'],
+            'file',
+            '/${e['filepath']}',
+            Icon(Icons.music_note, color: VelvetColors.accent),
+            null);
+
+        newItem.metadata = m;
+
+        newList.add(newItem);
+      });
+      BrowserManager().addListToStack(newList);
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getRecentlyAdded failed: $err');
-      return;
     }
-
-    BrowserManager().setBrowserLabel('Recent');
-
-    List<DisplayItem> newList = [];
-    res.forEach((e) {
-      MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
-
-      DisplayItem newItem = DisplayItem(
-          useThisServer,
-          e['filepath'],
-          'file',
-          '/${e['filepath']}',
-          Icon(Icons.music_note, color: VelvetColors.accent),
-          null);
-
-      newItem.metadata = m;
-
-      newList.add(newItem);
-    });
-    BrowserManager().addListToStack(newList);
   }
 
   Future<void> getRated({Server? useThisServer}) async {
-    dynamic res;
     try {
-      res = await makeServerCall(useThisServer, '/api/v1/db/rated', {}, 'GET');
+      final res =
+          await makeServerCall(useThisServer, '/api/v1/db/rated', {}, 'GET');
+
+      BrowserManager().setBrowserLabel('Rated');
+
+      List<DisplayItem> newList = [];
+      res.forEach((e) {
+        MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
+
+        DisplayItem newItem = DisplayItem(
+            useThisServer,
+            e['filepath'],
+            'file',
+            '/${e['filepath']}',
+            Icon(Icons.music_note, color: VelvetColors.accent),
+            m.artist);
+
+        newItem.metadata = m;
+
+        newList.add(newItem);
+      });
+      BrowserManager().addListToStack(newList);
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getRated failed: $err');
-      return;
     }
-
-    BrowserManager().setBrowserLabel('Rated');
-
-    List<DisplayItem> newList = [];
-    res.forEach((e) {
-      MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
-
-      DisplayItem newItem = DisplayItem(
-          useThisServer,
-          e['filepath'],
-          'file',
-          '/${e['filepath']}',
-          Icon(Icons.music_note, color: VelvetColors.accent),
-          m.artist);
-
-      newItem.metadata = m;
-
-      newList.add(newItem);
-    });
-    BrowserManager().addListToStack(newList);
   }
 
   /// POST /api/v1/db/rate-song — set [rating] (0–10 server scale, or null to
@@ -623,14 +645,19 @@ class ApiManager {
   /// a leading "/").
   Future<void> rateSong(Server server, String filepath, int? rating) async {
     final fp = filepath.startsWith('/') ? filepath.substring(1) : filepath;
-    final response = await http.post(
-      server.apiUri('/api/v1/db/rate-song'),
-      body: jsonEncode({'filepath': fp, 'rating': rating}),
-      headers: {
-        'Content-Type': 'application/json',
-        'x-access-token': server.jwt ?? '',
-      },
-    );
+    // Timeout matters here: the star-rating UI updates optimistically and its
+    // catch is the ONLY revert path — an unbounded hang against a black-holed
+    // server left a rating showing that the server never received.
+    final response = await _direct
+        .post(
+          server.apiUri('/api/v1/db/rate-song'),
+          body: jsonEncode({'filepath': fp, 'rating': rating}),
+          headers: {
+            'Content-Type': 'application/json',
+            'x-access-token': server.jwt ?? '',
+          },
+        )
+        .timeout(const Duration(seconds: 15));
     if (response.statusCode > 299) {
       throw Exception('Rating failed (HTTP ${response.statusCode})');
     }
@@ -710,7 +737,7 @@ class ApiManager {
       // defeats the bounded wait AutoApi._call exists to provide. Returns
       // null on timeout like every other failure here — the caller falls back
       // to the row's own lite metadata.
-      final response = await http
+      final response = await _direct
           .post(
             server.apiUri('/api/v1/db/metadata'),
             body: jsonEncode({'filepath': fp}),
@@ -743,7 +770,7 @@ class ApiManager {
       Map<String, dynamic> body,
       T Function(Map) parse) async {
     try {
-      final response = await http
+      final response = await _direct
           .post(
             server.apiUri(location),
             body: jsonEncode(body),
@@ -849,7 +876,7 @@ class ApiManager {
   Future<List<DisplayItem>> fetchSongSearch(Server server, String search,
       {int limit = 25}) async {
     try {
-      final response = await http
+      final response = await _direct
           .post(
             server.apiUri('/api/v1/db/search'),
             // Pre-filtered for the same reason as [searchServer]: an
@@ -974,7 +1001,7 @@ class ApiManager {
         if (e.value == false) e.key,
     ];
     try {
-      final response = await http
+      final response = await _direct
           .post(
             server.apiUri('/api/v1/db/random-songs'),
             body: jsonEncode({
@@ -1024,96 +1051,89 @@ class ApiManager {
   }
 
   Future<void> getArtists({Server? useThisServer}) async {
-    dynamic res;
     try {
-      res =
+      final res =
           await makeServerCall(useThisServer, '/api/v1/db/artists', {}, 'GET');
+
+      BrowserManager().setBrowserLabel('Artists');
+
+      List<DisplayItem> newList = [];
+      res['artists'].forEach((e) {
+        DisplayItem newItem = DisplayItem(useThisServer, e, 'artist', e,
+            Icon(Icons.library_music, color: VelvetColors.textSecondary), null);
+        newList.add(newItem);
+      });
+      BrowserManager().addListToStack(newList, alphabetical: true);
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getArtists failed: $err');
-      return;
     }
-
-    BrowserManager().setBrowserLabel('Artists');
-
-    List<DisplayItem> newList = [];
-    res['artists'].forEach((e) {
-      DisplayItem newItem = DisplayItem(useThisServer, e, 'artist', e,
-          Icon(Icons.library_music, color: VelvetColors.textSecondary), null);
-      newList.add(newItem);
-    });
-    BrowserManager().addListToStack(newList, alphabetical: true);
   }
 
   Future<void> getArtistAlbums(String artist, {Server? useThisServer}) async {
-    dynamic res;
     try {
-      res = await makeServerCall(useThisServer, '/api/v1/db/artists-albums',
-          {'artist': artist}, 'POST');
+      final res = await makeServerCall(useThisServer,
+          '/api/v1/db/artists-albums', {'artist': artist}, 'POST');
+
+      List<DisplayItem> newList = [];
+      res['albums'].forEach((e) {
+        String name = e['name'] ?? 'SINGLES';
+
+        // TODO: Errors on singles
+        DisplayItem newItem = DisplayItem(
+            useThisServer,
+            name,
+            'album',
+            e['name'],
+            Icon(Icons.album, color: VelvetColors.textSecondary),
+            e['year']?.toString() ?? '');
+        newItem.altAlbumArt = e['album_art_file'];
+
+        newList.add(newItem);
+      });
+
+      BrowserManager().addListToStack(newList);
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getArtistAlbums failed: $err');
-      return;
     }
-
-    List<DisplayItem> newList = [];
-    res['albums'].forEach((e) {
-      String name = e['name'] ?? 'SINGLES';
-
-      // TODO: Errors on singles
-      DisplayItem newItem = DisplayItem(
-          useThisServer,
-          name,
-          'album',
-          e['name'],
-          Icon(Icons.album, color: VelvetColors.textSecondary),
-          e['year']?.toString() ?? '');
-      newItem.altAlbumArt = e['album_art_file'];
-
-      newList.add(newItem);
-    });
-
-    BrowserManager().addListToStack(newList);
   }
 
   Future<void> getPlaylistContents(String playlistName,
       {Server? useThisServer}) async {
-    dynamic res;
     try {
-      res = await makeServerCall(useThisServer, '/api/v1/playlist/load',
+      final res = await makeServerCall(useThisServer, '/api/v1/playlist/load',
           {'playlistname': playlistName}, 'POST');
+
+      List<DisplayItem> newList = [];
+      res.forEach((e) {
+        MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
+
+        DisplayItem newItem = DisplayItem(
+            useThisServer,
+            e['filepath'],
+            'file',
+            '/${e['filepath']}',
+            Icon(Icons.music_note, color: VelvetColors.accent),
+            null);
+
+        newItem.metadata = m;
+        newList.add(newItem);
+      });
+
+      // Name the frame so the subheader can label it, the toolbar can offer
+      // the album-style controls, and an empty result reads as "playlist is
+      // empty" rather than a blank list.
+      BrowserManager().addListToStack(newList, playlist: playlistName);
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getPlaylistContents failed: $err');
-      return;
     }
-
-    List<DisplayItem> newList = [];
-    res.forEach((e) {
-      MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
-
-      DisplayItem newItem = DisplayItem(
-          useThisServer,
-          e['filepath'],
-          'file',
-          '/${e['filepath']}',
-          Icon(Icons.music_note, color: VelvetColors.accent),
-          null);
-
-      newItem.metadata = m;
-      newList.add(newItem);
-    });
-
-    // Name the frame so the subheader can label it, the toolbar can offer the
-    // album-style controls, and an empty result reads as "playlist is empty"
-    // rather than a blank list.
-    BrowserManager().addListToStack(newList, playlist: playlistName);
   }
 
   Future<void> getFileList(String directory, {Server? useThisServer}) async {
-    dynamic res;
     try {
-      res = await makeServerCall(useThisServer, '/api/v1/file-explorer', {
+      final res = await makeServerCall(useThisServer, '/api/v1/file-explorer', {
         "directory": directory,
         // Server defaults this to false (cheap listing). When the user
         // has the setting on, the server returns a `metadata` field on
@@ -1124,55 +1144,54 @@ class ApiManager {
         // notification.
         "pullMetadata": SettingsManager().fileExplorerMetadata,
       }, 'POST');
+
+      BrowserManager().setBrowserLabel('File Explorer');
+
+      List<DisplayItem> newList = [];
+      res['directories'].forEach((e) {
+        DisplayItem newItem = DisplayItem(
+            useThisServer,
+            e['name'],
+            'directory',
+            path.join(res['path'], e['name']),
+            Icon(Icons.folder, color: VelvetColors.warning),
+            null);
+        newList.add(newItem);
+      });
+
+      res['files'].forEach((e) {
+        // A playlist file opens a list rather than playing, so it should not
+        // wear the same icon as the tracks around it.
+        final isPlaylistFile = isM3u(e['name']?.toString());
+        DisplayItem newItem = DisplayItem(
+            useThisServer,
+            e['name'],
+            'file',
+            path.join(res['path'], e['name']),
+            Icon(isPlaylistFile ? Icons.queue_music : Icons.music_note,
+                color: VelvetColors.accent),
+            null);
+
+        // The server wraps each file's metadata as { filepath, metadata:
+        // {…actual fields…} } — drill in one level. Only set when
+        // pullMetadata=true was sent AND the file is in the library DB
+        // (unscanned files still arrive without an inner metadata
+        // object; we tolerate that and fall back to filename display).
+        final outer = e['metadata'];
+        final inner = outer is Map ? outer['metadata'] : null;
+        if (inner is Map) {
+          newItem.metadata = MusicMetadata.fromServerMap(inner);
+        }
+
+        newList.add(newItem);
+      });
+
+      BrowserManager()
+          .addListToStack(newList, alphabetical: true, path: res['path']);
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getFileList failed: $err');
-      return;
     }
-
-    BrowserManager().setBrowserLabel('File Explorer');
-
-    List<DisplayItem> newList = [];
-    res['directories'].forEach((e) {
-      DisplayItem newItem = DisplayItem(
-          useThisServer,
-          e['name'],
-          'directory',
-          path.join(res['path'], e['name']),
-          Icon(Icons.folder, color: VelvetColors.warning),
-          null);
-      newList.add(newItem);
-    });
-
-    res['files'].forEach((e) {
-      // A playlist file opens a list rather than playing, so it should not
-      // wear the same icon as the tracks around it.
-      final isPlaylistFile = isM3u(e['name']?.toString());
-      DisplayItem newItem = DisplayItem(
-          useThisServer,
-          e['name'],
-          'file',
-          path.join(res['path'], e['name']),
-          Icon(isPlaylistFile ? Icons.queue_music : Icons.music_note,
-              color: VelvetColors.accent),
-          null);
-
-      // The server wraps each file's metadata as { filepath, metadata:
-      // {…actual fields…} } — drill in one level. Only set when
-      // pullMetadata=true was sent AND the file is in the library DB
-      // (unscanned files still arrive without an inner metadata
-      // object; we tolerate that and fall back to filename display).
-      final outer = e['metadata'];
-      final inner = outer is Map ? outer['metadata'] : null;
-      if (inner is Map) {
-        newItem.metadata = MusicMetadata.fromServerMap(inner);
-      }
-
-      newList.add(newItem);
-    });
-
-    BrowserManager()
-        .addListToStack(newList, alphabetical: true, path: res['path']);
   }
 
   /// POST /api/v1/file-explorer/m3u — read a playlist FILE and push what it

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -1,3 +1,6 @@
+import 'dart:io' show File;
+
+import './file_explorer.dart';
 import './server_capabilities.dart';
 import './server_list.dart';
 import './browser_list.dart';
@@ -13,6 +16,7 @@ import '../objects/metadata.dart';
 import 'media.dart';
 import '../util/decode_json.dart';
 import '../util/media_format.dart';
+import '../util/server_version.dart';
 import '../util/stream_url.dart';
 import '../theme/velvet_theme.dart';
 import 'package:material_ui/material_ui.dart';
@@ -224,20 +228,68 @@ class ApiManager {
       final res = await makeServerCall(useThisServer,
           '/api/v1/file-explorer/recursive', {"directory": directory}, 'POST');
 
-      final items = <MediaItem>[
-        for (final e in res as List)
-          // Same transcode-aware stream URL as the rest of the app (honors the
-          // /transcode endpoint + codec/bitrate when transcoding is on). The
-          // recursive endpoint returns bare paths (no metadata), so these items
-          // carry only server + path — no rating / fidelity / tags. They
-          // populate if the same track is later reached via a metadata-bearing
-          // browse.
-          MediaItem(
-              id: buildServerStreamUrl(useThisServer, e.toString()),
-              title: e.toString().split("/").last,
-              extras: {'server': useThisServer.localname, 'path': e.toString()}),
-      ];
-      if (items.isEmpty) return;
+      final paths = [for (final e in res as List) e.toString()];
+      if (paths.isEmpty) return;
+
+      // The recursive endpoint returns bare paths, so fetch the metadata in
+      // ONE batched request — never per row, because a recursive folder can
+      // be thousands of files. Version-gated and best-effort exactly like
+      // prefillMetadata: on an older server, a request failure, or a track
+      // the DB doesn't know, the row queues bare (today's behaviour) and
+      // tops itself up as it becomes current.
+      var meta = const <String, MusicMetadata>{};
+      if (!metadataBatchKnownUnsupported(
+          ServerVersion.tryParse(useThisServer.serverVersion))) {
+        meta = await fetchTrackMetadataBatch(useThisServer, paths);
+      }
+
+      // Resolve the download dir ONCE; the per-file existence check is a
+      // cheap stat. Carrying localPath means an already-downloaded copy
+      // plays from disk immediately, instead of streaming until the offline
+      // sweep happens to re-mark it.
+      final dir = await FileExplorer().getDownloadDir(
+          useThisServer.storageMode, useThisServer.storageBasePath);
+
+      final items = <MediaItem>[];
+      for (final p in paths) {
+        final m = meta[p.startsWith('/') ? p.substring(1) : p];
+        final artUrl = m?.albumArt != null
+            ? buildAlbumArtUrl(useThisServer, m!.albumArt!, compress: 'l')
+            : null;
+        // Same on-disk formula as downloadOneFile (serverName + filepath,
+        // concatenated verbatim), so existing downloads are found exactly
+        // where the sweep put them.
+        final localPath = dir == null
+            ? null
+            : '${dir.path}/media/${useThisServer.localname}$p';
+        final isLocal = localPath != null && File(localPath).existsSync();
+        items.add(MediaItem(
+          // Same transcode-aware stream URL as the rest of the app (honors
+          // the /transcode endpoint + codec/bitrate when transcoding is on).
+          id: buildServerStreamUrl(useThisServer, p),
+          title: m?.title ?? p.split("/").last,
+          album: m?.album,
+          artist: m?.artist,
+          genre: m?.genreLabel,
+          duration: m?.duration,
+          artUri: artUrl == null ? null : Uri.parse(artUrl),
+          extras: {
+            if (m != null)
+              // The same full map a browse-added track gets.
+              ...queueExtras(m,
+                  server: useThisServer.localname, path: p, artUrl: artUrl)
+            else ...{
+              // No metadata block — keep the bare shape. Deliberately NOT
+              // queueExtras(null): that writes hasLyrics, whose presence
+              // marks an item as complete and would stop _topUpExtras from
+              // lazily filling it in as it plays.
+              'server': useThisServer.localname,
+              'path': p,
+            },
+            if (isLocal) 'localPath': localPath,
+          },
+        ));
+      }
       final handler = MediaManager().audioHandler;
       final wasEmpty = handler.queue.value.isEmpty;
       // One batch append: a single queue emission + one backend call, instead

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -367,14 +367,30 @@ class DownloadManager {
   /// session (terminal failures un-mark themselves so a recovery re-sweep
   /// retries them). Quiet: no per-file snackbars — the user didn't tap
   /// anything, and a whole-queue sweep can fail dozens of times at once.
+  // Last clipped-count logged by autoDownloadQueue, so the sweep says it
+  // once per change instead of on every queue emission / advance.
+  int _lastClippedLogged = 0;
+
   Future<void> autoDownloadQueue(List<MediaItem> items) async {
     if (!SettingsManager().offlineQueue) return;
     final wifiOnly = SettingsManager().offlineQueueWifiOnly;
     // Only fetch what the cap actually allows on disk. Tracks outside the
     // window are never marked in _autoAttempted, so they become candidates the
     // moment playback advances far enough to pull them into it.
-    final window =
-        cacheWindow(items, SettingsManager().autoDownloadCap, _playingIndex());
+    final cap = SettingsManager().autoDownloadCap;
+    final window = cacheWindow(items, cap, _playingIndex());
+    // Say when the cap clips a sweep — once per distinct count, not per
+    // sweep (this runs on every queue change and advance). "Added N,
+    // setting's on, two never downloaded" is indistinguishable from a
+    // download bug without this line; the two were simply beyond the window.
+    final clipped = items.length - window.length;
+    if (clipped != _lastClippedLogged) {
+      _lastClippedLogged = clipped;
+      if (clipped > 0) {
+        appLog('[auto-dl] $clipped queued track(s) beyond the cache window '
+            '(cap $cap) — they download as playback approaches them');
+      }
+    }
     for (final m in autoDownloadCandidates(window, _autoAttempted,
         fileExists: (p) => File(p).existsSync())) {
       await downloadOneFile(m.id, m.extras!['server'], m.extras!['path'],

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:mstream_music/singletons/file_explorer.dart';
 
 import '../objects/server.dart';
+import './api.dart';
 import './app_messenger.dart';
 import './browser_list.dart';
 import './log_manager.dart';
@@ -883,12 +884,17 @@ class ServerManager {
     await ensureActiveTunnel();
     await writeServerFile();
     syncInsecureTls();
+    // Pooled keep-alive sockets to the removed server would otherwise linger.
+    ApiManager().resetDirectClient();
   }
 
   Future<void> callAfterEditServer() async {
     _serverListStream.sink.add(serverList);
     syncInsecureTls();
     await writeServerFile();
+    // The edit may have changed URL/credentials — drop pooled connections so
+    // nothing rides a socket opened under the old identity.
+    ApiManager().resetDirectClient();
   }
 
   Future<void> makeDefault(int i) async {

--- a/lib/util/decode_json.dart
+++ b/lib/util/decode_json.dart
@@ -1,0 +1,20 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+/// Body size above which JSON decoding moves off the UI isolate.
+///
+/// The whole-library endpoints (/db/artists, /db/albums, /playlist/load,
+/// /file-explorer/recursive) return multi-MB bodies on a big library, and a
+/// jsonDecode that size blocks the UI thread for tens to hundreds of ms —
+/// right while the loading bar is animating. Small bodies stay inline: an
+/// isolate round-trip (spawn + copy) costs more than it saves there.
+const int kIsolateDecodeThreshold = 100 * 1024;
+
+/// jsonDecode, off-thread for large bodies (see [kIsolateDecodeThreshold]).
+/// async so a parse error always surfaces as a failed future, never a
+/// synchronous throw.
+Future<dynamic> decodeJsonBody(String body) async =>
+    body.length > kIsolateDecodeThreshold
+        ? await compute(jsonDecode, body)
+        : jsonDecode(body);

--- a/lib/util/queue_actions.dart
+++ b/lib/util/queue_actions.dart
@@ -13,6 +13,7 @@ import 'package:uuid/uuid.dart';
 
 import '../objects/display_item.dart';
 import '../objects/metadata.dart';
+import '../objects/server.dart';
 import '../singletons/api.dart';
 import '../singletons/file_explorer.dart';
 import '../singletons/media.dart';
@@ -46,6 +47,16 @@ MediaItem buildLocalFileMediaItem(DisplayItem i) {
 /// full block and skip the fetch. Best-effort: on a miss we keep whatever the row
 /// had (the lite block, or null) and fall back to its altAlbumArt for the cover.
 Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
+  final dir = await FileExplorer()
+      .getDownloadDir(i.server!.storageMode, i.server!.storageBasePath);
+  return _buildServerFileMediaItemWithDir(i, dir);
+}
+
+/// [buildServerFileMediaItem] with the download dir already resolved — the
+/// batch builder resolves it once per server instead of paying the
+/// path_provider platform round-trip per row.
+Future<MediaItem?> _buildServerFileMediaItemWithDir(
+    DisplayItem i, Directory? dir) async {
   MusicMetadata? meta = i.metadata;
   if (meta == null || i.partialMetadata) {
     final full = await ApiManager().fetchTrackMetadata(i.server!, i.data!);
@@ -53,8 +64,6 @@ Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
   }
 
   final String downloadDirectory = i.server!.localname + i.data!;
-  final dir = await FileExplorer()
-      .getDownloadDir(i.server!.storageMode, i.server!.storageBasePath);
   final String? finalString =
       dir == null ? null : '${dir.path}/media/$downloadDirectory';
   final bool isLocal =
@@ -96,6 +105,49 @@ Future<MediaItem?> buildServerFileMediaItem(DisplayItem i) async {
 Future<MediaItem?> buildMediaItemForRow(DisplayItem i) => i.type == 'localFile'
     ? Future.value(buildLocalFileMediaItem(i))
     : buildServerFileMediaItem(i);
+
+/// MediaItem builds allowed in flight at once. Each partial-metadata row (all
+/// search hits) posts /db/metadata during its build, so a bulk action used to
+/// run one SERIAL network round-trip per row before playback could start.
+const int _kBuildPool = 4;
+
+/// Builds MediaItems for [rows] with bounded concurrency, preserving order:
+/// the returned list is index-aligned with [rows] (null = build failed /
+/// download dir unavailable — callers compact it). The download dir is
+/// resolved once per server up front instead of once per row (path_provider
+/// re-does the platform call every time).
+Future<List<MediaItem?>> buildMediaItemsForRows(List<DisplayItem> rows) async {
+  final dirs = <Server, Directory?>{};
+  for (final r in rows) {
+    final s = r.server;
+    if (r.type == 'localFile' || s == null) continue;
+    if (!dirs.containsKey(s)) {
+      dirs[s] =
+          await FileExplorer().getDownloadDir(s.storageMode, s.storageBasePath);
+    }
+  }
+
+  final out = List<MediaItem?>.filled(rows.length, null);
+  var next = 0;
+  Future<void> worker() async {
+    while (true) {
+      final k = next++;
+      if (k >= rows.length) return;
+      final r = rows[k];
+      try {
+        out[k] = r.type == 'localFile'
+            ? buildLocalFileMediaItem(r)
+            : await _buildServerFileMediaItemWithDir(r, dirs[r.server]);
+      } catch (_) {
+        // Drop just this row; the serial path would have aborted the whole
+        // action on a throw.
+      }
+    }
+  }
+
+  await Future.wait([for (var i = 0; i < _kBuildPool; i++) worker()]);
+  return out;
+}
 
 /// Clears the queue, fills it with every playable item from [rows] (in order),
 /// jumps to the one at [tappedIndex], and plays. When [shuffle] is true the
@@ -174,20 +226,29 @@ Future<void> playFromHere(List<DisplayItem> rows, int tappedIndex,
     newIndex = 0;
   }
 
+  // One batched metadata request per server first (search/discovery rows),
+  // then the concurrent builds below fetch only what the batch missed.
   await prefillMetadata(playable);
 
+  final built = await buildMediaItemsForRows(playable);
+
+  // Compact the nulls while remapping the tapped index onto the survivors —
+  // a failed build used to shift every later index, landing the jump on the
+  // wrong track. If the tapped row itself failed, land on the nearest earlier
+  // survivor (or the top).
   final items = <MediaItem>[];
-  for (final i in playable) {
-    final m = await buildMediaItemForRow(i);
-    if (m != null) items.add(m);
+  int jumpTo = 0;
+  for (var k = 0; k < built.length; k++) {
+    final m = built[k];
+    if (m == null) continue;
+    if (k <= newIndex) jumpTo = items.length;
+    items.add(m);
   }
   if (items.isEmpty) return;
 
   await MediaManager().audioHandler.customAction('clearPlaylist');
-  for (final m in items) {
-    await MediaManager().audioHandler.addQueueItem(m);
-  }
-  await MediaManager().audioHandler.skipToQueueItem(newIndex);
+  await MediaManager().audioHandler.addQueueItems(items);
+  await MediaManager().audioHandler.skipToQueueItem(jumpTo);
   await MediaManager().audioHandler.play();
 }
 
@@ -196,20 +257,20 @@ Future<void> playFromHere(List<DisplayItem> rows, int tappedIndex,
 /// from a fresh state doesn't require a separate play press). Returns the
 /// number of tracks enqueued.
 Future<int> addRowsToQueue(List<DisplayItem> rows) async {
-  final wasEmpty = MediaManager().audioHandler.queue.value.isEmpty;
-  await prefillMetadata(rows);
-  int n = 0;
-  for (final i in rows) {
-    if (i.type != 'file' && i.type != 'localFile') continue;
-    final m = await buildMediaItemForRow(i);
-    if (m == null) continue;
-    await MediaManager().audioHandler.addQueueItem(m);
-    n++;
-  }
-  if (n > 0 && wasEmpty) {
-    await MediaManager().audioHandler.play();
-  }
-  return n;
+  final handler = MediaManager().audioHandler;
+  final wasEmpty = handler.queue.value.isEmpty;
+  final playable = [
+    for (final i in rows)
+      if (i.type == 'file' || i.type == 'localFile') i,
+  ];
+  // Same order as playFromHere: batch-prefill, then concurrent builds.
+  await prefillMetadata(playable);
+  final built = await buildMediaItemsForRows(playable);
+  final items = built.whereType<MediaItem>().toList();
+  if (items.isEmpty) return 0;
+  await handler.addQueueItems(items);
+  if (wasEmpty) await handler.play();
+  return items.length;
 }
 
 /// Applies the user's TapBehavior (Settings — the same setting the file browser

--- a/test/media/auto_dj_top_up_test.dart
+++ b/test/media/auto_dj_top_up_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/audio_stuff.dart';
+import 'package:mstream_music/media/playback_backend.dart';
+
+// The queue-end Auto-DJ top-up trigger. The regression this pins: an IDLE
+// player's stub index emissions land on the last row without any playback
+// behind them — a batch "Add all" onto a fresh-boot player with the DJ armed
+// fired the top-up, each appended pick re-emitted the new last index, and the
+// loop stacked eleven picks in nine seconds while the now-playing surface
+// flashed through them. Only a real playback session may top up.
+void main() {
+  bool topUp(int? index, int len, BackendProcessingState s) =>
+      AudioPlayerHandler.shouldTopUpAutoDJ(
+          index: index, queueLength: len, state: s);
+
+  test('advancing into the last track tops up', () {
+    expect(topUp(29, 30, BackendProcessingState.ready), isTrue);
+  });
+
+  test('the queue completing on the last track tops up (infinite play)', () {
+    expect(topUp(29, 30, BackendProcessingState.completed), isTrue);
+  });
+
+  test('IDLE emissions on the last row must NOT top up', () {
+    // The runaway: fresh-boot idle player, 30 tracks batch-added, stub emits
+    // index 29 — no session, no top-up.
+    expect(topUp(29, 30, BackendProcessingState.idle), isFalse);
+    // And each DJ append's follow-on idle emission (the loop's second half).
+    expect(topUp(30, 31, BackendProcessingState.idle), isFalse);
+  });
+
+  test('mid-queue emissions never top up', () {
+    expect(topUp(3, 30, BackendProcessingState.ready), isFalse);
+  });
+
+  test('null index / empty queue never top up', () {
+    expect(topUp(null, 30, BackendProcessingState.ready), isFalse);
+    expect(topUp(0, 0, BackendProcessingState.ready), isFalse);
+  });
+}

--- a/test/media/auto_dj_top_up_test.dart
+++ b/test/media/auto_dj_top_up_test.dart
@@ -9,9 +9,13 @@ import 'package:mstream_music/media/playback_backend.dart';
 // loop stacked eleven picks in nine seconds while the now-playing surface
 // flashed through them. Only a real playback session may top up.
 void main() {
-  bool topUp(int? index, int len, BackendProcessingState s) =>
+  bool topUp(int? index, int len, BackendProcessingState s,
+          {bool inFailureWalk = false}) =>
       AudioPlayerHandler.shouldTopUpAutoDJ(
-          index: index, queueLength: len, state: s);
+          index: index,
+          queueLength: len,
+          state: s,
+          inFailureWalk: inFailureWalk);
 
   test('advancing into the last track tops up', () {
     expect(topUp(29, 30, BackendProcessingState.ready), isTrue);
@@ -36,5 +40,19 @@ void main() {
   test('null index / empty queue never top up', () {
     expect(topUp(null, 30, BackendProcessingState.ready), isFalse);
     expect(topUp(0, 0, BackendProcessingState.ready), isFalse);
+  });
+
+  test('a live failure walk must NOT be fed picks', () {
+    // The other runaway: streams broken but the random-songs API healthy.
+    // Each failed-track skip lands on the last row LOADING (non-idle), so
+    // without this input the walk and the DJ feed each other unboundedly —
+    // the walk's exit conditions both chase the queue the DJ keeps growing.
+    expect(topUp(29, 30, BackendProcessingState.loading, inFailureWalk: true),
+        isFalse);
+    expect(topUp(29, 30, BackendProcessingState.ready, inFailureWalk: true),
+        isFalse);
+    // A recovered player (any track reached ready → the budget reset) tops
+    // up again as normal.
+    expect(topUp(29, 30, BackendProcessingState.ready), isTrue);
   });
 }

--- a/test/media/emulated_playlist_backend_test.dart
+++ b/test/media/emulated_playlist_backend_test.dart
@@ -38,6 +38,7 @@ class _FakeBackend extends EmulatedPlaylistBackend {
   }
 
   // Public wrappers for the protected advance API.
+  int get sourceCount => items.length;
   Future<void> endOfTrack() => advanceOnComplete();
   Future<void> failTrack(String reason, {bool play = true}) =>
       trackFailed(reason, play: play);
@@ -208,6 +209,34 @@ void main() {
       await b.endOfTrack();
       await b.failTrack('straggler poll');
       expect(b.loads, isEmpty);
+    });
+  });
+
+  group('addSources (batch append)', () {
+    // Must match addSource-per-item semantics: one call appends the whole
+    // batch and, on an empty list, promotes index 0 to current/ready.
+    test('appends in order onto an empty list and readies index 0', () async {
+      final b = _FakeBackend();
+      await b.addSources([_item(0), _item(1), _item(2)]);
+      expect(b.sourceCount, 3);
+      expect(b.currentIndex, 0);
+      expect(b.processingState, BackendProcessingState.ready);
+    });
+
+    test('appends onto a non-empty list without touching the current index',
+        () async {
+      final b = await _seeded(2); // playing index 0 of 2
+      await b.addSources([_item(2), _item(3)]);
+      expect(b.sourceCount, 4);
+      expect(b.currentIndex, 0);
+    });
+
+    test('empty batch is a no-op', () async {
+      final b = _FakeBackend();
+      await b.addSources(const []);
+      expect(b.sourceCount, 0);
+      expect(b.currentIndex, isNull);
+      expect(b.processingState, BackendProcessingState.idle);
     });
   });
 }

--- a/test/util/decode_json_test.dart
+++ b/test/util/decode_json_test.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/util/decode_json.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('decodeJsonBody', () {
+    test('small bodies decode inline and correctly', () async {
+      final decoded = await decodeJsonBody('{"a": [1, 2], "b": "x"}');
+      expect(decoded, {
+        'a': [1, 2],
+        'b': 'x',
+      });
+    });
+
+    test('bodies over the threshold decode off-isolate to the same result',
+        () async {
+      // Build a payload guaranteed past the isolate threshold, shaped like a
+      // whole-library response.
+      final artists =
+          List.generate(6000, (i) => 'Artist $i — padding padding padding');
+      final body = jsonEncode({'artists': artists});
+      expect(body.length, greaterThan(kIsolateDecodeThreshold));
+
+      final decoded = await decodeJsonBody(body);
+      expect(decoded['artists'], hasLength(6000));
+      expect(decoded['artists'][5999], artists[5999]);
+      // Must equal the inline decode exactly.
+      expect(decoded, jsonDecode(body));
+    });
+
+    test('malformed JSON throws (same contract as jsonDecode)', () async {
+      await expectLater(decodeJsonBody('{nope'), throwsFormatException);
+    });
+  });
+}


### PR DESCRIPTION
Batch 2 of the audit's medium-severity findings: the HTTP-layer family (#38 timeouts, #45 connection churn, #41 UI-isolate decode, #40 O(N²) enqueue, #39 serial playFromHere builds, #1 unguarded dynamic dispatch).

> **Stacked PR** — based on `claude/audit-batch1-persistence` (#120). Merge order: #119 → #120 → this → #118.

## Fixes

**Timeouts.** Every direct call is bounded to 15s (`getGenres`, `sharePlaylist`, `fetchLyrics`, `rateSong`, `fetchTrackMetadata` — matching the existing playlist-call precedent), and `makeServerCall`'s non-iroh send gets a 30s bound. Against a black-holed server these hung for the OS TCP timeout (minutes); `rateSong`'s hang also left the star UI's optimistic update showing forever, since its catch is the only revert path.

**Connection reuse.** The direct (non-browse) calls share one keep-alive `http.Client` instead of a fresh client — a TCP+TLS handshake — per call; queue enrichment posts once per track and Discover fires 3–4 per seed. The client resets on server edit/remove. `makeServerCall` keeps its per-request client on purpose: closing it is what makes Back-cancel abort.

**Off-isolate decode.** Browse responses over 100KB (whole-library artists/albums/playlist/recursive payloads, multi-MB on big libraries) decode via `compute` instead of blocking the UI thread mid-animation.

**Batch enqueue.** New `AudioHandler.addQueueItems` + backend `addSources` (just_audio `addAudioSources`; single `addAll` on the emulated cast base): one queue emission and one platform call for a whole batch. "Add all" used to fire an unawaited per-item add where every add re-ran the whole-queue listeners (iroh scan + offline sweep) — O(N²) on big folders.

**playFromHere/addRowsToQueue.** Item builds run 4-concurrent (was one serial /db/metadata round-trip per row), the download dir resolves once per server (was a platform-channel call per row), and the tapped index is remapped over failed builds instead of drifting onto the wrong track.

**Guarded parsing.** The nine browse functions' response parsing moved inside their try blocks — a response-shape surprise threw NoSuchMethodError past the guard and silently killed the browse mid-function. `getRecursiveFiles`' server param is now required (its only caller always passed it), removing the `useThisServer!` deref.

## Verification

- `flutter analyze` clean; full suite passes with new tests: batch-append semantics on the emulated backend (order, index promotion, empty no-op) and the decode helper (small/large/malformed, off-isolate result identical to inline).
- iOS Simulator smoke against the demo server: "Add all" on a folder landed all 26 tracks as **one** batch (single queue emission, snapshot valid), and a batch-added track streams and plays through the new `addAudioSources` path.
- Not separately staged: a stalling server to watch the 30s browse bound fire, and the iroh retry path (untouched logic, but adjacent) — both worth a glance in the device pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)