### PR TITLE
fix(autodj): clearing the queue starts a new lane

### DIFF
--- a/integration_test/auto_dj_clear_queue_test.dart
+++ b/integration_test/auto_dj_clear_queue_test.dart
@@ -1,0 +1,172 @@
+// Auto DJ across a queue clear.
+//
+// The bug this pins: clearing the queue used to leave the whole DJ session
+// standing — the round-tripped ignoreList, the sonic history/locked pin, the
+// Camelot anchor, and any in-flight random-songs request, whose response
+// would repopulate the queue the user just emptied. The next picks were then
+// anchored on the dead session instead of whatever the user queued next.
+//
+// Contract under test (AudioPlayerHandler._resetAutoDJSession +
+// _doClearPlaylist):
+//   1. A clear keeps the DJ ARMED but adds nothing itself — no start menu,
+//      no surprise pick.
+//   2. A pick in flight when the clear lands is discarded (epoch check), so
+//      the emptied queue stays empty.
+//   3. The next session starts clean: the first request after the clear
+//      carries an EMPTY ignoreList (the dead session's cooldown is gone).
+//   4. The one-shot sonic seed is consumed by the clear.
+//
+// Drives the real AudioPlayerHandler against an in-process MockServer whose
+// random-songs route records request bodies and can hold a response to
+// stage the in-flight race deterministically.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/singletons/auto_dj_manager.dart';
+import 'package:mstream_music/singletons/media.dart';
+
+import 'helpers/test_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  MockServer? mockServer;
+
+  // Every random-songs body the app sent, oldest first.
+  final djBodies = <Map<String, dynamic>>[];
+  // When set, the route holds its response this long — the window in which
+  // the test fires the clear to stage the race.
+  var djDelay = Duration.zero;
+  var nextPickId = 0;
+
+  Future<Object?> randomSongs(HttpRequest req) async {
+    final body =
+        jsonDecode(await utf8.decoder.bind(req).join()) as Map<String, dynamic>;
+    djBodies.add(body);
+    if (djDelay > Duration.zero) await Future<void>.delayed(djDelay);
+    final id = nextPickId++;
+    // Echo the server contract: the sent list plus this pick's id.
+    final ignore = List<int>.from(
+        (body['ignoreList'] as List?)?.cast<int>() ?? const <int>[])
+      ..add(id);
+    return {
+      'songs': [
+        {
+          'filepath': 'demo/track_$id.mp3',
+          'metadata': {'title': 'Track $id', 'artist': 'DJ Pick'},
+        }
+      ],
+      'ignoreList': ignore,
+    };
+  }
+
+  Future<void> waitFor(bool Function() cond, String what,
+      {Duration timeout = const Duration(seconds: 10)}) async {
+    final deadline = DateTime.now().add(timeout);
+    while (!cond()) {
+      if (DateTime.now().isAfter(deadline)) fail('timed out waiting for $what');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+  }
+
+  setUpAll(() async {
+    await MediaManager().start();
+  });
+
+  setUp(() async {
+    await resetAppState();
+    // A failed earlier run can leave a seed behind (the test consumes it
+    // mid-flow); a leftover would reroute the arm phase through the seeded
+    // start. In-memory only — no save needed for a test baseline.
+    AutoDJManager()
+      ..sonicSeedPath = null
+      ..sonicSeedTitle = null
+      ..sonicSeedServer = null;
+    djBodies.clear();
+    djDelay = Duration.zero;
+    nextPickId = 0;
+    mockServer = await MockServer.start(
+      {'/api/v1/db/random-songs': randomSongs},
+      // Everything else is a stream URL — serve playable audio so play()
+      // on a pick doesn't spiral into the error-recovery paths.
+      defaultHandler: (_) => buildSilentWav(),
+    );
+  });
+
+  tearDown(() async {
+    final handler = MediaManager().audioHandler;
+    // Disarm + clear so the shared singleton handler carries nothing into
+    // the next test (both are new-lane resets themselves).
+    await handler.customAction('setAutoDJ', {'autoDJServer': null});
+    await handler.customAction('clearPlaylist');
+    await mockServer?.close();
+    mockServer = null;
+  });
+
+  testWidgets('clearing the queue starts a new Auto-DJ lane',
+      (WidgetTester tester) async {
+    final handler = MediaManager().audioHandler;
+    final srv = Server(mockServer!.url, null, null, null, 'it-dj-server');
+
+    // ── Arm on an empty queue: the DJ opens the session itself. ──
+    await handler.customAction('setAutoDJ', {'autoDJServer': srv});
+    await waitFor(() => handler.queue.value.length >= 2, 'the DJ to open');
+
+    // The session accumulated state: a later request carried an earlier
+    // pick in its cooldown.
+    await waitFor(
+        () => djBodies.any((b) => ((b['ignoreList'] as List?) ?? []).isNotEmpty),
+        'a request carrying the session ignoreList');
+
+    // A pending one-shot seed, as the empty-queue start flow would leave
+    // one moments before arming.
+    await AutoDJManager().setSonicSeed(
+        path: 'demo/seed.mp3', title: 'Seed', server: 'it-dj-server');
+
+    // ── Stage the race: a pick leaves, the clear lands first. ──
+    final sentBefore = djBodies.length;
+    djDelay = const Duration(milliseconds: 800);
+    final inFlight = handler.autoDJ();
+    await waitFor(() => djBodies.length > sentBefore,
+        'the in-flight request to reach the mock');
+
+    await handler.customAction('clearPlaylist');
+
+    expect(handler.queue.value, isEmpty);
+    expect((handler.customState.valueOrNull as dynamic)?.autoDJState, same(srv),
+        reason: 'the clear must leave the DJ armed');
+    expect(AutoDJManager().sonicSeedPath, isNull,
+        reason: 'the clear consumes the one-shot seed');
+
+    // The held response lands AFTER the clear — and must be discarded.
+    await inFlight;
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    expect(handler.queue.value, isEmpty,
+        reason: 'an in-flight pick must not repopulate a cleared queue');
+
+    // ── The user queues something: the DJ resumes from a clean slate. ──
+    djBodies.clear();
+    djDelay = Duration.zero;
+    await handler.addQueueItem(MediaItem(
+      id: '${mockServer!.url}/media/demo/user_pick.mp3',
+      title: 'User pick',
+      extras: {'server': 'it-dj-server', 'path': 'demo/user_pick.mp3'},
+    ));
+    await handler.play();
+
+    await waitFor(() => djBodies.isNotEmpty, 'the post-clear top-up');
+    expect(djBodies.first['ignoreList'], isEmpty,
+        reason: 'the reset must drop the dead session\'s cooldown — a stale '
+            'list here is the original bug');
+    await waitFor(() => handler.queue.value.length >= 2,
+        'the DJ topping up behind the user\'s track');
+    expect(handler.queue.value.first.title, 'User pick',
+        reason: 'the user\'s track leads the new lane; DJ picks follow it');
+  });
+}

