### PR TITLE
feat(federation): federated servers — model, transport, and the server picker

### DIFF
--- a/FEDERATION_PLAN.md
+++ b/FEDERATION_PLAN.md
@@ -1,0 +1,245 @@
+# Federated server support
+
+Bringing mStream's federation feature to the mobile app: browse and play a
+paired peer's library from inside the app, using the existing multi-server
+machinery rather than a parallel one.
+
+Server side is already done and merged:
+
+| PR | What it added |
+|---|---|
+| (pre-existing, 6.24.0) | `GET /api/v1/federation/peers/:id/stream/*path` — peer audio, ranges forwarded |
+| [#927](https://github.com/IrosTheBeggar/mStream/pull/927) | the browse half: peers projection, API proxy, art proxy, `federationBrowse` ping flag |
+| [#932](https://github.com/IrosTheBeggar/mStream/pull/932) | layered `GET /api/`, added to the federation allowlist |
+| [#934](https://github.com/IrosTheBeggar/mStream/pull/934) | `/api/` back behind the auth wall; version returns to every response |
+
+---
+
+## 1. What the server offers
+
+### Routes reachable from the app
+
+| Route | Purpose |
+|---|---|
+| `GET /api/v1/federation/peers` | `{peers:[{id,name,lastSeen,lastStatus,useDiscovery}]}` — any logged-in user, never credentials |
+| `ALL /api/v1/federation/peers/:id/api/<local-path>` | one allowlisted read, executed on the peer |
+| `GET /api/v1/federation/peers/:id/art/<file>?compress=` | that peer's album art |
+| `GET /api/v1/federation/peers/:id/stream/<path>` | that peer's audio |
+
+Gated by the ping flag `federationBrowse` (federation enabled **and** at least
+one peer). Flags, never probes — the house rule on both sides.
+
+### Three constraints that shape everything
+
+**The path prefix is literal.** `/api/v1/federation/peers/{id}/api` + the
+normal local path, so `…/peers/3/api/api/v1/db/albums`. The doubled `api` is
+correct.
+
+**Query params are dropped.** The API proxy forwards none; art forwards only
+`compress`. Deliberate — the app's `?token=` is the *parent's* JWT and
+forwarding it would hand a peer a working credential for the parent. Every
+call the allowlist covers puts its params in a POST body or the path, so
+nothing is lost today. Any future call that relies on a query string will
+silently lose it.
+
+**The allowlist is the entire feature surface**
+([`federation-auth.js`](https://github.com/IrosTheBeggar/mStream/blob/master/src/api/federation-auth.js)).
+
+Reachable: `GET /api` · `GET /api/` · `db/status` · `db/metadata{,/batch}` ·
+`db/artists` · `db/artists-albums` · `db/albums` · `db/genres` ·
+`db/genre-songs` · `db/album-songs` · `db/recent/added` · `db/search` ·
+`file-explorer{,/recursive,/m3u}` · `GET /media/*` · `GET /album-art/*`
+
+Not reachable, so the app must hide it: **all `playlist/*`** · `db/rated` ·
+`rate-song` · **`db/random-songs` (Auto DJ is impossible)** · `/transcode` ·
+`/api/v1/lyrics` · `/api/v1/share` · `torrent/*` · `album-art/search` ·
+**`/api/v1/ping`** (403s a federation key — pinned by test).
+
+### `GET /api` is the one capability call
+
+Post-#934, a federation key gets the full response: `server` (version),
+`features.{discoveryReady, discovery, discoveryP2p, transcode,
+supportedAudioFiles}`, and a key-scoped `user.{username, admin, federation,
+vpaths, noMkdir, noUpload, noFileModify, federationDiscovery, vpathMetaData}`.
+
+Because ping 403s a federation key, this is the *only* capability route for a
+peer. Call it as `/api` without the trailing slash — both spellings are
+allowlisted, but the bare form sidesteps how Express 5's `*path` wildcard
+hands a trailing slash to the proxy's segment join.
+
+> **Trap:** a peer's advertised capability is not what the app can reach. A
+> peer may report `features.transcode` or `features.discovery: true` while
+> `/transcode` and `/api/v1/discovery/*` stay off the allowlist. Federated
+> servers force `transcodeAvailable = false` and all discovery flags false
+> regardless of the payload. Read through only: `server`, `user.vpaths`,
+> `user.vpathMetaData`, and the permission flags.
+
+---
+
+## 2. Architecture: a federated server is a virtual `Server`
+
+The app's entire request layer funnels through three functions:
+
+- [`Server.apiUri`](lib/objects/server.dart) — 25 call sites
+- [`buildServerStreamUrl`](lib/util/stream_url.dart)
+- [`buildAlbumArtUrl`](lib/util/stream_url.dart)
+
+Teach those three about federation and browse + playback follow, the same way
+iroh's loopback rewrite already works.
+
+```dart
+String? federationParent;   // parent server's localname
+int? federationPeerId;      // peer id on that parent
+bool federationMissing;     // parent no longer lists this peer
+bool get isFederated => federationParent != null;
+```
+
+- `effectiveBaseUrl` → the parent's, so **an iroh parent works with no extra
+  code** (the request rides the parent's loopback tunnel).
+- `jwt` → the parent's, always.
+- `apiUri(loc)` → `parent.apiUri('/api/v1/federation/peers/$id/api$loc')`,
+  which also picks up the `__lt` loopback token for an iroh parent.
+- stream → `…/peers/{id}/stream{p}?app_uuid=…&token={parent.jwt}{parent.localTokenQuery}`
+- art → `…/peers/{id}/art/{encodeComponent(artFile)}?compress={c}&token=…`
+  (art files are single-segment hashes — `/album-art/:file` — so
+  one-component encoding is right).
+
+Setting `transcodeAvailable = false` routes `buildServerStreamUrl` to `/media`
+through its **existing** branch. The one capability that is genuinely gone
+needs no new code path.
+
+### Parent link
+
+Held as a runtime-only `Server? parentServer`, resolved by `ServerManager`
+after load and on every reconcile — matching the existing runtime-only pattern
+(`tunnelPort`, `tunnelToken`) and avoiding an import cycle between
+`objects/server.dart` and `singletons/server_list.dart`. When the link is
+missing the accessors return an unroutable origin so a stray request fails
+fast, exactly as `effectiveBaseUrl` already does for a null `tunnelPort`.
+
+### `localname`
+
+Keys both queue restore (`byLocalname`) and the download directory
+`media/<localname>`, so it must be stable, unique, and filesystem-safe.
+Federated servers get their **own independent** localname, generated once at
+first discovery and persisted forever — *not* derived from the parent's,
+because the parent's localname is user-editable and a rename would otherwise
+force a download-folder migration for every child.
+
+`federationParent` stores the parent's localname, so the edit path in
+`add_server.dart` must update children when a parent is renamed.
+
+### Lifecycle: persist a stub, reconcile from the parent
+
+Peers are the parent admin's data, but the app cannot be purely derived —
+`QueueStore` resolves tracks by `localname` at launch, before any network
+call. So:
+
+- Persist a minimal record in `servers.json` (localname, name, parent,
+  peerId) so resolution works cold and downloads keep their folder.
+- After each successful capability refresh of a parent advertising
+  `federationBrowse`, fetch `GET /api/v1/federation/peers` and reconcile: add
+  new, rename changed, **flag** vanished peers rather than deleting them (a
+  queued or downloaded track would otherwise lose its home). Hidden from the
+  picker; deleted only on explicit user action or when the parent goes.
+- Removing a parent removes its children.
+
+---
+
+## 3. Phases
+
+### Phase 1 — model + transport (no UI) ✅ done
+
+1. `Server`: federation fields, `isFederated`, parent-aware
+   `effectiveBaseUrl` / `jwt` / `apiUri` / `localTokenQuery`, JSON round-trip.
+2. `stream_url.dart`: federated stream + art URL rewrites.
+3. `ServerManager`: parent linking, `refreshFederatedPeers` + reconcile,
+   federated branch in the capability refresh (one `GET /api` call),
+   cascade delete with the parent, rename propagation.
+4. Unit tests — URL building is pure and cheap to pin.
+
+### Phase 1b — migrate capability refresh to `GET /api` ✅ done
+
+Now that `/api/` carries version *and* capabilities for every caller type
+including federation keys, `getServerPaths` moves off `/api/v1/ping`
+entirely and uses one call for regular and federated servers alike. This
+folds the federated path into the normal one instead of adding a sibling,
+and drops the separate `fetchServerVersion` round trip since the version
+rides along.
+
+Two wrinkles:
+
+- `/api/` deliberately omits `playlists` (a resource, not a capability) —
+  read them from `/api/v1/playlist/getall`, which `ApiManager` already
+  wraps. Federated servers skip this: playlists are off the allowlist.
+- `/api/` omits `discoveryPath`, a ping-only legacy field that #934 notes is
+  always identical to `discovery` on any build carrying this code — so
+  `discoveryPathAvailable` tracks `features.discovery`.
+
+Older servers (pre-#932) return the old flat `/api/` shape — version only, no
+`features`/`user`. Keep the ping call as the fallback when the response has no
+`features` key, so the app still works against every released server.
+
+### Phase 2 — the server picker
+
+The picker at `main.dart` iterates `serverList` by index, so federated servers
+appear the moment they are in the list. Refinements:
+
+- render federated rows indented, with a distinct icon and a "via &lt;parent&gt;"
+  subtitle
+- add `Server.displayName` — a federated row has no meaningful `url` (also
+  used by the app-bar subtitle)
+- the `throwErr: true` capability call on select must take the federated path
+  instead of throwing
+
+`goToNavScreen()` builds seven fixed rows — drop **Playlists** and **Rated**
+for a federated server, keeping File Explorer / Albums / Artists / Recent /
+Local Files, plus a read-only note mirroring the webapp's left-nav
+explanation.
+
+### Phase 3 — capability gates
+
+`isFederated` checks for: Auto DJ (picker + `toggleAutoDJ`), star rating, the
+lyrics badge, share, and the torrent panel. `manage_server.dart` offers
+federated rows nothing but "Forget" — no edit, no pairing code, no storage
+settings.
+
+**`.m3u` rows.** The webapp hides them on a peer (mStream 9dfc3bfb): its row
+handlers called local APIs with a peer path, which poisoned the breadcrumb or
+loaded a same-named *local* playlist. The app's equivalents thread the server
+through (`makeServerCall(useThisServer, …)`) and `POST
+/api/v1/file-explorer/m3u` is allowlisted, so it may well work — but this is
+the one place the webapp found a path-namespace collision, so verify it on a
+peer before deciding to keep the rows.
+
+### Phase 4 — playback, queue, downloads
+
+- queue restore across a restart (a federated server must resolve by
+  localname before `QueueStore.init`)
+- **cast fix:** `irohServerFor` tests `s.isIroh` on the item's own server. A
+  federated server whose *parent* is iroh answers `false`, so casting would
+  hand a DLNA renderer a `127.0.0.1` URL it cannot reach. That resolution has
+  to follow the parent chain.
+- downloads: `/media` and ranges are allowlisted, so this should work once the
+  URL is rewritten — verify the `media/<localname>` directory is created.
+
+### Phase 5 — optional: make Discover leads actionable
+
+`/api/v1/discovery/federation/similar` already returns `peer:{id,name}` on the
+wire, but `DiscoveryLead` parses only the name. Parsing `peer.id` lets a
+"From your peers" row become "Open on &lt;peer&gt;" → search that federated
+server. Leads carry no filepath, so it is a search hop, not direct playback.
+
+---
+
+## 4. Risks
+
+**Peer ids are parent-side rowids.** An admin who removes and re-adds a peer
+gets a new id, silently orphaning queue entries and the download folder.
+Reconciling by name as well as id mitigates it. Decide before Phase 1 fixes
+the localname format.
+
+**Stale server comment.** The allowlist comment at `federation-auth.js:42-43`
+still says the route "is mounted before the wall and resolves the key itself"
+— untrue as of #934, though the both-spellings justification below it still
+holds. Server-side nit, not an app blocker.

--- a/FEDERATION_PLAN.md
+++ b/FEDERATION_PLAN.md
@@ -180,7 +180,7 @@ Older servers (pre-#932) return the old flat `/api/` shape — version only, no
 `features`/`user`. Keep the ping call as the fallback when the response has no
 `features` key, so the app still works against every released server.
 
-### Phase 2 — the server picker
+### Phase 2 — the server picker ✅ done
 
 The picker at `main.dart` iterates `serverList` by index, so federated servers
 appear the moment they are in the list. Refinements:
@@ -212,16 +212,54 @@ through (`makeServerCall(useThisServer, …)`) and `POST
 the one place the webapp found a path-namespace collision, so verify it on a
 peer before deciding to keep the rows.
 
-### Phase 4 — playback, queue, downloads
+### Phase 4 — the `isIroh` / transport split (blocks release on iroh)
+
+Bigger than "verify playback". A federated server has
+`connectionType == 'http'`, so **`isIroh` is false for it even when its parent
+is iroh** — and every site that asks "is this an iroh server?" in order to
+apply loopback handling will answer wrong for a peer of an iroh parent.
+
+There are ~29 `isIroh` call sites and they are asking two different questions:
+
+- **"Is this server itself an iroh server?"** — config and identity: the
+  one-iroh-max rule, the pairing-code menu item, the edit form, the whole
+  tunnel lifecycle in `ServerManager`. These stay on `isIroh`, untouched.
+- **"Do this server's bytes travel over a loopback tunnel?"** — transport.
+  For a peer of an iroh parent the answer is *yes*, and these are wrong today.
+
+The fix is to make that distinction explicit on `Server` — a `transportServer`
+getter (`parentServer ?? this`) and an `isIrohTransport` built on it — then
+audit each site for which question it is asking. `getServerPaths` already
+computes exactly this as a local; it wants promoting to the model.
+
+Triage list for the transport half (from a grep — confirm per site, this is
+not a find-and-replace):
+
+| Site | Why it matters |
+|---|---|
+| `cast_origin.dart:23` `irohServerFor` | hands a DLNA renderer an unreachable `127.0.0.1` URL |
+| `audio_stuff.dart` ×5 (231, 890, 905, 1378, 2407) | URL rebinding and tunnel waits on the playback path |
+| `downloads.dart:231` | "only loopback URLs rotate this way" — a federated URL through an iroh parent IS one, and needs the same stale-port rotation |
+| `queue_store.dart:340`, `playlist.dart:89` | art URL rebinding |
+| `api.dart:148` | the retry-on-tunnel-drop branch in `makeServerCall` |
+| `auto_browse.dart:810` | tunnel-serving check |
+
+**Blast radius is bounded but the failure mode is nasty.** Only peers of an
+*iroh* parent are affected; with a plain HTTP parent every one of these sites
+answers correctly today. But iroh is the roaming transport, so it is a real
+configuration — and the symptom is that browsing works fine while playback,
+casting and downloads break in ways that do not point at federation.
+
+Treat this as **blocking release for iroh users**, not as cleanup. Phases 2
+and 3 are shippable against an HTTP parent without it.
+
+Also in this phase:
 
 - queue restore across a restart (a federated server must resolve by
   localname before `QueueStore.init`)
-- **cast fix:** `irohServerFor` tests `s.isIroh` on the item's own server. A
-  federated server whose *parent* is iroh answers `false`, so casting would
-  hand a DLNA renderer a `127.0.0.1` URL it cannot reach. That resolution has
-  to follow the parent chain.
-- downloads: `/media` and ranges are allowlisted, so this should work once the
-  URL is rewritten — verify the `media/<localname>` directory is created.
+- downloads: `/media` and ranges are allowlisted and `_ensureDownloadDir` now
+  covers both entry points, so this should work once the URL is rewritten —
+  verify on a peer.
 
 ### Phase 5 — optional: make Discover leads actionable
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1981,5 +1981,22 @@
         "type": "String"
       }
     }
+  },
+  "serverPickerVia": "via {parent}",
+  "@serverPickerVia": {
+    "description": "Subtitle under a federated peer in the server picker, naming the server it is reached through.",
+    "placeholders": {
+      "parent": {
+        "type": "String"
+      }
+    }
+  },
+  "browserFederatedReadOnly": "Read-only server",
+  "@browserFederatedReadOnly": {
+    "description": "Title of the note row on a federated peer's section list."
+  },
+  "browserFederatedReadOnlyNote": "Playlists and ratings stay on your own",
+  "@browserFederatedReadOnlyNote": {
+    "description": "Subtitle of the note row explaining what a federated peer cannot do."
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3969,7 +3969,7 @@ abstract class AppLocalizations {
   /// Subtitle of the note row explaining what a federated peer cannot do.
   ///
   /// In en, this message translates to:
-  /// **'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.'**
+  /// **'Playlists and ratings stay on your own'**
   String get browserFederatedReadOnlyNote;
 }
 

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3953,6 +3953,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'\"{name}\" is already in the client'**
   String torrentDuplicate(String name);
+
+  /// Subtitle under a federated peer in the server picker, naming the server it is reached through.
+  ///
+  /// In en, this message translates to:
+  /// **'via {parent}'**
+  String serverPickerVia(String parent);
+
+  /// Title of the note row on a federated peer's section list.
+  ///
+  /// In en, this message translates to:
+  /// **'Read-only server'**
+  String get browserFederatedReadOnly;
+
+  /// Subtitle of the note row explaining what a federated peer cannot do.
+  ///
+  /// In en, this message translates to:
+  /// **'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.'**
+  String get browserFederatedReadOnlyNote;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2284,4 +2284,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String torrentDuplicate(String name) {
     return '\"$name\" ist bereits im Client';
   }
+
+  @override
+  String serverPickerVia(String parent) {
+    return 'via $parent';
+  }
+
+  @override
+  String get browserFederatedReadOnly => 'Read-only server';
+
+  @override
+  String get browserFederatedReadOnlyNote =>
+      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2295,5 +2295,5 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get browserFederatedReadOnlyNote =>
-      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
+      'Playlists and ratings stay on your own';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2256,4 +2256,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String torrentDuplicate(String name) {
     return '\"$name\" is already in the client';
   }
+
+  @override
+  String serverPickerVia(String parent) {
+    return 'via $parent';
+  }
+
+  @override
+  String get browserFederatedReadOnly => 'Read-only server';
+
+  @override
+  String get browserFederatedReadOnlyNote =>
+      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2267,5 +2267,5 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get browserFederatedReadOnlyNote =>
-      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
+      'Playlists and ratings stay on your own';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2296,5 +2296,5 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get browserFederatedReadOnlyNote =>
-      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
+      'Playlists and ratings stay on your own';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2285,4 +2285,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String torrentDuplicate(String name) {
     return '\"$name\" ya está en el cliente';
   }
+
+  @override
+  String serverPickerVia(String parent) {
+    return 'via $parent';
+  }
+
+  @override
+  String get browserFederatedReadOnly => 'Read-only server';
+
+  @override
+  String get browserFederatedReadOnlyNote =>
+      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2295,5 +2295,5 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get browserFederatedReadOnlyNote =>
-      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
+      'Playlists and ratings stay on your own';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2284,4 +2284,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String torrentDuplicate(String name) {
     return '« $name » est déjà dans le client';
   }
+
+  @override
+  String serverPickerVia(String parent) {
+    return 'via $parent';
+  }
+
+  @override
+  String get browserFederatedReadOnly => 'Read-only server';
+
+  @override
+  String get browserFederatedReadOnlyNote =>
+      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2283,4 +2283,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String torrentDuplicate(String name) {
     return '\"$name\" è già nel client';
   }
+
+  @override
+  String serverPickerVia(String parent) {
+    return 'via $parent';
+  }
+
+  @override
+  String get browserFederatedReadOnly => 'Read-only server';
+
+  @override
+  String get browserFederatedReadOnlyNote =>
+      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2294,5 +2294,5 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get browserFederatedReadOnlyNote =>
-      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
+      'Playlists and ratings stay on your own';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2190,5 +2190,5 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get browserFederatedReadOnlyNote =>
-      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
+      'Playlists and ratings stay on your own';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2179,4 +2179,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String torrentDuplicate(String name) {
     return '「$name」は既にクライアントにあります';
   }
+
+  @override
+  String serverPickerVia(String parent) {
+    return 'via $parent';
+  }
+
+  @override
+  String get browserFederatedReadOnly => 'Read-only server';
+
+  @override
+  String get browserFederatedReadOnlyNote =>
+      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2306,5 +2306,5 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get browserFederatedReadOnlyNote =>
-      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
+      'Playlists and ratings stay on your own';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2295,4 +2295,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String torrentDuplicate(String name) {
     return '„$name” jest już w kliencie';
   }
+
+  @override
+  String serverPickerVia(String parent) {
+    return 'via $parent';
+  }
+
+  @override
+  String get browserFederatedReadOnly => 'Read-only server';
+
+  @override
+  String get browserFederatedReadOnlyNote =>
+      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2289,5 +2289,5 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get browserFederatedReadOnlyNote =>
-      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
+      'Playlists and ratings stay on your own';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2278,4 +2278,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String torrentDuplicate(String name) {
     return '\"$name\" já está no cliente';
   }
+
+  @override
+  String serverPickerVia(String parent) {
+    return 'via $parent';
+  }
+
+  @override
+  String get browserFederatedReadOnly => 'Read-only server';
+
+  @override
+  String get browserFederatedReadOnlyNote =>
+      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2298,4 +2298,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String torrentDuplicate(String name) {
     return '«$name» уже в клиенте';
   }
+
+  @override
+  String serverPickerVia(String parent) {
+    return 'via $parent';
+  }
+
+  @override
+  String get browserFederatedReadOnly => 'Read-only server';
+
+  @override
+  String get browserFederatedReadOnlyNote =>
+      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2309,5 +2309,5 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get browserFederatedReadOnlyNote =>
-      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
+      'Playlists and ratings stay on your own';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2135,4 +2135,16 @@ class AppLocalizationsZh extends AppLocalizations {
   String torrentDuplicate(String name) {
     return '「$name」已在客户端中';
   }
+
+  @override
+  String serverPickerVia(String parent) {
+    return 'via $parent';
+  }
+
+  @override
+  String get browserFederatedReadOnly => 'Read-only server';
+
+  @override
+  String get browserFederatedReadOnlyNote =>
+      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2146,5 +2146,5 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get browserFederatedReadOnlyNote =>
-      'A peer shared with your server. Playlists, ratings and Auto DJ stay on your own.';
+      'Playlists and ratings stay on your own';
 }

--- a/lib/l10n/enum_labels.dart
+++ b/lib/l10n/enum_labels.dart
@@ -152,6 +152,10 @@ String browserChromeLabel(AppLocalizations l, String? english) {
       return l.browserRated;
     case 'Search':
       return l.browserSearch;
+    case 'Read-only server':
+      return l.browserFederatedReadOnly;
+    case 'Playlists and ratings stay on your own':
+      return l.browserFederatedReadOnlyNote;
     case 'Welcome To mStream':
       return l.browserWelcomeTitle;
     case 'Click here to add server':

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -604,7 +604,7 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
             !TunnelPolicy.showTunnelBanner(
                 status: st,
                 browsingTunnelServer:
-                    ServerManager().currentServer?.isIroh ?? false)) {
+                    ServerManager().currentServer?.isIrohTransport ?? false)) {
           return const SizedBox.shrink();
         }
         final l = AppLocalizations.of(context);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -870,6 +870,40 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
   // over the browser ↔ album-detail body. It sits BELOW the player overlay and
   // the outer Scaffold's drawer in build()'s Stack, so an open drawer dims it
   // like any other content.
+  // One row of the server picker. A federated peer is indented under the
+  // server it is reached through and names it, since a peer has no URL of its
+  // own to be identified by — only a name its parent reports.
+  Widget _serverPickerRow(AppLocalizations l, Server server) {
+    final selected = server == ServerManager().currentServer;
+    final color = selected ? VelvetColors.primary : VelvetColors.textPrimary;
+    if (!server.isFederated) {
+      return Text(server.displayName, style: TextStyle(color: color));
+    }
+    final parent = server.parentServer?.displayName ?? server.federationParent;
+    return Padding(
+      padding: const EdgeInsets.only(left: 16),
+      child: Row(mainAxisSize: MainAxisSize.min, children: [
+        Icon(Icons.hub_outlined, size: 16, color: VelvetColors.textSecondary),
+        const SizedBox(width: 8),
+        Flexible(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(server.displayName,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(color: color)),
+              Text(l.serverPickerVia(parent ?? ''),
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                      fontSize: 11, color: VelvetColors.textSecondary)),
+            ],
+          ),
+        ),
+      ]),
+    );
+  }
+
   Widget _homeScaffold(BuildContext context, AppLocalizations l) {
     return Scaffold(
       // The only text input over this Scaffold is the search field in the
@@ -914,7 +948,7 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
                   return Visibility(
                     visible: cServer != null,
                     child: Text(
-                      cServer == null ? '' : cServer.url,
+                      cServer == null ? '' : cServer.displayName,
                       style: TextStyle(
                           fontSize: 11,
                           color: VelvetColors.appBarTextSecondary,
@@ -947,7 +981,11 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
           StreamBuilder<List<Server>>(
               stream: ServerManager().serverListStream,
               builder: (context, snapshot) {
-                final isVisible = snapshot.hasData && snapshot.data!.length > 1;
+                // A peer the parent has stopped listing isn't selectable, so it
+                // doesn't count towards "is there more than one server here".
+                final isVisible = snapshot.hasData &&
+                    snapshot.data!.where((s) => !s.federationMissing).length >
+                        1;
                 return Visibility(
                   visible: isVisible,
                   child: PopupMenuButton(
@@ -983,20 +1021,20 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
                       },
                       icon: Icon(Icons.cloud),
                       itemBuilder: (BuildContext context) {
-                        List<PopupMenuEntry<int>> popUpWidgetList =
-                            ServerManager().serverList.map((server) {
-                          return PopupMenuItem(
-                            value: ServerManager().serverList.indexOf(server),
-                            child: Text(server.url,
-                                style: TextStyle(
-                                    color: server ==
-                                            ServerManager().currentServer
-                                        ? VelvetColors.primary
-                                        : VelvetColors.textPrimary)),
-                          );
-                        }).toList();
-
-                        return popUpWidgetList;
+                        final servers = ServerManager().serverList;
+                        return <PopupMenuEntry<int>>[
+                          for (final server in servers)
+                            // A peer its parent no longer lists stays in the
+                            // list so queued and downloaded tracks keep
+                            // resolving, but selecting it could only fail.
+                            if (!server.federationMissing)
+                              PopupMenuItem<int>(
+                                // The index into the FULL list — that is what
+                                // changeCurrentServer takes.
+                                value: servers.indexOf(server),
+                                child: _serverPickerRow(l, server),
+                              ),
+                        ];
                       }),
                 );
               }),

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -3230,7 +3230,7 @@ class AudioPlayerHandler extends BaseAudioHandler
           autoDJServer!.apiUri('/api/v1/db/random-songs'),
           headers: {
             'Content-Type': 'application/json',
-            'x-access-token': autoDJServer?.jwt ?? '',
+            'x-access-token': autoDJServer?.authToken ?? '',
           },
           body: jsonEncode(filtered.body),
         ).timeout(const Duration(seconds: 15));
@@ -3265,7 +3265,7 @@ class AudioPlayerHandler extends BaseAudioHandler
             autoDJServer!.apiUri('/api/v1/db/random-songs'),
             headers: {
               'Content-Type': 'application/json',
-              'x-access-token': autoDJServer?.jwt ?? '',
+              'x-access-token': autoDJServer?.authToken ?? '',
             },
             body: jsonEncode(retry.body),
           ).timeout(const Duration(seconds: 15));

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -307,7 +307,9 @@ class AudioPlayerHandler extends BaseAudioHandler
     queue.listen((items) {
       Server? iroh;
       for (final it in items) {
-        final s = _serverFor(it);
+        // A federated peer's songs ride its parent's tunnel: that is the
+        // server to keep connected, not the peer (which has no tunnel).
+        final s = _serverFor(it)?.transportServer;
         if (s != null && s.isIroh) {
           iroh = s;
           break;

--- a/lib/media/auto_browse.dart
+++ b/lib/media/auto_browse.dart
@@ -872,7 +872,7 @@ class AutoApi {
           caller: 'auto-browse');
     }
     final uri = server.apiUri(location);
-    final headers = <String, String>{'x-access-token': server.jwt ?? ''};
+    final headers = <String, String>{'x-access-token': server.authToken ?? ''};
     late http.Response resp;
     if (body == null) {
       resp = await http.get(uri, headers: headers).timeout(_fetchTimeout);

--- a/lib/objects/display_item.dart
+++ b/lib/objects/display_item.dart
@@ -121,7 +121,8 @@ class DisplayItem {
       // item (addServer) carry fixed English names; localize them.
       // Server folder/file names pass through browserChromeLabel
       // unchanged (default case), so real data is never mistranslated.
-      (l != null && (type == 'execAction' || type == 'addServer'))
+      (l != null &&
+              (type == 'execAction' || type == 'addServer' || type == 'note'))
           ? browserChromeLabel(l, name)
           : name,
       // Same style as the metadata and file branches above. This used to
@@ -143,7 +144,7 @@ class DisplayItem {
     // itself), so those fall through to the artist exactly as before.
     if (subtext != null) {
       return Text(
-        (l != null && type == 'addServer')
+        (l != null && (type == 'addServer' || type == 'note'))
             ? browserChromeLabel(l, subtext!)
             : subtext!,
         style: TextStyle(fontSize: 13, color: VelvetColors.textPrimary),

--- a/lib/objects/server.dart
+++ b/lib/objects/server.dart
@@ -103,6 +103,21 @@ class Server {
 
   bool get isFederated => federationParent != null;
 
+  /// The server whose transport carries this server's bytes: the parent for a
+  /// federated server, itself for everything else. Null only for a federated
+  /// server whose parent is not linked yet (nothing can be addressed then).
+  ///
+  /// Two different questions hide behind "is this an iroh server?": identity
+  /// (the pairing-code menu, the one-iroh cap, the edit form — [isIroh]) and
+  /// transport (does a request for it ride a loopback tunnel, and whose —
+  /// [isIrohTransport]). A peer of an iroh parent answers no to the first and
+  /// yes to the second.
+  Server? get transportServer => isFederated ? parentServer : this;
+
+  /// True when requests for this server travel over an iroh loopback tunnel —
+  /// its own, or its parent's for a federated server.
+  bool get isIrohTransport => transportServer?.isIroh == true;
+
   /// What to call this server in the UI: a peer's name, or the URL that
   /// identifies every other kind of server.
   String get displayName => isFederated

--- a/lib/objects/server.dart
+++ b/lib/objects/server.dart
@@ -70,6 +70,45 @@ class Server {
   // server, the role [url] plays for an HTTP server). Null for HTTP servers.
   String? irohPairingCode;
 
+  // ─── Federation ────────────────────────────────────────────────────────
+  // A federated server is another server's PEER, reached through that
+  // parent's browse proxy (mStream #927) instead of by a URL of its own. It
+  // has no credentials, no transport and no version of its own — every one
+  // of those is the parent's, which is why the accessors below delegate
+  // rather than storing copies.
+  //
+  // [federationParent] is the parent's localname: the durable link, resolved
+  // to a live object by ServerManager. [federationPeerId] is the peer's row
+  // id ON THAT PARENT, which is what every proxy route keys on.
+  String? federationParent;
+  int? federationPeerId;
+
+  // The peer's name as the parent reports it. A federated server has no URL to
+  // show — [url] holds a synthetic `federated://…` identity — so this is what
+  // the UI displays. Refreshed on every reconcile; a rename on the parent is
+  // just a new label, and never moves [localname].
+  String? federationPeerName;
+
+  // The parent stopped listing this peer. Flagged rather than deleted: a
+  // queued track and a downloaded file both point at this localname, and
+  // dropping the record would strand them. Hidden from the picker; removed
+  // only when the user says so, or with the parent.
+  bool federationMissing = false;
+
+  // Runtime-only (never persisted): the live parent, linked by ServerManager
+  // after the list loads and on every peer reconcile. Same contract as
+  // [tunnelPort] — null means "not resolvable yet", and every accessor below
+  // fails closed onto an unroutable origin rather than guessing.
+  Server? parentServer;
+
+  bool get isFederated => federationParent != null;
+
+  /// What to call this server in the UI: a peer's name, or the URL that
+  /// identifies every other kind of server.
+  String get displayName => isFederated
+      ? (federationPeerName ?? 'Peer $federationPeerId')
+      : url;
+
   /// Raw `server` string from `GET /api/` — display as reported, compare via
   /// ServerVersion.tryParse. Null means the server has never answered that
   /// endpoint, which puts it before 5.4.2 (see util/server_version.dart).
@@ -103,23 +142,58 @@ class Server {
 
   bool get isIroh => connectionType == 'iroh';
 
-  /// The base origin to use for requests/streams right now. For an iroh server
-  /// this is the live local tunnel (`http://127.0.0.1:<tunnelPort>`, set by
-  /// ServerManager when the server is active); for HTTP it's [url]. When an iroh
-  /// tunnel isn't up yet [tunnelPort] is null and this returns an unroutable
-  /// origin, so a stray request fails fast instead of hitting the placeholder url.
-  String get effectiveBaseUrl =>
-      isIroh ? 'http://127.0.0.1:${tunnelPort ?? 0}' : url;
+  /// Origin a request falls back to when this server can't be addressed yet —
+  /// a dialing iroh tunnel, or a federated server whose parent isn't linked.
+  /// Unroutable on purpose: a stray request fails fast instead of reaching
+  /// something that isn't this server.
+  static const String _unroutable = 'http://127.0.0.1:0';
+
+  /// Prefix shared by every route the parent proxies on a peer's behalf
+  /// (`/api/…`, `/art/…`, `/stream/…`). Meaningless unless [isFederated].
+  String get federationPrefix => '/api/v1/federation/peers/$federationPeerId';
+
+  /// The token that authenticates requests for this server. A federated server
+  /// has none of its own: the proxy runs normal local-user auth on the PARENT,
+  /// and the peer beyond it is reached with the parent's federation key, which
+  /// never leaves the parent. Read this — not [jwt] — for anything that ends up
+  /// on the wire.
+  String? get authToken => isFederated ? parentServer?.jwt : jwt;
+
+  /// The base origin to use for requests/streams right now. A federated server
+  /// borrows its parent's, which is what makes an iroh parent work for free —
+  /// the request rides the parent's loopback tunnel and the proxy dials the
+  /// peer from there. For an iroh server it's the live local tunnel
+  /// (`http://127.0.0.1:<tunnelPort>`, set by ServerManager when the server is
+  /// active); for HTTP it's [url]. Before an iroh tunnel is up, or before a
+  /// federated server's parent is linked, this is [_unroutable].
+  String get effectiveBaseUrl {
+    if (isFederated) return parentServer?.effectiveBaseUrl ?? _unroutable;
+    return isIroh ? 'http://127.0.0.1:${tunnelPort ?? 0}' : url;
+  }
 
   /// Query suffix authenticating a loopback request to the iroh tunnel
   /// (`&__lt=<token>`); empty for HTTP servers or before the token is known. For
   /// URLs built as strings that ALREADY carry a `?` (stream / art / download).
-  String get localTokenQuery =>
-      (isIroh && tunnelToken != null) ? '&__lt=$tunnelToken' : '';
+  /// A federated server inherits its parent's: the URL lands on the parent's
+  /// loopback, and the browse proxy forwards no query params onward, so the
+  /// loopback token can't ride through to the peer.
+  String get localTokenQuery {
+    if (isFederated) return parentServer?.localTokenQuery ?? '';
+    return (isIroh && tunnelToken != null) ? '&__lt=$tunnelToken' : '';
+  }
 
   /// Resolve [location] against [effectiveBaseUrl], adding the loopback token for
   /// an iroh server so the shim accepts the request. Use for all API calls.
+  ///
+  /// A federated server rewrites [location] onto the parent's browse proxy and
+  /// then defers to the parent — so an iroh parent's `__lt` is applied once, to
+  /// the outer loopback URL, and the peer sees only the proxied path.
   Uri apiUri(String location) {
+    if (isFederated) {
+      final parent = parentServer;
+      if (parent == null) return Uri.parse(_unroutable);
+      return parent.apiUri('$federationPrefix/api$location');
+    }
     final u = Uri.parse(effectiveBaseUrl).resolve(location);
     if (!isIroh || tunnelToken == null) return u;
     return u.replace(queryParameters: {
@@ -170,6 +244,11 @@ class Server {
             : null,
         connectionType = json['connectionType'] as String? ?? 'http',
         irohPairingCode = json['irohPairingCode'] as String?,
+        federationParent = json['federationParent'] as String?,
+        federationPeerId =
+            json['federationPeerId'] is int ? json['federationPeerId'] : null,
+        federationPeerName = json['federationPeerName'] as String?,
+        federationMissing = json['federationMissing'] == true,
         serverVersion = json['serverVersion'] as String?,
         versionCheckedAt = json['versionCheckedAt'] is int
             ? DateTime.fromMillisecondsSinceEpoch(json['versionCheckedAt'])
@@ -199,6 +278,10 @@ class Server {
         'discoveryPathAvailable': discoveryPathAvailable,
         'connectionType': connectionType,
         'irohPairingCode': irohPairingCode,
+        'federationParent': federationParent,
+        'federationPeerId': federationPeerId,
+        'federationPeerName': federationPeerName,
+        'federationMissing': federationMissing,
         'serverVersion': serverVersion,
         'versionCheckedAt': versionCheckedAt?.millisecondsSinceEpoch
       };

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -825,6 +825,10 @@ class MyCustomFormState extends State<MyCustomForm> {
         if (mounted) setState(() => submitPending = false);
         return;
       }
+      // Any federated server reached through this one links to it BY
+      // localname, so re-point them before the rename lands or they resolve
+      // against a name nothing answers to.
+      ServerManager().renameFederationParent(s.localname, folder);
       // localname + storage aren't part of editServer's signature — set
       // them directly (callAfterEditServer below persists the change).
       s.localname = folder;

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -72,7 +72,7 @@ class ApiManager {
           body: jsonEncode(body),
           headers: {
             'Content-Type': 'application/json',
-            'x-access-token': server.jwt ?? '',
+            'x-access-token': server.authToken ?? '',
           },
         )
         .timeout(const Duration(seconds: 15));
@@ -101,7 +101,7 @@ class ApiManager {
           body: json.encode(body),
           headers: {
             'Content-Type': 'application/json',
-            'x-access-token': server.jwt ?? '',
+            'x-access-token': server.authToken ?? '',
           },
         )
         .timeout(const Duration(seconds: 15));
@@ -130,7 +130,7 @@ class ApiManager {
         '?path=$encodedPath${server.localTokenQuery}');
 
     final response = await _direct
-        .get(uri, headers: {'x-access-token': server.jwt ?? ''})
+        .get(uri, headers: {'x-access-token': server.authToken ?? ''})
         .timeout(const Duration(seconds: 15));
     if (response.statusCode == 404) return null; // no lyrics for this track
     if (response.statusCode > 299) {
@@ -165,10 +165,10 @@ class ApiManager {
 
       final sw = Stopwatch()..start();
       Future<http.Response> send() => getOrPost == 'GET'
-          ? client.get(currentUri, headers: {'x-access-token': server.jwt ?? ''})
+          ? client.get(currentUri, headers: {'x-access-token': server.authToken ?? ''})
           : client.post(currentUri, body: json.encode(payload), headers: {
               'Content-Type': 'application/json',
-              'x-access-token': server.jwt ?? ''
+              'x-access-token': server.authToken ?? ''
             });
       http.Response response;
       final bool isIroh = server.isIroh;
@@ -372,7 +372,7 @@ class ApiManager {
           body: jsonEncode({'playlist': playlist, 'song': fp}),
           headers: {
             'Content-Type': 'application/json',
-            'x-access-token': server.jwt ?? '',
+            'x-access-token': server.authToken ?? '',
           },
         )
         .timeout(const Duration(seconds: 15));
@@ -396,7 +396,7 @@ class ApiManager {
           body: jsonEncode({'title': playlist, 'songs': songs}),
           headers: {
             'Content-Type': 'application/json',
-            'x-access-token': server.jwt ?? '',
+            'x-access-token': server.authToken ?? '',
           },
         )
         .timeout(const Duration(seconds: 15));
@@ -716,7 +716,7 @@ class ApiManager {
           body: jsonEncode({'filepath': fp, 'rating': rating}),
           headers: {
             'Content-Type': 'application/json',
-            'x-access-token': server.jwt ?? '',
+            'x-access-token': server.authToken ?? '',
           },
         )
         .timeout(const Duration(seconds: 15));
@@ -756,7 +756,7 @@ class ApiManager {
             body: jsonEncode(fps),
             headers: {
               'Content-Type': 'application/json',
-              'x-access-token': server.jwt ?? '',
+              'x-access-token': server.authToken ?? '',
             },
           )
           // Longer than the single-track 15s because it stands in for N of
@@ -805,7 +805,7 @@ class ApiManager {
             body: jsonEncode({'filepath': fp}),
             headers: {
               'Content-Type': 'application/json',
-              'x-access-token': server.jwt ?? '',
+              'x-access-token': server.authToken ?? '',
             },
           )
           .timeout(const Duration(seconds: 15));
@@ -838,7 +838,7 @@ class ApiManager {
             body: jsonEncode(body),
             headers: {
               'Content-Type': 'application/json',
-              'x-access-token': server.jwt ?? '',
+              'x-access-token': server.authToken ?? '',
             },
           )
           .timeout(const Duration(seconds: 15));
@@ -958,7 +958,7 @@ class ApiManager {
             }).body),
             headers: {
               'Content-Type': 'application/json',
-              'x-access-token': server.jwt ?? '',
+              'x-access-token': server.authToken ?? '',
             },
           )
           .timeout(const Duration(seconds: 15));
@@ -1024,7 +1024,7 @@ class ApiManager {
             body: jsonEncode(filtered.body),
             headers: {
               'Content-Type': 'application/json',
-              'x-access-token': server.jwt ?? '',
+              'x-access-token': server.authToken ?? '',
             },
           )
           .timeout(const Duration(seconds: 15));
@@ -1073,7 +1073,7 @@ class ApiManager {
             }),
             headers: {
               'Content-Type': 'application/json',
-              'x-access-token': server.jwt ?? '',
+              'x-access-token': server.authToken ?? '',
             },
           )
           .timeout(const Duration(seconds: 15));
@@ -1327,7 +1327,7 @@ class ApiManager {
     final uri = s.apiUri(
         '/api/v1/torrent/preflight?path=${Uri.encodeQueryComponent(path)}');
     final res = await http
-        .get(uri, headers: {'x-access-token': s.jwt ?? ''})
+        .get(uri, headers: {'x-access-token': s.authToken ?? ''})
         .timeout(const Duration(seconds: 15));
     if (res.statusCode != 200) {
       throw Exception(_torrentError(res) ?? 'Torrent unavailable');
@@ -1342,7 +1342,7 @@ class ApiManager {
     if (s == null) throw Exception('No server selected');
     final res = await http
         .get(s.apiUri('/api/v1/torrent/path-templates'),
-            headers: {'x-access-token': s.jwt ?? ''})
+            headers: {'x-access-token': s.authToken ?? ''})
         .timeout(const Duration(seconds: 15));
     if (res.statusCode != 200) {
       throw Exception(_torrentError(res) ?? 'Could not load path templates');
@@ -1366,7 +1366,7 @@ class ApiManager {
     final s = server ?? ServerManager().currentServer;
     if (s == null) throw Exception('No server selected');
     final req = http.MultipartRequest('POST', s.apiUri('/api/v1/torrent/add'));
-    req.headers['x-access-token'] = s.jwt ?? '';
+    req.headers['x-access-token'] = s.authToken ?? '';
     req.fields['vpath'] = vpath;
     if (subPath != null && subPath.isNotEmpty) req.fields['subPath'] = subPath;
     req.fields['directoryName'] = directoryName;
@@ -1409,7 +1409,7 @@ class ApiManager {
     if (s == null) throw Exception('No server selected');
     final req = http.MultipartRequest(
         'POST', s.apiUri('/api/v1/torrent/auto-detect'));
-    req.headers['x-access-token'] = s.jwt ?? '';
+    req.headers['x-access-token'] = s.authToken ?? '';
     if (vpath != null && vpath.isNotEmpty) req.fields['vpath'] = vpath;
     req.files.add(http.MultipartFile.fromBytes('torrentFile', torrentBytes,
         filename: torrentFilename ?? 'upload.torrent'));
@@ -1440,7 +1440,7 @@ class ApiManager {
     if (s == null) throw Exception('No server selected');
     final req = http.MultipartRequest(
         'POST', s.apiUri('/api/v1/torrent/seed-existing'));
-    req.headers['x-access-token'] = s.jwt ?? '';
+    req.headers['x-access-token'] = s.authToken ?? '';
     if (vpaths != null && vpaths.isNotEmpty) {
       req.fields['vpaths'] = jsonEncode(vpaths);
     }

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -287,80 +287,56 @@ class BrowserManager {
     searchTermCache.clear();
     playlistCache.clear();
 
-    if (ServerManager().currentServer == null) {
+    final Server? server = ServerManager().currentServer;
+    if (server == null) {
       return;
     }
 
-    DisplayItem newItem1 = DisplayItem(
-        ServerManager().currentServer!,
-        'File Explorer',
-        'execAction',
-        'fileExplorer',
-        Icon(Icons.folder, color: VelvetColors.warning),
-        null);
+    // A federated server is a read-only view of someone else's library: the
+    // playlist routes and db/rated are off the federation allowlist, so those
+    // two sections could only ever 403. Everything else here is allowlisted,
+    // and Local Files is this device's own downloads either way.
+    final bool federated = server.isFederated;
 
-    DisplayItem newItem2 = DisplayItem(
-        ServerManager().currentServer!,
-        'Playlists',
-        'execAction',
-        'playlists',
-        Icon(Icons.queue_music, color: VelvetColors.textSecondary),
-        null);
+    final List<DisplayItem> sections = [
+      if (federated)
+        DisplayItem(
+            server,
+            'Read-only server',
+            'note',
+            null,
+            Icon(Icons.hub_outlined, color: VelvetColors.textSecondary),
+            'Playlists and ratings stay on your own'),
+      DisplayItem(server, 'File Explorer', 'execAction', 'fileExplorer',
+          Icon(Icons.folder, color: VelvetColors.warning), null),
+      if (!federated)
+        DisplayItem(server, 'Playlists', 'execAction', 'playlists',
+            Icon(Icons.queue_music, color: VelvetColors.textSecondary), null),
+      DisplayItem(server, 'Albums', 'execAction', 'albums',
+          Icon(Icons.album, color: VelvetColors.textSecondary), null),
+      DisplayItem(server, 'Artists', 'execAction', 'artists',
+          Icon(Icons.library_music, color: VelvetColors.textSecondary), null),
+      if (!federated)
+        DisplayItem(server, 'Rated', 'execAction', 'rated',
+            Icon(Icons.star, color: VelvetColors.textSecondary), null),
+      DisplayItem(server, 'Recent', 'execAction', 'recent',
+          Icon(Icons.query_builder, color: VelvetColors.textSecondary), null),
+      DisplayItem(
+          server,
+          'Local Files',
+          'execAction',
+          'localFiles',
+          Icon(Icons.folder_open_outlined, color: VelvetColors.textSecondary),
+          null),
+    ];
 
-    DisplayItem newItem3 = DisplayItem(
-        ServerManager().currentServer!,
-        'Albums',
-        'execAction',
-        'albums',
-        Icon(Icons.album, color: VelvetColors.textSecondary),
-        null);
-
-    DisplayItem newItem4 = DisplayItem(
-        ServerManager().currentServer!,
-        'Artists',
-        'execAction',
-        'artists',
-        Icon(Icons.library_music, color: VelvetColors.textSecondary),
-        null);
-
-    DisplayItem newItem5 = DisplayItem(
-        ServerManager().currentServer!,
-        'Rated',
-        'execAction',
-        'rated',
-        Icon(Icons.star, color: VelvetColors.textSecondary),
-        null);
-
-    DisplayItem newItem6 = DisplayItem(
-        ServerManager().currentServer!,
-        'Recent',
-        'execAction',
-        'recent',
-        Icon(Icons.query_builder, color: VelvetColors.textSecondary),
-        null);
-
-    DisplayItem newItem7 = DisplayItem(
-        ServerManager().currentServer!,
-        'Local Files',
-        'execAction',
-        'localFiles',
-        Icon(Icons.folder_open_outlined, color: VelvetColors.textSecondary),
-        null);
-
-    browserCache.add(
-        [newItem1, newItem2, newItem3, newItem4, newItem5, newItem6, newItem7]);
+    browserCache.add(sections);
     // Nav screen isn't alphabetical content — just the section list.
     alphabeticalCache.add(false);
     pathCache.add(null); // home nav isn't the file explorer — no path row
     searchTermCache.add(null); // home nav isn't a search result — no term row
     playlistCache.add(null); // ...nor a playlist — no name row
-    browserList.add(newItem1);
-    browserList.add(newItem2);
-    browserList.add(newItem3);
-    browserList.add(newItem4);
-    browserList.add(newItem5);
-    browserList.add(newItem6);
-    browserList.add(newItem7);
+    browserList.addAll(sections);
 
     _browserLabel.sink.add('Browser');
     _browserStream.sink.add(browserList);

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -66,7 +66,10 @@ class ServerManager {
   bool _startRejected = false;
   // The launch ping was skipped because the tunnel was not up yet; the next
   // successful dial runs it (vpaths, transcode defaults, version).
-  String? _pingPendingFor;
+  // Servers whose launch-time capability refresh skipped because their
+  // TRANSPORT's tunnel was not up: the iroh server itself, and any federated
+  // peer riding it. A set, not a slot — one dial serves all of them.
+  final Set<String> _pingPendingFor = {};
   // A Retry tap that lands while a network change is in flight must not be
   // downgraded to an automatic re-run.
   bool _rerunUser = false;
@@ -149,7 +152,7 @@ class ServerManager {
       // running on the chain; the first browse/playback awaits the tunnel
       // itself. A standard default needs nothing and must not wait on the
       // chain either (a queued iroh server's dial may already be running on it).
-      if (currentServer!.isIroh) {
+      if (currentServer!.isIrohTransport) {
         await ensureActiveTunnel(reason: 'launch', bypassBackoff: true)
             .timeout(const Duration(seconds: 12), onTimeout: () {});
       }
@@ -167,7 +170,8 @@ class ServerManager {
       // that on loadServerList completing). Bounded by awaitTunnelReady's cap.
       final resumeName = await QueueStore().peekResumeServer();
       if (resumeName != null && resumeName != currentServer?.localname) {
-        final rs = byLocalname(resumeName);
+        // A federated resume server needs its PARENT's tunnel.
+        final rs = byLocalname(resumeName)?.transportServer;
         if (rs != null && rs.isIroh) {
           setQueueIrohServer(rs);
           await awaitTunnelReady(
@@ -304,7 +308,7 @@ class ServerManager {
   Future<void> _settleTunnelForSwitch(String reason) async {
     final s = currentServer!;
     appLog('[srv] switched to ${s.localname} ($reason)');
-    if (!s.isIroh) {
+    if (!s.isIrohTransport) {
       BrowserManager().goToNavScreen();
       unawaited(getServerPaths(s));
       unawaited(ensureActiveTunnel(reason: reason, bypassBackoff: true));
@@ -349,7 +353,7 @@ class ServerManager {
       }
       if (transport.tunnelPort == null) {
         if (throwErr) throw Exception('iroh tunnel not connected');
-        _pingPendingFor = server.localname; // re-run when the dial lands
+        _pingPendingFor.add(server.localname); // re-run when the dial lands
         return;
       }
     }
@@ -640,10 +644,14 @@ class ServerManager {
   // IS the iroh server, OR the iroh server whose songs are queued. Null → no
   // tunnel. (One-iroh-server cap, so these resolve to the same server when both
   // apply — there's never a second iroh server to contend for the tunnel.)
+  //
+  // Both sides resolve through the TRANSPORT server: a federated peer has no
+  // tunnel of its own and rides its parent's, so browsing a peer (or queuing
+  // its songs) must keep the parent's tunnel up, not release it.
   Server? _tunnelTargetServer() {
-    final c = currentServer;
+    final c = currentServer?.transportServer;
     if (c != null && c.isIroh) return c;
-    final q = _queueIrohServer;
+    final q = _queueIrohServer?.transportServer;
     return (q != null && q.isIroh) ? q : null;
   }
 
@@ -782,9 +790,14 @@ class ServerManager {
             'in ${sw.elapsedMilliseconds}ms ($reason)');
         // The launch sweep no longer waits for a slow dial; run the ping it
         // skipped so vpaths / transcode / version are not stale all session.
-        if (_pingPendingFor == s.localname) {
-          _pingPendingFor = null;
-          unawaited(getServerPaths(s));
+        for (final name in _pingPendingFor.toList()) {
+          final pending = byLocalname(name);
+          if (pending == null) {
+            _pingPendingFor.remove(name);
+          } else if (identical(pending.transportServer, s)) {
+            _pingPendingFor.remove(name);
+            unawaited(getServerPaths(pending));
+          }
         }
         // This bind set a loopback port + token. Any queued iroh stream URL built
         // before now is stale, so rebuild them off the live effectiveBaseUrl.

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -133,6 +133,11 @@ class ServerManager {
       }
     }
 
+    // Before ANYTHING resolves a URL: a federated server addresses itself
+    // through its parent, and QueueStore.init restores tracks against these
+    // objects moments from now.
+    _linkFederatedParents();
+
     _serverListStream.sink.add(serverList);
     syncInsecureTls();
 
@@ -197,21 +202,7 @@ class ServerManager {
       BrowserManager().goToNavScreen();
     }
 
-    // Create server directory (for downloads)
-    Directory? file = await FileExplorer()
-        .getDownloadDir(newServer.storageMode, newServer.storageBasePath);
-    if (file != null) {
-      try {
-        String dir = path.join(file.path, "media/${newServer.localname}");
-        await Directory(dir).create(recursive: true);
-      } catch (e) {
-        // A permanent/SD path can fail to create (unmounted, read-only).
-        // Don't let that abort the save below and lose the server entirely.
-        showGlobalSnack(
-            'Saved, but the download folder could not be created — storage '
-            'may be unavailable.');
-      }
-    }
+    await _ensureDownloadDir(newServer);
 
     await writeServerFile();
 
@@ -227,6 +218,28 @@ class ServerManager {
     // that the user finds out from us rather than from a feature quietly
     // doing nothing.
     unawaited(_warnIfBelowFloor(newServer));
+  }
+
+  /// Create `media/<localname>`, where this server's downloads land.
+  ///
+  /// Every server needs one, but they arrive by two doors: the add-server form
+  /// ([addServer]) and the peer reconcile ([refreshFederatedPeers]), which adds
+  /// its servers to the list directly.
+  Future<void> _ensureDownloadDir(Server server) async {
+    Directory? file = await FileExplorer()
+        .getDownloadDir(server.storageMode, server.storageBasePath);
+    if (file == null) return;
+    try {
+      String dir = path.join(file.path, "media/${server.localname}");
+      await Directory(dir).create(recursive: true);
+    } catch (e) {
+      // A permanent/SD path can fail to create (unmounted, read-only).
+      // Don't let that abort the save that follows and lose the server
+      // entirely.
+      showGlobalSnack(
+          'Saved, but the download folder could not be created — storage '
+          'may be unavailable.');
+    }
   }
 
   Future<void> _warnIfBelowFloor(Server server) async {
@@ -303,8 +316,18 @@ class ServerManager {
   }
 
   Future<void> getServerPaths(Server server, {bool throwErr = false}) async {
-    // An iroh server can only be pinged through its live tunnel.
-    if (server.isIroh && server.tunnelPort == null) {
+    // Whatever actually carries this server's bytes. A federated server has no
+    // transport of its own — it rides the parent's, so a peer of an iroh
+    // server has to wait on the PARENT's tunnel, not its own (it has none).
+    final transport = server.isFederated ? server.parentServer : server;
+    // A federated server whose parent isn't linked yet can't be addressed at
+    // all; every URL would resolve to the unroutable origin.
+    if (transport == null) {
+      if (throwErr) throw Exception('federation parent not linked');
+      return;
+    }
+    // An iroh server can only be reached through its live tunnel.
+    if (transport.isIroh && transport.tunnelPort == null) {
       // At launch this fires for the ACTIVE server too: loadServerList pings
       // every server as soon as the list is read, and the tunnel is still
       // dialling. Skipping meant its capabilities and — since the version
@@ -316,117 +339,66 @@ class ServerManager {
       // other iroh server's is never coming up and waiting on it would stall
       // the launch sweep for nothing. extendWhileDialing:false keeps the bound
       // real — the default re-arms for as long as a dial is in flight.
-      if (identical(server, currentServer)) {
+      if (identical(transport, currentServer) ||
+          identical(server, currentServer)) {
         await awaitTunnelReady(
-            server: server,
+            server: transport,
             timeout: const Duration(seconds: 12),
             extendWhileDialing: false,
             caller: 'ping');
       }
-      if (server.tunnelPort == null) {
+      if (transport.tunnelPort == null) {
         if (throwErr) throw Exception('iroh tunnel not connected');
         _pingPendingFor = server.localname; // re-run when the dial lands
         return;
       }
     }
     try {
-      var response = await http
-          .get(server.apiUri('/api/v1/ping'),
-              headers: {
-        'Content-Type': 'application/json',
-        'x-access-token': server.jwt ?? ''
-      }).timeout(Duration(seconds: 5));
+      // GET /api — version, server-wide `features` and the caller-scoped
+      // `user` block in ONE call (mStream #932/#934). Also the only capability
+      // route a federated server answers: /api/v1/ping is off the federation
+      // allowlist and 403s a peer key.
+      final info = await _fetchServerInfo(server);
 
-      if (response.statusCode != 200) {
-        throw Exception('Failed to connect to server');
-      }
-
-      var res = jsonDecode(response.body);
-
-      Set<String> pathCompare = {};
-      final vpaths = res['vpaths'];
-      if (vpaths is List) {
-        for (final raw in vpaths) {
-          if (raw is! String) continue; // tolerate unexpected element shapes
-          pathCompare.add(raw);
-          // add new keys
-          if (!server.autoDJPaths.containsKey(raw)) {
-            server.autoDJPaths[raw] = true;
-          }
-        }
-      }
-
-      // Remove outdated entries
-      server.autoDJPaths
-          .removeWhere((key, value) => !pathCompare.contains(key));
-
-      // Make sure all entries are not false
-      bool falseFlag = true;
-      server.autoDJPaths.forEach((key, value) {
-        if (value == true) {
-          falseFlag = false;
-        }
-      });
-      if (falseFlag == true) {
-        server.autoDJPaths.forEach((key, value) {
-          server.autoDJPaths[key] = true;
-        });
-      }
-
-      // Update Playlists. Accept both the bare-name form (["A", "B"]) and the
-      // object form ([{"name": "A"}, ...]) that some builds (e.g. Velvet) return.
-      server.playlists.clear();
-      final pls = res['playlists'];
-      if (pls is List) {
-        for (final raw in pls) {
-          final name = raw is String ? raw : (raw is Map ? raw['name'] : null);
-          if (name is String && name.isNotEmpty) server.playlists.add(name);
-        }
-      }
-
-      // Transcoding capability (mStream/Velvet /api/v1/ping): `transcode` is
-      // false when the server has no working ffmpeg, otherwise
-      // { defaultCodec, defaultBitrate } — the values /transcode falls back to
-      // when we omit the codec/bitrate params.
       final bool? prevAvail = server.transcodeAvailable;
       final String? prevCodec = server.transcodeDefaultCodec;
       final String? prevBitrate = server.transcodeDefaultBitrate;
-      final transcodeInfo = res['transcode'];
-      if (transcodeInfo is Map) {
-        server.transcodeAvailable = true;
-        // Coerce defensively: a fork may return these as objects/numbers rather
-        // than strings. A shape mismatch must never throw here — it would surface
-        // as a bogus "failed to connect" on a server that actually responded 200.
-        final codec = transcodeInfo['defaultCodec'];
-        final bitrate = transcodeInfo['defaultBitrate'];
-        server.transcodeDefaultCodec = codec is String ? codec : null;
-        server.transcodeDefaultBitrate = bitrate is String ? bitrate : null;
-      } else {
-        server.transcodeAvailable = false;
-        server.transcodeDefaultCodec = null;
-        server.transcodeDefaultBitrate = null;
-      }
-      // Discovery (sonic-similarity) capability flags. Older servers omit the
-      // keys entirely → false. The UI gates strictly on == true — the webapp
-      // never calls a /discovery endpoint unless the ping advertised it, and
-      // the app follows the same rule (see Server.discoveryAvailable).
       final bool? prevDiscovery = server.discoveryAvailable;
       final bool? prevDiscoveryP2p = server.discoveryP2pAvailable;
       final bool? prevFedDiscovery = server.federationDiscoveryAvailable;
       final bool? prevDiscoveryPath = server.discoveryPathAvailable;
-      server.discoveryAvailable = res['discovery'] == true;
-      server.discoveryP2pAvailable = res['discoveryP2p'] == true;
-      server.federationDiscoveryAvailable = res['federationDiscovery'] == true;
-      server.discoveryPathAvailable = res['discoveryPath'] == true;
-
-      // Version rides along with the capability refresh: same moment, same
-      // persistence, and it is a cheap unauthenticated GET. Failure leaves the
-      // stored value alone rather than blanking it — a momentary blip should
-      // not make a known-good server look ancient.
       final prevVersion = server.serverVersion;
-      final fetched = (await fetchServerVersion(server)).version;
-      if (fetched != null) {
-        server.serverVersion = fetched;
+
+      // Whichever payload carried the caller-scoped flags. A layered answer
+      // has `user`; a pre-#932 server answers the same route with a flat
+      // {server, apiVersions, features:{subsonic}} and keeps its capabilities
+      // on ping.
+      Map? scoped;
+      if (info != null && info['user'] is Map) {
+        _applyServerInfo(server, info);
+        scoped = info['user'] as Map;
+        // Playlists left the boot payload in #932 — a resource, not a
+        // capability. Federated servers skip it: every playlist route is off
+        // the federation allowlist.
+        if (!server.isFederated) await _refreshPlaylists(server);
+      } else if (server.isFederated) {
+        // A peer too old for #932 has nothing else to offer — ping would 403
+        // even if we asked. Keep the federated defaults rather than invent
+        // capabilities we cannot confirm.
+        appLog('[server] ${server.localname}: peer has no layered /api; '
+            'keeping federated defaults');
+        _applyFederatedDefaults(server);
+      } else {
+        scoped = await _applyPing(server);
+      }
+
+      // The version rides along with whichever shape answered — both carry
+      // `server` — so it costs no extra round trip. Failure leaves the stored
+      // value alone rather than blanking it: a momentary blip should not make
+      // a known-good server look ancient.
+      final fetched = info?['server'];
+      if (fetched is String && fetched.trim().isNotEmpty) {
+        server.serverVersion = fetched.trim();
         server.versionCheckedAt = DateTime.now();
       } else {
         // Never successfully checked AND it just failed: record the attempt so
@@ -435,7 +407,8 @@ class ServerManager {
       }
 
       // Persist the capabilities so the NEXT launch knows them before the queue
-      // is restored — otherwise restore races the ping and bakes in /media URLs.
+      // is restored — otherwise restore races the refresh and bakes in /media
+      // URLs.
       if (server.serverVersion != prevVersion ||
           server.transcodeAvailable != prevAvail ||
           server.transcodeDefaultCodec != prevCodec ||
@@ -446,10 +419,167 @@ class ServerManager {
           server.discoveryPathAvailable != prevDiscoveryPath) {
         unawaited(writeServerFile());
       }
+
+      // Peers are the parent's data, so only a parent reconciles them — and
+      // only when it says it has some (flags, never probes).
+      if (!server.isFederated && scoped?['federationBrowse'] == true) {
+        unawaited(refreshFederatedPeers(server));
+      }
     } catch (err) {
       if (throwErr) {
         rethrow;
       }
+    }
+  }
+
+  /// `GET /api/` — the layered server-info endpoint (mStream #932/#934):
+  /// version, server-wide `features`, and the caller-scoped `user` block in one
+  /// call.
+  ///
+  /// Returns the decoded body, or null when the server answered but had nothing
+  /// to say (404 on a pre-5.4.2 build, 403 from a peer whose allowlist predates
+  /// #932). Transport failures throw, so [getServerPaths]'s throwErr still
+  /// reports a server that is simply down.
+  ///
+  /// Sent WITH the access token: #934 put this route back behind the auth wall,
+  /// where a tokenless request is a 401 by contract — that 401 is how a client
+  /// detects "this server needs a login", deliberately not a silent downgrade
+  /// to a public payload.
+  Future<Map<String, dynamic>?> _fetchServerInfo(Server server) async {
+    final response = await http.get(
+      server.apiUri('/api/'),
+      headers: {'x-access-token': server.authToken ?? ''},
+    ).timeout(const Duration(seconds: 8));
+    if (response.statusCode != 200) {
+      appLog('[server] /api on ${server.localname} -> '
+          'HTTP ${response.statusCode}');
+      return null;
+    }
+    final decoded = jsonDecode(response.body);
+    return decoded is Map<String, dynamic> ? decoded : null;
+  }
+
+  /// Fold a layered `GET /api/` response into [server].
+  ///
+  /// `features` is server-wide; `user` is scoped to the credential that asked —
+  /// for a federated server that credential is the parent's federation key, so
+  /// `user.vpaths` arrives already narrowed to the libraries the key was
+  /// granted.
+  void _applyServerInfo(Server server, Map info) {
+    final features = info['features'];
+    final user = info['user'];
+
+    _applyVpaths(server, user is Map ? user['vpaths'] : null);
+    _applyTranscode(server, features is Map ? features['transcode'] : null);
+
+    server.discoveryAvailable = features is Map && features['discovery'] == true;
+    server.discoveryP2pAvailable =
+        features is Map && features['discoveryP2p'] == true;
+    server.federationDiscoveryAvailable =
+        user is Map && user['federationDiscovery'] == true;
+    // /api carries no discoveryPath. It was only ever a "this server VERSION
+    // has the sonic-path route" gate, and mStream #934 records that it is
+    // identical to `discovery` on every build carrying that code.
+    server.discoveryPathAvailable = server.discoveryAvailable;
+
+    if (server.isFederated) _applyFederatedDefaults(server);
+  }
+
+  /// `GET /api/v1/ping` — the pre-#932 boot payload, still served (frozen) by
+  /// every mStream build. The fallback when `/api/` answers with the old flat
+  /// shape, so the app keeps working against servers released before the
+  /// layered endpoint. Returns the decoded body for its caller-scoped flags.
+  Future<Map?> _applyPing(Server server) async {
+    final response = await http.get(
+      server.apiUri('/api/v1/ping'),
+      headers: {
+        'Content-Type': 'application/json',
+        'x-access-token': server.authToken ?? '',
+      },
+    ).timeout(const Duration(seconds: 5));
+    if (response.statusCode != 200) {
+      throw Exception('Failed to connect to server');
+    }
+    final res = jsonDecode(response.body);
+    if (res is! Map) throw Exception('Failed to connect to server');
+
+    _applyVpaths(server, res['vpaths']);
+    _applyPlaylists(server, res['playlists']);
+    _applyTranscode(server, res['transcode']);
+    server.discoveryAvailable = res['discovery'] == true;
+    server.discoveryP2pAvailable = res['discoveryP2p'] == true;
+    server.federationDiscoveryAvailable = res['federationDiscovery'] == true;
+    server.discoveryPathAvailable = res['discoveryPath'] == true;
+    return res;
+  }
+
+  /// Reconcile [server]'s Auto DJ path map against the library list it just
+  /// reported: add new vpaths (enabled), drop ones that are gone, and re-enable
+  /// everything if the user's selection has emptied out.
+  void _applyVpaths(Server server, dynamic vpaths) {
+    final Set<String> reported = {};
+    if (vpaths is List) {
+      for (final raw in vpaths) {
+        if (raw is! String) continue; // tolerate unexpected element shapes
+        reported.add(raw);
+        if (!server.autoDJPaths.containsKey(raw)) {
+          server.autoDJPaths[raw] = true;
+        }
+      }
+    }
+    server.autoDJPaths.removeWhere((key, value) => !reported.contains(key));
+    if (server.autoDJPaths.values.every((v) => v != true)) {
+      server.autoDJPaths.updateAll((key, value) => true);
+    }
+  }
+
+  /// Accept both the bare-name form (["A", "B"]) and the object form
+  /// ([{"name": "A"}, ...]) that some builds (e.g. Velvet) return.
+  void _applyPlaylists(Server server, dynamic pls) {
+    server.playlists.clear();
+    if (pls is! List) return;
+    for (final raw in pls) {
+      final name = raw is String ? raw : (raw is Map ? raw['name'] : null);
+      if (name is String && name.isNotEmpty) server.playlists.add(name);
+    }
+  }
+
+  /// `transcode` is false when the server has no working ffmpeg, otherwise
+  /// { defaultCodec, defaultBitrate } — the values /transcode falls back to
+  /// when the client omits those params. Same field on ping's flat payload and
+  /// on /api's `features`.
+  void _applyTranscode(Server server, dynamic transcodeInfo) {
+    if (transcodeInfo is! Map) {
+      server.transcodeAvailable = false;
+      server.transcodeDefaultCodec = null;
+      server.transcodeDefaultBitrate = null;
+      return;
+    }
+    server.transcodeAvailable = true;
+    // Coerce defensively: a fork may return these as objects/numbers rather
+    // than strings. A shape mismatch must never throw here — it would surface
+    // as a bogus "failed to connect" on a server that actually responded 200.
+    final codec = transcodeInfo['defaultCodec'];
+    final bitrate = transcodeInfo['defaultBitrate'];
+    server.transcodeDefaultCodec = codec is String ? codec : null;
+    server.transcodeDefaultBitrate = bitrate is String ? bitrate : null;
+  }
+
+  /// `GET /api/v1/playlist/getall` — the playlist names ping used to carry.
+  ///
+  /// Fetched separately since #932 moved playlists off the boot payload (a
+  /// resource, not a capability). Best-effort: the names only feed pickers, and
+  /// losing them must not cost a capability refresh that already succeeded.
+  Future<void> _refreshPlaylists(Server server) async {
+    try {
+      final response = await http.get(
+        server.apiUri('/api/v1/playlist/getall'),
+        headers: {'x-access-token': server.authToken ?? ''},
+      ).timeout(const Duration(seconds: 8));
+      if (response.statusCode != 200) return;
+      _applyPlaylists(server, jsonDecode(response.body));
+    } catch (err) {
+      appLog('[server] playlist refresh for ${server.localname} failed: $err');
     }
   }
 
@@ -1061,7 +1191,7 @@ class ServerManager {
         // the ping in the same call — identical URL builder, but carrying
         // this header — came back 200. Sent unconditionally; a plain HTTP
         // server ignores it on a route that never asked.
-        headers: {'x-access-token': s.jwt ?? ''},
+        headers: {'x-access-token': s.authToken ?? ''},
       ).timeout(const Duration(seconds: 8));
       if (resp.statusCode > 299) {
         // 404 is the expected answer from a pre-5.4.2 server, not a fault.
@@ -1378,6 +1508,12 @@ class ServerManager {
   Future<void> removeServer(
       Server removeThisServer, bool removeSyncedFiles) async {
     serverList.remove(removeThisServer);
+    // A peer is only reachable through its parent, so removing the parent
+    // removes them too — leaving them would strand entries that can no longer
+    // resolve a URL. Done before the queue cleanup below so their tracks go in
+    // the same sweep.
+    final orphans = federatedChildren(removeThisServer);
+    serverList.removeWhere(orphans.contains);
     _serverListStream.sink.add(serverList);
     // Deleting a server also deletes its queued tracks — they can't stream
     // anymore and their metadata context (ratings, art, URL re-resolution)
@@ -1388,9 +1524,11 @@ class ServerManager {
     // writeServerFile, and the server the user just deleted would be back on
     // the next launch.
     try {
-      await MediaManager()
-          .audioHandler
-          .removeServerQueueItems(removeThisServer.localname);
+      for (final gone in [removeThisServer, ...orphans]) {
+        await MediaManager()
+            .audioHandler
+            .removeServerQueueItems(gone.localname);
+      }
     } catch (err) {
       appLog('[server] clearing queued tracks failed: $err');
     }
@@ -1407,7 +1545,9 @@ class ServerManager {
 
       currentServer = null;
       _currentServerStream.sink.add(currentServer);
-    } else if (removeThisServer == currentServer) {
+    } else if (!serverList.contains(currentServer)) {
+      // The active server went — either it IS the one being removed, or it was
+      // one of its peers, swept out with it.
       currentServer = serverList[0];
       // clear the browser
       BrowserManager().goToNavScreen();
@@ -1460,6 +1600,181 @@ class ServerManager {
       if (s.localname == localname) return s;
     }
     return null;
+  }
+
+  // ─── Federation ──────────────────────────────────────────────────────────
+  // A federated server stands in for one PEER of a configured server, reached
+  // through that parent's browse proxy (mStream #927). It is an ordinary entry
+  // in [serverList] — which is what makes the picker, queue restore and the
+  // download folder work without a parallel code path — but it owns no
+  // transport, credentials or peer list of its own.
+
+  /// Point every federated server at its live parent. Must run after the list
+  /// is read and after anything that changes it: [Server.parentServer] is
+  /// runtime-only, and every federated URL resolves through it.
+  void _linkFederatedParents() {
+    for (final s in serverList) {
+      if (s.isFederated) s.parentServer = byLocalname(s.federationParent);
+    }
+  }
+
+  /// The federated servers reached through [parent].
+  List<Server> federatedChildren(Server parent) => serverList
+      .where((s) => s.isFederated && s.federationParent == parent.localname)
+      .toList();
+
+  Server? _childByPeerId(Server parent, int peerId) {
+    for (final s in serverList) {
+      if (s.isFederated &&
+          s.federationParent == parent.localname &&
+          s.federationPeerId == peerId) {
+        return s;
+      }
+    }
+    return null;
+  }
+
+  /// Follow a parent's rename through to its peers. [Server.federationParent]
+  /// stores the parent's localname, and the edit screen lets the user change
+  /// it; without this the children would point at a name nothing answers to.
+  void renameFederationParent(String oldName, String newName) {
+    if (oldName == newName) return;
+    for (final s in serverList) {
+      if (s.federationParent == oldName) s.federationParent = newName;
+    }
+    _linkFederatedParents();
+  }
+
+  /// `GET /api/v1/federation/peers` on [parent] — the read-only projection any
+  /// logged-in user may read (never api_key or the endpoint ticket) — folded
+  /// into the servers we already hold for that parent.
+  ///
+  /// A mirror, not a source: peers are the parent admin's data. New ones
+  /// appear, renames follow, and a peer that stops being listed is FLAGGED,
+  /// not deleted — a queued track and a downloaded file both point at its
+  /// localname, so deleting the record would strand them. It goes when the
+  /// user says so, or with its parent.
+  Future<void> refreshFederatedPeers(Server parent) async {
+    if (parent.isFederated) return; // a peer has no peers of its own
+    final List peers;
+    try {
+      final response = await http.get(
+        parent.apiUri('/api/v1/federation/peers'),
+        headers: {'x-access-token': parent.authToken ?? ''},
+      ).timeout(const Duration(seconds: 8));
+      if (response.statusCode != 200) {
+        appLog('[federation] peer list on ${parent.localname} -> '
+            'HTTP ${response.statusCode}');
+        return;
+      }
+      final decoded = jsonDecode(response.body);
+      final raw = decoded is Map ? decoded['peers'] : null;
+      if (raw is! List) return;
+      peers = raw;
+    } catch (err) {
+      appLog('[federation] peer list on ${parent.localname} failed: $err');
+      return;
+    }
+
+    bool changed = false;
+    final Set<int> listed = {};
+    for (final p in peers) {
+      if (p is! Map) continue;
+      final id = p['id'];
+      final name = p['name'];
+      if (id is! int || name is! String || name.isEmpty) continue;
+      listed.add(id);
+
+      final existing = _childByPeerId(parent, id);
+      if (existing == null) {
+        final fresh = _newFederatedServer(parent, id, name);
+        serverList.add(fresh);
+        await _ensureDownloadDir(fresh);
+        changed = true;
+        continue;
+      }
+      // A rename on the parent is just a new label; the localname (and so the
+      // download folder and every queued track) deliberately stays put.
+      if (existing.federationPeerName != name || existing.federationMissing) {
+        existing.federationPeerName = name;
+        existing.federationMissing = false;
+        changed = true;
+      }
+    }
+
+    for (final child in federatedChildren(parent)) {
+      final gone = !listed.contains(child.federationPeerId);
+      if (gone != child.federationMissing) {
+        child.federationMissing = gone;
+        changed = true;
+      }
+    }
+
+    if (!changed) return;
+    _linkFederatedParents();
+    _serverListStream.sink.add(serverList);
+    await writeServerFile();
+    // Capabilities for anything new or newly back: one /api through the proxy.
+    for (final child in federatedChildren(parent)) {
+      if (!child.federationMissing) unawaited(getServerPaths(child));
+    }
+  }
+
+  /// A Server standing in for peer [id] of [parent], named [name].
+  ///
+  /// Storage follows the parent so a peer's downloads land beside it. The
+  /// capabilities start at the federated floor rather than unknown: the
+  /// allowlist already rules them out, and leaving transcodeAvailable null
+  /// would send the first stream URL to /transcode optimistically.
+  Server _newFederatedServer(Server parent, int id, String name) {
+    final s = Server('federated://${parent.localname}/$id', null, null, null,
+        _federatedLocalname(name))
+      ..federationParent = parent.localname
+      ..federationPeerId = id
+      ..federationPeerName = name
+      ..parentServer = parent
+      ..storageMode = parent.storageMode
+      ..storageBasePath = parent.storageBasePath;
+    _applyFederatedDefaults(s);
+    return s;
+  }
+
+  /// Pin the capabilities a federated server cannot have, whatever the peer
+  /// says about itself.
+  ///
+  /// A peer's answer describes what IT can do; the federation allowlist decides
+  /// what we can reach through the parent's proxy, and it is the narrower of
+  /// the two. /transcode, every /api/v1/discovery/* route and every playlist
+  /// route are off it — so a peer reporting working ffmpeg or a finished
+  /// discovery scan would otherwise light up UI whose requests can only 403.
+  void _applyFederatedDefaults(Server server) {
+    server.transcodeAvailable = false;
+    server.transcodeDefaultCodec = null;
+    server.transcodeDefaultBitrate = null;
+    server.discoveryAvailable = false;
+    server.discoveryP2pAvailable = false;
+    server.federationDiscoveryAvailable = false;
+    server.discoveryPathAvailable = false;
+    server.playlists.clear();
+  }
+
+  /// A stable, unique, filesystem-safe download-folder name for a peer.
+  ///
+  /// This server's OWN name, never derived from the parent's: localname keys
+  /// queue restore and `media/<localname>`, and the parent's localname is
+  /// user-editable — deriving from it would force a folder migration for every
+  /// child on a rename. Suffixed on collision because two parents can each have
+  /// a peer called "home".
+  String _federatedLocalname(String peerName) {
+    final slug = peerName
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+        .replaceAll(RegExp(r'^-+|-+$'), '');
+    final base = slug.isEmpty ? 'peer' : 'peer-$slug';
+    for (int n = 1;; n++) {
+      final candidate = n == 1 ? base : '$base-$n';
+      if (byLocalname(candidate) == null) return candidate;
+    }
   }
 
   // Self-signed / insecure TLS (full flavor only) — see SelfSignedHttpOverrides

--- a/lib/util/stream_url.dart
+++ b/lib/util/stream_url.dart
@@ -61,7 +61,18 @@ String buildServerStreamUrl(Server server, String path) {
     p += '/${Uri.encodeComponent(element)}';
   }
   final tm = TranscodeManager();
-  final String token = server.jwt == null ? '' : '&token=${server.jwt!}';
+  final String token =
+      server.authToken == null ? '' : '&token=${server.authToken!}';
+  // A federated server's tracks live on a peer, reached through the parent's
+  // byte proxy (which forwards Range, so seeking still works). /transcode is
+  // off the federation allowlist entirely — there is no transcode branch to
+  // take here, and transcodeAvailable is pinned false for these servers so the
+  // check below would land on /media regardless. Explicit anyway: the endpoint
+  // differs, not just the flag.
+  if (server.isFederated) {
+    return '${server.effectiveBaseUrl}${server.federationPrefix}/stream$p'
+        '?app_uuid=${Uuid().v4()}$token${server.localTokenQuery}';
+  }
   // iOS codec fallback: formats AVPlayer can't decode (ogg/opus & co) stream
   // through /transcode even with the user's transcode setting OFF — the
   // alternative is a track that silently fails. Device-verified that AVPlayer
@@ -116,6 +127,34 @@ bool sameStreamUrl(String a, String b) {
   return mapEquals(qa, qb);
 }
 
+/// The URL to fetch a server file's ORIGINAL bytes, for downloading.
+///
+/// Deliberately not [buildServerStreamUrl]: a download is stored on disk, so it
+/// must never arrive transcoded whatever the playback setting says. It shares
+/// the escaping and the federated rewrite — a peer's bytes come through the
+/// parent's byte proxy, the same route playback uses.
+///
+/// The query is assembled from parts rather than concatenated so a server with
+/// no token still produces `?__lt=…` and not `?&__lt=…` — an iroh server can be
+/// public, and then the loopback token is the only param.
+String buildServerDownloadUrl(Server server, String path) {
+  String p = '';
+  for (final element in path.split('/')) {
+    if (element.isEmpty) continue;
+    p += '/${Uri.encodeComponent(element)}';
+  }
+  final String base = server.isFederated
+      ? '${server.effectiveBaseUrl}${server.federationPrefix}/stream$p'
+      : '${server.effectiveBaseUrl}/media$p';
+  final parts = <String>[
+    if (server.authToken != null) 'token=${server.authToken!}',
+    // localTokenQuery is built for string concatenation onto an existing
+    // query, so it carries a leading '&' this join supplies itself.
+    if (server.localTokenQuery.isNotEmpty) server.localTokenQuery.substring(1),
+  ];
+  return parts.isEmpty ? base : '$base?${parts.join('&')}';
+}
+
 /// Single source of truth for a server's album-art URL.
 ///
 /// [artFile] is the `album_art_file` / metadata `album-art` value. [compress]
@@ -125,7 +164,17 @@ bool sameStreamUrl(String a, String b) {
 /// percent-encoded. Assumes [Server.url] carries no trailing slash — the app's
 /// stored convention, shared with the stream-URL builder above.
 String buildAlbumArtUrl(Server server, String artFile, {String compress = 's'}) {
-  final String token = server.jwt == null ? '' : '&token=${server.jwt!}';
+  final String token =
+      server.authToken == null ? '' : '&token=${server.authToken!}';
+  // The art proxy takes the file as ONE path segment — the peer serves
+  // /album-art/:file, a single hash name — and forwards only `compress`.
+  // encodeComponent, not encodeFull: the segment is escaped exactly once, the
+  // way the webapp's peerArtUrl does it.
+  if (server.isFederated) {
+    return '${server.effectiveBaseUrl}${server.federationPrefix}'
+        '/art/${Uri.encodeComponent(artFile)}'
+        '?compress=$compress$token${server.localTokenQuery}';
+  }
   return Uri.encodeFull(
       '${server.effectiveBaseUrl}/album-art/$artFile?compress=$compress$token${server.localTokenQuery}');
 }

--- a/lib/widgets/browser_toolbar.dart
+++ b/lib/widgets/browser_toolbar.dart
@@ -30,6 +30,7 @@ import '../singletons/settings.dart';
 import '../theme/velvet_theme.dart';
 import '../util/media_format.dart';
 import '../util/queue_actions.dart';
+import '../util/stream_url.dart';
 import 'local_search_bar.dart';
 
 // Combined snapshot the toolbar renders from.
@@ -149,9 +150,8 @@ class _BrowserToolbarState extends State<BrowserToolbar> {
             onPressed: () {
               Navigator.of(ctx).pop();
               for (final e in files) {
-                final downloadUrl = '${e.server!.effectiveBaseUrl}/media${e.data!}'
-                    '${e.server!.jwt == null ? '' : '?token=${e.server!.jwt!}'}'
-                    '${e.server!.localTokenQuery}';
+                final downloadUrl =
+                    buildServerDownloadUrl(e.server!, e.data!);
                 DownloadManager().downloadOneFile(
                     downloadUrl, e.server!.localname, e.data!,
                     referenceItem: e);

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -44,6 +44,7 @@ target) on exit, including on Ctrl-C. Nothing prints pairing codes or tokens.
 | `android/media-resumption.sh` | headless boot on a PLAY key after a force-kill | 1 min |
 | `android/bt-late-pause.sh` | the car-off late PAUSE is ignored | 1 min |
 | `android/dead-zone.sh` | hand-off, 75 s outage, Retry tap, Wi-Fi return — all in place | 5 min |
+| `android/federation-rig.sh` | two local mStream servers paired over federation; the peer reconciles, browses, plays and downloads through the parent's proxies — over HTTP, or with `SMOKE_RIG_IROH=1` over the parent's Quick Connect tunnel, which must survive a switch to a standard server. Needs a server checkout (header) | 4 min |
 | `android/playback-soak.sh` | screen-off playback survives (Samsung app-sleep) | 2 h |
 | `android/cast-through-rebuild.sh` | opt-in (`SMOKE_CAST=1`, plays on a TV): cast + tunnel disturbance | 2 min |
 | `ios/sim-launch.sh` | app-owned engine boots, UI renders, resume reaches Dart | 1 min |

--- a/smoke/android/federation-rig.sh
+++ b/smoke/android/federation-rig.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Federation rig: two local mStream servers paired over the federation
+# endpoint (peer A grants a library to parent B), parent B planted on the phone,
+# and A browsed, played and downloaded THROUGH B's proxies — reached over plain
+# HTTP on the LAN, or (SMOKE_RIG_IROH=1) over B's Quick Connect tunnel, so the
+# peer rides the parent's loopback tunnel and the tunnel must survive a switch
+# to a standard server while a peer track plays (the transport-aware tunnel
+# target + queue listener, PR #129).
+#
+# Needs: a server checkout with node_modules (SMOKE_MSTREAM_SRC, default
+# ~/code/mStream — a `git worktree` of the server's master works, with
+# node_modules symlinked), node, a music folder (SMOKE_RIG_MUSIC, default
+# ~/code/mstream-demo-music, ~10 albums), the phone on the Mac's LAN
+# (SMOKE_RIG_HOST, default en0's address). Taps use the Galaxy S25 coordinates
+# and assume the picker lists the parent first and the peer last.
+#
+# Everything it creates is torn down: both servers, their scratch dirs, the
+# phone's server list (cfg_restore) and the peer's download folder.
+set -u
+source "$(dirname "$0")/../lib.sh"; pick_device; cfg_backup
+SRC="${SMOKE_MSTREAM_SRC:-$HOME/code/mStream}"; MUSIC="${SMOKE_RIG_MUSIC:-$HOME/code/mstream-demo-music}"
+HOST="${SMOKE_RIG_HOST:-$(ipconfig getifaddr en0)}"; IROH="${SMOKE_RIG_IROH:-0}"
+PA=3101; PB=3102; RIG="$OUT/rig"; mkdir -p "$RIG"; J='Content-Type: application/json'
+PICKER=${SMOKE_PICKER_XY:-"1007 187"}; ALBUMS_ROW=${SMOKE_ALBUMS_ROW_XY:-"234 909"}
+ALBUM1=${SMOKE_ALBUM1_XY:-"278 708"}; TRACK1=${SMOKE_TRACK1_XY:-"468 886"}
+[ -f "$SRC/cli-boot-wrapper.js" ] && [ -d "$SRC/node_modules" ] || { echo "no server checkout with node_modules at $SRC"; exit 2; }
+[ -d "$MUSIC" ] || { echo "no music folder at $MUSIC"; exit 2; }
+NODES=""
+cleanup() {
+  [ -n "$NODES" ] && kill $NODES 2>/dev/null
+  adbx shell "run-as $PKG rm -rf app_flutter/media/peer-rig-peer-a" 2>/dev/null
+  cfg_restore
+}
+trap cleanup EXIT
+
+# ── the two servers ────────────────────────────────────────────────────────
+rig_cfg() { # <name> <port> <bind address> <folder path>
+  python3 - "$RIG/$1" "$2" "$3" "$4" "$5" <<'PY'
+import json,os,sys
+d,port,addr,root,name=sys.argv[1:]; os.makedirs(d, exist_ok=True)
+st={k: os.path.join(d,v) for k,v in dict(albumArtDirectory='image-cache', dbDirectory='db', logsDirectory='logs', waveformCacheDirectory='waveform-cache').items()}
+for p in st.values(): os.makedirs(p, exist_ok=True)
+json.dump({"port":int(port),"address":addr,"ui":"default","folders":{"demo":{"root":root}},"storage":st,
+  "federation":{"enabled":True,"serverName":name},
+  "scanOptions":{"autoAlbumArt":False,"collectDiscoveryData":False,"analyzeBpm":False},
+  "discoveryP2p":{"seedListUrl":"http://127.0.0.1:9/discovery-seeds.json","useCommunitySeeds":False}},
+  open(os.path.join(d,'config.json'),'w'), indent=2)
+PY
+}
+rig_cfg a $PA 127.0.0.1 "$MUSIC" "Rig Peer A"
+rig_cfg b $PB 0.0.0.0 "$MUSIC/$(ls "$MUSIC" | head -1)" "Rig Parent B"
+export NODE_ENV=test MSTREAM_TEST_BAKED_SEEDS='[]' MSTREAM_SIDECAR_BASE=http://127.0.0.1:9 MSTREAM_PLAYER_BASE=http://127.0.0.1:9
+# exec, so $! is node itself and the cleanup kill reaches it, not a wrapper shell
+( cd "$SRC" && exec node cli-boot-wrapper.js -j "$RIG/a/config.json" > "$RIG/a.log" 2>&1 ) & NODES="$!"
+( cd "$SRC" && exec node cli-boot-wrapper.js -j "$RIG/b/config.json" > "$RIG/b.log" 2>&1 ) & NODES="$NODES $!"
+for i in $(seq 1 60); do
+  [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:$PA/api/)" = 200 ] && [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:$PB/api/)" = 200 ] && break; sleep 2
+done
+[ "$i" -lt 60 ] && pass "both servers up (${i}x2s)" || { fail "servers did not come up (see $RIG/*.log)"; summary; exit 1; }
+sleep 8 # boot scan of the demo folder
+
+# ── pair them: users, a key minted on A, the ticket added on B ─────────────
+for p in $PA $PB; do curl -s -o /dev/null -X PUT "http://127.0.0.1:$p/api/v1/admin/users" -H "$J" -d '{"username":"rig","password":"rigpw","vpaths":["demo"],"admin":true}'; done
+tok() { curl -s -X POST "http://127.0.0.1:$1/api/v1/auth/login" -H "$J" -d '{"username":"rig","password":"rigpw"}' | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])"; }
+TA=$(tok $PA); TB=$(tok $PB)
+TICKET=$(curl -s -X POST "http://127.0.0.1:$PA/api/v1/admin/federation/keys" -H "$J" -H "x-access-token: $TA" -d '{"name":"Rig Parent B","vpaths":["demo"]}' | python3 -c "import sys,json; print(json.load(sys.stdin)['ticket'])")
+PEER=$(curl -s -X POST "http://127.0.0.1:$PB/api/v1/admin/federation/peers" -H "$J" -H "x-access-token: $TB" -d "{\"ticket\":$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$TICKET")}")
+PEER_ID=$(echo "$PEER" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))")
+STATUS=$(curl -s "http://127.0.0.1:$PB/api/v1/federation/peers" -H "x-access-token: $TB" | python3 -c "import sys,json; p=json.load(sys.stdin)['peers']; print(p[0]['lastStatus'] if p else 'none')")
+[ "$STATUS" = ok ] && pass "B dialed A over the federation endpoint (peer id $PEER_ID, status ok)" || fail "peer status on B: $STATUS"
+VIA=$(curl -s "http://127.0.0.1:$PB/api/v1/federation/peers/$PEER_ID/api/api/" -H "x-access-token: $TB" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('server'), d.get('user',{}).get('vpaths'))")
+case "$VIA" in *"['demo']"*) pass "proxied /api/ reaches A scoped to the granted library ($VIA)";; *) fail "proxied /api/ answered: $VIA";; esac
+
+# ── the parent on the phone ────────────────────────────────────────────────
+if [ "$IROH" = 1 ]; then
+  curl -s -o /dev/null -X POST "http://127.0.0.1:$PB/api/v1/admin/iroh" -H "$J" -H "x-access-token: $TB" -d '{"enabled":true}'; sleep 3
+  CODE=$(curl -s "http://127.0.0.1:$PB/api/v1/admin/iroh" -H "x-access-token: $TB" | python3 -c "import sys,json; print(json.load(sys.stdin).get('qr') or '')")
+  [ -n "$CODE" ] && pass "Quick Connect up on B" || { fail "no pairing code from B"; summary; exit 1; }
+  PARENT=iroh-rig-b; URL="iroh://rig-b"; CT=iroh
+else
+  CODE=""; PARENT=rig-b; URL="http://$HOST:$PB"; CT=http
+fi
+python3 - "$CFG_BACKUP/servers.json" "$RIG/servers.json" "$URL" "$TB" "$PARENT" "$CT" "$CODE" <<'PY'
+import json,sys
+src,dst,url,tok,name,ct,code=sys.argv[1:]
+L=json.load(open(src))
+b={"url":url,"jwt":tok,"username":"rig","password":"rigpw","localname":name,"autoDJPaths":{},"autoDJminRating":None,"autoDJGenreEnabled":False,"autoDJGenreMode":"whitelist","autoDJGenres":[],"playlists":[],"allowSelfSigned":False,"storageMode":"appLocal","storageBasePath":None,"transcodeAvailable":None,"transcodeDefaultCodec":None,"transcodeDefaultBitrate":None,"discoveryAvailable":None,"federationDiscoveryAvailable":None,"discoveryPathAvailable":None,"connectionType":ct,"irohPairingCode":code or None,"serverVersion":None,"versionCheckedAt":None}
+json.dump([b]+L, open(dst,'w'))
+PY
+app_stop; cfg_write servers.json "$RIG/servers.json"; logcat_clear; wake; app_start
+wait_for_log '\[app\] default server ready' 30 || fail "default never published"
+for i in $(seq 1 30); do
+  cfg_read servers.json | python3 -c "import sys,json; sys.exit(0 if any(s.get('federationParent')=='$PARENT' for s in json.load(sys.stdin)) else 1)" && break; sleep 1
+done
+[ "$i" -lt 30 ] && pass "peer reconciled under $PARENT in ${i}s" || { save_applog rig-launch; fail "no peer entry after 30s"; summary; exit 1; }
+N=$(cfg_read servers.json | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
+PEER_Y=$((222 + 144 * (N - 1))) # picker rows: 222, 366, 510, … — the peer is listed last
+tap $PICKER; sleep 1.5; shot picker; tap 639 $PEER_Y; sleep 3
+wait_for_log '\[srv\] switched to peer-rig-peer-a' 5 && pass "peer selected from the picker" || fail "no switch to the peer"
+shot peer-nav
+tap $ALBUMS_ROW; sleep 4; shot peer-albums; tap $ALBUM1; sleep 3; tap $TRACK1; sleep 6
+if wait_for_log '\[queue\] add [0-9]+ tracks' 5 && is_playing; then pass "peer album queued and playing through the stream proxy ($(session_state))"; else save_applog rig-play; fail "peer track did not play ($(session_state))"; fi
+shot peer-playing
+adbx shell "run-as $PKG test -d app_flutter/media/peer-rig-peer-a" && pass "download folder created for the peer" || fail "no media/peer-rig-peer-a folder"
+if [ "$IROH" = 1 ]; then
+  [ "$(count_log 'tunnel stopped')" -eq 0 ] && pass "browsing the peer kept the parent's tunnel" || fail "the parent's tunnel was stopped while the peer was browsed"
+  # switch to the first standard server (row 2) while the peer track plays
+  T=$(now_ts); tap $PICKER; sleep 1.5; tap 782 366; sleep 5
+  wait_for_log_after "$T" '\[srv\] switched to ' 5 || fail "no switch away from the peer"
+  if is_playing && [ "$(count_log 'tunnel stopped')" -eq 0 ]; then pass "tunnel kept for the queued peer track after switching to a standard server"; else fail "tunnel or playback lost after the switch ($(session_state))"; fi
+fi
+media_key pause; sleep 1
+save_applog federation-rig
+summary

--- a/test/objects/federated_server_test.dart
+++ b/test/objects/federated_server_test.dart
@@ -75,6 +75,45 @@ void main() {
     });
   });
 
+  group('transport', () {
+    // Two questions hide behind "is this an iroh server?": identity (isIroh)
+    // and transport (whose tunnel carries the bytes). ServerManager picks the
+    // tunnel target, the launch wait and the queue's tunnel from the transport.
+    test('a plain server is its own transport', () {
+      final s = Server('https://music.example.com', null, null, null, 'main');
+      expect(identical(s.transportServer, s), isTrue);
+      expect(s.isIrohTransport, isFalse);
+    });
+
+    test('an iroh server is its own iroh transport', () {
+      final s = Server('iroh://placeholder', null, null, null, 'quick')
+        ..connectionType = 'iroh';
+      expect(identical(s.transportServer, s), isTrue);
+      expect(s.isIrohTransport, isTrue);
+    });
+
+    test('a peer of an HTTP parent rides the parent, not a tunnel', () {
+      final pair = _pair();
+      expect(identical(pair.peer.transportServer, pair.parent), isTrue);
+      expect(pair.peer.isIroh, isFalse);
+      expect(pair.peer.isIrohTransport, isFalse);
+    });
+
+    test('a peer of an iroh parent is an iroh transport without being iroh',
+        () {
+      final pair = _pair(iroh: true, tunnelPort: 41773, tunnelToken: 'lt');
+      expect(identical(pair.peer.transportServer, pair.parent), isTrue);
+      expect(pair.peer.isIroh, isFalse);
+      expect(pair.peer.isIrohTransport, isTrue);
+    });
+
+    test('an unlinked peer has no transport and is not an iroh transport', () {
+      final peer = _pair(iroh: true).peer..parentServer = null;
+      expect(peer.transportServer, isNull);
+      expect(peer.isIrohTransport, isFalse);
+    });
+  });
+
   group('credentials', () {
     test('a peer authenticates with the parent token, never its own', () {
       final p = _pair();

--- a/test/objects/federated_server_test.dart
+++ b/test/objects/federated_server_test.dart
@@ -1,0 +1,194 @@
+// A federated server is one PEER of another configured server, addressed
+// through that parent's browse proxy (mStream #927) instead of by a URL of its
+// own. Everything below pins the rewrite: the app's three URL builders are the
+// only places that know federation exists, so if they are right the browse and
+// playback paths follow.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/util/stream_url.dart';
+
+/// A parent + one peer of it, wired the way ServerManager wires them.
+({Server parent, Server peer}) _pair({
+  String parentUrl = 'https://home.example.com',
+  String? jwt = 'PARENT-JWT',
+  bool iroh = false,
+  int? tunnelPort,
+  String? tunnelToken,
+}) {
+  final parent = Server(parentUrl, 'alice', 'secret', jwt, 'home');
+  if (iroh) {
+    parent.connectionType = 'iroh';
+    parent.tunnelPort = tunnelPort;
+    parent.tunnelToken = tunnelToken;
+  }
+  final peer = Server('federated://home/3', null, null, null, 'peer-basement')
+    ..federationParent = 'home'
+    ..federationPeerId = 3
+    ..federationPeerName = 'Basement'
+    ..parentServer = parent;
+  return (parent: parent, peer: peer);
+}
+
+void main() {
+  group('identity', () {
+    test('a plain server is not federated and shows its URL', () {
+      final s = Server('https://music.example.com', null, null, null, 'main');
+      expect(s.isFederated, isFalse);
+      expect(s.displayName, 'https://music.example.com');
+    });
+
+    test('a peer is federated and shows the name the parent reported', () {
+      final peer = _pair().peer;
+      expect(peer.isFederated, isTrue);
+      expect(peer.displayName, 'Basement');
+    });
+
+    test('falls back to the peer id when the name has not arrived', () {
+      final peer = _pair().peer..federationPeerName = null;
+      expect(peer.displayName, 'Peer 3');
+    });
+
+    test('survives a JSON round trip', () {
+      final peer = _pair().peer..federationMissing = true;
+      final back = Server.fromJson(peer.toJson());
+      expect(back.federationParent, 'home');
+      expect(back.federationPeerId, 3);
+      expect(back.federationPeerName, 'Basement');
+      expect(back.federationMissing, isTrue);
+      expect(back.isFederated, isTrue);
+      // The parent link is runtime-only — it is never persisted, and
+      // ServerManager re-establishes it after the list loads.
+      expect(back.parentServer, isNull);
+    });
+
+    test('a server file written before federation loads as non-federated', () {
+      final s = Server.fromJson({
+        'url': 'https://music.example.com',
+        'username': null,
+        'password': null,
+        'jwt': null,
+        'localname': 'home',
+      });
+      expect(s.isFederated, isFalse);
+      expect(s.federationMissing, isFalse);
+    });
+  });
+
+  group('credentials', () {
+    test('a peer authenticates with the parent token, never its own', () {
+      final p = _pair();
+      expect(p.peer.jwt, isNull);
+      expect(p.peer.authToken, 'PARENT-JWT');
+    });
+
+    test('a public parent gives a peer no token at all', () {
+      final p = _pair(jwt: null);
+      expect(p.peer.authToken, isNull);
+    });
+
+    test('a plain server still uses its own token', () {
+      final p = _pair();
+      expect(p.parent.authToken, 'PARENT-JWT');
+    });
+  });
+
+  group('apiUri', () {
+    test('rewrites onto the parent browse proxy', () {
+      final peer = _pair().peer;
+      expect(peer.apiUri('/api/v1/db/albums').toString(),
+          'https://home.example.com/api/v1/federation/peers/3/api/api/v1/db/albums');
+    });
+
+    test('the capability call lands on an allowlisted spelling', () {
+      final peer = _pair().peer;
+      // Both `GET /api` and `GET /api/` are on the federation allowlist
+      // (mStream #932), so either survives the proxy's segment join.
+      expect(peer.apiUri('/api/').toString(),
+          'https://home.example.com/api/v1/federation/peers/3/api/api/');
+    });
+
+    test('an unlinked parent yields an unroutable origin, not the peer url',
+        () {
+      final peer = _pair().peer..parentServer = null;
+      final uri = peer.apiUri('/api/v1/db/albums');
+      expect(uri.host, '127.0.0.1');
+      expect(uri.port, 0);
+    });
+
+    test('an iroh parent contributes its loopback origin and token once', () {
+      final p = _pair(
+          iroh: true, tunnelPort: 41234, tunnelToken: 'LT', parentUrl: 'iroh://abc');
+      final uri = p.peer.apiUri('/api/v1/db/albums');
+      expect(uri.host, '127.0.0.1');
+      expect(uri.port, 41234);
+      expect(uri.path,
+          '/api/v1/federation/peers/3/api/api/v1/db/albums');
+      expect(uri.queryParameters['__lt'], 'LT');
+    });
+  });
+
+  group('stream urls', () {
+    test('a peer track streams through the parent byte proxy', () {
+      final peer = _pair().peer;
+      final url = buildServerStreamUrl(peer, '/Music/Icarus/track 01.mp3');
+      expect(
+          url,
+          startsWith('https://home.example.com/api/v1/federation/peers/3'
+              '/stream/Music/Icarus/track%2001.mp3?app_uuid='));
+      expect(url, contains('&token=PARENT-JWT'));
+      // /transcode is off the federation allowlist entirely.
+      expect(url, isNot(contains('/transcode')));
+    });
+
+    test('a peer download takes the same proxy, never transcoded', () {
+      final peer = _pair().peer;
+      expect(
+          buildServerDownloadUrl(peer, '/Music/a.flac'),
+          'https://home.example.com/api/v1/federation/peers/3'
+          '/stream/Music/a.flac?token=PARENT-JWT');
+    });
+
+    test('a download from a public iroh server needs no leading ampersand', () {
+      // No token and a loopback token is the one combination that used to
+      // produce `?&__lt=…`.
+      final s = Server('iroh://abc', null, null, null, 'tunnel')
+        ..connectionType = 'iroh'
+        ..tunnelPort = 41234
+        ..tunnelToken = 'LT';
+      expect(buildServerDownloadUrl(s, '/Music/a.flac'),
+          'http://127.0.0.1:41234/media/Music/a.flac?__lt=LT');
+    });
+
+    test('a plain server is untouched by any of this', () {
+      final parent = _pair().parent;
+      final url = buildServerStreamUrl(parent, '/Music/a.mp3');
+      expect(url, startsWith('https://home.example.com/media/Music/a.mp3?'));
+      expect(url, isNot(contains('federation')));
+    });
+  });
+
+  group('album art', () {
+    test('a peer cover goes through the art proxy with compress forwarded', () {
+      final peer = _pair().peer;
+      expect(
+          buildAlbumArtUrl(peer, 'abc123.jpg', compress: 'm'),
+          'https://home.example.com/api/v1/federation/peers/3/art/abc123.jpg'
+          '?compress=m&token=PARENT-JWT');
+    });
+
+    test('the art file is escaped as ONE segment', () {
+      // The peer serves /album-art/:file — a single hash name — and the proxy
+      // joins wildcard segments, so a stray slash must not become one.
+      final peer = _pair().peer;
+      expect(buildAlbumArtUrl(peer, 'a b/c.jpg'),
+          contains('/art/a%20b%2Fc.jpg?'));
+    });
+
+    test('a plain server keeps whole-URL escaping', () {
+      final parent = _pair().parent;
+      expect(buildAlbumArtUrl(parent, 'abc123.jpg'),
+          'https://home.example.com/album-art/abc123.jpg?compress=s&token=PARENT-JWT');
+    });
+  });
+}

--- a/test/singletons/federated_nav_test.dart
+++ b/test/singletons/federated_nav_test.dart
@@ -1,0 +1,114 @@
+// The section list a federated server gets. Playlists and Rated are the two
+// nav entries whose routes are off the federation allowlist (every
+// /api/v1/playlist/* route, and db/rated), so they can only ever 403 on a
+// peer — everything else on this screen is allowlisted, and Local Files is
+// this device's own downloads either way.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/singletons/browser_list.dart';
+import 'package:mstream_music/singletons/server_list.dart';
+
+/// The `data` slug of every execAction row currently on the nav screen.
+List<String?> _sections() => BrowserManager()
+    .browserList
+    .where((i) => i.type == 'execAction')
+    .map((i) => i.data)
+    .toList();
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final manager = ServerManager();
+
+  setUp(() {
+    manager.serverList.clear();
+    manager.currentServer = null;
+  });
+
+  tearDown(() {
+    manager.serverList.clear();
+    manager.currentServer = null;
+  });
+
+  test('a plain server gets every section', () {
+    final s = Server('https://home.example.com', null, null, 'JWT', 'home');
+    manager.serverList.add(s);
+    manager.currentServer = s;
+
+    BrowserManager().goToNavScreen();
+
+    expect(_sections(), [
+      'fileExplorer',
+      'playlists',
+      'albums',
+      'artists',
+      'rated',
+      'recent',
+      'localFiles',
+    ]);
+    expect(BrowserManager().browserList.any((i) => i.type == 'note'), isFalse);
+  });
+
+  test('a federated server loses Playlists and Rated', () {
+    final parent = Server('https://home.example.com', null, null, 'JWT', 'home');
+    final peer = Server('federated://home/3', null, null, null, 'peer-basement')
+      ..federationParent = 'home'
+      ..federationPeerId = 3
+      ..federationPeerName = 'Basement'
+      ..parentServer = parent;
+    manager.serverList.addAll([parent, peer]);
+    manager.currentServer = peer;
+
+    BrowserManager().goToNavScreen();
+
+    expect(_sections(), [
+      'fileExplorer',
+      'albums',
+      'artists',
+      'recent',
+      'localFiles',
+    ]);
+  });
+
+  test('a federated server explains itself with an inert note row', () {
+    final parent = Server('https://home.example.com', null, null, 'JWT', 'home');
+    final peer = Server('federated://home/3', null, null, null, 'peer-basement')
+      ..federationParent = 'home'
+      ..federationPeerId = 3
+      ..parentServer = parent;
+    manager.serverList.addAll([parent, peer]);
+    manager.currentServer = peer;
+
+    BrowserManager().goToNavScreen();
+
+    final notes =
+        BrowserManager().browserList.where((i) => i.type == 'note').toList();
+    expect(notes, hasLength(1));
+    // First row, so the explanation precedes what it explains.
+    expect(BrowserManager().browserList.first.type, 'note');
+    // No `data` and no handler for the type: browser.dart's handleTap falls
+    // through every branch, so tapping it does nothing.
+    expect(notes.single.data, isNull);
+    expect(notes.single.subtext, isNotNull);
+  });
+
+  test('switching back to a plain server restores the full list', () {
+    final parent = Server('https://home.example.com', null, null, 'JWT', 'home');
+    final peer = Server('federated://home/3', null, null, null, 'peer-basement')
+      ..federationParent = 'home'
+      ..federationPeerId = 3
+      ..parentServer = parent;
+    manager.serverList.addAll([parent, peer]);
+
+    manager.currentServer = peer;
+    BrowserManager().goToNavScreen();
+    expect(_sections(), isNot(contains('playlists')));
+
+    manager.currentServer = parent;
+    BrowserManager().goToNavScreen();
+    expect(_sections(), contains('playlists'));
+    expect(_sections(), contains('rated'));
+    expect(BrowserManager().browserList.any((i) => i.type == 'note'), isFalse);
+  });
+}


### PR DESCRIPTION
Phases 1, 1b and 2 of the plan this PR also adds, [`FEDERATION_PLAN.md`](FEDERATION_PLAN.md). Federated servers are now addressable, browsable and selectable; Phases 3–4 (capability gates, the iroh transport split) follow separately.

Server side is merged: the stream proxy shipped in 6.24.0, and mStream #927 (browse) / #932 + #934 (layered `GET /api`) are on master. Verified each contract against merged master rather than the PR heads.

## The shape

A federated server is one **peer** of another configured server, reached through that parent's browse proxy instead of by a URL of its own. It's an ordinary entry in `serverList` — which is what makes the picker, queue restore and the `media/<localname>` download folder work without a parallel code path — but it owns no transport, credentials or peer list.

The app's request layer already funnelled through three functions, so teaching those three about federation is the whole of it:

| | rewrite |
|---|---|
| `Server.apiUri` | `parent.apiUri('<prefix>/api<location>')` |
| `buildServerStreamUrl` | `<prefix>/stream/…` |
| `buildAlbumArtUrl` | `<prefix>/art/<one segment>` |

Delegating `effectiveBaseUrl` to the parent means **an iroh parent works with no federation-specific code**: the request rides the parent's loopback tunnel and `__lt` is applied once, to the outer URL. The proxy forwards no query params, so it can't ride through to the peer.

Credentials needed their own accessor. A federated server has no JWT, so `Server.authToken` returns the parent's and the 27 consumption sites move onto it; `jwt` stays the stored field.

## Phase 1b: capability refresh moves to `GET /api`

`getServerPaths` now issues one `GET /api` for version, server-wide `features` and the caller-scoped `user` block. That's also the **only** capability route a peer answers — ping 403s a federation key — so the federated and normal paths are now the same code rather than siblings.

Pre-#932 servers answer the same route with the old flat shape and fall back to ping. They're detected by the absence of `user`, **not** the absence of `features` — the old response carried a `features` key too (`{subsonic}`). Playlists left that payload deliberately in #932 (a resource, not a capability) and come from `/api/v1/playlist/getall`.

## The trap this design has to avoid

`_applyFederatedDefaults` pins transcode and the four discovery flags false *after* parsing whatever the peer said about itself. A peer's answer describes what **it** can do; the federation allowlist decides what we can reach through the proxy, and it's the narrower of the two. `/transcode` and every `/api/v1/discovery/*` route are off it, so a peer reporting working ffmpeg would otherwise light up UI whose requests can only 403.

## Peer lifecycle

`refreshFederatedPeers` mirrors the parent's list rather than owning it — peers are the parent admin's data. New ones appear, renames follow, and a peer that stops being listed is **flagged, not deleted**: a queued track and a downloaded file both point at its localname, so deleting the record would strand them. Removing a parent cascades to its peers; renaming one re-points them first.

Peer records persist a minimal stub because `QueueStore` resolves tracks by localname at launch, before any network call. A peer's localname is its **own** (`peer-<slug>`), never derived from the parent's — the parent's is user-editable, and deriving would force a download-folder migration for every child on a rename.

## Phase 2: the picker and the nav screen

Peers already appeared in the picker once the reconcile added them, since the menu maps over `serverList`. What they needed was to *read* as peers rather than as servers with a broken URL — indented under the server they're reached through, with a hub icon and a "via &lt;parent&gt;" line. Rows render `Server.displayName` (a peer's reported name; the URL for everything else), and the app-bar subtitle follows.

A peer whose parent has stopped listing it is skipped in the menu and excluded from the "&gt;1 server" visibility test. The menu value stays the index into the **full** list, which is what `changeCurrentServer` takes.

On the nav screen, **Playlists** and **Rated** are dropped for a peer — every `/api/v1/playlist/*` route and `db/rated` are off the allowlist, so they could only 403 — and a leading note row says why. The note is an ordinary `DisplayItem` of a new `'note'` type: `handleTap` has no branch for it and no fallback, so it's inert, and with a subtext it lands on the existing 74px `_rowExtent` without touching the list's extent math.

## Fixed in passing

All three surfaced by making these paths federation-aware:

- **`browser_toolbar` hand-assembled a `/media` download URL** instead of using the builder. On a *public iroh* server that produced `?&__lt=…`, since the loopback suffix assumes a token precedes it. Replaced with a new `buildServerDownloadUrl` (original bytes, never transcoded), pinned by a test.
- **Federated servers bypass `addServer`**, so nothing created their download folder. Extracted `_ensureDownloadDir` and called it from both doors.
- **`removeServer`'s active-server fallback keyed on identity** with the removed server, so an active server swept out as a peer of its parent left `currentServer` dangling. Now keys on list membership.

## What's left, and one finding

Phase 4 turned out bigger than the plan first had it, and the PR updates the plan to say so. A federated server has `connectionType == 'http'`, so **`isIroh` is false for it even when its parent is iroh** — and roughly 12 of the 29 `isIroh` call sites are really asking "do this server's bytes travel over a loopback tunnel?" (`cast_origin`, five in `audio_stuff`, `downloads`' stale-port rotation, art rebinding in `queue_store`/`playlist`, `makeServerCall`'s retry). Peers of an iroh parent break at every one.

It's now scoped as a `transportServer` / `isIrohTransport` split with a per-site audit, and marked **blocking release for iroh users** rather than cleanup. Blast radius is bounded — with a plain HTTP parent every one of those sites answers correctly today — but the failure mode is nasty, since browsing works while playback and casting break in ways that don't point at federation.

## Testing

23 new tests: `test/objects/federated_server_test.dart` (identity, JSON round-trip including a pre-federation server file, credential delegation, the three URL rewrites, iroh-parent composition, the `?&__lt=` regression) and `test/singletons/federated_nav_test.dart` (section gating both ways, the inert note row). Full suite **340 green**; analyzer at its 17-issue pre-existing baseline.

Not yet exercised against a live two-server rig — the peer reconcile and the `/api`-through-proxy call want an on-device pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
