### PR TITLE
fix(quick-connect): sign in on a pushed page, not under the fold

### DIFF
--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -24,6 +24,7 @@ import '../singletons/browser_list.dart';
 import '../singletons/migration_manager.dart';
 import '../singletons/downloads.dart';
 import '../theme/velvet_theme.dart';
+import 'iroh_login_screen.dart';
 
 class AddServerScreen extends StatelessWidget {
   const AddServerScreen({super.key});
@@ -1382,6 +1383,14 @@ class MyCustomFormState extends State<MyCustomForm> {
         // the one-iroh cap backstop in _saveIrohServer clears state otherwise).
         showGlobalSnack(l.connectionSuccessful);
         await _saveIrohServer(code: code, port: port, jwt: '');
+      } else {
+        // Private server: go straight to the sign-in PAGE. The old inline
+        // reveal put the credential fields at the bottom of this (long,
+        // scrollable) tab — under the fold on most phones, so the test
+        // reported success and nothing visibly happened next. A pushed page
+        // can't be missed; backing out of it lands here with the tunnel
+        // still up and the Sign in & save button as the way back in.
+        await _openIrohSignIn();
       }
     } on IrohTunnelException catch (e) {
       IrohTunnel.instance.stop();
@@ -1402,6 +1411,45 @@ class MyCustomFormState extends State<MyCustomForm> {
       _irohTestSuccess = success;
       _irohTestResult = message;
     });
+  }
+
+  // Collect credentials on the dedicated sign-in page (validated there,
+  // through the live tunnel, so a wrong password is retryable in place), then
+  // run the unchanged sign-in-and-save. The extra login POST inside
+  // _signInAndSaveIroh re-uses the just-validated credentials, so it is one
+  // cheap request in exchange for keeping every save/error path identical.
+  Future<void> _openIrohSignIn() async {
+    final l = AppLocalizations.of(context);
+    final port = _irohPort;
+    if (port == null) return;
+    final lt = IrohTunnel.instance.localToken ?? '';
+    final creds = await Navigator.of(context).push<(String, String)>(
+      MaterialPageRoute(
+        builder: (_) => IrohLoginScreen(
+          title: l.irohSignInHeader,
+          validate: (username, password) async {
+            try {
+              final login = await http.post(
+                Uri.parse('http://127.0.0.1:$port/api/v1/auth/login?__lt=$lt'),
+                body: {'username': username, 'password': password},
+              ).timeout(Duration(seconds: 8));
+              if (login.statusCode != 200) {
+                return l.irohSignInFailedHttp(login.statusCode);
+              }
+              return null;
+            } on TimeoutException {
+              return l.irohSignInTimeout;
+            } catch (e) {
+              return l.irohSignInFailed('$e');
+            }
+          },
+        ),
+      ),
+    );
+    if (creds == null || !mounted) return; // backed out — tunnel stays up
+    _irohUserCtrl.text = creds.$1;
+    _irohPassCtrl.text = creds.$2;
+    await _signInAndSaveIroh();
   }
 
   // Authenticate THROUGH the live tunnel (mirrors the standard login), then save