--- a/integration_test/helpers/test_helpers.dart
+++ b/integration_test/helpers/test_helpers.dart
@@ -16,7 +16,9 @@
 // test to serve audio bytes for /media/*).
 //
 // Handler return values: null → 404; List<int> → returned as
-// audio/wav bytes (used for media); anything else → JSON-encoded.
+// audio/wav bytes (used for media); anything else → JSON-encoded. A
+// Future of any of these is awaited first, so a handler can read the
+// request body or hold its response to stage a race.
 //
 // seedServer writes a single-server servers.json so MStreamApp's
 // initState loads it on startup, skipping the welcome screen.
@@ -87,7 +89,12 @@ class MockServer {
         return;
       }
 
-      final body = handler(req);
+      // A handler may be async — to read the request body, or to delay its
+      // response so a test can race it against another action (the Auto-DJ
+      // clear test does both). A returned Future is resolved before the
+      // type dispatch below, so sync handlers behave exactly as before.
+      var body = handler(req);
+      if (body is Future) body = await body;
       if (body == null) {
         req.response.statusCode = 404;
       } else if (body is List<int>) {

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -107,7 +107,7 @@ class AudioPlayerHandler extends BaseAudioHandler
   // Session-only: rolling sonic anchor — the last few DJ-picked filepaths,
   // sent as random-songs' `similarTo` seeds so the server centroids the
   // session's own recent sound (webapp auto-dj.js parity). Reset alongside
-  // the ignoreList on setAutoDJ off / server switch.
+  // the ignoreList on every new-lane event (see _resetAutoDJSession).
   List<String> _sonicHistory = const [];
   // Session-only: the pinned anchor for LOCKED sonic mode ("stay on seed") —
   // lazily locked on the session's first pick (explicit seed, else the
@@ -124,8 +124,43 @@ class AudioPlayerHandler extends BaseAudioHandler
   // the first DJ-picked song with a recognised key (after that, every
   // subsequent pick uses the anchor's 6 Camelot neighbours, keeping
   // the session musically coherent rather than drifting). Reset on
-  // setAutoDJ off or server switch.
+  // every new-lane event (see _resetAutoDJSession).
   String? _camelotAnchor;
+
+  // Bumped by _resetAutoDJSession; autoDJ() captures it per call and drops a
+  // response that comes back under a different value. A request is nearly
+  // always in flight during a session (every advance onto the last row fires
+  // the top-up), so without this a queue clear gets repopulated by the
+  // landing pick — which also overwrites the just-reset ignoreList and
+  // pushes a dead-session track into the fresh sonic history, quietly
+  // undoing the reset it raced. The same check is what keeps a late pick
+  // from dereferencing autoDJServer after the DJ was switched off.
+  int _djSessionEpoch = 0;
+
+  /// Start a new Auto-DJ "lane": forget everything the session learned from
+  /// the queue it was working, and invalidate any in-flight pick.
+  ///
+  /// Webapp parity — resetAnchors() there wipes the same set whenever a
+  /// manual (non-DJ) pick becomes current while the DJ is on. The mobile
+  /// equivalents of "the user steered somewhere new" all funnel through
+  /// here: setAutoDJ off / on / server switch, a queue clear (which
+  /// playFromHere also routes through), and a server removal that empties
+  /// the queue. The next pick then anchors on whatever the user plays, not
+  /// on the dead session.
+  ///
+  /// The stored sonic seed is deliberately NOT cleared here: setAutoDJ
+  /// resets BEFORE _startAutoDJFromSeed reads the seed, so clearing it in
+  /// this helper would break every seeded start. The clear path consumes it
+  /// separately (see _doClearPlaylist).
+  void _resetAutoDJSession() {
+    _djSessionEpoch++;
+    jsonAutoDJIgnoreList = null;
+    _camelotAnchor = null;
+    _sonicHistory = const [];
+    _sonicLockedAnchor = null;
+    _autoDJAuthWarned = false; // fresh lane, fresh warning budget
+    _sonicWarned = false;
+  }
 
   // The repeat mode requested by the UI / Android Auto, and the source of truth
   // for the published PlaybackState: it preserves all of none/all/one (and
@@ -1912,6 +1947,10 @@ class AudioPlayerHandler extends BaseAudioHandler
       // Forget it too, or the next launch would try to restore a server that
       // no longer exists.
       unawaited(AutoDJManager().setEnabledServer(null));
+      // Drop the session state and any in-flight pick with it — a response
+      // landing after this would re-plant the dead session's anchors and
+      // null-deref autoDJServer trying to queue the track.
+      _resetAutoDJSession();
       customState.add(CustomEvent(autoDJServer));
     }
     final q = queue.value;
