### PR TITLE
Migrate to the standalone material_ui package

### DIFF
--- a/integration_test/add_server_test.dart
+++ b/integration_test/add_server_test.dart
@@ -7,7 +7,7 @@
 //   4. Tap Save — the first-run setup flow appears over the browser.
 //   5. Skip it — browser is shown with the server URL.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 

--- a/integration_test/helpers/test_helpers.dart
+++ b/integration_test/helpers/test_helpers.dart
@@ -28,7 +28,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'package:mstream_music/main.dart';

--- a/integration_test/playback_progress_test.dart
+++ b/integration_test/playback_progress_test.dart
@@ -19,7 +19,7 @@
 // finder is scoped to the mini-player's Key('miniPlayer') so we read the
 // collapsed bar, not the sheet.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 

--- a/integration_test/playlist_create_test.dart
+++ b/integration_test/playlist_create_test.dart
@@ -7,7 +7,7 @@
 
 import 'dart:io';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:path_provider/path_provider.dart';

--- a/integration_test/search_categories_test.dart
+++ b/integration_test/search_categories_test.dart
@@ -13,7 +13,7 @@
 // single-subscription singleton stream (DownloadManager) — so one mount,
 // one scenario, per file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 

--- a/integration_test/search_test.dart
+++ b/integration_test/search_test.dart
@@ -14,7 +14,7 @@
 // search_categories_test.dart (mounting MStreamApp twice in one process
 // re-subscribes a singleton stream, so each scenario gets its own file).
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 

--- a/integration_test/settings_persist_test.dart
+++ b/integration_test/settings_persist_test.dart
@@ -8,7 +8,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:path_provider/path_provider.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io' show HttpOverrides;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:mstream_music/singletons/browser_list.dart';
 import 'package:permission_handler/permission_handler.dart';

--- a/lib/objects/display_item.dart
+++ b/lib/objects/display_item.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'server.dart';
 import 'metadata.dart';

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../app_version.dart';

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -5,7 +5,7 @@ import 'dart:math';
 
 import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';

--- a/lib/screens/album_detail_view.dart
+++ b/lib/screens/album_detail_view.dart
@@ -11,7 +11,7 @@
 // them (older API builds omit them; see MusicMetadata).
 
 import 'package:audio_service/audio_service.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/screens/attributions_screen.dart
+++ b/lib/screens/attributions_screen.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../app_version.dart';

--- a/lib/screens/auto_dj.dart
+++ b/lib/screens/auto_dj.dart
@@ -15,7 +15,7 @@
 
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../l10n/enum_labels.dart';

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -1,5 +1,5 @@
 import 'package:audio_service/audio_service.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:mstream_music/singletons/file_explorer.dart';
 import '../l10n/app_localizations.dart';
 import '../l10n/enum_labels.dart';

--- a/lib/screens/diagnostics_screen.dart
+++ b/lib/screens/diagnostics_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';

--- a/lib/screens/discover_screen.dart
+++ b/lib/screens/discover_screen.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:audio_service/audio_service.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/screens/downloads.dart
+++ b/lib/screens/downloads.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 // import 'package:disk_space/disk_space.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/screens/eq_screen.dart
+++ b/lib/screens/eq_screen.dart
@@ -22,7 +22,7 @@ import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:audio_service/audio_service.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:just_audio/just_audio.dart';
 
 import '../media/cast_target.dart';

--- a/lib/screens/imported_shaders_screen.dart
+++ b/lib/screens/imported_shaders_screen.dart
@@ -5,7 +5,7 @@
 
 import 'dart:io';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:path/path.dart' as p;
 import 'package:permission_handler/permission_handler.dart';

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../objects/lyrics.dart';

--- a/lib/screens/manage_server.dart
+++ b/lib/screens/manage_server.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:mstream_music/singletons/file_explorer.dart';
 import 'package:flutter/services.dart';
 

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -1,7 +1,7 @@
 import 'dart:ui' show ImageFilter;
 
 import 'package:audio_service/audio_service.dart' show MediaItem;
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/screens/playlists_screen.dart
+++ b/lib/screens/playlists_screen.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../objects/playlist.dart';

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,7 +1,7 @@
 import 'dart:async' show unawaited;
 import 'dart:io' show Platform;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart' show FilteringTextInputFormatter;
 
 import '../l10n/app_localizations.dart';

