### PR TITLE
Upgrade to Flutter 3.47.1 (Dart 3.13.1, AGP 9.1.0, Gradle 9.3.1, Kotlin 2.4.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         # same day doesn't surprise us mid-release-cut.
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.44.4'
+          flutter-version: '3.47.0'
           cache: true
 
       - name: Restore keystore from secret
@@ -193,7 +193,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select newest stable Xcode
-        # Flutter 3.44 needs a current Xcode; the runner image ships several
+        # Flutter 3.47 needs a current Xcode; the runner image ships several
         # side by side and the default can lag.
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -203,7 +203,7 @@ jobs:
         # Same pin as the Android job — see the comment there.
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.44.4'
+          flutter-version: '3.47.0'
           cache: true
 
       - name: Build iOS (release, unsigned)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         # same day doesn't surprise us mid-release-cut.
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.47.0'
+          flutter-version: '3.47.1'
           cache: true
 
       - name: Restore keystore from secret
@@ -203,7 +203,7 @@ jobs:
         # Same pin as the Android job — see the comment there.
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.47.0'
+          flutter-version: '3.47.1'
           cache: true
 
       - name: Build iOS (release, unsigned)

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -7,7 +7,7 @@ A tight regression-detection loop for an existing Flutter app whose modernizatio
 ## What we have today
 
 - **App version**: 0.14.0+25
-- **Flutter**: 3.44.4 / Dart 3.12.2 (Android: AGP 9.0.1 / Gradle 9.1.0 / Kotlin 2.3.20)
+- **Flutter**: 3.47.0 / Dart 3.13.0 (Android: AGP 9.1.0 / Gradle 9.3.1 / Kotlin 2.4.0)
 - **Source tree**: `lib/main.dart` (root UI), `lib/screens/*` (page widgets), `lib/singletons/*` (state + side effects), `lib/objects/*` (data classes), `lib/media/*` (audio_service handler)
 - **Existing tests**: a 2021 boilerplate counter test that never matched the app — replaced.
 - **Baseline `flutter analyze`**: 2 minor issues

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -7,7 +7,7 @@ A tight regression-detection loop for an existing Flutter app whose modernizatio
 ## What we have today
 
 - **App version**: 0.14.0+25
-- **Flutter**: 3.47.0 / Dart 3.13.0 (Android: AGP 9.1.0 / Gradle 9.3.1 / Kotlin 2.4.0)
+- **Flutter**: 3.47.1 / Dart 3.13.1 (Android: AGP 9.1.0 / Gradle 9.3.1 / Kotlin 2.4.0)
 - **Source tree**: `lib/main.dart` (root UI), `lib/screens/*` (page widgets), `lib/singletons/*` (state + side effects), `lib/objects/*` (data classes), `lib/media/*` (audio_service handler)
 - **Existing tests**: a 2021 boilerplate counter test that never matched the app — replaced.
 - **Baseline `flutter analyze`**: 2 minor issues

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "9.0.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.3.20" apply false
+    id "com.android.application" version "9.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/lib/media/local_media_server.dart
+++ b/lib/media/local_media_server.dart
@@ -254,7 +254,7 @@ class LocalMediaServer {
       final seg = req.uri.pathSegments;
       final token = seg.isEmpty ? null : seg.first;
       if (token != null && _proxies.containsKey(token)) {
-        return _proxyRequest(req, _proxies[token]!);
+        return await _proxyRequest(req, _proxies[token]!);
       }
       String? path;
       String? contentType;
@@ -270,9 +270,9 @@ class LocalMediaServer {
           }
         }
       }
-      if (path == null) return _notFound(res);
+      if (path == null) return await _notFound(res);
       final file = File(path);
-      if (!await file.exists()) return _notFound(res);
+      if (!await file.exists()) return await _notFound(res);
 
       final length = await file.length();
       res.headers

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      sha256: ace891da0862b0e4cabbb064ee3fd87b2728b898949fdb366d83fe98342c9f19
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.9"
+    version: "4.2.0"
   args:
     dependency: transitive
     description:
@@ -61,34 +61,34 @@ packages:
     dependency: "direct main"
     description:
       name: background_downloader
-      sha256: aceacec2b2a72ec3a8862ab5895fcbbc71ab33765f3619d57963f3110dd268e3
+      sha256: bdd41f116998233182cc4ec04cb6afac534067d640ddebb791ce44593f574b87
       url: "https://pub.dev"
     source: hosted
-    version: "9.5.5"
+    version: "9.5.8"
   bonsoir:
     dependency: "direct main"
     description:
       name: bonsoir