@@ -1924,7 +1963,12 @@ class AudioPlayerHandler extends BaseAudioHandler
     _restoreSpot = null; // row indices shift — a parked index would lie
     if (plan.keep.isEmpty) {
       // The whole queue belonged to it: same teardown as clearPlaylist,
-      // including dropping the now-playing metadata.
+      // including dropping the now-playing metadata and starting a new
+      // Auto-DJ lane — the DJ can be armed on a DIFFERENT server than the
+      // deleted one, and its session state described a queue that no
+      // longer exists.
+      _resetAutoDJSession();
+      unawaited(AutoDJManager().clearSonicSeed());
       _intentionalStop = true;
       await _backend.stop();
       await super.stop();
@@ -1960,6 +2004,21 @@ class AudioPlayerHandler extends BaseAudioHandler
 
   Future<void> _doClearPlaylist() async {
     appLog('[queue] cleared');
+    // A cleared queue is a new Auto-DJ lane — the user threw the old one
+    // away. The DJ stays ARMED and adds nothing here (no start menu, no
+    // surprise pick): it resumes from a clean slate when the user queues
+    // something, via the queue-end listener. Reset FIRST, synchronously —
+    // an in-flight pick can land during the awaits below, and it must
+    // already see the new epoch to be discarded.
+    _resetAutoDJSession();
+    // The one-shot sonic seed is spent with the lane (webapp resetAnchors
+    // "the seed is consumed" semantics). This is also what ends a seeded
+    // start's use of it: _startAutoDJFromSeed reads the path into a local
+    // before its own clearPlaylist lands here, so the opener still plays —
+    // but the stored value never outlives the session it opened. A stale
+    // one used to hijack any later empty-queue setAutoDJ (Android Auto's
+    // Shuffle All replayed the last seed song instead of shuffling).
+    unawaited(AutoDJManager().clearSonicSeed());
     _restoreSpot = null; // the queue the spot described is gone
     _intentionalStop = true;
     await _backend.stop();
@@ -2075,14 +2134,7 @@ class AudioPlayerHandler extends BaseAudioHandler
         // change resets the session state — and only a real change is allowed
         // to take the queue, below.
         final freshSession = autoDJServer == null || autoDJServer != nextDJ;
-        if (freshSession) {
-          jsonAutoDJIgnoreList = null;
-          _camelotAnchor = null;
-          _autoDJAuthWarned = false; // fresh server, fresh warning budget
-          _sonicHistory = const []; // fresh server, fresh sonic session
-          _sonicLockedAnchor = null;
-          _sonicWarned = false;
-        }
+        if (freshSession) _resetAutoDJSession();
         autoDJServer = nextDJ;
         // Remembered across restarts. Every toggle path funnels through here,
         // so this is the one place that has to record it.
@@ -2516,7 +2568,11 @@ class AudioPlayerHandler extends BaseAudioHandler
         null));
     if (seed == null) return false;
     // Same order as playFromHere — the one flow in the app that replaces a