--- a/lib/screens/setup_flow.dart
+++ b/lib/screens/setup_flow.dart
@@ -1,7 +1,7 @@
 import 'dart:async' show unawaited;
 import 'dart:io' show Platform;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../l10n/enum_labels.dart';

--- a/lib/screens/share_playlist_dialog.dart
+++ b/lib/screens/share_playlist_dialog.dart
@@ -10,7 +10,7 @@
 // expressed as a single share. We surface a clear blocker dialog
 // rather than silently dropping items.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/screens/sonic_path_screen.dart
+++ b/lib/screens/sonic_path_screen.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../objects/discovery.dart';

--- a/lib/screens/transcode_screen.dart
+++ b/lib/screens/transcode_screen.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../singletons/media.dart';

--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -6,7 +6,7 @@
 import 'dart:io' show Platform;
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -13,7 +13,7 @@ import 'media.dart';
 import '../util/media_format.dart';
 import '../util/stream_url.dart';
 import '../theme/velvet_theme.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:path/path.dart' as path;
 import 'package:audio_service/audio_service.dart';
 

--- a/lib/singletons/app_messenger.dart
+++ b/lib/singletons/app_messenger.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Global ScaffoldMessenger key so context-less singletons (e.g.
 // DownloadManager) can surface SnackBars. Wired into

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../singletons/server_list.dart';

--- a/lib/singletons/file_explorer.dart
+++ b/lib/singletons/file_explorer.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'dart:async';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';

--- a/lib/singletons/track_capture.dart
+++ b/lib/singletons/track_capture.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../objects/display_item.dart';

--- a/lib/theme/velvet_theme.dart
+++ b/lib/theme/velvet_theme.dart
@@ -10,7 +10,7 @@
 // MaterialApp rebuilds (see main.dart's StreamBuilder wrapping).
 // Existing callers (e.g. `VelvetColors.bg`) work unchanged.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 enum AppTheme {
   velvet,

--- a/lib/util/media_format.dart
+++ b/lib/util/media_format.dart
@@ -1,7 +1,7 @@
 // Shared media-UI helpers, de-duplicated from player_panel / queue_list /
 // more_actions_sheet (each used to carry its own near-identical copy).
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/velvet_theme.dart';
 

--- a/lib/util/real_audio_permission.dart
+++ b/lib/util/real_audio_permission.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/visualizer/shader_visualizer_screen.dart
+++ b/lib/visualizer/shader_visualizer_screen.dart
@@ -3,7 +3,7 @@ import 'dart:io' show Platform;
 import 'dart:ui' as ui;
 
 import 'package:audio_service/audio_service.dart' show MediaItem;
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 

--- a/lib/widgets/accent_color_sheet.dart
+++ b/lib/widgets/accent_color_sheet.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../singletons/settings.dart';

--- a/lib/widgets/album_grid.dart
+++ b/lib/widgets/album_grid.dart
@@ -6,7 +6,7 @@
 // to a passed-in handler so the same Browser navigation logic still
 // drives drilldown.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../objects/display_item.dart';
 import '../theme/velvet_theme.dart';

--- a/lib/widgets/auto_dj_start_sheet.dart
+++ b/lib/widgets/auto_dj_start_sheet.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../singletons/auto_dj_manager.dart';

--- a/lib/widgets/browser_toolbar.dart
+++ b/lib/widgets/browser_toolbar.dart
@@ -17,7 +17,7 @@
 
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/widgets/cast_picker_sheet.dart
+++ b/lib/widgets/cast_picker_sheet.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../media/cast_target.dart';

--- a/lib/widgets/discover_queue_bar.dart
+++ b/lib/widgets/discover_queue_bar.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:audio_service/audio_service.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../objects/discovery.dart';

--- a/lib/widgets/fact_badge.dart
+++ b/lib/widgets/fact_badge.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/velvet_theme.dart';
 

--- a/lib/widgets/iroh_pairing_qr_sheet.dart
+++ b/lib/widgets/iroh_pairing_qr_sheet.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 

--- a/lib/widgets/iroh_repair_sheet.dart
+++ b/lib/widgets/iroh_repair_sheet.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:permission_handler/permission_handler.dart';
 

--- a/lib/widgets/iroh_scanner.dart
+++ b/lib/widgets/iroh_scanner.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/widgets/letter_strip.dart
+++ b/lib/widgets/letter_strip.dart
@@ -23,7 +23,7 @@
 // scroll offset, so the same strip works above a ListView, a
 // GridView, or anything else with a ScrollController.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 
 import '../objects/display_item.dart';

--- a/lib/widgets/local_search_bar.dart
+++ b/lib/widgets/local_search_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../theme/velvet_theme.dart';

--- a/lib/widgets/more_actions_sheet.dart
+++ b/lib/widgets/more_actions_sheet.dart
@@ -1,6 +1,6 @@
 import 'dart:io' show Platform;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../media/cast_target.dart';

--- a/lib/widgets/player_panel.dart
+++ b/lib/widgets/player_panel.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:audio_service/audio_service.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/widgets/playlist_name_dialog.dart
+++ b/lib/widgets/playlist_name_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../theme/velvet_theme.dart';

--- a/lib/widgets/playlist_picker_sheet.dart
+++ b/lib/widgets/playlist_picker_sheet.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../objects/server.dart';

--- a/lib/widgets/queue_list.dart
+++ b/lib/widgets/queue_list.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:audio_service/audio_service.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:rxdart/rxdart.dart';

--- a/lib/widgets/server_version_line.dart
+++ b/lib/widgets/server_version_line.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/widgets/sleep_timer_sheet.dart
+++ b/lib/widgets/sleep_timer_sheet.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 
 import '../l10n/app_localizations.dart';

--- a/lib/widgets/song_picker_sheet.dart
+++ b/lib/widgets/song_picker_sheet.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../objects/display_item.dart';

--- a/lib/widgets/star_rating.dart
+++ b/lib/widgets/star_rating.dart
@@ -1,5 +1,5 @@
 import 'package:audio_service/audio_service.dart' show MediaItem;
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../objects/server.dart';

--- a/lib/widgets/track_actions_sheet.dart
+++ b/lib/widgets/track_actions_sheet.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../l10n/app_localizations.dart';
 import '../objects/display_item.dart';

--- a/lib/widgets/waveform_progress.dart
+++ b/lib/widgets/waveform_progress.dart
@@ -15,7 +15,7 @@
 
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/velvet_theme.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  cupertino_ui:
+    dependency: transitive
+    description:
+      name: cupertino_ui
+      sha256: "2137c0d41f3b62cc4d3d2495e6c354bd6b6133cd21c6bb155736cc31dbd49a11"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   dbus:
     dependency: transitive
     description:
@@ -226,7 +234,7 @@ packages:
     source: hosted
     version: "4.1.1"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
@@ -523,6 +531,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: "7ba1ca315d50a004791dbab290417c52a61466d56db2822fe3c5c2994903110c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   media_cast_dlna:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,6 +85,7 @@ dependencies:
   # model (built by rust/viz_decoder/build-ios.sh).
   viz_decoder_native:
     path: packages/viz_decoder_native
+  material_ui: ^1.1.0
 dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
@@ -92,6 +93,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
 
+  fake_async: any
 flutter_icons:
   android: true
   ios: true


### PR DESCRIPTION
## Summary
Flutter 3.47's headline change: Material moves out of the core SDK into the standalone `material_ui` package (weekly release cadence; the core copy is formally deprecated in the November stable). This PR is the app-side migration, done entirely with the official tooling:

- `flutter pub add material_ui` → material_ui 1.1.0 (pulls cupertino_ui 1.0.1 transitively; we import no Cupertino directly)
- `dart fix --apply --code=migrate_design_widgets` → rewrote `package:flutter/material.dart` → `package:material_ui/material_ui.dart` in **63 files** (one import line each), and added the missing `fake_async` dev-dep (retiring a baseline `depend_on_referenced_packages` lint)

No hand-edits beyond that. `MaterialUiCompatibilityBridge` is **not** needed: material_ui 1.1.0 is type-compatible with core Material, so third-party widget packages (flutter_slidable, qr_flutter, mobile_scanner, …) interop unchanged.

> **Stacked on #125** (Flutter 3.47.1 upgrade) — retarget this PR's base to `master` after #125 merges, before merging this one.

## Test plan
- [x] `flutter analyze` — zero new findings (17 baseline info items, one fewer than before)
- [x] `flutter test` — 231/231 pass
- [x] Debug build installed on S25 via wireless adb: launches, runs, logcat clean
- [ ] Visual pass on device (shares the pending pass from #125)

🤖 Generated with [Claude Code](https://claude.com/claude-code)