-      sha256: "86a8f55539d29c17ac2cb8a16698978aaa9e7c5d14139fb2234dad33b6ecfc33"
+      sha256: "20fed01e4616e625f4bafd9007ff899d231d8d79bebc8564853fa1e3570294a6"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.4"
+    version: "7.1.5"
   bonsoir_android:
     dependency: transitive
     description:
       name: bonsoir_android
-      sha256: c6413e82150074d56e71ffe2e54bb1dfe66a59310affc4486d33e9eee6b362e6
+      sha256: "0dda1164e826553b8ee90a3fd1aabd462d17f19348f542b95f9d5b5455e4157f"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.2"
+    version: "7.1.3"
   bonsoir_darwin:
     dependency: transitive
     description:
       name: bonsoir_darwin
-      sha256: "04425a8657e3131683c7966689d4e65e114cb5181de94aac89d2fba84cfaaca4"
+      sha256: "6f695a0b4465514b75fc1a457746ab6dfc10d7180f0d04810fd9512e6520df69"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.1.1"
   bonsoir_linux:
     dependency: transitive
     description:
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
+      sha256: cfd4f5f575a49c5f10ca856e9846073f1e6c3ee94912377eea5f6cefc5272941
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.0.0"
   collection:
     dependency: transitive
     description:
@@ -173,10 +173,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: cad0e811a289ea2a941119dc483c204ec1684cbb9a8fc7351fe4a230b8313160
+      sha256: "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.3.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      sha256: f141ea4f277af142a0356955707f6556f37b03947d39d55585981a06ca437bd6
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+4"
+    version: "0.3.5+5"
   crypto:
     dependency: transitive
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
+      sha256: a48d5da28e89bd02196e80d81ed8d7954923d00a0f4a68cc20b575038f023383
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.14"
+    version: "0.7.15"
   fading_edge_scrollview:
     dependency: transitive
     description:
@@ -274,18 +274,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_cache_manager
-      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      sha256: "1de7849213b4c73c85aca7e0ac687a9a5d82ccdb594366b9dcc26cb6a2189cd2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.4.2"
   flutter_chrome_cast:
     dependency: "direct main"
     description:
       name: flutter_chrome_cast
-      sha256: "3d412fa1831591466df4ae5d61edd8e4fdd8b2992008eed0d44dde5958e21287"
+      sha256: e6f769ffd30be0ac79cab00cb82c9db3956ffc718c5199f75cd5e53d2be86976
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.6"
+    version: "1.4.8"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -347,10 +347,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
+      sha256: eaac480a35ec0814146c2c48d96aaa829e0e44a7662c88ae84c9edf4bc35651f
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.2.0"
   http:
     dependency: "direct main"
     description:
@@ -371,10 +371,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      sha256: "1976370a4df3091bb0f72409c187ad1f9132a818bc6b95ca59c0bae1c75c688e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.2"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -399,18 +399,26 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   jni_flutter:
     dependency: transitive
     description:
       name: jni_flutter
-      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
+  jni_util:
+    dependency: transitive
+    description:
+      name: jni_util
+      sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
@@ -543,10 +551,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
+      sha256: ce3f059ebd6dbfab7292bba0e893e354b46730636820d3c9ef69005ce2d55bce
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.4.0"
   nm:
     dependency: transitive
     description:
@@ -559,26 +567,26 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
+      sha256: ad56fd53a78ff6b1472fa59ff2a4e8b8ccabafc586fc263a1dfad0b99b5553e3
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.1"
+    version: "9.6.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      sha256: ffcf4cf3d6c0b74ac43708d9f56625506e8a68aa935abe9d267a7330f320eb5d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   package_info_plus:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: f5c435dc0e0d461e5b32471a870f769b6a1cc46930637efe24fbc535314e78ad
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "10.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -663,34 +671,34 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
+      sha256: f49cb15a064ea9d974fc7fbb302099353b7b170d07284e86e264561579e5bcf8
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.10"
+    version: "9.6.1"
   permission_handler_html:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      sha256: "6ea98b3f17f60d3b527f2647ed2ab4dc0f6bfe25b22cb1c363f5d8f62252f6ac"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+5"
+    version: "0.1.4+1"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      sha256: a5c8a97ecf5616112a5b16d4b8e9ec0e5ae90ef63ac69c0d7b8ae240be760b23
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
-      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      sha256: caeae01858a0a7d2df67a445ac98e1ad95e55a0e77c73044f4e9b1c8c2289cbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   petitparser:
     dependency: transitive
     description:
@@ -719,10 +727,10 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.5.2"
   process:
     dependency: transitive
     description:
@@ -759,10 +767,10 @@ packages:
     dependency: transitive
     description:
       name: record_use
-      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      sha256: "1cb8564af8d43b464294411db9217f5ec04891c6f22ee2c32d73ae05e88a6bd2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "1.1.1"
   rxdart:
     dependency: "direct main"
     description:
@@ -775,18 +783,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "9eee8283462d91a7a1c8bdb67d08874abd75a2f8fae3bc0ca033035e375fb3d8"
+      sha256: "34f00f9becd2743c1fb05363d624f9f70d37f7ccdcdda47450bc0b8c9d327b8c"
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.0"
+    version: "13.3.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
+      sha256: "365ef7379fc22507256adda3385152942ffce08935452bc972c2e52a0bebae41"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -876,10 +884,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
+      sha256: "3a7b5d17422dd0f8d5c6c14feaa5a1c65638b9455f871a96f08437562c046931"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.4.1+2"
   term_glyph:
     dependency: transitive
     description:
@@ -972,10 +980,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.3"
+    version: "4.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -995,10 +1003,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.3.0"
   web:
     dependency: transitive
     description:
@@ -1026,10 +1034,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
+      sha256: a0b93865d5644f11cf6a8c3f6db909f1ec168958b5805f6cc684adea957cd63d
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.4.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1042,10 +1050,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: "direct main"
     description:
       name: background_downloader
-      sha256: bdd41f116998233182cc4ec04cb6afac534067d640ddebb791ce44593f574b87
+      sha256: aceacec2b2a72ec3a8862ab5895fcbbc71ab33765f3619d57963f3110dd268e3
       url: "https://pub.dev"
     source: hosted
-    version: "9.5.8"
+    version: "9.5.5"
   bonsoir:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,12 @@ dependencies:
   audio_service: ^0.18.18
   just_audio: ^0.10.3
   flutter_slidable: ^4.0.3
-  background_downloader: ^9.4.4
+  # Pinned: 9.5.8 fails :background_downloader:compileDebugKotlin under the
+  # transitional android.builtInKotlin=false toolchain — its build.gradle tries
+  # to re-apply legacy KGP for that case but checks hasProperty('builtInKotlin')
+  # (missing the android. prefix), so the branch never fires. 9.5.5 is the last
+  # version verified to build here; unpin once upstream fixes the property check.
+  background_downloader: 9.5.5
   flutter_launcher_icons: ^0.14.2
   permission_handler: ^12.0.1
   url_launcher: ^6.3.1


### PR DESCRIPTION
## Summary
- Flutter 3.44.4 → **3.47.1** (Dart 3.13.1); CI pins updated in both release.yml jobs, TEST_PLAN.md toolchain row updated
- Android toolchain aligned to 3.47's verified set: AGP 9.0.1 → 9.1.0, Kotlin 2.3.20 → 2.4.0, Gradle wrapper 9.1.0 → 9.3.1
- `analysis_options.yaml`: platform-dir excludes appended by 3.47's automatic pub-get migration
- `local_media_server.dart`: `return await` on three futures returned inside `_handle`'s try block, so a rejected proxy/not-found future hits the handler's catch (flagged by Dart 3.13's new `unawaited_return_in_try_block` lint)
- **`background_downloader` pinned to 9.5.5**: 9.5.8 fails `compileDebugKotlin` under the transitional `android.builtInKotlin=false` toolchain — its build.gradle re-applies legacy KGP for that case but checks `hasProperty('builtInKotlin')` without the `android.` prefix, so the branch never fires. Worth an upstream issue; unpin when fixed.

## Notes
- Transitional gradle flags (`newDsl=false`, `builtInKotlin=false`) stay: the 3.47 template itself still ships both `=false`, and `disable-abi-filtering` is still honored (confirmed in the 3.47 Flutter Gradle plugin source)
- KGP deprecation warning list under 3.47 is now: `bonsoir_android`, `flutter_chrome_cast`, `media_cast_dlna`, `mobile_scanner` (warning only)
- iOS needed no changes (deployment target 15 + UIScene + SwiftPM already in place); the `build-ios-unsigned` CI job at the next release tag is its real verification
- The `material_ui`/`cupertino_ui` package split is deliberately deferred to its own PR (core SDK deprecation lands ~November)

## Test plan
- [x] `flutter analyze` — no new findings (18 pre-existing info-level items unchanged)
- [x] `flutter test` — 231/231 pass
- [x] Release artifacts build + sign: `apk --flavor full`, `appbundle --flavor play`
- [x] ABI packaging assertions (local run of the CI checks): armeabi-v7a present and lib-free; `libiroh_tunnel`/`libprojectM-4`/`libvisualizer_bridge` on arm64-v8a + x86_64 only; `--split-per-abi` splits package correctly under AGP 9's migrated split DSL
- [x] On-device (S25, wireless adb): installed and running, no errors in logcat
- [ ] Visual pass on device (playback + visualizer orientation — 3.47 removed an Impeller texture Y-flip workaround on the SurfaceTexture path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)