-    // queue and starts it.
+    // queue and starts it. The clear also CONSUMES the stored seed (it is a
+    // one-shot opener; see _doClearPlaylist) — [path] and [seed] are already
+    // in hand above, and the follow-up picks anchor the same either way: with
+    // the seed gone and the history fresh, sonicParams falls back to the
+    // playing track, which IS the seed song.
     await customAction('clearPlaylist');
     await addQueueItem(seed);
     await skipToQueueItem(0);
@@ -2533,6 +2589,8 @@ class AudioPlayerHandler extends BaseAudioHandler
   Future<void> autoDJ(
       {bool autoPlay = false, bool incrementIndex = false}) async {
     if (autoDJServer == null) return;
+    // The lane this call belongs to — checked when each response lands.
+    final epoch = _djSessionEpoch;
 
     final mgr = AutoDJManager();
     Map<String, dynamic>? lastDecoded;
@@ -2808,6 +2866,13 @@ class AudioPlayerHandler extends BaseAudioHandler
         appLog('[dj] random-songs failed: $e');
         return;
       }
+
+      // The lane changed while the request was out — the queue was cleared,
+      // or the DJ was switched off / to another server. Drop the pick:
+      // landing it would smuggle a dead-session track into the fresh queue,
+      // overwrite the just-reset ignoreList with the old session's, and push
+      // the pick into the new lane's sonic history.
+      if (epoch != _djSessionEpoch) return;
 
       jsonAutoDJIgnoreList = decoded['ignoreList'];
       final songs = decoded['songs'] as List?;