@@ -1559,7 +1607,7 @@ class MyCustomFormState extends State<MyCustomForm> {
 
       String jwt = '';
       if (!isPublic) {
-        creds = await _promptDiscoveredLogin(server);
+        creds = await _promptDiscoveredLogin(server, baseUri);
         if (creds == null) {
           if (mounted) setState(() => _connectingId = null);
           return; // user cancelled
@@ -1632,14 +1680,39 @@ class MyCustomFormState extends State<MyCustomForm> {
     }
   }
 
-  // Modal sheet collecting credentials for a discovered private server.
-  // Returns (username, password), or null if cancelled.
-  Future<(String, String)?> _promptDiscoveredLogin(DiscoveredServer server) {
-    return showModalBottomSheet<(String, String)>(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: VelvetColors.surface,
-      builder: (ctx) => _LanLoginSheet(serverName: server.name),
+  // Full-screen sign-in for a discovered private server; returns
+  // (username, password) validated against [baseUri], or null if cancelled.
+  // Used to be a modal bottom sheet — easy to lose behind the keyboard and,
+  // per user feedback, missed outright on most phones. The page validates
+  // the login itself, so a typo'd password retries in place instead of
+  // bouncing back to the server list; the caller's own login POST then runs
+  // against known-good credentials (kept as a backstop rather than plumbing
+  // the token out of the page).
+  Future<(String, String)?> _promptDiscoveredLogin(
+      DiscoveredServer server, Uri baseUri) {
+    final l = AppLocalizations.of(context);
+    return Navigator.of(context).push<(String, String)>(
+      MaterialPageRoute(
+        builder: (_) => IrohLoginScreen(
+          title: l.lanLoginTitle(server.name),
+          validate: (username, password) async {
+            try {
+              final login = await http.post(
+                baseUri.resolve('/api/v1/auth/login'),
+                body: {'username': username, 'password': password},
+              ).timeout(Duration(seconds: 8));
+              if (login.statusCode != 200) {
+                return l.irohSignInFailedHttp(login.statusCode);
+              }
+              return null;
+            } on TimeoutException {
+              return l.irohSignInTimeout;
+            } catch (e) {
+              return l.irohSignInFailed('$e');
+            }
+          },
+        ),
+      ),
     );
   }
 
@@ -1906,41 +1979,12 @@ class MyCustomFormState extends State<MyCustomForm> {
               _statusBanner(_irohTestResult!, _irohTestSuccess ?? false),
             ],
             if (_irohSignedInReady) ...[
-              SizedBox(height: 20),
-              Divider(color: VelvetColors.border2),
-              SizedBox(height: 12),
-              Text(l.irohSignInHeader,
-                  style: TextStyle(
-                      color: VelvetColors.textPrimary,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w700)),
-              SizedBox(height: 12),
-              // No public-server toggle: the test already determined this server
-              // needs auth (a public one would have skipped straight to saved).
-              TextField(
-                controller: _irohUserCtrl,
-                enabled: !_irohSaving,
-                autocorrect: false,
-                keyboardType: TextInputType.emailAddress,
-                style: TextStyle(color: VelvetColors.textPrimary),
-                decoration: InputDecoration(
-                  labelText: l.fieldUsername,
-                  prefixIcon: Icon(Icons.person_outline),
-                ),
-              ),
-              SizedBox(height: 12),
-              TextField(
-                controller: _irohPassCtrl,
-                enabled: !_irohSaving,
-                obscureText: true,
-                autocorrect: false,
-                enableSuggestions: false,
-                style: TextStyle(color: VelvetColors.textPrimary),
-                decoration: InputDecoration(
-                  labelText: l.fieldPassword,
-                  prefixIcon: Icon(Icons.lock_outline),
-                ),
-              ),
+              // The credentials themselves are collected on the pushed
+              // sign-in PAGE (see _openIrohSignIn — the inline fields that
+              // used to live here sat under the fold and were missed). The
+              // page opens automatically when the test finds a private
+              // server; this button is the way back in after backing out of
+              // it — the tunnel is still up.
               SizedBox(height: 16),
               ElevatedButton.icon(
                 style: ElevatedButton.styleFrom(
@@ -1964,7 +2008,7 @@ class MyCustomFormState extends State<MyCustomForm> {
                       )
                     : Icon(Icons.login),
                 label: Text(_irohSaving ? l.irohSigningIn : l.irohSignInSave),
-                onPressed: _irohSaving ? null : _signInAndSaveIroh,
+                onPressed: _irohSaving ? null : _openIrohSignIn,
               ),
             ],
           ],
@@ -2293,94 +2337,10 @@ class MyCustomFormState extends State<MyCustomForm> {
 // The QR scanner page moved to lib/widgets/iroh_scanner.dart (IrohScannerPage),
 // shared with the re-pair sheet.
 
-// Login sheet for a discovered private server; pops with (username, password).
-// A StatefulWidget so the TextEditingControllers live until the route is fully
-// gone: disposing them in whenComplete() runs when the pop STARTS, but the
-// closing sheet keeps rebuilding through its exit animation (the collapsing
-// keyboard changes viewInsets), and a TextField building with a disposed
-// controller throws — a full-screen error page over the still-running flow.
-class _LanLoginSheet extends StatefulWidget {
-  final String serverName;
-
-  const _LanLoginSheet({required this.serverName});
-
-  @override
-  State<_LanLoginSheet> createState() => _LanLoginSheetState();
-}
-
-class _LanLoginSheetState extends State<_LanLoginSheet> {
-  final _userCtrl = TextEditingController();
-  final _passCtrl = TextEditingController();
-
-  @override
-  void dispose() {
-    _userCtrl.dispose();
-    _passCtrl.dispose();
-    super.dispose();
-  }
-
-  void _submit() =>
-      Navigator.of(context).pop((_userCtrl.text, _passCtrl.text));
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    return Padding(
-      padding: EdgeInsets.fromLTRB(
-          20, 16, 20, MediaQuery.of(context).viewInsets.bottom + 20),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Text(l.lanLoginTitle(widget.serverName),
-              style: TextStyle(
-                  color: VelvetColors.textPrimary,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w700)),
-          SizedBox(height: 16),
-          TextField(
-            controller: _userCtrl,
-            autofocus: true,
-            autocorrect: false,
-            keyboardType: TextInputType.emailAddress,
-            style: TextStyle(color: VelvetColors.textPrimary),
-            decoration: InputDecoration(
-              labelText: l.fieldUsername,
-              prefixIcon: Icon(Icons.person_outline),
-            ),
-          ),
-          SizedBox(height: 12),
-          TextField(
-            controller: _passCtrl,
-            obscureText: true,
-            autocorrect: false,
-            enableSuggestions: false,
-            onSubmitted: (_) => _submit(),
-            style: TextStyle(color: VelvetColors.textPrimary),
-            decoration: InputDecoration(
-              labelText: l.fieldPassword,
-              prefixIcon: Icon(Icons.lock_outline),
-            ),
-          ),
-          SizedBox(height: 16),
-          ElevatedButton.icon(
-            style: ElevatedButton.styleFrom(
-              backgroundColor: VelvetColors.primary,
-              padding: EdgeInsets.symmetric(vertical: 14),
-            ),
-            icon: Icon(Icons.login),
-            label: Text(l.irohSignInSave),
-            onPressed: _submit,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
 // "New folder" prompt for the download-folder browser; pops with the trimmed
-// name. Stateful for the same reason as _LanLoginSheet: the controller must
-// outlive the dialog's exit animation.
+// name. Stateful because the controller must outlive the dialog's exit
+// animation (disposing in whenComplete() runs when the pop STARTS, and a
+// TextField building with a disposed controller throws).
 class _NewFolderDialog extends StatefulWidget {
   const _NewFolderDialog();
 

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -1508,6 +1508,14 @@ class MyCustomFormState extends State<MyCustomForm> {
       ..connectionType = 'iroh'
       ..irohPairingCode = code
       ..tunnelPort = port
+      // The loopback token too, not just the port: the ping below and the
+      // add-time version probe build their URIs off THIS object, and without
+      // the token apiUri omits `__lt` — whether such a request passes the
+      // shim then depends on landing on an already-authenticated pooled
+      // socket. The version probe usually drew a fresh one, failed, and
+      // toasted "older than 5.5" at a brand-new server. registerActiveTunnel
+      // still runs after addServer and re-sets the same values.
+      ..tunnelToken = IrohTunnel.instance.localToken
       ..storageMode = 'appLocal';
     // Ping through the live tunnel to populate vpaths / transcode caps.
     await ServerManager().getServerPaths(server);

--- a/lib/screens/iroh_login_screen.dart
+++ b/lib/screens/iroh_login_screen.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+
+import 'package:material_ui/material_ui.dart';
+
+import '../l10n/app_localizations.dart';
+import '../theme/velvet_theme.dart';
+
+/// Full-screen sign-in for the Quick Connect flows.
+///
+/// Both Quick Connect paths — pasting/scanning a pairing code and tapping a
+/// server discovered on the LAN — used to surface their credential form at
+/// the bottom of the add-server page (an inline reveal under the Test button,
+/// and a modal sheet respectively). On most phones that landed under the
+/// fold: the test reported success and, as far as the user could see,
+/// nothing else happened. A pushed page cannot be missed, and backing out of
+/// it returns to the Quick Connect tab with the connection still live.
+///
+/// The page owns only the credentials and their validation round-trip:
+/// [validate] runs the actual login (through the live tunnel, or against the
+/// LAN address) and returns null on success or a message to show inline —
+/// so a wrong password is retryable right here instead of bouncing the user
+/// back a screen. On success the page pops with `(username, password)`; the
+/// caller finishes its flow (save / pairing-code fetch) exactly as before.
+class IrohLoginScreen extends StatefulWidget {
+  /// AppBar title — "Sign in" for the pairing-code flow, or
+  /// "Sign in to {server}" for a discovered LAN server.
+  final String title;
+
+  /// Runs the login attempt; returns null on success, or the error message
+  /// to display under the fields.
+  final Future<String?> Function(String username, String password) validate;
+
+  const IrohLoginScreen(
+      {super.key, required this.title, required this.validate});
+
+  @override
+  State<IrohLoginScreen> createState() => _IrohLoginScreenState();
+}
+
+class _IrohLoginScreenState extends State<IrohLoginScreen> {
+  final _userCtrl = TextEditingController();
+  final _passCtrl = TextEditingController();
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _userCtrl.dispose();
+    _passCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_busy) return;
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    final err = await widget.validate(_userCtrl.text, _passCtrl.text);
+    if (!mounted) return;
+    if (err != null) {
+      setState(() {
+        _busy = false;
+        _error = err;
+      });
+      return;
+    }
+    Navigator.of(context).pop((_userCtrl.text, _passCtrl.text));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Scaffold(
+      backgroundColor: VelvetColors.bg,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        foregroundColor: VelvetColors.textPrimary,
+        title: Text(widget.title, overflow: TextOverflow.ellipsis),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 24, 20, 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Icon(Icons.lock_outline,
+                  size: 40, color: VelvetColors.textSecondary),
+              const SizedBox(height: 20),
+              TextField(
+                controller: _userCtrl,
+                autofocus: true,
+                enabled: !_busy,
+                autocorrect: false,
+                keyboardType: TextInputType.emailAddress,
+                style: TextStyle(color: VelvetColors.textPrimary),
+                decoration: InputDecoration(
+                  labelText: l.fieldUsername,
+                  prefixIcon: Icon(Icons.person_outline),
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _passCtrl,
+                enabled: !_busy,
+                obscureText: true,
+                autocorrect: false,
+                enableSuggestions: false,
+                onSubmitted: (_) => _submit(),
+                style: TextStyle(color: VelvetColors.textPrimary),
+                decoration: InputDecoration(
+                  labelText: l.fieldPassword,
+                  prefixIcon: Icon(Icons.lock_outline),
+                ),
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 14),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: VelvetColors.error.withValues(alpha: 0.12),
+                    borderRadius:
+                        BorderRadius.circular(VelvetColors.radiusSmall),
+                  ),
+                  child: Text(
+                    _error!,
+                    style: TextStyle(color: VelvetColors.error, fontSize: 13),
+                  ),
+                ),
+              ],
+              const SizedBox(height: 20),
+              ElevatedButton.icon(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: VelvetColors.primary,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius:
+                        BorderRadius.circular(VelvetColors.radiusSmall),
+                  ),
+                  textStyle:
+                      const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+                ),
+                icon: _busy
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation(Colors.white),
+                        ),
+                      )
+                    : const Icon(Icons.login),
+                label: Text(_busy ? l.irohSigningIn : l.irohSignInSave),
+                onPressed: _busy ? null : _submit,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -177,21 +177,37 @@ class ServerManager {
   }
 
   Future<void> _warnIfBelowFloor(Server server) async {
-    final raw = await fetchServerVersion(server);
-    if (raw != null) {
-      server.serverVersion = raw;
+    final probe = await fetchServerVersion(server);
+    if (probe.version != null) {
+      server.serverVersion = probe.version;
       server.versionCheckedAt = DateTime.now();
       await writeServerFile();
       _serverListStream.sink.add(serverList);
     }
-    final parsed = ServerVersion.tryParse(raw);
-    if (!isBelowSupportFloor(parsed)) return;
-    // Null reads as the endpoint being absent, which puts the server before
-    // 5.4.2 — older than the floor, so it lands here too.
-    showGlobalSnack(parsed == null
-        ? 'This server is older than 5.5. Some features will be unavailable.'
-        : 'This server is version ${parsed.raw}. Some features need 5.5 or '
-            'newer and will be unavailable.');
+    final parsed = ServerVersion.tryParse(probe.version);
+    // Only two outcomes are evidence of age: a version below the floor, and
+    // a 404 (pre-5.4.2 has no /api/ at all). A probe that FAILED — the
+    // just-added iroh server whose tunnel auth hadn't settled, a Wi-Fi blip
+    // on an HTTP add — says nothing about the server, and greeting a new
+    // user's current server with "older than 5.5" is exactly the wrong
+    // first impression. Stay quiet there: the capability re-check re-probes
+    // and stores the version when it lands, and the nav-drawer update flag
+    // reads that.
+    switch (floorVerdictFor(parsed, notFound: probe.notFound)) {
+      case FloorVerdict.ok:
+        return;
+      case FloorVerdict.belowFloor:
+        showGlobalSnack(
+            'This server is version ${parsed!.raw}. Some features need 5.5 '
+            'or newer and will be unavailable.');
+      case FloorVerdict.preVersionEndpoint:
+        showGlobalSnack(
+            'This server is older than 5.5. Some features will be '
+            'unavailable.');
+      case FloorVerdict.unknown:
+        appLog('[api] add-time version probe inconclusive for '
+            '${server.localname} — not warning');
+    }
   }
 
   // Storage mode + base path are set directly on the Server in the
@@ -336,7 +352,7 @@ class ServerManager {
       // stored value alone rather than blanking it — a momentary blip should
       // not make a known-good server look ancient.
       final prevVersion = server.serverVersion;
-      final fetched = await fetchServerVersion(server);
+      final fetched = (await fetchServerVersion(server)).version;
       if (fetched != null) {
         server.serverVersion = fetched;
         server.versionCheckedAt = DateTime.now();
@@ -573,7 +589,14 @@ class ServerManager {
   /// Logs its failures. This runs unattended and its only visible symptom is
   /// a version that never appears, which is indistinguishable from an old
   /// server unless something says otherwise.
-  Future<String?> fetchServerVersion(Server s) async {
+  /// Probe `GET /api/` for the server's version. [notFound] is true only for
+  /// a 404 — the one answer that genuinely means "pre-5.4.2, the endpoint
+  /// does not exist". Every other empty outcome (timeout, connection failure,
+  /// an auth layer answering for the route, junk body) is a FAILED probe, not
+  /// evidence of age — the two used to collapse into one null, and a blip at
+  /// add time toasted "older than 5.5" at a current server.
+  Future<({String? version, bool notFound})> fetchServerVersion(
+      Server s) async {
     try {
       final resp = await http.get(
         s.apiUri('/api/'),
@@ -590,16 +613,18 @@ class ServerManager {
           appLog('[api] version probe ${s.localname} → '
               'HTTP ${resp.statusCode}');
         }
-        return null;
+        return (version: null, notFound: resp.statusCode == 404);
       }
       final decoded = jsonDecode(resp.body);
       final v = decoded is Map ? decoded['server'] : null;
-      if (v is String && v.trim().isNotEmpty) return v.trim();
+      if (v is String && v.trim().isNotEmpty) {
+        return (version: v.trim(), notFound: false);
+      }
       appLog('[api] version probe ${s.localname} → no version in response');
-      return null;
+      return (version: null, notFound: false);
     } catch (e) {
       appLog('[api] version probe ${s.localname} failed: $e');
-      return null;
+      return (version: null, notFound: false);
     }
   }
 

--- a/lib/util/server_version.dart
+++ b/lib/util/server_version.dart
@@ -112,6 +112,35 @@ UpdateBand updateBandFor(ServerVersion? v) {
 /// warning, and the reason a null version is not treated as "probably fine".
 bool isBelowSupportFloor(ServerVersion? v) => v == null || v < supportFloor;
 
+/// What the add-time floor check learned about a server.
+enum FloorVerdict {
+  /// Reported a version at or above the floor — say nothing.
+  ok,
+
+  /// Reported a version below the floor — warn with the number.
+  belowFloor,
+
+  /// `/api/` answered 404: the endpoint does not exist, which genuinely puts
+  /// the server before 5.4.2 — warn "older than 5.5".
+  preVersionEndpoint,
+
+  /// The probe failed or the body was junk. Says nothing about the server's
+  /// age — a tunnel whose auth hadn't settled and a Wi-Fi blip both land
+  /// here, and both used to toast "older than 5.5" at brand-new servers.
+  /// Say nothing; later re-probes fill the version in.
+  unknown,
+}
+
+/// Classify an add-time version probe. [notFound] is the probe's "404"
+/// signal; [parsed] is the parsed version when one came back. Pure;
+/// unit-tested.
+FloorVerdict floorVerdictFor(ServerVersion? parsed, {required bool notFound}) {
+  if (parsed != null) {
+    return isBelowSupportFloor(parsed) ? FloorVerdict.belowFloor : FloorVerdict.ok;
+  }
+  return notFound ? FloorVerdict.preVersionEndpoint : FloorVerdict.unknown;
+}
+
 
 // ---------------------------------------------------------------------------
 // Feature table

--- a/lib/widgets/server_version_line.dart
+++ b/lib/widgets/server_version_line.dart
@@ -31,7 +31,7 @@ class _ServerVersionLineState extends State<ServerVersionLine> {
     try {
       // Straight through ensureServerCapabilities' sibling: one unauthenticated
       // GET, and the result is persisted by the caller.
-      final v = await ServerManager().fetchServerVersion(server);
+      final v = (await ServerManager().fetchServerVersion(server)).version;
       if (v != null) {
         server.serverVersion = v;
         server.versionCheckedAt = DateTime.now();

--- a/test/util/server_version_test.dart
+++ b/test/util/server_version_test.dart
@@ -182,4 +182,35 @@ void main() {
       expect(metadataBatchKnownUnsupported(null), isFalse);
     });
   });
+
+  group('floorVerdictFor (the add-time warning)', () {
+    FloorVerdict verdict(String? raw, {bool notFound = false}) =>
+        floorVerdictFor(ServerVersion.tryParse(raw), notFound: notFound);
+
+    test('a current server says nothing', () {
+      expect(verdict('6.25.0'), FloorVerdict.ok);
+      // Patch part optional on the wire.
+      expect(verdict('6.25'), FloorVerdict.ok);
+      expect(verdict('v6.25.0'), FloorVerdict.ok);
+    });
+
+    test('a reported version below the floor warns with the number', () {
+      expect(verdict('5.4.2'), FloorVerdict.belowFloor);
+    });
+
+    test('a 404 is the one no-version answer that means old', () {
+      expect(verdict(null, notFound: true), FloorVerdict.preVersionEndpoint);
+    });
+
+    test('a FAILED probe must not read as "older than 5.5"', () {
+      // The regression this pins: a just-added Quick Connect server whose
+      // tunnel auth had not settled (or any network blip at add time)
+      // produced a null version and toasted "older than 5.5" at a v6.25
+      // server. No 404 → no age claim.
+      expect(verdict(null), FloorVerdict.unknown);
+      // Junk body → parse fails → same rule: a server that answered /api/
+      // is self-evidently not pre-5.4.2.
+      expect(verdict('<!doctype html>'), FloorVerdict.unknown);
+    });
+  });
 }


### PR DESCRIPTION
## Problem (user feedback)

In the Quick Connect flow, the credential step was easy to miss:

- **Pairing code + Test Connection** (private server): the sign-in fields appeared as an inline reveal at the *bottom* of the long, scrollable add-server page — under the fold on most phones. The test reported success and, visibly, nothing happened next.
- **Tapping a server under "Servers on your local network"**: credentials came up in a modal bottom sheet — cramped behind the keyboard and, per feedback, missed outright.

## Fix

Both flows now push a dedicated **full-screen sign-in page** (`IrohLoginScreen`) the moment credentials are needed — an unmissable next step.

- The page runs the login round-trip itself (through the live tunnel for the code flow; against the discovered LAN address for a tapped server), so a wrong password shows an **inline error and retries in place** instead of bouncing the user back a screen.
- On success it pops with the credentials and the callers finish exactly as before — the follow-up login inside `_signInAndSaveIroh` / `_connectDiscovered` runs against just-validated credentials and stays as a backstop, keeping every save/error path untouched.
- Backing out is safe: the tunnel stays up, and the Quick Connect tab keeps a **Sign in & save** button as the way back in.
- `_LanLoginSheet` (the bottom sheet) is deleted. No new localization strings were needed — the page reuses `lanLoginTitle` / `irohSignInHeader` / `irohSignInSave` / `irohSigningIn`.

## Verification

- `flutter analyze` clean; all 333 unit tests pass.
- End-to-end on an Android emulator against a live dev server (auth user + `iroh.enabled` + `shareCodePublic`): pasted a real pairing code → Test Connection dialed the actual tunnel → **the sign-in page auto-opened** → wrong password showed the inline HTTP 401 banner and stayed put → correct password signed in through the tunnel and saved the iroh server (JWT persisted, server switched current, app proceeded to Quick Setup).
- The LAN-tap path shares the same page and validate mechanics but couldn't be exercised on the emulator (mDNS doesn't cross its NAT) — worth one real-phone tap while smoking this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)