--- a/lib/singletons/auto_dj_manager.dart
+++ b/lib/singletons/auto_dj_manager.dart
@@ -152,9 +152,14 @@ class AutoDJManager {
   // sonicSeed parity). It wins over the playing track for a session's
   // first pick; the rolling history takes over after that. Tied to the
   // server it was picked from ([sonicSeedServer], a Server.localname) —
-  // audio_stuff only sends it when the DJ runs on that server. Setting or
-  // clearing it is a "new lane": the screen also asks the audio handler to
-  // clear its rolling history (customAction 'clearSonicSession').
+  // audio_stuff only sends it when the DJ runs on that server.
+  //
+  // ONE-SHOT, like the webapp's (resetAnchors consumes it there): set by the
+  // empty-queue start flow moments before the DJ is armed, and consumed by
+  // the seeded start's own queue clear (_doClearPlaylist), so it never
+  // outlives the session it opened. It used to persist forever, which made
+  // any later empty-queue setAutoDJ — Android Auto's Shuffle All — silently
+  // replay the last seed song instead of starting fresh.
   String? sonicSeedPath; // vpath-form, no leading slash
   String? sonicSeedTitle; // display only
   String? sonicSeedServer;
@@ -496,6 +501,15 @@ class AutoDJManager {
   }
 
   Future<void> clearSonicSeed() async {
+    // No-op when nothing is stored: the seed is one-shot and this runs on
+    // every queue clear (see AudioPlayerHandler._doClearPlaylist), so an
+    // unconditional body would rewrite auto_dj.json and rebuild the Auto DJ
+    // screen on each clear for nothing.
+    if (sonicSeedPath == null &&
+        sonicSeedTitle == null &&
+        sonicSeedServer == null) {
+      return;
+    }
     sonicSeedPath = null;
     sonicSeedTitle = null;
     sonicSeedServer = null;

--- a/test/singletons/auto_dj_seed_test.dart
+++ b/test/singletons/auto_dj_seed_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/singletons/auto_dj_manager.dart';
+
+// The sonic seed is ONE-SHOT: the empty-queue start flow sets it moments
+// before arming, and the seeded start's own queue clear consumes it (see
+// AudioPlayerHandler._doClearPlaylist). Because that consume now runs on
+// EVERY clear, clearSonicSeed must be a true no-op when nothing is stored —
+// otherwise each clear would rewrite auto_dj.json and rebuild the Auto DJ
+// screen for nothing.
+//
+// These are plain VM tests, so the persistence path (path_provider) is
+// unavailable and would throw. That is exactly what makes the no-op
+// assertion meaningful: completing normally proves the guard returned
+// before touching the filesystem. The clearing branch (fields set → nulled
+// + one change tick + save) goes through the platform channel and is
+// covered by the simulator smoke pass instead.
+void main() {
+  final mgr = AutoDJManager();
+
+  setUp(() {
+    mgr.sonicSeedPath = null;
+    mgr.sonicSeedTitle = null;
+    mgr.sonicSeedServer = null;
+  });
+
+  test('clearSonicSeed with nothing stored never reaches the save', () async {
+    await expectLater(mgr.clearSonicSeed(), completes);
+  });
+
+  test('clearSonicSeed no-op emits no change tick', () async {
+    var ticks = 0;
+    final sub = mgr.changeStream.skip(1).listen((_) => ticks++);
+    await mgr.clearSonicSeed();
+    await Future<void>.delayed(Duration.zero);
+    expect(ticks, 0,
+        reason: 'a no-op clear must not rebuild the Auto DJ screen');
+    await sub.cancel();
+  });
+
+  test('clearing a stored seed nulls every field before persisting', () async {
+    mgr.sonicSeedPath = 'music/x.mp3';
+    mgr.sonicSeedTitle = 'X';
+    mgr.sonicSeedServer = 'srv';
+    // The trailing _save() needs path_provider and fails in a VM test; the
+    // in-memory clear happens before it, which is the contract the queue
+    // clear depends on (autoDJ() reads these fields synchronously).
+    await mgr.clearSonicSeed().catchError((_) {});
+    expect(mgr.sonicSeedPath, isNull);
+    expect(mgr.sonicSeedTitle, isNull);
+    expect(mgr.sonicSeedServer, isNull);
+  });
+
+  test('a partially stored seed (any field set) still gets cleaned up', () async {
+    // The guard keys on all three fields so a torn state is not mistaken for
+    // "nothing stored".
+    mgr.sonicSeedServer = 'some-server';
+    await mgr.clearSonicSeed().catchError((_) {});
+    expect(mgr.sonicSeedServer, isNull);
+  });
+}


### PR DESCRIPTION
## Problem

With Auto DJ armed, clearing the queue left the entire DJ session standing, so the DJ kept working the queue the user had just thrown away:

- `jsonAutoDJIgnoreList`, the rolling sonic history, the locked sonic pin, and the Camelot anchor all survived the clear. In rolling mode `similarTo` is built from the history **alone** whenever it is non-empty, so after a clear the freshly added track had zero influence on the next ~5 picks — they stayed centroided on the dead session's sound. Locked mode never recovered at all, and harmonic mixing stayed pinned to the old key.
- There is nearly always a `random-songs` request in flight during a session (every advance onto the last row fires the top-up). A clear during one got repopulated by the landing pick — the ghost track also overwrote the ignoreList and re-seeded the sonic history with a dead-session pick.
- The webapp resets all of this whenever a manually picked song becomes current (`resetAnchors()`, "manual pick = new lane"); that reset was never ported to mobile.

## Fix

- New `_resetAutoDJSession()` wipes the session state (ignoreList, Camelot anchor, sonic history + locked pin, warn budgets) and bumps a session **epoch**. It runs on every new-lane event: queue clear (which `playFromHere` also routes through, restoring the webapp's manual-pick semantics), `setAutoDJ` off/on/switch, and both server-removal branches.
- `autoDJ()` captures the epoch per call and discards a response that lands under a changed epoch, so an in-flight pick can no longer repopulate a cleared queue or pollute the fresh lane. This also fixes a latent null-deref: a pick landing after its DJ server was deleted used to dereference the now-null `autoDJServer`.
- The DJ **stays armed** across a clear and adds nothing on its own — no start menu, no surprise pick. It resumes from the clean slate when the user queues something, via the existing queue-end listener. The empty-queue start menu remains tied to stop/restart.
- Adjacent fix: the stored sonic seed is now **one-shot** (webapp parity — `resetAnchors` consumes it there). The clear consumes it; the seeded start reads it into locals before its own internal clear, so opening from a seed still works, but a stale seed can no longer hijack a later empty-queue `setAutoDJ` — which is exactly what made Android Auto's Shuffle All replay the last seed song instead of shuffling. `clearSonicSeed()` no-ops when nothing is stored so routine clears don't rewrite `auto_dj.json`.

## Verification

- `flutter analyze` clean; all 321 unit tests pass (4 new in `test/singletons/auto_dj_seed_test.dart` pinning the seed no-op guard).
- New `integration_test/auto_dj_clear_queue_test.dart` drives the **real `AudioPlayerHandler`** on an iOS simulator against an in-process mock whose `random-songs` route records request bodies and can hold a response to stage the race deterministically. It pins all four contracts: the pick in flight during the clear is discarded (the queue stays empty), the DJ stays armed, the seed is consumed, and the first post-clear request carries an empty `ignoreList` behind the user's track. `test_helpers.dart` now awaits async mock handlers to support this.

## Note for reviewers

The same-lane multi-fire (several picks landing per trigger) is **not** addressed here — that is audit finding #16's in-flight guard on the unmerged `claude/audit-batch3-playback` branch. Both changes touch `autoDJ()`, so whichever lands second needs a small conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)