### PR TITLE
fix(iroh): keep Quick Connect alive across dead zones

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -164,6 +164,8 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
   final GlobalKey<ScaffoldState> _outerScaffoldKey = GlobalKey<ScaffoldState>();
   StreamSubscription<String>? _castErrorSub;
   StreamSubscription<List<ConnectivityResult>>? _connectivitySub;
+  // Coalesces the burst connectivity_plus emits for one transport switch.
+  Timer? _connectivityDebounce;
   StreamSubscription<List<Server>>? _serverListSub;
   // Guards the first-run setup push: serverListStream re-emits on every server
   // edit, and the flow marks onboarding complete only once it's dismissed.
@@ -222,13 +224,28 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
     // An iroh tunnel is a long-lived QUIC connection; unlike fresh per-request
     // HTTP sockets it needs an explicit kick when the device network changes.
     // Nudge it on every connectivity transition that has a usable network.
+    // Every result is logged, including [none]: the drive logs could not say
+    // what fired each network change, and a [none]→[mobile] edge is a modem
+    // re-attach the tunnel policy treats differently from a hand-off.
     _connectivitySub = Connectivity().onConnectivityChanged.listen((results) {
-      if (results.any((r) => r != ConnectivityResult.none)) {
-        unawaited(ServerManager().handleNetworkChange());
+      final names = results.map((r) => r.name).join('+');
+      appLog('[net] connectivity → [$names]');
+      if (results.every((r) => r == ConnectivityResult.none)) {
+        // A usable result seconds ago must not fire into an offline device.
+        _connectivityDebounce?.cancel();
+        _connectivityDebounce = null;
+        ServerManager().noteConnectivityLost();
+        return;
+      }
+      _connectivityDebounce?.cancel();
+      _connectivityDebounce = Timer(const Duration(milliseconds: 1500), () {
+        _connectivityDebounce = null;
+        unawaited(ServerManager()
+            .handleNetworkChange(reason: 'connectivity:$names'));
         // Resume on-device playback if a network outage had paused it (no-op
         // unless the audio handler is in the network-stalled state).
         MediaManager().audioHandler.onNetworkRegained();
-      }
+      });
     });
   }
 
@@ -510,7 +527,7 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
     // resume, nudge iroh + rebuild it if it's hard-down. Fire-and-forget — the
     // native start can block for tens of seconds.
     if (state == AppLifecycleState.resumed) {
-      unawaited(ServerManager().handleNetworkChange());
+      unawaited(ServerManager().handleNetworkChange(reason: 'resume'));
     }
     // Flush the queue/position to disk when leaving the foreground, so a
     // backgrounded app that's later killed by the OS still reopens in place.
@@ -526,6 +543,7 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
     WidgetsBinding.instance.removeObserver(this);
     _castErrorSub?.cancel();
     _connectivitySub?.cancel();
+    _connectivityDebounce?.cancel();
     _serverListSub?.cancel();
     DownloadManager().dispose();
     super.dispose();
@@ -579,8 +597,9 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
             return _bannerStrip(
                 Icons.cloud_off, VelvetColors.warning, l.irohBannerDisconnected,
                 action: TextButton(
-                  onPressed: () =>
-                      unawaited(ServerManager().handleNetworkChange()),
+                  onPressed: () => unawaited(ServerManager()
+                      .handleNetworkChange(
+                          reason: 'retry-tap', userInitiated: true)),
                   child: Text(l.irohRetry,
                       style: TextStyle(color: VelvetColors.primary)),
                 ));
@@ -593,12 +612,17 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
                   child: CircularProgressIndicator(strokeWidth: 2),
                 ));
           default: // reconnecting
+            // Retry here forces a fresh endpoint (the policy's `escalate`):
+            // the supervisor keeps re-dialing on its own, but a user who has
+            // watched the spinner long enough gets to cut it short.
             return _bannerStrip(
                 Icons.sync_problem, VelvetColors.warning, l.irohBannerReconnecting,
-                action: const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
+                action: TextButton(
+                  onPressed: () => unawaited(ServerManager()
+                      .handleNetworkChange(
+                          reason: 'retry-tap', userInitiated: true)),
+                  child: Text(l.irohRetry,
+                      style: TextStyle(color: VelvetColors.primary)),
                 ));
         }
       },

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -3398,7 +3398,16 @@ class AudioPlayerHandler extends BaseAudioHandler
     // add followed by seek(index + 1) reached ExoPlayer with an index past the
     // end (IllegalSeekPositionException) and left the darwin player's index
     // out of range.
-    await addQueueItem(item);
+    // Tolerant of the platform insert throwing (Android's known just_audio
+    // IllegalArgumentException on concatenatingInsertAll): the item is already
+    // in the queue subject by then, and an unawaited add used to let the pick
+    // proceed regardless — awaiting it must not turn that into an aborted
+    // pick with no resume.
+    try {
+      await addQueueItem(item);
+    } catch (e) {
+      appLog('[dj] queue insert threw (continuing): $e');
+    }
     final resume = wasParked && _parkedForDJ;
     _releasePark();
 

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -4,7 +4,7 @@ import 'dart:io' show File;
 
 import 'package:audio_service/audio_service.dart';
 import 'package:audio_session/audio_session.dart'
-    show AudioSession, AudioSessionConfiguration;
+    show AudioSession, AudioSessionConfiguration, AudioInterruptionType;
 import 'package:just_audio/just_audio.dart';
 import 'package:mstream_music/main.dart';
 import 'package:rxdart/rxdart.dart';
@@ -16,6 +16,7 @@ import 'dlna_playback_backend.dart';
 import 'chromecast_playback_backend.dart';
 import 'local_media_server.dart';
 import 'auto_browse.dart';
+import 'cast_origin.dart' show rebindLoopbackArt;
 import 'cast_log.dart';
 import 'cast_target.dart';
 import '../native/iroh_tunnel.dart';
@@ -31,12 +32,19 @@ import '../singletons/settings.dart';
 import '../singletons/server_capabilities.dart';
 import '../singletons/api.dart';
 import '../singletons/server_list.dart';
+import '../singletons/tunnel_policy.dart';
 import '../singletons/visualizer_audio.dart';
 import '../objects/display_item.dart';
 import '../util/camelot.dart';
 import '../util/queue_actions.dart';
 import '../util/connectivity_probe.dart';
 import '../util/stream_url.dart';
+
+/// What the queue's end does: stop (the normal end, or the user's intent is
+/// pause); park waiting for a deferred Auto DJ pick while the tunnel is down;
+/// or retry the pick right now when the tunnel is serving and the earlier
+/// failure was transient. See [AudioPlayerHandler.queueEndAction].
+enum QueueEndAction { stop, park, retryPick }
 
 /// An [AudioHandler] for playing a list of podcast episodes.
 /// What [AudioPlayerHandler.healAction] decided the tunnel heal should do:
@@ -160,6 +168,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     _sonicLockedAnchor = null;
     _autoDJAuthWarned = false; // fresh lane, fresh warning budget
     _sonicWarned = false;
+    _clearDeferredPick();
   }
 
   // The repeat mode requested by the UI / Android Auto, and the source of truth
@@ -207,6 +216,17 @@ class AudioPlayerHandler extends BaseAudioHandler
       session.interruptionEventStream.listen((event) {
         appLog('[audio] interruption '
             '${event.begin ? 'begin' : 'end'} type=${event.type}');
+        // Remembered as a TIMESTAMP, not a flag: Android never delivers the
+        // matching `end` for a permanent loss (6 begins, 0 ends across two
+        // drive logs), so a boolean would stick and disable every later
+        // auto-resume. The auto URL rebuild reads it (it must not blast
+        // audio over a call); play() and the window elapsing clear it.
+        if (!event.begin) {
+          _interruptedAt = null;
+        } else if (event.type != AudioInterruptionType.duck &&
+            identical(_backend, _localBackend)) {
+          _interruptedAt = DateTime.now();
+        }
       });
       session.becomingNoisyEventStream.listen((_) {
         // Local playback only. On a cast the audio is coming out of the
@@ -315,15 +335,55 @@ class AudioPlayerHandler extends BaseAudioHandler
     });
     // Stop the service when playback reaches the end of the queue.
     _backendSubject.switchMap((b) => b.processingStateStream).listen((state) {
+      // Transitions only (a few lines per track). Without them the drive logs
+      // could not tell "playing from the buffer" from "buffering on a dead
+      // tunnel" during the 30s the native status still says connected.
+      if (state != _lastLoggedProcState) {
+        final prev = _lastLoggedProcState;
+        _lastLoggedProcState = state;
+        if (state == BackendProcessingState.buffering) {
+          _bufferingSince ??= DateTime.now(); // logged on the way out
+        } else {
+          final since = _bufferingSince;
+          _bufferingSince = null;
+          if (prev == BackendProcessingState.buffering &&
+              state == BackendProcessingState.ready) {
+            // A weak link flaps buffering↔ready every few seconds; only a
+            // stall long enough to hear gets a line, so the 2000-line log
+            // ring keeps the tunnel lifecycle instead of the flaps.
+            final stall = since == null ? null : DateTime.now().difference(since);
+            if (stall != null && stall >= const Duration(seconds: 3)) {
+              appLog('[play] rebuffered ${stall.inSeconds}s');
+            }
+          } else {
+            appLog('[play] state → ${state.name}');
+          }
+        }
+      }
       if (state == BackendProcessingState.completed) {
         // Log the context so a "stopped on its own" report can be told apart
         // from a genuine end-of-queue stop: how far into the track we were vs.
         // its duration, and where we were in the queue.
-        appLog('[play] completed → stop '
+        final dj = autoDJServer;
+        final action = queueEndAction(
+            onLocalBackend: identical(_backend, _localBackend),
+            isIrohDJ: dj != null && dj.isIroh,
+            djPickPending: _djPickPending,
+            playIntent: _playIntent,
+            tunnelServes: dj != null && ServerManager().tunnelServes(dj),
+            pickInFlight: _djInFlight);
+        appLog('[play] completed → ${action.name} '
             'pos=${_backend.position.inSeconds}s/'
             '${_backend.duration?.inSeconds ?? '?'}s '
             'index=${_backend.currentIndex} of ${queue.value.length}');
-        stop();
+        switch (action) {
+          case QueueEndAction.park:
+            _parkForDeferredPick();
+          case QueueEndAction.retryPick:
+            _retryPickAtQueueEnd();
+          case QueueEndAction.stop:
+            stop();
+        }
       }
       // Playback just parked (idle with tracks still queued). The tunnel may
       // ALREADY be connected — a status edge that landed while this load was
@@ -878,7 +938,8 @@ class AudioPlayerHandler extends BaseAudioHandler
   List<MediaItem> _queueWithFreshUrls() {
     final q = queue.value;
     if (q.isEmpty) return q;
-    final rebuilt = q.map(_withRebuiltUrl).toList();
+    final rebuilt =
+        q.map((m) => _withRebuiltArt(_withRebuiltUrl(m))).toList();
     var changed = false;
     for (int i = 0; i < q.length; i++) {
       if (!identical(rebuilt[i], q[i])) changed = true;
@@ -1059,8 +1120,15 @@ class AudioPlayerHandler extends BaseAudioHandler
     // queued, so it's already the target); just wait for it and re-seed.
     _switchChain = _switchChain.then((_) async {
       if (queue.value.isEmpty) return;
-      final ready = await ServerManager().awaitTunnelReady(server: server);
-      if (!ready) return; // tunnel didn't come up; the banner shows why
+      final ready = await ServerManager()
+          .awaitTunnelReady(server: server, caller: 'playback');
+      if (!ready) {
+        // Parked. The tunnel's next `→ connected` edge (from the supervisor
+        // or the retry loop's fresh dial) fires _onTunnelReconnected.
+        appLog('[play] iroh recovery: tunnel not ready for '
+            '${server.localname} — parked until it reconnects');
+        return;
+      }
       // Spot read AFTER the wait, not before: awaitTunnelReady re-arms its
       // deadline for as long as a dial is in flight and can run tens of
       // seconds, so a skip or seek landing in that window is the newer truth.
@@ -1072,12 +1140,17 @@ class AudioPlayerHandler extends BaseAudioHandler
       // queue.value: a hard restart may have changed the port/token, and the
       // concurrent rebuild-on-(re)bind might not have refreshed queue.value yet —
       // _withRebuiltUrl uses the current effectiveBaseUrl, so these are always live.
-      final fresh = queue.value.map(_withRebuiltUrl).toList();
+      final fresh = queue.value
+          .map((m) => _withRebuiltArt(_withRebuiltUrl(m)))
+          .toList();
       queue.add(fresh);
       await _loadAtSpot(_localBackend, fresh, spot);
       // Resume with the user's intent: a mid-stream drop while playing resumes
-      // playing; a launch-time recovery (never played) stays paused.
-      if (_playIntent) unawaited(_localBackend.play());
+      // playing; a launch-time recovery (never played) stays paused. Never
+      // over a call (the interruption window).
+      if (_playIntent && !_recentlyInterrupted) {
+        unawaited(_localBackend.play());
+      }
     }).catchError((Object e) {
       castLog('iroh playback recovery failed', error: e);
     }).whenComplete(() => _recoveringPlayback = false);
@@ -1347,7 +1420,9 @@ class AudioPlayerHandler extends BaseAudioHandler
     // doesn't flash track 0 on the reload.
     await _localBackend.setSources(fresh,
         initialIndex: idx, initialPosition: spot.position);
-    if (_playIntent) unawaited(_localBackend.play());
+    if (_playIntent && !_recentlyInterrupted) {
+      unawaited(_localBackend.play());
+    }
   }
 
   // Resume playback parked by an iroh server outage, fired on the tunnel's
@@ -1397,6 +1472,38 @@ class AudioPlayerHandler extends BaseAudioHandler
   void _onTunnelReconnected() {
     _tunnelHealRetry?.cancel();
     _tunnelHealRetry = null;
+    // A pick owed from the outage comes first: the queue may have ENDED while
+    // the tunnel was down (parked on `completed`, not idle — healAction alone
+    // would only re-arm forever). The pick appends the next track and, when
+    // the park held the play intent, seeks to it and plays. A failing retry
+    // re-sets the pending flag and the 11s re-arm brings us back here,
+    // bounded by kMaxDeferredPickFailures and the park timer.
+    final dj = autoDJServer;
+    if (dj != null &&
+        shouldRetryDeferredPick(
+            pending: _djPickPending,
+            tunnelServes: ServerManager().tunnelServes(dj),
+            onLocalBackend: identical(_backend, _localBackend),
+            intentionalStop: _intentionalStop,
+            failures: _deferredPickFailures)) {
+      if (_djInFlight) {
+        // A pick is already running (an index re-emission beat the status
+        // edge to the tunnel); it lands with the park-derived resume below.
+        _rearmTunnelHeal();
+        return;
+      }
+      final parked = _stillParked;
+      _djPickPending = false;
+      appLog('[dj] tunnel back — retrying the deferred pick'
+          '${parked ? ' and resuming' : ''}');
+      // No flags: whether the landing pick resumes is decided by the park
+      // (see _queueAutoDJSong), so a pick started by someone else resumes too.
+      unawaited(autoDJ());
+      if (parked) {
+        _rearmTunnelHeal();
+        return;
+      }
+    }
     final q = queue.value;
     switch (healAction(
       onLocalBackend: identical(_backend, _localBackend),
@@ -1530,6 +1637,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     // Explicit navigation supersedes a failed-restore park -- without this a
     // stale spot would hijack the next re-seed back to the old track.
     _restoreSpot = null;
+    _releasePark(); // explicit navigation supersedes a queue-end park too
     // Deliberately re-tapping a track that failed from disk is a request to
     // try it again, so don't let the one-attempt guard deny it.
     _localRetryKey = null;
@@ -1703,6 +1811,99 @@ class AudioPlayerHandler extends BaseAudioHandler
   // re-seed resumes PAUSED rather than autoplaying on open.
   bool _playIntent = false;
 
+  // ── Auto DJ across a tunnel outage ──
+  // A pick was due but the tunnel wasn't serving (or the POST failed); the
+  // tunnel's connected edge retries it (_onTunnelReconnected).
+  bool _djPickPending = false;
+  // One "random-songs failed" line per outage — the player's index
+  // re-emissions re-fire the pick every ~30s.
+  bool _djFailLogged = false;
+  int _deferredPickFailures = 0;
+  // The queue ended while a pick was pending: paused with the play intent
+  // kept, so the retried pick resumes playback (see queueEndAction).
+  bool _parkedForDJ = false;
+  Timer? _parkTimer;
+  // When an audio-focus interruption began (see the session listener).
+  DateTime? _interruptedAt;
+  BackendProcessingState? _lastLoggedProcState;
+  DateTime? _bufferingSince;
+
+  bool get _recentlyInterrupted {
+    final t = _interruptedAt;
+    return t != null &&
+        DateTime.now().difference(t) < TunnelTiming.interruptionWindow;
+  }
+
+  void _clearDeferredPick() {
+    _djPickPending = false;
+    _djFailLogged = false;
+    _deferredPickFailures = 0;
+    _releasePark();
+  }
+
+  /// Leave the queue-end park without forgetting that a pick is owed: the
+  /// user moved on (play/pause/skip/seek), so the tunnel's return must
+  /// neither re-seek them nor stop them thirty minutes later.
+  void _releasePark() {
+    _parkedForDJ = false;
+    _parkTimer?.cancel();
+    _parkTimer = null;
+  }
+
+  /// True while the park is real: the local player is still sitting at the
+  /// completed last row, paused. Anything else means the user moved on.
+  bool get _stillParked =>
+      _parkedForDJ &&
+      identical(_backend, _localBackend) &&
+      _localBackend.processingState == BackendProcessingState.completed &&
+      !_localBackend.playing;
+
+  /// The queue ended while an Auto DJ pick is owed to a tunnel outage: hold
+  /// the spot instead of stopping. The BACKEND's pause, not the handler's —
+  /// _playIntent must survive so the retried pick can resume — and the
+  /// foreground service stays up (bounded by parkMax). stop() used to run
+  /// here unconditionally, which set _intentionalStop and made healAction
+  /// discard every later tunnel-back edge: an outage-drained queue looked
+  /// exactly like the user pressing stop.
+  void _parkForDeferredPick() {
+    _parkedForDJ = true;
+    unawaited(_localBackend.pause());
+    _broadcastState();
+    _parkTimer?.cancel();
+    _parkTimer = Timer(TunnelTiming.parkMax, () {
+      _parkTimer = null;
+      // Only a park that is still real gets stopped: if the user queued an
+      // album and pressed play meanwhile, this must not cut it off.
+      if (!_stillParked) {
+        _parkedForDJ = false;
+        return;
+      }
+      appLog('[play] parked ${TunnelTiming.parkMax.inMinutes} min waiting '
+          'for the tunnel — stopping');
+      _parkedForDJ = false;
+      stop();
+    });
+    unawaited(ServerManager()
+        .ensureActiveTunnel(verify: true, reason: 'queue-end-park'));
+  }
+
+  /// The queue ended with a pick owed although the tunnel IS serving (the
+  /// earlier POST failed transiently, or an in-place reconnect has since
+  /// healed): try once, now, and stop as before if it fails — never a silent
+  /// park with nothing scheduled. The park flag makes the landing pick resume.
+  void _retryPickAtQueueEnd() {
+    _parkedForDJ = true;
+    unawaited(_localBackend.pause());
+    _broadcastState();
+    unawaited(() async {
+      await autoDJ();
+      if (_djPickPending) {
+        _releasePark();
+        stop();
+      }
+    }());
+  }
+
   /// Whether a currentIndex emission landing on the LAST queue row should
   /// fire the Auto-DJ top-up.
   ///
@@ -1740,6 +1941,56 @@ class AudioPlayerHandler extends BaseAudioHandler
       index == queueLength - 1 &&
       state != BackendProcessingState.idle &&
       !inFailureWalk;
+
+  /// What the queue's end does. Park only when a pick is actually owed to a
+  /// tunnel outage AND playback is wanted AND this backend/server pair can be
+  /// healed by the tunnel coming back: the local player with an iroh Auto DJ
+  /// server. A cast session or an HTTP DJ server has no tunnel edge to wait
+  /// for, so parking would be a silent 30-minute wait — strictly worse than
+  /// today's stop. Pure; unit-tested.
+  ///
+  /// With the tunnel already serving there is no edge to wait for, so the
+  /// pick is retried on the spot ([QueueEndAction.retryPick]) — unless one is
+  /// already in flight, which lands on its own and resumes from the park.
+  static QueueEndAction queueEndAction({
+    required bool onLocalBackend,
+    required bool isIrohDJ,
+    required bool djPickPending,
+    required bool playIntent,
+    required bool tunnelServes,
+    required bool pickInFlight,
+  }) {
+    if (!(onLocalBackend && isIrohDJ && djPickPending && playIntent)) {
+      return QueueEndAction.stop;
+    }
+    if (tunnelServes && !pickInFlight) return QueueEndAction.retryPick;
+    return QueueEndAction.park;
+  }
+
+  /// Whether an Auto DJ pick should wait for the tunnel instead of POSTing
+  /// at a loopback that cannot answer. Pure; unit-tested.
+  static bool shouldDeferDJPick(
+          {required bool isIroh, required bool tunnelServes}) =>
+      isIroh && !tunnelServes;
+
+  /// Whether the tunnel-back heal should retry a deferred pick. Pure;
+  /// unit-tested.
+  static bool shouldRetryDeferredPick({
+    required bool pending,
+    required bool tunnelServes,
+    required bool onLocalBackend,
+    required bool intentionalStop,
+    required int failures,
+  }) =>
+      pending &&
+      tunnelServes &&
+      onLocalBackend &&
+      !intentionalStop &&
+      failures < kMaxDeferredPickFailures;
+
+  /// A deferred pick that keeps failing against a serving tunnel is the
+  /// server's problem, not the path's; stop retrying after this many.
+  static const int kMaxDeferredPickFailures = 5;
 
   /// Whether play() must re-seed the local player instead of issuing a bare
   /// backend.play(): just_audio parked idle (a playback error tears the
@@ -1808,6 +2059,18 @@ class AudioPlayerHandler extends BaseAudioHandler
     appLog('[play] play');
     _playIntent = true;
     _intentionalStop = false;
+    _interruptedAt = null; // the user wants audio; an old interruption is moot
+    if (_parkedForDJ) {
+      // The user pressed play on a parked queue end: leave the park (a pick
+      // landing later appends without hijacking them) and replay the last
+      // track from the top, which is what the old completed→stop→play did.
+      final wasParked = _stillParked;
+      _releasePark();
+      if (wasParked) {
+        final idx = _localBackend.currentIndex;
+        if (idx != null) await _localBackend.seek(Duration.zero, index: idx);
+      }
+    }
     if (queue.value.isEmpty && !_restoreSettled.isCompleted) {
       await _awaitQueueRestore();
       // The wait can run tens of seconds — a pause/stop that arrived during
@@ -1837,18 +2100,21 @@ class AudioPlayerHandler extends BaseAudioHandler
   Future<void> pause() {
     appLog('[play] pause');
     _playIntent = false;
+    _releasePark(); // their intent wins; a landing pick appends only
     return _backend.pause();
   }
 
   @override
   Future<void> skipToNext() async {
     _restoreSpot = null; // user navigation supersedes a failed-restore park
+    _releasePark();
     _backend.seekToNext();
   }
 
   @override
   Future<void> skipToPrevious() async {
     _restoreSpot = null; // user navigation supersedes a failed-restore park
+    _releasePark();
     _backend.seekToPrevious();
   }
 
@@ -1857,6 +2123,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     // A manual scrub supersedes the parked position (keep nothing: the next
     // re-seed should read the live player, which this seek just updated).
     _restoreSpot = null;
+    _releasePark();
     return _backend.seek(position);
   }
 
@@ -1873,6 +2140,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     appLog('[play] stop');
     _playIntent = false;
     _intentionalStop = true;
+    _clearDeferredPick();
     // Don't touch the tunnel here: it follows the QUEUE, not the play/stop state,
     // so a stopped-but-still-queued iroh song keeps its tunnel (the queue listener
     // tears it down when the iroh songs are actually removed/cleared).
@@ -2272,6 +2540,14 @@ class AudioPlayerHandler extends BaseAudioHandler
     return sameStreamUrl(newId, m.id) ? m : m.copyWith(id: newId);
   }
 
+  /// Re-derive [m]'s album-art URL against the live tunnel (iroh items only;
+  /// downloaded items included). Same instance when nothing changes.
+  MediaItem _withRebuiltArt(MediaItem m) {
+    final server = _serverFor(m);
+    if (server == null || !server.isIroh) return m;
+    return rebindLoopbackArt(m, server);
+  }
+
   /// The URI the CURRENT item actually plays from: the downloaded file when
   /// one exists (mirroring LocalPlaybackBackend's source resolution), else the
   /// stream URL re-derived against the live tunnel / transcode state —
@@ -2347,7 +2623,23 @@ class AudioPlayerHandler extends BaseAudioHandler
       for (int i = 0; i < q.length; i++) {
         if (!identical(rebuilt[i], q[i])) changed = true;
       }
-      if (!changed) return;
+      // Album art carries the loopback port + token too, and (unlike the
+      // stream URL) it matters for DOWNLOADED items — the notification and
+      // lock screen fetch it. Rebind it; when nothing else changed, publish
+      // the art without a player reload.
+      final withArt = rebuilt.map(_withRebuiltArt).toList();
+      bool artChanged = false;
+      for (int i = 0; i < q.length; i++) {
+        if (!identical(withArt[i], rebuilt[i])) artChanged = true;
+      }
+      if (!changed) {
+        if (artChanged) {
+          appLog('[queue] album-art URLs rebound to the live tunnel');
+          queue.add(withArt);
+          _emitCurrentMediaItem();
+        }
+        return;
+      }
       // _reviveSpot, not the backend's index: this runs on a tunnel re-bind,
       // which is exactly when a previous load may have failed and left the
       // player reporting track 1. Reading that back would relocate the
@@ -2359,13 +2651,16 @@ class AudioPlayerHandler extends BaseAudioHandler
       // after a tunnel bind would reload the track and sit silent. _playIntent
       // is the user's actual intent (cleared by pause/stop, false at boot), so
       // OR-ing it in resumes only where playback was genuinely wanted.
-      final wasPlaying = _backend.playing || (auto && _playIntent);
+      // …and not over an audio-focus interruption (a call): the rebuild's
+      // resume used to re-request focus mid-call (log: 19:30:43 → 19:30:47).
+      final wasPlaying =
+          _backend.playing || (auto && _playIntent && !_recentlyInterrupted);
       final wasShuffle = _backend.shuffleEnabled;
       final wasRepeat = _backend.repeat;
       _reordering = true;
       try {
-        queue.add(rebuilt);
-        await _loadAtSpot(_backend, rebuilt, spot);
+        queue.add(withArt);
+        await _loadAtSpot(_backend, withArt, spot);
         // Re-read the intent AFTER the load: the load is network-bound and can
         // run for seconds over a fresh tunnel, and a pause landing inside that
         // window must win over what we captured before it. Same doctrine as
@@ -2690,6 +2985,30 @@ class AudioPlayerHandler extends BaseAudioHandler
     // The lane this call belongs to — checked when each response lands.
     final epoch = _djSessionEpoch;
 
+    // The tunnel isn't serving the DJ server (an outage, or a dial in
+    // flight): wait briefly rather than POSTing at a dead loopback. Not ready
+    // → remember that a pick is owed; the tunnel's connected edge retries it
+    // (_onTunnelReconnected), and a queue that ends meanwhile parks instead
+    // of stopping (queueEndAction).
+    final dj = autoDJServer!;
+    if (shouldDeferDJPick(
+        isIroh: dj.isIroh, tunnelServes: ServerManager().tunnelServes(dj))) {
+      final ready = await ServerManager().awaitTunnelReady(
+          server: dj,
+          timeout: const Duration(seconds: 12),
+          extendWhileDialing: false,
+          caller: 'dj');
+      if (epoch != _djSessionEpoch) return;
+      if (!ready) {
+        if (!_djPickPending) {
+          appLog('[dj] tunnel not serving ${dj.localname} — '
+              'pick deferred until it is back');
+        }
+        _djPickPending = true;
+        return;
+      }
+    }
+
     final mgr = AutoDJManager();
     Map<String, dynamic>? lastDecoded;
 
@@ -2958,10 +3277,20 @@ class AudioPlayerHandler extends BaseAudioHandler
         // fail-loud toast.
         _autoDJAuthWarned = false;
         _sonicWarned = false;
+        _djPickPending = false;
+        _djFailLogged = false;
+        _deferredPickFailures = 0;
       } catch (e) {
         // Network error → bail without a toast (an offline queue-end is
-        // normal), but leave a trace for Diagnostics.
-        appLog('[dj] random-songs failed: $e');
+        // normal). Logged once per outage — the player's index re-emissions
+        // re-fire this every ~30s — and remembered, so the tunnel's return
+        // retries it instead of leaving the queue one track short.
+        if (!_djFailLogged) {
+          _djFailLogged = true;
+          appLog('[dj] random-songs failed: $e');
+        }
+        _djPickPending = true;
+        _deferredPickFailures++;
         return;
       }
 
@@ -2979,7 +3308,7 @@ class AudioPlayerHandler extends BaseAudioHandler
       lastDecoded = decoded;
 
       if (!mgr.isKeywordBlocked(songs[0] as Map<String, dynamic>)) {
-        _queueAutoDJSong(decoded,
+        await _queueAutoDJSong(decoded,
             autoPlay: autoPlay,
             incrementIndex: incrementIndex,
             sonicPick: sonic != null);
@@ -2990,17 +3319,17 @@ class AudioPlayerHandler extends BaseAudioHandler
     }
 
     if (lastDecoded != null) {
-      _queueAutoDJSong(lastDecoded,
+      await _queueAutoDJSong(lastDecoded,
           autoPlay: autoPlay,
           incrementIndex: incrementIndex,
           sonicPick: sonic != null);
     }
   }
 
-  void _queueAutoDJSong(Map<String, dynamic> decoded,
+  Future<void> _queueAutoDJSong(Map<String, dynamic> decoded,
       {bool autoPlay = false,
       bool incrementIndex = false,
-      bool sonicPick = false}) {
+      bool sonicPick = false}) async {
     final song = decoded['songs'][0] as Map<String, dynamic>;
     final metadata = (song['metadata'] as Map?) ?? const {};
     final filepath = song['filepath'] as String?;
@@ -3058,18 +3387,42 @@ class AudioPlayerHandler extends BaseAudioHandler
       if (code != null) _camelotAnchor = code;
     }
 
-    addQueueItem(item);
+    // Whether this pick resumes a parked queue end is a property of the PARK,
+    // not of the caller's flags: the pick that lands may be one an index
+    // re-emission started (no flags) while the tunnel-back retry was dropped
+    // by _djInFlight. Read before the append (the append can move a completed
+    // player to ready) and re-checked after it (the user may have moved on).
+    final wasParked = _stillParked;
+    // Awaited: just_audio delivers the insert to the platform only after its
+    // own bookkeeping, while a seek gets there after one await — an unawaited
+    // add followed by seek(index + 1) reached ExoPlayer with an index past the
+    // end (IllegalSeekPositionException) and left the darwin player's index
+    // out of range.
+    await addQueueItem(item);
+    final resume = wasParked && _parkedForDJ;
+    _releasePark();
 
     // Feed the rolling sonic anchor with every DJ pick (kept even while the
     // mode is off, so toggling it on mid-session already has the session's
     // recent sound to centroid on).
     _sonicHistory = pushSonicHistory(_sonicHistory, filepath);
 
-    if (incrementIndex == true && index != null) {
-      _backend.seek(Duration.zero, index: index! + 1);
+    if ((incrementIndex || resume) && queue.value.isNotEmpty) {
+      final last = queue.value.length - 1;
+      final target = (index != null ? index! + 1 : last).clamp(0, last);
+      try {
+        await _backend.seek(Duration.zero, index: target);
+      } catch (e) {
+        appLog('[dj] seek to the new pick failed: $e');
+      }
     }
-    if (autoPlay == true) {
-      play();
+    if (autoPlay) {
+      await play();
+    } else if (resume && _playIntent && !_recentlyInterrupted) {
+      // The backend's play, not the handler's: this is automatic, so it must
+      // not erase the interruption window the way a user's play does.
+      appLog('[dj] pick landed — resuming the parked queue');
+      unawaited(_localBackend.play());
     }
   }
 

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -1897,10 +1897,17 @@ class AudioPlayerHandler extends BaseAudioHandler
     _broadcastState();
     unawaited(() async {
       await autoDJ();
-      if (_djPickPending) {
-        _releasePark();
-        stop();
-      }
+      if (!_djPickPending) return; // landed; the park-derived resume ran
+      // The tunnel SAID it was serving and the pick still failed. On real
+      // cellular the native status can read connected for ~70s after the
+      // link dies (Galaxy S25, airplane mode), so this is most often the
+      // dead-but-connected window, not a broken server: park (bounded) and
+      // ask the tunnel for ground truth — a failed probe rebuilds it, and the
+      // resulting connected edge retries the pick and resumes.
+      appLog('[dj] queue-end retry failed — parking and re-checking the tunnel');
+      _parkForDeferredPick();
+      final dj = autoDJServer;
+      if (dj != null) unawaited(ServerManager().reverifyTunnel(dj));
     }());
   }
 
@@ -1960,10 +1967,15 @@ class AudioPlayerHandler extends BaseAudioHandler
     required bool tunnelServes,
     required bool pickInFlight,
   }) {
-    if (!(onLocalBackend && isIrohDJ && djPickPending && playIntent)) {
+    // A pick still in flight is owed too: it lands with the park-derived
+    // resume, or fails and sets the pending flag for the tunnel's edge. On
+    // a Galaxy the last track ended 3s after its top-up POST went out.
+    final owed = djPickPending || pickInFlight;
+    if (!(onLocalBackend && isIrohDJ && owed && playIntent)) {
       return QueueEndAction.stop;
     }
-    if (tunnelServes && !pickInFlight) return QueueEndAction.retryPick;
+    if (pickInFlight) return QueueEndAction.park;
+    if (tunnelServes) return QueueEndAction.retryPick;
     return QueueEndAction.park;
   }
 
@@ -2993,6 +3005,12 @@ class AudioPlayerHandler extends BaseAudioHandler
     final dj = autoDJServer!;
     if (shouldDeferDJPick(
         isIroh: dj.isIroh, tunnelServes: ServerManager().tunnelServes(dj))) {
+      // Owed from THIS moment, not from when the wait gives up: a track that
+      // ends inside the 12s wait (a short track, a seek to the end — seen on
+      // a Galaxy: completed 11s after the top-up started) would otherwise
+      // reach the queue end with nothing pending and stop instead of park.
+      // Cleared only by a pick that lands.
+      _djPickPending = true;
       final ready = await ServerManager().awaitTunnelReady(
           server: dj,
           timeout: const Duration(seconds: 12),
@@ -3000,11 +3018,11 @@ class AudioPlayerHandler extends BaseAudioHandler
           caller: 'dj');
       if (epoch != _djSessionEpoch) return;
       if (!ready) {
-        if (!_djPickPending) {
+        if (!_djFailLogged) {
+          _djFailLogged = true;
           appLog('[dj] tunnel not serving ${dj.localname} — '
               'pick deferred until it is back');
         }
-        _djPickPending = true;
         return;
       }
     }
@@ -3291,6 +3309,12 @@ class AudioPlayerHandler extends BaseAudioHandler
         }
         _djPickPending = true;
         _deferredPickFailures++;
+        // Parked on this pick and the tunnel still claims to serve: ask for
+        // ground truth now rather than waiting up to a minute for the idle
+        // timeout to flip the status (see _retryPickAtQueueEnd).
+        if (_parkedForDJ && dj.isIroh && ServerManager().tunnelServes(dj)) {
+          unawaited(ServerManager().reverifyTunnel(dj));
+        }
         return;
       }
 

--- a/lib/media/auto_browse.dart
+++ b/lib/media/auto_browse.dart
@@ -811,7 +811,8 @@ class AutoApi {
       await ServerManager().awaitTunnelReady(
           server: server,
           timeout: const Duration(seconds: 12),
-          extendWhileDialing: false);
+          extendWhileDialing: false,
+          caller: 'auto-browse');
     }
     final uri = server.apiUri(location);
     final headers = <String, String>{'x-access-token': server.jwt ?? ''};

--- a/lib/media/cast_origin.dart
+++ b/lib/media/cast_origin.dart
@@ -42,6 +42,38 @@ Uri irohLoopbackUri(Server server, String stored) {
   );
 }
 
+/// [item] with its album-art URL (artUri + extras['artUrl']) rebound to
+/// [server]'s LIVE tunnel when it points at the phone's loopback. Returns the
+/// same instance when nothing changes (same port and token already). Unlike
+/// the stream URL, art matters for DOWNLOADED items too — the notification and
+/// lock screen fetch it — so there is no localPath skip. Pure given [server]'s
+/// current port + token; unit-tested.
+///
+/// Without this, every tunnel rebuild left the queue's art on the dead port:
+/// "Error loading artUri … Connection refused" every ~30s for minutes.
+MediaItem rebindLoopbackArt(MediaItem item, Server server) {
+  if (!server.isIroh || server.tunnelPort == null) return item;
+  bool stale(String? u) {
+    if (u == null) return false;
+    final p = Uri.tryParse(u);
+    if (p == null || p.host != '127.0.0.1') return false;
+    return p.port != server.tunnelPort ||
+        p.queryParameters['__lt'] != server.tunnelToken;
+  }
+
+  final art = item.artUri?.toString();
+  final extraArt = item.extras?['artUrl'] as String?;
+  final artStale = stale(art);
+  final extraStale = stale(extraArt);
+  if (!artStale && !extraStale) return item;
+  return item.copyWith(
+    artUri: artStale ? irohLoopbackUri(server, art!) : item.artUri,
+    extras: extraStale
+        ? {...?item.extras, 'artUrl': irohLoopbackUri(server, extraArt!).toString()}
+        : item.extras,
+  );
+}
+
 /// Re-origin a loopback iroh URL through the LAN proxy so a renderer can reach
 /// it. [loopback] is a stored `http://127.0.0.1:<port>/...` URL, rebound to the
 /// LIVE tunnel ([irohLoopbackUri]) so a stale port/token self-heals; the loopback

--- a/lib/native/iroh_tunnel.dart
+++ b/lib/native/iroh_tunnel.dart
@@ -68,6 +68,13 @@ class _Bindings {
   final _LastErrNative lastError;
   final _FreeDart stringFree;
   final _LastErrNative localTokenPtr;
+  // Optional symbols (Phase 2 of the reconnect work): looked up defensively so
+  // the Dart side runs against a committed binary that predates them — a
+  // missing symbol degrades to "no kick / no native events" instead of a
+  // lookupFunction crash at first use.
+  final _VoidDart? forceReconnect;
+  final _LastErrNative? drainEventsPtr;
+  final _Int32Dart? relayOnlineCode;
 
   factory _Bindings.open() {
     final lib = _openNativeLib();
@@ -81,12 +88,42 @@ class _Bindings {
       lib.lookupFunction<_LastErrNative, _LastErrNative>('mstream_iroh_last_error'),
       lib.lookupFunction<_FreeNative, _FreeDart>('mstream_iroh_string_free'),
       lib.lookupFunction<_LastErrNative, _LastErrNative>('mstream_iroh_local_token'),
+      forceReconnect: _tryVoid(lib, 'mstream_iroh_force_reconnect'),
+      drainEventsPtr: _tryString(lib, 'mstream_iroh_drain_events'),
+      relayOnlineCode: _tryInt32(lib, 'mstream_iroh_relay_online'),
     );
   }
 
   _Bindings._(this.start, this.stop, this.isActive, this.statusCode,
       this.pathKindCode, this.networkChanged, this.lastError, this.stringFree,
-      this.localTokenPtr);
+      this.localTokenPtr,
+      {this.forceReconnect, this.drainEventsPtr, this.relayOnlineCode});
+
+  // dart:ffi needs the native signature spelled out at each lookup (no generic
+  // helper), so one small try/catch per optional signature.
+  static _VoidDart? _tryVoid(DynamicLibrary lib, String name) {
+    try {
+      return lib.lookupFunction<_VoidNative, _VoidDart>(name);
+    } on ArgumentError {
+      return null;
+    }
+  }
+
+  static _LastErrNative? _tryString(DynamicLibrary lib, String name) {
+    try {
+      return lib.lookupFunction<_LastErrNative, _LastErrNative>(name);
+    } on ArgumentError {
+      return null;
+    }
+  }
+
+  static _Int32Dart? _tryInt32(DynamicLibrary lib, String name) {
+    try {
+      return lib.lookupFunction<_Int32Native, _Int32Dart>(name);
+    } on ArgumentError {
+      return null;
+    }
+  }
 
   String? takeLastError() {
     final p = lastError();
@@ -103,6 +140,24 @@ class _Bindings {
     if (p == nullptr) return null;
     try {
       return p.toDartString();
+    } finally {
+      stringFree(p);
+    }
+  }
+
+  /// Native supervisor events since the last drain (one per line), or an
+  /// empty list when the binary has no events ring / nothing happened.
+  List<String> takeEvents() {
+    final fn = drainEventsPtr;
+    if (fn == null) return const [];
+    final p = fn();
+    if (p == nullptr) return const [];
+    try {
+      return p
+          .toDartString()
+          .split('\n')
+          .where((l) => l.trim().isNotEmpty)
+          .toList();
     } finally {
       stringFree(p);
     }
@@ -194,6 +249,33 @@ class IrohTunnel {
   /// Android). Cheap; safe to call when nothing is running.
   void networkChanged() {
     if (isSupported) _b.networkChanged();
+  }
+
+  /// Whether the running native binary offers an in-place reconnect (close the
+  /// current QUIC connection so the supervisor re-dials on the SAME
+  /// endpoint/port/token). False on a binary that predates it, in which case
+  /// the Dart side falls back to a rate-limited hard rebuild.
+  bool get hasKick => isSupported && _b.forceReconnect != null;
+
+  /// Force an in-place reconnect (see [hasKick]). No-op when unsupported.
+  void kick() {
+    if (hasKick) _b.forceReconnect!();
+  }
+
+  /// Native supervisor events since the last call, for the app log. Empty on
+  /// a binary without the events ring.
+  List<String> drainEvents() => isSupported ? _b.takeEvents() : const [];
+
+  /// Whether the native endpoint's home relay is currently reachable, or null
+  /// when the binary cannot say. Drives the reconnect watchdog: a reconnect
+  /// failing WITH the relay up is worth a fresh endpoint; one failing without
+  /// it is a dead zone the supervisor handles better.
+  bool? get relayOnline {
+    if (!isSupported) return null;
+    final fn = _b.relayOnlineCode;
+    if (fn == null) return null;
+    final code = fn();
+    return code < 0 ? null : code != 0;
   }
 }
 

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -186,7 +186,8 @@ class ApiManager {
         if (isIroh && !BrowserManager().isLoadCancelled(loadToken)) {
           // Wait for THIS call's server (the tunnel may be serving a background
           // playback server instead of the browsed one).
-          final ready = await ServerManager().awaitTunnelReady(server: server);
+          final ready = await ServerManager()
+              .awaitTunnelReady(server: server, caller: 'browse');
           if (!ready) {
             appLog('[api] iroh tunnel down; $getOrPost $location failed: $e');
             rethrow;

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -232,7 +232,10 @@ class DownloadManager {
 
     // Bring the tunnel up (rebuilds it if hard-down) and wait for a live port;
     // if it can't connect, this is a real failure.
-    if (!await ServerManager().awaitTunnelReady(server: server)) return false;
+    if (!await ServerManager()
+        .awaitTunnelReady(server: server, caller: 'download')) {
+      return false;
+    }
     final freshUrl = irohLoopbackUri(server, dt.serverUrl).toString();
     if (freshUrl == dt.serverUrl) return false; // port + token didn't rotate
 

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -13,6 +13,7 @@ import '../util/insecure_tls_channel.dart';
 import '../util/server_version.dart';
 import '../util/write_chain.dart';
 import '../native/iroh_tunnel.dart';
+import './tunnel_policy.dart';
 import '../media/cast_target.dart';
 import 'cast_manager.dart';
 import './media.dart';
@@ -31,6 +32,41 @@ class ServerManager {
   // or null when no tunnel is running. Drives (re)start decisions in
   // [ensureActiveTunnel]; the shim holds one tunnel at a time, for the active server.
   String? _activeTunnelCode;
+
+  // ── Reconnect bookkeeping (the rules live in tunnel_policy.dart) ──
+  // Single-flight handleNetworkChange: a burst (app resume + a connectivity
+  // event) runs once, plus one re-run if anything landed while it was busy.
+  Future<void>? _networkChangeInFlight;
+  bool _networkChangeRerun = false;
+  String _rerunReason = '';
+  // When the reported status last left `connected` (null while connected).
+  DateTime? _notConnectedSince;
+  // Last in-place kick (native force-reconnect; null when never/unsupported).
+  DateTime? _kickedAt;
+  // Last hard rebuild (stop + fresh dial) from ANY caller — rate-limited, since
+  // it rotates the loopback port and token.
+  DateTime? _lastHardRebuildAt;
+  // Last `[none]` connectivity event, to tell a modem re-attach from a hand-off.
+  DateTime? _lastOfflineAt;
+  // Last failed cold dial; gates every non-user ensure behind the retry timer.
+  DateTime? _lastFailedDialAt;
+  DateTime? _lastSkipLogAt;
+  // The retry loop that makes "no tunnel and nothing scheduled" unreachable
+  // while an iroh server is the tunnel's target.
+  Timer? _retryTimer;
+  int _retryAttempt = 0;
+  // Ensures queued on _tunnelChain but not finished (awaitTunnelReady extends
+  // its deadline while one is pending, not just while a dial is in flight).
+  int _pendingEnsures = 0;
+  // A cold dial answered "NO": surface Repair (not Retry) and stop re-dialing
+  // on every network event — no native tunnel exists to report `rejected`.
+  bool _startRejected = false;
+  // The launch ping was skipped because the tunnel was not up yet; the next
+  // successful dial runs it (vpaths, transcode defaults, version).
+  String? _pingPendingFor;
+  // A Retry tap that lands while a network change is in flight must not be
+  // downgraded to an automatic re-run.
+  bool _rerunUser = false;
 
   // streams
   late final BehaviorSubject<List<Server>> _serverListStream =
@@ -100,8 +136,11 @@ class ServerManager {
     if (serverList.isNotEmpty) {
       currentServer = serverList[0];
       // Bring up the tunnel for an iroh default server BEFORE the browser queries
-      // it.
-      await ensureActiveTunnel();
+      // it — bounded: a cold dial in a dead zone takes up to ~43s and the retry
+      // loop owns failures now, so launch must not wait on it. The dial keeps
+      // running on the chain; the first browse/playback awaits the tunnel itself.
+      await ensureActiveTunnel(reason: 'launch', bypassBackoff: true)
+          .timeout(const Duration(seconds: 12), onTimeout: () {});
       // Pre-warm the saved queue's iroh server (if it's a DIFFERENT server) in the
       // BACKGROUND — without selecting it — so the queue restores against a live
       // tunnel instead of a dead loopback port. The default stays selected; this
@@ -112,7 +151,8 @@ class ServerManager {
         final rs = byLocalname(resumeName);
         if (rs != null && rs.isIroh) {
           setQueueIrohServer(rs);
-          await awaitTunnelReady(server: rs);
+          await awaitTunnelReady(
+              server: rs, caller: 'launch', extendWhileDialing: false);
         }
       }
       BrowserManager().goToNavScreen();
@@ -228,7 +268,7 @@ class ServerManager {
     _currentServerStream.sink.add(currentServer);
     // Bring the tunnel up for the newly-active iroh server (or tear it down when
     // switching to HTTP) before the browser queries it.
-    await ensureActiveTunnel();
+    await ensureActiveTunnel(reason: 'server-switch', bypassBackoff: true);
     BrowserManager().goToNavScreen();
     unawaited(getServerPaths(currentServer!));
   }
@@ -255,6 +295,7 @@ class ServerManager {
       }
       if (server.tunnelPort == null) {
         if (throwErr) throw Exception('iroh tunnel not connected');
+        _pingPendingFor = server.localname; // re-run when the dial lands
         return;
       }
     }
@@ -403,7 +444,7 @@ class ServerManager {
     final next = (s != null && s.isIroh) ? s : null;
     if (next?.localname == _queueIrohServer?.localname) return;
     _queueIrohServer = next;
-    unawaited(ensureActiveTunnel());
+    unawaited(ensureActiveTunnel(reason: 'queue-server', bypassBackoff: true));
   }
 
   // Which iroh server the single tunnel should serve: the browsed server when it
@@ -436,13 +477,41 @@ class ServerManager {
   /// also force a rebuild when the native tunnel is fully *down* despite our
   /// bookkeeping (the shim's supervisor self-heals transient drops, so this only
   /// fires for a hard-down tunnel). Serialized against concurrent callers.
-  Future<void> ensureActiveTunnel({bool verify = false}) {
-    final next = _tunnelChain.then((_) => _ensureActiveTunnel(verify));
+  ///
+  /// [reason] is logged with every start/stop so the next incident log says who
+  /// asked. [bypassBackoff] lets the retry timer and user-driven callers dial
+  /// even when a cold dial failed moments ago; everything else waits for the
+  /// timer (see [TunnelPolicy.shouldSkipColdDial]).
+  ///
+  /// Invariants (hold them when touching anything below):
+  ///  1. Every native mutation — start, stop, kick, pairing-code swap — runs
+  ///     inside _tunnelChain. Probes may run outside it, but a consequence of a
+  ///     probe re-checks the tunnel identity (code, port) inside the chain
+  ///     before acting (see _sameTunnel).
+  ///  2. A native tunnel reporting `reconnecting` is never stopped unless the
+  ///     user asked (Retry) or the watchdog says the relay is reachable and the
+  ///     supervisor is not converging.
+  ///  3. s.tunnelPort / s.tunnelToken / _activeTunnelCode change only inside
+  ///     the chain; a kick leaves all three unchanged.
+  ///  4. While the target is an iroh server and no native tunnel exists, a retry
+  ///     Timer is armed (unless the pairing was rejected). There is no "down
+  ///     with nothing scheduled" state.
+  ///  5. At most one hard rebuild per hardRebuildMinGap across all callers; a
+  ///     user-initiated Retry/Repair bypasses the gap.
+  Future<void> ensureActiveTunnel(
+      {bool verify = false,
+      String reason = 'ensure',
+      bool bypassBackoff = false}) {
+    _pendingEnsures++;
+    final next = _tunnelChain
+        .then((_) => _ensureActiveTunnel(verify, reason, bypassBackoff))
+        .whenComplete(() => _pendingEnsures--);
     _tunnelChain = next.catchError((_) {});
     return next;
   }
 
-  Future<void> _ensureActiveTunnel(bool verify) async {
+  Future<void> _ensureActiveTunnel(
+      bool verify, String reason, bool bypassBackoff) async {
     if (!IrohTunnel.isSupported) return;
     final s = _tunnelTargetServer();
     if (s != null && s.isIroh && s.irohPairingCode != null) {
@@ -465,6 +534,33 @@ class ServerManager {
           return;
         }
       }
+      // A cold dial answered "NO" (wrong/rotated secret): only a repair or a
+      // user tap may dial again. Otherwise every automatic caller — a DJ pick
+      // re-fired every ~30s, a playback error, a download — would re-dial
+      // into the same rejection and flicker the banner Repair↔Connecting.
+      if (_activeTunnelCode == null && _startRejected && !bypassBackoff) {
+        return;
+      }
+      // No tunnel and a cold dial failed recently: the retry timer owns the
+      // next attempt. Without this gate every caller that wants the tunnel
+      // would queue its own 33–43s dial behind the last one, so a dead zone
+      // became back-to-back radio time with no backoff at all.
+      if (_activeTunnelCode == null &&
+          TunnelPolicy.shouldSkipColdDial(
+              sinceFailedDial: _since(_lastFailedDialAt),
+              nextRetry: TunnelPolicy.retryDelay(_retryAttempt),
+              bypassBackoff: bypassBackoff)) {
+        final now = DateTime.now();
+        if (_lastSkipLogAt == null ||
+            now.difference(_lastSkipLogAt!) >= const Duration(seconds: 60)) {
+          _lastSkipLogAt = now;
+          appLog('[iroh] start skipped ($reason) — a dial failed '
+              '${_since(_lastFailedDialAt)!.inSeconds}s ago; '
+              'retry #${_retryAttempt + 1} owns the next attempt');
+        }
+        if (_retryTimer == null && !_startRejected) _scheduleRetry();
+        return;
+      }
       // The shim holds one tunnel; switching servers (or rebuilding a dead one)
       // requires dropping the old one first (start() returns the stale port otherwise).
       if (_activeTunnelCode != null) {
@@ -476,16 +572,30 @@ class ServerManager {
         if (_activeTunnelCode != s.irohPairingCode && CastManager().isCasting) {
           unawaited(CastManager().selectTarget(CastTarget.local));
         }
-        IrohTunnel.instance.stop();
-        _activeTunnelCode = null;
+        _stopTunnel('switch/$reason');
       }
       _tunnelStarting = true;
       _refreshTunnelStatus(); // surface "Connecting…" while the dial runs
+      final sw = Stopwatch()..start();
       try {
         final port = await IrohTunnel.instance.start(s.irohPairingCode!);
         s.tunnelPort = port;
         s.tunnelToken = IrohTunnel.instance.localToken;
         _activeTunnelCode = s.irohPairingCode;
+        _cancelRetry();
+        _startRejected = false;
+        _lastFailedDialAt = null;
+        _notConnectedSince = null;
+        _kickedAt = null;
+        appLog('[iroh] tunnel up port=$port '
+            'path=${IrohTunnel.instance.pathKind.name} '
+            'in ${sw.elapsedMilliseconds}ms ($reason)');
+        // The launch sweep no longer waits for a slow dial; run the ping it
+        // skipped so vpaths / transcode / version are not stale all session.
+        if (_pingPendingFor == s.localname) {
+          _pingPendingFor = null;
+          unawaited(getServerPaths(s));
+        }
         // This bind set a loopback port + token. Any queued iroh stream URL built
         // before now is stale, so rebuild them off the live effectiveBaseUrl.
         // Unconditional on purpose: besides a port that changed on a reconnect /
@@ -516,51 +626,292 @@ class ServerManager {
         s.tunnelPort = null;
         s.tunnelToken = null;
         _activeTunnelCode = null;
-        // Leave it down; requests fail fast via effectiveBaseUrl until retried.
-        appLog('[iroh] tunnel start failed: $e');
+        _lastFailedDialAt = DateTime.now();
+        // The native side distinguishes a "NO" handshake (wrong/rotated secret)
+        // from an unreachable server; only the latter is worth retrying.
+        _startRejected = '$e'.contains('rejected');
+        appLog('[iroh] tunnel start failed after ${sw.elapsedMilliseconds}ms '
+            '($reason): $e');
+        if (_startRejected) {
+          _cancelRetry();
+        } else {
+          _scheduleRetry();
+        }
       } finally {
         _tunnelStarting = false;
       }
       _refreshTunnelStatus();
     } else if (_activeTunnelCode != null) {
-      IrohTunnel.instance.stop();
-      _activeTunnelCode = null;
+      _stopTunnel('no-target/$reason');
+      _cancelRetry();
       _stopStatusPolling();
     } else {
+      _cancelRetry();
       _stopStatusPolling();
     }
   }
 
-  /// React to a device network change / app resume: nudge iroh to re-probe paths
-  /// (it can't self-detect on Android) and rebuild the tunnel if it's hard-down.
-  /// Cheap and safe when the active server isn't iroh.
-  Future<void> handleNetworkChange() async {
-    // Nudge whichever server the tunnel serves (a background playback server, not
-    // just the browsed one) so a Wi-Fi/cellular switch re-probes the live tunnel.
+  Duration? _since(DateTime? t) =>
+      t == null ? null : DateTime.now().difference(t);
+
+  /// Run [fn] on the tunnel chain (invariant 1). Returns the chained future so
+  /// the caller can await the mutation; the chain itself swallows errors.
+  Future<void> _mutateTunnel(String reason, FutureOr<void> Function() fn) {
+    final next = _tunnelChain.then((_) => fn());
+    _tunnelChain = next.catchError((_) {});
+    return next;
+  }
+
+  /// Stop the native tunnel and forget its assignment. ONLY from inside the
+  /// chain (invariant 3).
+  void _stopTunnel(String reason) {
+    if (_activeTunnelCode != null) {
+      appLog('[iroh] tunnel stopped ($reason) '
+          'port=${_tunnelTargetServer()?.tunnelPort}');
+    }
+    IrohTunnel.instance.stop();
+    _activeTunnelCode = null;
+  }
+
+  /// True when the tunnel is still the one a probe was taken against — the
+  /// re-check every probe consequence runs inside the chain before acting.
+  bool _sameTunnel(Server s, String? code, int? port) =>
+      code != null &&
+      _activeTunnelCode == code &&
+      s.tunnelPort == port &&
+      s.irohPairingCode == code;
+
+  /// Arm the retry after a failed cold dial (invariant 4). The attempt index is
+  /// only reset by a success or a target change, so a burst of callers cannot
+  /// shorten the backoff.
+  void _scheduleRetry() {
+    _retryTimer?.cancel();
+    final d = TunnelPolicy.retryDelay(_retryAttempt);
+    appLog('[iroh] retry #${_retryAttempt + 1} in ${d.inSeconds}s');
+    _retryTimer = Timer(d, () {
+      _retryTimer = null;
+      final s = _tunnelTargetServer();
+      if (s == null ||
+          !s.isIroh ||
+          _activeTunnelCode != null ||
+          _tunnelStarting ||
+          _startRejected) {
+        return;
+      }
+      _retryAttempt++;
+      unawaited(ensureActiveTunnel(
+          verify: true, reason: 'retry#$_retryAttempt', bypassBackoff: true));
+    });
+  }
+
+  void _cancelRetry() {
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    _retryAttempt = 0;
+  }
+
+  /// Called by the connectivity listener on a `[none]` result (invariant: the
+  /// only place _lastOfflineAt is written).
+  void noteConnectivityLost() {
+    _lastOfflineAt = DateTime.now();
+  }
+
+  /// React to a device network change / app resume / the banner's Retry tap:
+  /// nudge iroh to re-probe paths (it can't self-detect on Android), then let
+  /// the pure [TunnelPolicy] decide — leave a reconnecting tunnel to its
+  /// supervisor, probe a connected-reporting one for ground truth, or (re)start
+  /// a missing one. Single-flight: overlapping calls (a resume plus a
+  /// connectivity burst) coalesce into one run plus at most one re-run.
+  ///
+  /// History: this used to probe the loopback unconditionally and hard-drop on
+  /// any failure. During a reconnect the shim fails every loopback request
+  /// within a second, so the probe always failed, and the app killed the very
+  /// supervisor that would have healed the tunnel in place — replacing it with
+  /// one cold dial (drive log: 15:08:50 "resume probe failed" → 15:09:23
+  /// "tunnel start failed", then nothing until the user tapped a track). The
+  /// probe is now reserved for the case it was written for (98d06c8): native
+  /// status `connected` on a QUIC connection that is actually dead after an
+  /// iOS thaw — and it has to fail twice, with a grace window for iroh's own
+  /// path migration, before anything is torn down.
+  Future<void> handleNetworkChange(
+      {String reason = 'unknown', bool userInitiated = false}) {
+    if (_networkChangeInFlight != null) {
+      _networkChangeRerun = true;
+      _rerunReason = reason;
+      _rerunUser = _rerunUser || userInitiated;
+      return _networkChangeInFlight!;
+    }
+    Future<void> run() async {
+      var r = reason;
+      var user = userInitiated;
+      do {
+        _networkChangeRerun = false;
+        try {
+          await _handleNetworkChangeOnce(r, user);
+        } catch (e) {
+          appLog('[iroh] network change ($r) failed: $e');
+        }
+        r = _rerunReason;
+        user = _rerunUser;
+        _rerunUser = false;
+      } while (_networkChangeRerun);
+    }
+
+    final f = run().whenComplete(() => _networkChangeInFlight = null);
+    _networkChangeInFlight = f;
+    return f;
+  }
+
+  Future<void> _handleNetworkChangeOnce(String reason, bool user) async {
     final s = _tunnelTargetServer();
     if (!IrohTunnel.isSupported || s == null) return;
     IrohTunnel.instance.networkChanged();
-    // A suspension thaw can leave the native side REPORTING connected on a
-    // dead QUIC connection — nothing has exercised it yet, so the supervisor
-    // hasn't noticed (observed on iPhone: pause, background a few minutes,
-    // resume → streaming dead, status still "connected"). That stale status
-    // makes verify's is-it-down check a no-op, so probe ground truth through
-    // the loopback and hard-drop the tunnel when the path is dead —
-    // ensureActiveTunnel below then rebuilds it and re-derives the queue's
-    // stream URLs on the fresh bind.
-    if (_activeTunnelCode != null &&
-        s.isIroh &&
-        s.tunnelPort != null &&
-        !await _probeTunnel(s)) {
-      appLog('[iroh] resume probe failed — rebuilding the tunnel');
-      final drop = _tunnelChain.then((_) {
-        IrohTunnel.instance.stop();
-        _activeTunnelCode = null;
-      });
-      _tunnelChain = drop.catchError((_) {});
-      await drop;
+    final native = IrohTunnel.instance.status;
+    final code = _activeTunnelCode;
+    final port = s.tunnelPort;
+    appLog('[iroh] network change ($reason) native=${native.name} port=$port '
+        'notConnectedFor=${_since(_notConnectedSince)?.inSeconds ?? 0}s');
+    switch (TunnelPolicy.onNetworkChange(
+        native: native,
+        assigned: tunnelAssignedTo(s) && port != null,
+        starting: _tunnelStarting,
+        rejected: native == IrohTunnelStatus.rejected || _startRejected,
+        sinceOffline: _since(_lastOfflineAt),
+        userInitiated: user)) {
+      case NetworkChangeRemedy.leaveRejected:
+        appLog('[iroh] pairing rejected — waiting for a repair, not re-dialing');
+        return;
+      case NetworkChangeRemedy.leaveToSupervisor:
+        appLog('[iroh] leaving the reconnect to the supervisor');
+        return;
+      case NetworkChangeRemedy.escalate:
+        await _hardRebuild(s,
+            code: code, port: port, reason: 'escalate/$reason', user: user);
+        return;
+      case NetworkChangeRemedy.probe:
+        if (await _probeTwice(s, code: code, port: port)) {
+          await _remedyDeadTunnel(s,
+              code: code, port: port, reason: reason, user: user);
+        }
+        return;
+      case NetworkChangeRemedy.ensureOnly:
+        break;
     }
-    await ensureActiveTunnel(verify: true);
+    // No tunnel (or a dial in flight): make sure one is coming. An automatic
+    // trigger with a failed dial behind it does not dial on the spot — the
+    // network just changed and is often not usable yet (log: the re-attach at
+    // 15:08:49 landed while service was still dead) — but it restarts the
+    // retry schedule so the next attempt is seconds away, not a minute.
+    if (!user &&
+        _activeTunnelCode == null &&
+        !_tunnelStarting &&
+        _lastFailedDialAt != null &&
+        !_startRejected) {
+      // Clamp rather than zero: a flapping dead zone emits a transport event
+      // every few minutes, and a full 5/10/20/40s ramp per event would keep
+      // the radio busy; one quick attempt per event is enough.
+      _retryAttempt = _retryAttempt.clamp(0, 1);
+      _scheduleRetry();
+      return;
+    }
+    await ensureActiveTunnel(verify: true, reason: reason, bypassBackoff: user);
+  }
+
+  /// True only when two probes, spaced across iroh's migration window, both
+  /// failed AND the tunnel is still the same one reporting connected. A
+  /// supervisor that noticed the drop in between (status → reconnecting) owns
+  /// the recovery, so that is a "false" too.
+  Future<bool> _probeTwice(Server s,
+      {required String? code, required int? port}) async {
+    final t0 = DateTime.now();
+    await Future<void>.delayed(TunnelTiming.probeFirstDelay);
+    if (!_sameTunnel(s, code, port)) return false;
+    final r1 = await _probeTunnel(s);
+    appLog('[iroh] probe #1 ${r1.ok ? 'passed' : 'failed'} '
+        '(${r1.reason}, ${r1.ms}ms, native=${IrohTunnel.instance.status.name})');
+    if (r1.ok) return false;
+    final wait = TunnelTiming.probeSecondAt - DateTime.now().difference(t0);
+    if (wait > Duration.zero) await Future<void>.delayed(wait);
+    if (!_sameTunnel(s, code, port) ||
+        IrohTunnel.instance.status != IrohTunnelStatus.connected) {
+      return false;
+    }
+    final r2 = await _probeTunnel(s);
+    appLog('[iroh] probe #2 ${r2.ok ? 'passed' : 'failed'} '
+        '(${r2.reason}, ${r2.ms}ms)');
+    return !r2.ok;
+  }
+
+  /// A connected-reporting tunnel is dead (two probes, or repeated load
+  /// failures): kick it in place when the binary can, else rebuild — rate
+  /// limited, because a rebuild rotates the port and token.
+  Future<void> _remedyDeadTunnel(Server s,
+      {required String? code,
+      required int? port,
+      required String reason,
+      required bool user}) async {
+    switch (TunnelPolicy.onProbeFailedTwice(
+        canKick: IrohTunnel.instance.hasKick,
+        sinceHardRebuild: _since(_lastHardRebuildAt),
+        sinceKick: _since(_kickedAt),
+        userInitiated: user)) {
+      case DeadTunnelRemedy.kick:
+        await _mutateTunnel('kick/$reason', () {
+          if (!_sameTunnel(s, code, port)) return;
+          _kickedAt = DateTime.now();
+          _notConnectedSince ??= _kickedAt;
+          appLog('[iroh] kicking the tunnel in place ($reason) — port $port kept');
+          IrohTunnel.instance.kick();
+        });
+      case DeadTunnelRemedy.hardRebuild:
+        await _hardRebuild(s,
+            code: code,
+            port: port,
+            reason: 'dead/$reason',
+            user: user,
+            onlyIfConnected: !user);
+      case DeadTunnelRemedy.wait:
+        appLog('[iroh] tunnel dead but a rebuild ran '
+            '${_since(_lastHardRebuildAt)?.inSeconds}s ago — waiting');
+    }
+  }
+
+  /// Stop the native tunnel and dial fresh (new port + token). The one path
+  /// that discards the supervisor, so it re-checks the tunnel identity inside
+  /// the chain and honours hardRebuildMinGap unless the user asked.
+  ///
+  /// [onlyIfConnected]: a probe-derived rebuild must not stop a supervisor
+  /// that flipped to `reconnecting` while the probe was running (the QUIC
+  /// idle timeout lands inside that window) — it is already healing on the
+  /// same port. The watchdog and a user tap target a reconnecting tunnel on
+  /// purpose and leave this false.
+  Future<void> _hardRebuild(Server s,
+      {required String? code,
+      required int? port,
+      required String reason,
+      required bool user,
+      bool onlyIfConnected = false}) async {
+    final gap = _since(_lastHardRebuildAt);
+    if (!user && gap != null && gap < TunnelTiming.hardRebuildMinGap) {
+      appLog('[iroh] hard rebuild ($reason) skipped — last one '
+          '${gap.inSeconds}s ago');
+      return;
+    }
+    var dropped = false;
+    await _mutateTunnel('drop/$reason', () {
+      if (!_sameTunnel(s, code, port)) return; // already rebuilt or dropped
+      if (onlyIfConnected &&
+          IrohTunnel.instance.status != IrohTunnelStatus.connected) {
+        appLog('[iroh] rebuild ($reason) skipped — the supervisor took over');
+        return;
+      }
+      _lastHardRebuildAt = DateTime.now();
+      _stopTunnel('rebuild/$reason');
+      dropped = true;
+    });
+    if (!dropped) return;
+    await ensureActiveTunnel(
+        verify: true, reason: 'rebuild/$reason', bypassBackoff: true);
   }
 
   /// Read the server's version from `GET /api/` — public, no auth, and served
@@ -634,19 +985,31 @@ class ServerManager {
   /// error status — proves the path; only a connect failure/timeout means
   /// dead. A FRESH client per probe is load-bearing: the shim authenticates
   /// per TCP connection, and a pooled socket would test yesterday's
-  /// connection instead of the tunnel.
-  Future<bool> _probeTunnel(Server s) async {
+  /// connection instead of the tunnel. Returns WHY it failed, classified by
+  /// [TunnelPolicy.classifyProbeError], because "refused", "reset" and
+  /// "timeout" are three different tunnel states.
+  Future<({bool ok, String reason, int ms})> _probeTunnel(Server s) async {
+    final sw = Stopwatch()..start();
     final client = HttpClient()
-      ..connectionTimeout = const Duration(seconds: 4);
+      ..connectionTimeout = TunnelTiming.probeLoopbackTimeout;
     try {
       final req = await client
           .getUrl(s.apiUri('/api/v1/ping'))
-          .timeout(const Duration(seconds: 4));
-      final resp = await req.close().timeout(const Duration(seconds: 6));
+          .timeout(TunnelTiming.probeLoopbackTimeout);
+      final resp =
+          await req.close().timeout(TunnelTiming.probeResponseTimeout);
       await resp.drain<void>();
-      return true;
-    } catch (_) {
-      return false;
+      return (
+        ok: true,
+        reason: 'http ${resp.statusCode}',
+        ms: sw.elapsedMilliseconds
+      );
+    } catch (e) {
+      return (
+        ok: false,
+        reason: TunnelPolicy.classifyProbeError(e),
+        ms: sw.elapsedMilliseconds
+      );
     } finally {
       client.close(force: true);
     }
@@ -678,14 +1041,57 @@ class ServerManager {
       st = IrohTunnelStatus.down;
     } else if (_tunnelStarting) {
       st = IrohTunnelStatus.connecting;
+    } else if (_startRejected && _activeTunnelCode == null) {
+      // A cold dial answered "NO": no native tunnel exists to say so, but the
+      // banner must offer Repair, not Retry.
+      st = IrohTunnelStatus.rejected;
     } else {
       st = IrohTunnel.instance.status;
     }
-    if (st != _tunnelStatus.value) _tunnelStatus.add(st);
     final pk = (isIroh && !_tunnelStarting)
         ? IrohTunnel.instance.pathKind
         : IrohPathKind.unknown;
+    final now = DateTime.now();
+    if (st != _tunnelStatus.value) {
+      final was = _notConnectedSince;
+      final after = (st == IrohTunnelStatus.connected && was != null)
+          ? ' after ${now.difference(was).inSeconds}s'
+          : '';
+      appLog('[iroh] status ${_tunnelStatus.value.name} → ${st.name}$after '
+          'path=${pk.name} port=${_tunnelTargetServer()?.tunnelPort}');
+      _tunnelStatus.add(st);
+    }
+    if (st == IrohTunnelStatus.connected) {
+      _notConnectedSince = null;
+      _kickedAt = null;
+    } else if (isIroh) {
+      _notConnectedSince ??= now;
+    }
     if (pk != _pathKind.value) _pathKind.add(pk);
+    // Native supervisor events (a binary with the events ring); nothing on
+    // older binaries.
+    for (final line in IrohTunnel.instance.drainEvents()) {
+      appLog('[iroh-native] $line');
+    }
+    // Watchdog: a supervisor that is not converging although the relay is
+    // reachable (or a kick that did not take) gets a fresh endpoint. Never in
+    // a dead zone — see TunnelPolicy.shouldEscalate — and never more than one
+    // rebuild per minute (_hardRebuild), so the 2s poll is a safe caller.
+    final s = _tunnelTargetServer();
+    if (s != null &&
+        !_tunnelStarting &&
+        _activeTunnelCode != null &&
+        TunnelPolicy.shouldEscalate(
+            native: IrohTunnel.instance.status,
+            notConnectedFor: _since(_notConnectedSince),
+            sinceKick: _since(_kickedAt),
+            relayReachable: IrohTunnel.instance.relayOnline)) {
+      unawaited(_hardRebuild(s,
+          code: _activeTunnelCode,
+          port: s.tunnelPort,
+          reason: 'watchdog',
+          user: false));
+    }
   }
 
   void _startStatusPolling() {
@@ -699,6 +1105,7 @@ class ServerManager {
   void _stopStatusPolling() {
     _statusPoll?.cancel();
     _statusPoll = null;
+    _notConnectedSince = null;
     if (_tunnelStatus.value != IrohTunnelStatus.down) {
       _tunnelStatus.add(IrohTunnelStatus.down);
     }
@@ -717,15 +1124,29 @@ class ServerManager {
   Future<bool> awaitTunnelReady(
       {Server? server,
       Duration timeout = const Duration(seconds: 12),
-      bool extendWhileDialing = true}) async {
+      bool extendWhileDialing = true,
+      String caller = '?',
+      bool bypassBackoff = false}) async {
     // Default to the browsed server; callers on the playback path pass the
     // track's server (which the single tunnel may be serving instead).
     final s = server ?? currentServer;
     if (!IrohTunnel.isSupported || s == null || !s.isIroh) return true;
-    unawaited(ensureActiveTunnel(verify: true));
-    // start() can take ~30s; don't report not-ready while a dial is in flight.
-    // Keep extending the window while connecting, bounded by a hard cap.
-    final hardCap = DateTime.now().add(const Duration(seconds: 45));
+    // A rejected cold dial leaves no native tunnel to report it; answer
+    // before firing an ensure that would only re-dial into the rejection.
+    if (_startRejected &&
+        !bypassBackoff &&
+        s.localname == _tunnelTargetServer()?.localname) {
+      return false;
+    }
+    unawaited(ensureActiveTunnel(
+        verify: true, reason: 'await-ready:$caller', bypassBackoff: bypassBackoff));
+    // start() can take ~30s; don't report not-ready while a dial is in flight
+    // — or while an ensure is still queued behind one (a rebuild's fresh dial
+    // runs after the drop). Keep extending the window while so, bounded by a
+    // hard cap that fits two full attempts.
+    final hardCap = DateTime.now().add(extendWhileDialing
+        ? const Duration(seconds: 90)
+        : const Duration(seconds: 45));
     var deadline = DateTime.now().add(timeout);
     while (DateTime.now().isBefore(deadline) && DateTime.now().isBefore(hardCap)) {
       // Ready only when the tunnel is connected AND serving THIS server — with one
@@ -735,7 +1156,12 @@ class ServerManager {
           IrohTunnel.instance.status == IrohTunnelStatus.rejected) {
         return false; // this server's code was rejected (needs re-pair)
       }
-      if (_tunnelStarting && extendWhileDialing) {
+      // A rejected cold dial leaves no native tunnel to report it.
+      if (_startRejected &&
+          s.localname == _tunnelTargetServer()?.localname) {
+        return false;
+      }
+      if (extendWhileDialing && (_tunnelStarting || _pendingEnsures > 0)) {
         deadline = DateTime.now().add(timeout);
       }
       await Future.delayed(const Duration(milliseconds: 300));
@@ -743,23 +1169,17 @@ class ServerManager {
     return tunnelServes(s);
   }
 
-  // At most one forced rebuild per minute. A hard stop/start rotates the
-  // loopback port AND the per-connection token: every in-flight download
-  // fails, and _reEnqueueOnLiveTunnel only re-resolves twice before giving
-  // up. Worth paying once for a tunnel that is lying about being up; a loop
-  // of them is worse than the outage it is trying to fix.
-  DateTime? _lastForcedRebuild;
   bool _reverifying = false;
 
   /// Ground-truth check for a tunnel that REPORTS connected while nothing can
   /// actually stream through it — the shim only flips to reconnecting once the
-  /// QUIC connection's close arrives, so a link that vanished underneath it
-  /// keeps claiming to be up, and the playback heal fires on a status
-  /// TRANSITION that therefore never comes.
+  /// QUIC connection's close arrives (≤30s idle timeout), so a link that
+  /// vanished underneath it keeps claiming to be up, and the playback heal
+  /// fires on a status TRANSITION that therefore never comes.
   ///
-  /// Probes the loopback and, only when the probe fails, hard-drops and
-  /// rebuilds — the same sequence [handleNetworkChange] runs, which is the one
-  /// path that has ever recovered this state. A passing probe means the tunnel
+  /// Probes the loopback and, only when the probe fails, hands the tunnel to
+  /// [_remedyDeadTunnel] (kick in place when the binary can, else a hard
+  /// rebuild rate-limited to one per minute). A passing probe means the tunnel
   /// is fine and the failures were the source's own problem, so nothing moves.
   Future<void> reverifyTunnel(Server s) async {
     if (!IrohTunnel.isSupported || !s.isIroh || _reverifying) return;
@@ -767,26 +1187,27 @@ class ServerManager {
     // Already known down: ensureActiveTunnel / awaitTunnelReady own that case
     // and this would only race them.
     if (!tunnelServes(s)) return;
-    final now = DateTime.now();
-    final last = _lastForcedRebuild;
-    if (last != null && now.difference(last) < const Duration(seconds: 60)) {
-      return;
-    }
+    final gap = _since(_lastHardRebuildAt);
+    if (gap != null && gap < TunnelTiming.hardRebuildMinGap) return;
     _reverifying = true;
     try {
-      if (await _probeTunnel(s)) {
-        appLog('[iroh] tunnel probe passed — the failures were not the path');
+      final code = _activeTunnelCode;
+      final port = s.tunnelPort;
+      final r = await _probeTunnel(s);
+      if (r.ok) {
+        appLog('[iroh] tunnel probe passed (${r.reason}, ${r.ms}ms) — '
+            'the failures were not the path');
         return;
       }
-      _lastForcedRebuild = DateTime.now();
-      appLog('[iroh] tunnel says connected but the path is dead — rebuilding');
-      final drop = _tunnelChain.then((_) {
-        IrohTunnel.instance.stop();
-        _activeTunnelCode = null;
-      });
-      _tunnelChain = drop.catchError((_) {});
-      await drop;
-      await ensureActiveTunnel(verify: true);
+      if (!tunnelServes(s)) {
+        appLog('[iroh] probe failed (${r.reason}) but the supervisor '
+            'noticed meanwhile — leaving it');
+        return;
+      }
+      appLog('[iroh] tunnel says connected but the probe failed '
+          '(${r.reason}, ${r.ms}ms) after repeated load failures');
+      await _remedyDeadTunnel(s,
+          code: code, port: port, reason: 'reverify', user: false);
     } finally {
       _reverifying = false;
     }
@@ -806,12 +1227,18 @@ class ServerManager {
     final oldCode = s.irohPairingCode;
 
     Future<void> activate(String? code) async {
-      s.irohPairingCode = code;
-      IrohTunnel.instance.stop();
-      _activeTunnelCode = null;
-      s.tunnelPort = null;
-      s.tunnelToken = null;
-      await ensureActiveTunnel(verify: true);
+      // The swap runs on the chain (invariant 1) so an in-flight ensure can't
+      // record the OLD code as the one it dialed.
+      await _mutateTunnel('repair', () {
+        s.irohPairingCode = code;
+        _stopTunnel('repair');
+        s.tunnelPort = null;
+        s.tunnelToken = null;
+        _startRejected = false;
+        _cancelRetry();
+      });
+      await ensureActiveTunnel(
+          verify: true, reason: 'repair', bypassBackoff: true);
     }
 
     // Try the new code WITHOUT persisting yet.
@@ -838,6 +1265,9 @@ class ServerManager {
       s.tunnelPort = port;
       s.tunnelToken = token;
       _activeTunnelCode = s.irohPairingCode;
+      _cancelRetry();
+      _startRejected = false;
+      _lastFailedDialAt = null;
     }).catchError((_) {});
   }
 
@@ -881,7 +1311,7 @@ class ServerManager {
     }
 
     // Start/stop the tunnel to match the (possibly changed) active server.
-    await ensureActiveTunnel();
+    await ensureActiveTunnel(reason: 'remove-server');
     await writeServerFile();
     syncInsecureTls();
     // Pooled keep-alive sockets to the removed server would otherwise linger.
@@ -909,7 +1339,7 @@ class ServerManager {
     // changeCurrentServer().
     currentServer = s;
     _currentServerStream.sink.add(currentServer);
-    await ensureActiveTunnel();
+    await ensureActiveTunnel(reason: 'make-default', bypassBackoff: true);
     BrowserManager().goToNavScreen();
 
     // Persist the new order so serverList[0] — the default loaded on the

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -291,7 +291,8 @@ class ServerManager {
         await awaitTunnelReady(
             server: server,
             timeout: const Duration(seconds: 12),
-            extendWhileDialing: false);
+            extendWhileDialing: false,
+            caller: 'ping');
       }
       if (server.tunnelPort == null) {
         if (throwErr) throw Exception('iroh tunnel not connected');
@@ -444,7 +445,11 @@ class ServerManager {
     final next = (s != null && s.isIroh) ? s : null;
     if (next?.localname == _queueIrohServer?.localname) return;
     _queueIrohServer = next;
-    unawaited(ensureActiveTunnel(reason: 'queue-server', bypassBackoff: true));
+    // No backoff bypass: this fires from the launch queue restore as well as
+    // from a user queuing songs, and a bypass here re-dialed a REJECTED code
+    // 0.3s after the launch dial was refused (simulator run 2026-09-01).
+    // When nothing failed it dials right away; otherwise the timer owns it.
+    unawaited(ensureActiveTunnel(reason: 'queue-server'));
   }
 
   // Which iroh server the single tunnel should serve: the browsed server when it
@@ -782,7 +787,9 @@ class ServerManager {
         appLog('[iroh] pairing rejected — waiting for a repair, not re-dialing');
         return;
       case NetworkChangeRemedy.leaveToSupervisor:
-        appLog('[iroh] leaving the reconnect to the supervisor');
+        appLog(native == IrohTunnelStatus.connected
+            ? '[iroh] network just re-attached — leaving the connection to iroh'
+            : '[iroh] leaving the reconnect to the supervisor');
         return;
       case NetworkChangeRemedy.escalate:
         await _hardRebuild(s,

--- a/lib/singletons/tunnel_policy.dart
+++ b/lib/singletons/tunnel_policy.dart
@@ -1,0 +1,253 @@
+// Pure decision logic for the iroh tunnel lifecycle — no I/O, no singletons —
+// so the rules that keep Quick Connect alive on a flaky link are unit-tested
+// instead of living in comments.
+//
+// Background (two drive logs, 2026-09-01): the Rust supervisor re-dials a
+// dropped tunnel forever on the SAME loopback port and token, and playback
+// resumes on its own when it reconnects. The Dart side used to probe the
+// loopback on every network change WITHOUT reading the native status; during
+// a reconnect the shim fails every loopback request within a second, so the
+// probe always failed, and a failing probe meant stop the tunnel and start a
+// fresh one with a single cold dial (8s relay wait + 25s connect). When that
+// dial failed — likely, since service was still bad — nothing retried: every
+// URL pointed at 127.0.0.1:0 until the user tapped something. These rules
+// reserve the probe for the one case it was written for (commit 98d06c8: an
+// iOS thaw leaves the native side REPORTING connected on a dead connection),
+// leave a reconnecting tunnel to its supervisor, and guarantee that "no
+// tunnel and nothing scheduled" is not a reachable state.
+import 'dart:async';
+import 'dart:io';
+
+import '../native/iroh_tunnel.dart';
+
+/// Timing constants, each chosen against an iroh 1.0 / noq constant.
+class TunnelTiming {
+  TunnelTiming._();
+
+  /// Grace after the network_change nudge before the first probe: netwatch
+  /// debounces 250ms, then iroh re-dials the relay and pings every path.
+  /// Most hand-offs settle within ~3s.
+  static const Duration probeFirstDelay = Duration(seconds: 3);
+
+  /// The second probe, measured from the nudge. The relay actor's connect
+  /// timeout is 10s, so two failures spanning it are not migration noise.
+  static const Duration probeSecondAt = Duration(seconds: 10);
+
+  /// Loopback TCP connect + request open: instant unless the listener is gone.
+  static const Duration probeLoopbackTimeout = Duration(seconds: 2);
+
+  /// One QUIC round trip through a relay on weak cellular (covers the Initial
+  /// retransmits at ~1s and ~3s).
+  static const Duration probeResponseTimeout = Duration(seconds: 6);
+
+  /// A supervisor that has not converged in this long is escalated to a hard
+  /// rebuild — only when the relay is known reachable, see
+  /// [TunnelPolicy.shouldEscalate]; in a dead zone the supervisor's
+  /// relay-back wake is the fastest path and must not be discarded.
+  static const Duration reconnectingWatchdog = Duration(seconds: 120);
+
+  /// The same watchdog when the binary cannot say whether the relay is up
+  /// (no `relay_online` symbol yet). Long, because in a dead zone a fresh
+  /// endpoint fails exactly like the supervisor and costs its relay-back
+  /// wake — but not infinite, because a supervisor that never converges
+  /// (a dead UDP socket after an iOS thaw) would otherwise spin forever with
+  /// nothing else scheduled. The banner's Retry cuts it short.
+  static const Duration reconnectingWatchdogBlind = Duration(minutes: 5);
+
+  /// After an in-place kick (a native force-reconnect), how long to wait for
+  /// CONNECTED before falling back to a fresh endpoint (iOS dead-socket case).
+  static const Duration postKickWatchdog = Duration(seconds: 45);
+
+  /// A hard rebuild rotates port + token: every stored URL goes stale, the
+  /// player reloads, in-flight downloads die. At most one per minute unless
+  /// the user asked.
+  static const Duration hardRebuildMinGap = Duration(seconds: 60);
+
+  /// A [none]→[x] connectivity edge inside this window is a modem re-attach;
+  /// iroh's idle timeout + the supervisor handle those on their own.
+  static const Duration recentlyOffline = Duration(seconds: 15);
+
+  /// Retry schedule after a failed cold dial: fast for a blip, then at most one
+  /// dial a minute, then [retryLongDelay] once it is clearly a long outage
+  /// (each attempt holds the radio for up to ~43s).
+  static const List<int> retryDelaySeconds = [5, 10, 20, 40, 60];
+  static const Duration retryLongDelay = Duration(minutes: 5);
+  static const int retryLongAfter = 10;
+
+  /// Bound on a queue-end park waiting for the tunnel to come back.
+  static const Duration parkMax = Duration(minutes: 30);
+
+  /// How long after an audio-focus interruption began an auto rebuild must not
+  /// resume playback. A window, not a flag: Android never delivers the `end`
+  /// for a permanent loss (6 begins, 0 ends across the two drive logs).
+  static const Duration interruptionWindow = Duration(seconds: 90);
+}
+
+/// What [handleNetworkChange] does after nudging iroh.
+enum NetworkChangeRemedy {
+  /// No tunnel (or a dial in flight): make sure one is coming up.
+  ensureOnly,
+
+  /// Native says connected; verify with the loopback probe (98d06c8 case).
+  probe,
+
+  /// Native says reconnecting: the supervisor owns it, do nothing.
+  leaveToSupervisor,
+
+  /// Stop the native tunnel and dial fresh (user asked, or watchdog).
+  escalate,
+
+  /// Pairing rejected: only a repair helps; do not re-dial on every event.
+  leaveRejected,
+}
+
+/// What to do about a tunnel that reports connected but failed two probes.
+enum DeadTunnelRemedy { kick, hardRebuild, wait }
+
+class TunnelPolicy {
+  TunnelPolicy._();
+
+  /// Decide the remedy for a network change / app resume / Retry tap.
+  ///
+  /// [assigned]: a native tunnel is up for this server (code matches and a
+  /// port is recorded). [starting]: a Dart-side dial is in flight.
+  /// [rejected]: native status is rejected OR a cold dial answered "NO" (then
+  /// no native tunnel exists to report it). [sinceOffline]: time since the
+  /// last `[none]` connectivity event, null if never.
+  static NetworkChangeRemedy onNetworkChange({
+    required IrohTunnelStatus native,
+    required bool assigned,
+    required bool starting,
+    required bool rejected,
+    required Duration? sinceOffline,
+    required bool userInitiated,
+  }) {
+    if (rejected) {
+      // A user-initiated Retry may re-dial (the code may have been fixed on
+      // the server side); anything automatic waits for a repair.
+      return userInitiated
+          ? NetworkChangeRemedy.ensureOnly
+          : NetworkChangeRemedy.leaveRejected;
+    }
+    if (starting || !assigned) return NetworkChangeRemedy.ensureOnly;
+    switch (native) {
+      case IrohTunnelStatus.rejected:
+        return NetworkChangeRemedy.leaveRejected;
+      case IrohTunnelStatus.reconnecting:
+      case IrohTunnelStatus.connecting:
+        // The supervisor is already re-dialing on the same port. Only the
+        // user may cut it short (the banner's Retry).
+        return userInitiated
+            ? NetworkChangeRemedy.escalate
+            : NetworkChangeRemedy.leaveToSupervisor;
+      case IrohTunnelStatus.connected:
+        // A modem that just re-attached: the connection is either fine or
+        // about to hit the idle timeout, after which the supervisor heals it
+        // in place. Probing now would only race iroh's own re-homing.
+        if (!userInitiated &&
+            sinceOffline != null &&
+            sinceOffline < TunnelTiming.recentlyOffline) {
+          return NetworkChangeRemedy.leaveToSupervisor;
+        }
+        return NetworkChangeRemedy.probe;
+      case IrohTunnelStatus.down:
+        return NetworkChangeRemedy.ensureOnly;
+    }
+  }
+
+  /// Two consecutive probes failed on a tunnel whose native status is
+  /// connected. Prefer the in-place kick when the native side offers one
+  /// (same port/token, no reload); fall back to a rate-limited hard rebuild.
+  static DeadTunnelRemedy onProbeFailedTwice({
+    required bool canKick,
+    required Duration? sinceHardRebuild,
+    required Duration? sinceKick,
+    required bool userInitiated,
+  }) {
+    if (canKick &&
+        (userInitiated ||
+            sinceKick == null ||
+            sinceKick >= TunnelTiming.postKickWatchdog)) {
+      return DeadTunnelRemedy.kick;
+    }
+    if (userInitiated ||
+        sinceHardRebuild == null ||
+        sinceHardRebuild >= TunnelTiming.hardRebuildMinGap) {
+      return DeadTunnelRemedy.hardRebuild;
+    }
+    return DeadTunnelRemedy.wait;
+  }
+
+  /// Status-poll watchdog: escalate a supervisor that is not converging.
+  ///
+  /// [relayReachable] is the native side's word on whether its home relay is
+  /// up (null when the running binary cannot say). A reconnect that is failing
+  /// WITH the relay reachable is the iOS dead-socket case and deserves a
+  /// fresh endpoint after [TunnelTiming.reconnectingWatchdog]; one failing
+  /// WITHOUT it is a dead zone, where a fresh endpoint would fail exactly the
+  /// same way and cost the supervisor's relay-back wake, so never. Unknown
+  /// gets the long [TunnelTiming.reconnectingWatchdogBlind] ceiling. After a
+  /// kick, the post-kick watchdog applies unless the relay is known down.
+  static bool shouldEscalate({
+    required IrohTunnelStatus native,
+    required Duration? notConnectedFor,
+    required Duration? sinceKick,
+    required bool? relayReachable,
+  }) {
+    if (native != IrohTunnelStatus.reconnecting &&
+        native != IrohTunnelStatus.connecting) {
+      return false;
+    }
+    if (sinceKick != null && sinceKick >= TunnelTiming.postKickWatchdog) {
+      return relayReachable != false;
+    }
+    if (relayReachable == false) return false;
+    final ceiling = relayReachable == true
+        ? TunnelTiming.reconnectingWatchdog
+        : TunnelTiming.reconnectingWatchdogBlind;
+    return (notConnectedFor ?? Duration.zero) >= ceiling;
+  }
+
+  /// Delay before retry number [attempt] (0-based) after a failed cold dial.
+  static Duration retryDelay(int attempt) {
+    if (attempt >= TunnelTiming.retryLongAfter) {
+      return TunnelTiming.retryLongDelay;
+    }
+    final i = attempt.clamp(0, TunnelTiming.retryDelaySeconds.length - 1);
+    return Duration(seconds: TunnelTiming.retryDelaySeconds[i]);
+  }
+
+  /// Whether an ensure should skip a cold dial because one failed recently and
+  /// the retry timer owns the next attempt. Without this gate every caller
+  /// that wants the tunnel (a DJ pick re-fired every ~30s by the player's
+  /// index re-emissions, a browse, a download re-enqueue, a playback error)
+  /// would queue its own 33–43s cold dial behind the last one, defeating the
+  /// backoff. [bypassBackoff] is for the retry timer itself and for
+  /// user-driven callers.
+  static bool shouldSkipColdDial({
+    required Duration? sinceFailedDial,
+    required Duration nextRetry,
+    required bool bypassBackoff,
+  }) =>
+      !bypassBackoff && sinceFailedDial != null && sinceFailedDial < nextRetry;
+
+  /// Collapse a probe exception into the three cases that mean different
+  /// things — the old probe swallowed them into one line.
+  ///   timeout — the request went out and nothing came back: a QUIC zombie
+  ///             (the 98d06c8 case) or a path mid-migration;
+  ///   refused — the loopback listener is gone (the tunnel was stopped);
+  ///   reset   — the shim accepted the socket and dropped it: open_bi failed,
+  ///             i.e. the supervisor is RECONNECTING and will heal in place.
+  static String classifyProbeError(Object e) {
+    if (e is TimeoutException) return 'timeout';
+    final m = e.toString().toLowerCase();
+    if (m.contains('refused')) return 'refused';
+    if (m.contains('reset') ||
+        m.contains('before full header') ||
+        m.contains('closed')) {
+      return 'reset';
+    }
+    if (e is SocketException) return 'socket:${e.osError?.errorCode ?? '?'}';
+    return 'error:${e.runtimeType}';
+  }
+}

--- a/test/media/queue_end_action_test.dart
+++ b/test/media/queue_end_action_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/audio_stuff.dart';
+
+void main() {
+  group('AudioPlayerHandler.queueEndAction', () {
+    QueueEndAction act({
+      bool onLocalBackend = true,
+      bool isIrohDJ = true,
+      bool djPickPending = true,
+      bool playIntent = true,
+      bool tunnelServes = false,
+      bool pickInFlight = false,
+    }) =>
+        AudioPlayerHandler.queueEndAction(
+            onLocalBackend: onLocalBackend,
+            isIrohDJ: isIrohDJ,
+            djPickPending: djPickPending,
+            playIntent: playIntent,
+            tunnelServes: tunnelServes,
+            pickInFlight: pickInFlight);
+
+    // The regression this exists for: an outage-drained queue used to stop()
+    // like a user stop, which set the intentional-stop flag and made every
+    // later tunnel-back edge a no-op.
+    test('pick owed to the outage + playback wanted + tunnel down → park', () {
+      expect(act(), QueueEndAction.park);
+    });
+
+    // A transient POST failure with the tunnel fine has no edge to wait for:
+    // a park would be a silent 30-minute wait. Retry now, stop if it fails.
+    test('pick owed but the tunnel is serving → retry the pick now', () {
+      expect(act(tunnelServes: true), QueueEndAction.retryPick);
+    });
+
+    test('tunnel serving but a pick is already in flight → park (it lands)',
+        () {
+      expect(act(tunnelServes: true, pickInFlight: true), QueueEndAction.park);
+    });
+
+    test('no pick pending (a normal end) → stop', () {
+      expect(act(djPickPending: false), QueueEndAction.stop);
+      expect(act(djPickPending: false, tunnelServes: true),
+          QueueEndAction.stop);
+    });
+
+    test('the user had paused → stop (their intent wins)', () {
+      expect(act(playIntent: false), QueueEndAction.stop);
+    });
+
+    // A cast session or an HTTP DJ server has no tunnel edge to wait for;
+    // parking would be a silent 30-minute wait.
+    test('casting, or an HTTP Auto DJ server → stop', () {
+      expect(act(onLocalBackend: false), QueueEndAction.stop);
+      expect(act(isIrohDJ: false), QueueEndAction.stop);
+    });
+  });
+
+  group('AudioPlayerHandler.shouldDeferDJPick', () {
+    test('only an iroh server whose tunnel is not serving defers', () {
+      expect(
+          AudioPlayerHandler.shouldDeferDJPick(
+              isIroh: true, tunnelServes: false),
+          isTrue);
+      expect(
+          AudioPlayerHandler.shouldDeferDJPick(
+              isIroh: true, tunnelServes: true),
+          isFalse);
+      expect(
+          AudioPlayerHandler.shouldDeferDJPick(
+              isIroh: false, tunnelServes: false),
+          isFalse);
+    });
+  });
+
+  group('AudioPlayerHandler.shouldRetryDeferredPick', () {
+    bool retry({
+      bool pending = true,
+      bool tunnelServes = true,
+      bool onLocalBackend = true,
+      bool intentionalStop = false,
+      int failures = 0,
+    }) =>
+        AudioPlayerHandler.shouldRetryDeferredPick(
+            pending: pending,
+            tunnelServes: tunnelServes,
+            onLocalBackend: onLocalBackend,
+            intentionalStop: intentionalStop,
+            failures: failures);
+
+    test('all gates open → retry', () {
+      expect(retry(), isTrue);
+    });
+
+    test('each gate closes it', () {
+      expect(retry(pending: false), isFalse);
+      expect(retry(tunnelServes: false), isFalse);
+      expect(retry(onLocalBackend: false), isFalse);
+      expect(retry(intentionalStop: true), isFalse);
+    });
+
+    test('bounded by kMaxDeferredPickFailures', () {
+      expect(retry(failures: AudioPlayerHandler.kMaxDeferredPickFailures - 1),
+          isTrue);
+      expect(retry(failures: AudioPlayerHandler.kMaxDeferredPickFailures),
+          isFalse);
+    });
+  });
+}

--- a/test/media/queue_end_action_test.dart
+++ b/test/media/queue_end_action_test.dart
@@ -37,6 +37,15 @@ void main() {
       expect(act(tunnelServes: true, pickInFlight: true), QueueEndAction.park);
     });
 
+    // The top-up POST is out but has not failed yet (nothing pending): the
+    // pick is still owed — it lands and resumes, or fails into pending.
+    test('pick in flight with nothing pending yet → park', () {
+      expect(act(djPickPending: false, pickInFlight: true), QueueEndAction.park);
+      expect(
+          act(djPickPending: false, pickInFlight: true, tunnelServes: true),
+          QueueEndAction.park);
+    });
+
     test('no pick pending (a normal end) → stop', () {
       expect(act(djPickPending: false), QueueEndAction.stop);
       expect(act(djPickPending: false, tunnelServes: true),

--- a/test/media/rebind_loopback_art_test.dart
+++ b/test/media/rebind_loopback_art_test.dart
@@ -1,0 +1,81 @@
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/cast_origin.dart';
+import 'package:mstream_music/objects/server.dart';
+
+Server _iroh({int? port = 52345, String? token = 'newtok'}) {
+  final s = Server('iroh://placeholder', null, null, 'jwt', 'home');
+  s.connectionType = 'iroh';
+  s.tunnelPort = port;
+  s.tunnelToken = token;
+  return s;
+}
+
+MediaItem _item({String? art, String? extraArt, String? localPath}) =>
+    MediaItem(
+      id: 'http://127.0.0.1:34113/media/a.mp3?token=jwt&__lt=oldtok',
+      title: 'a',
+      artUri: art == null ? null : Uri.parse(art),
+      extras: {
+        'server': 'home',
+        'path': 'a.mp3',
+        'artUrl': ?extraArt,
+        'localPath': ?localPath,
+      },
+    );
+
+void main() {
+  const stale =
+      'http://127.0.0.1:34113/album-art/abc.jpeg?compress=l&token=jwt&__lt=oldtok';
+
+  group('rebindLoopbackArt', () {
+    // The regression this exists for: after a tunnel rebuild the queue's
+    // stream URLs were rebound but the art kept the dead port + token, so the
+    // notification fetched "Connection refused" every ~30s for minutes.
+    test('rebinds a stale loopback artUri and extras artUrl', () {
+      final out = rebindLoopbackArt(_item(art: stale, extraArt: stale), _iroh());
+      expect(out.artUri!.port, 52345);
+      expect(out.artUri!.queryParameters['__lt'], 'newtok');
+      expect(out.artUri!.path, '/album-art/abc.jpeg');
+      expect(out.artUri!.queryParameters['token'], 'jwt');
+      final extra = Uri.parse(out.extras!['artUrl'] as String);
+      expect(extra.port, 52345);
+      expect(extra.queryParameters['__lt'], 'newtok');
+      // Untouched fields survive the copy.
+      expect(out.id, startsWith('http://127.0.0.1:34113/media/a.mp3'));
+      expect(out.extras!['path'], 'a.mp3');
+    });
+
+    test('downloaded items are rebound too (the notification fetches art)', () {
+      final out = rebindLoopbackArt(
+          _item(art: stale, localPath: '/data/a.mp3'), _iroh());
+      expect(out.artUri!.port, 52345);
+      expect(out.extras!['localPath'], '/data/a.mp3');
+    });
+
+    test('same instance when the art already matches the live tunnel', () {
+      final live =
+          'http://127.0.0.1:52345/album-art/abc.jpeg?compress=l&token=jwt&__lt=newtok';
+      final item = _item(art: live, extraArt: live);
+      expect(identical(rebindLoopbackArt(item, _iroh()), item), isTrue);
+    });
+
+    test('same instance for an HTTP server, no art, or a tunnel not up', () {
+      final http = Server('https://music.example', null, null, 'jwt', 'home');
+      final item = _item(art: stale);
+      expect(identical(rebindLoopbackArt(item, http), item), isTrue);
+      expect(identical(rebindLoopbackArt(_item(), _iroh()), _item()), isFalse,
+          reason: 'sanity: distinct instances are distinct');
+      final noArt = _item();
+      expect(identical(rebindLoopbackArt(noArt, _iroh()), noArt), isTrue);
+      expect(identical(rebindLoopbackArt(item, _iroh(port: null)), item), isTrue);
+    });
+
+    test('non-loopback art (an HTTP server\'s URL on a mixed item) is left alone',
+        () {
+      const remote = 'https://music.example/album-art/abc.jpeg?compress=l';
+      final item = _item(art: remote);
+      expect(identical(rebindLoopbackArt(item, _iroh()), item), isTrue);
+    });
+  });
+}

--- a/test/singletons/tunnel_policy_test.dart
+++ b/test/singletons/tunnel_policy_test.dart
@@ -1,0 +1,280 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/native/iroh_tunnel.dart';
+import 'package:mstream_music/singletons/tunnel_policy.dart';
+
+NetworkChangeRemedy change({
+  IrohTunnelStatus native = IrohTunnelStatus.connected,
+  bool assigned = true,
+  bool starting = false,
+  bool rejected = false,
+  Duration? sinceOffline,
+  bool userInitiated = false,
+}) =>
+    TunnelPolicy.onNetworkChange(
+      native: native,
+      assigned: assigned,
+      starting: starting,
+      rejected: rejected,
+      sinceOffline: sinceOffline,
+      userInitiated: userInitiated,
+    );
+
+void main() {
+  group('TunnelPolicy.onNetworkChange', () {
+    // The regression this exists for: a reconnecting tunnel is the
+    // supervisor's — probing it always fails (the shim RSTs every loopback
+    // request on a closed QUIC connection), and acting on that failure killed
+    // the one component that was about to heal the tunnel in place.
+    test('reconnecting → leave it to the supervisor', () {
+      expect(change(native: IrohTunnelStatus.reconnecting),
+          NetworkChangeRemedy.leaveToSupervisor);
+      expect(change(native: IrohTunnelStatus.connecting),
+          NetworkChangeRemedy.leaveToSupervisor);
+    });
+
+    test('reconnecting + the user tapped Retry → escalate', () {
+      expect(change(native: IrohTunnelStatus.reconnecting, userInitiated: true),
+          NetworkChangeRemedy.escalate);
+    });
+
+    test('connected → probe (the iOS thaw case)', () {
+      expect(change(), NetworkChangeRemedy.probe);
+    });
+
+    test('connected within 15s of a [none] → leave it (modem re-attach)', () {
+      expect(change(sinceOffline: const Duration(seconds: 5)),
+          NetworkChangeRemedy.leaveToSupervisor);
+      expect(change(sinceOffline: const Duration(seconds: 15)),
+          NetworkChangeRemedy.probe);
+      // A user tap still probes.
+      expect(
+          change(sinceOffline: const Duration(seconds: 5), userInitiated: true),
+          NetworkChangeRemedy.probe);
+    });
+
+    test('rejected → leave rejected unless the user asked', () {
+      expect(change(native: IrohTunnelStatus.rejected),
+          NetworkChangeRemedy.leaveRejected);
+      expect(change(rejected: true, assigned: false),
+          NetworkChangeRemedy.leaveRejected);
+      expect(change(rejected: true, assigned: false, userInitiated: true),
+          NetworkChangeRemedy.ensureOnly);
+    });
+
+    test('no tunnel / dial in flight / native down → ensure only', () {
+      expect(change(assigned: false), NetworkChangeRemedy.ensureOnly);
+      expect(change(starting: true), NetworkChangeRemedy.ensureOnly);
+      expect(change(native: IrohTunnelStatus.down),
+          NetworkChangeRemedy.ensureOnly);
+    });
+  });
+
+  group('TunnelPolicy.onProbeFailedTwice', () {
+    test('kick when the binary can and no kick is pending', () {
+      expect(
+          TunnelPolicy.onProbeFailedTwice(
+              canKick: true,
+              sinceHardRebuild: null,
+              sinceKick: null,
+              userInitiated: false),
+          DeadTunnelRemedy.kick);
+      expect(
+          TunnelPolicy.onProbeFailedTwice(
+              canKick: true,
+              sinceHardRebuild: null,
+              sinceKick: const Duration(seconds: 45),
+              userInitiated: false),
+          DeadTunnelRemedy.kick);
+    });
+
+    test('a kick 20s ago that did not take → rebuild if the gap allows', () {
+      expect(
+          TunnelPolicy.onProbeFailedTwice(
+              canKick: true,
+              sinceHardRebuild: null,
+              sinceKick: const Duration(seconds: 20),
+              userInitiated: false),
+          DeadTunnelRemedy.hardRebuild);
+      expect(
+          TunnelPolicy.onProbeFailedTwice(
+              canKick: true,
+              sinceHardRebuild: const Duration(seconds: 30),
+              sinceKick: const Duration(seconds: 20),
+              userInitiated: false),
+          DeadTunnelRemedy.wait);
+    });
+
+    test('no kick support → rate-limited hard rebuild', () {
+      expect(
+          TunnelPolicy.onProbeFailedTwice(
+              canKick: false,
+              sinceHardRebuild: null,
+              sinceKick: null,
+              userInitiated: false),
+          DeadTunnelRemedy.hardRebuild);
+      expect(
+          TunnelPolicy.onProbeFailedTwice(
+              canKick: false,
+              sinceHardRebuild: const Duration(seconds: 59),
+              sinceKick: null,
+              userInitiated: false),
+          DeadTunnelRemedy.wait);
+      expect(
+          TunnelPolicy.onProbeFailedTwice(
+              canKick: false,
+              sinceHardRebuild: const Duration(seconds: 60),
+              sinceKick: null,
+              userInitiated: false),
+          DeadTunnelRemedy.hardRebuild);
+    });
+
+    test('the user bypasses every gap', () {
+      expect(
+          TunnelPolicy.onProbeFailedTwice(
+              canKick: false,
+              sinceHardRebuild: const Duration(seconds: 1),
+              sinceKick: null,
+              userInitiated: true),
+          DeadTunnelRemedy.hardRebuild);
+      expect(
+          TunnelPolicy.onProbeFailedTwice(
+              canKick: true,
+              sinceHardRebuild: const Duration(seconds: 1),
+              sinceKick: const Duration(seconds: 1),
+              userInitiated: true),
+          DeadTunnelRemedy.kick);
+    });
+  });
+
+  group('TunnelPolicy.shouldEscalate', () {
+    bool esc({
+      IrohTunnelStatus native = IrohTunnelStatus.reconnecting,
+      Duration? notConnectedFor,
+      Duration? sinceKick,
+      bool? relayReachable,
+    }) =>
+        TunnelPolicy.shouldEscalate(
+            native: native,
+            notConnectedFor: notConnectedFor,
+            sinceKick: sinceKick,
+            relayReachable: relayReachable);
+
+    test('only a reconnecting/connecting tunnel can be escalated', () {
+      for (final st in [
+        IrohTunnelStatus.connected,
+        IrohTunnelStatus.down,
+        IrohTunnelStatus.rejected,
+      ]) {
+        expect(
+            esc(
+                native: st,
+                notConnectedFor: const Duration(minutes: 10),
+                relayReachable: true),
+            isFalse,
+            reason: '$st');
+      }
+    });
+
+    // A dead zone (relay unreachable) is the supervisor's to ride out; a fresh
+    // endpoint would fail the same way and lose the relay-back wake.
+    test('never while the relay is known unreachable', () {
+      expect(
+          esc(notConnectedFor: const Duration(minutes: 10), relayReachable: false),
+          isFalse);
+    });
+
+    // A binary that cannot say (no relay_online symbol yet) gets a long
+    // ceiling: a supervisor that never converges must still have an exit.
+    test('relay state unknown: 5-minute ceiling', () {
+      expect(
+          esc(
+              notConnectedFor: const Duration(minutes: 4, seconds: 59),
+              relayReachable: null),
+          isFalse);
+      expect(
+          esc(notConnectedFor: const Duration(minutes: 5), relayReachable: null),
+          isTrue);
+    });
+
+    test('relay reachable: 119s → no, 120s → yes', () {
+      expect(
+          esc(notConnectedFor: const Duration(seconds: 119), relayReachable: true),
+          isFalse);
+      expect(
+          esc(notConnectedFor: const Duration(seconds: 120), relayReachable: true),
+          isTrue);
+    });
+
+    test('a kick that did not take within 45s → escalate unless relay is down',
+        () {
+      expect(esc(sinceKick: const Duration(seconds: 45), relayReachable: null),
+          isTrue);
+      expect(esc(sinceKick: const Duration(seconds: 45), relayReachable: false),
+          isFalse);
+      expect(esc(sinceKick: const Duration(seconds: 44), relayReachable: null),
+          isFalse);
+    });
+  });
+
+  group('TunnelPolicy.retryDelay', () {
+    test('5, 10, 20, 40, 60 … then 5 minutes after ten attempts', () {
+      expect(
+          [for (var i = 0; i < 12; i++) TunnelPolicy.retryDelay(i).inSeconds],
+          [5, 10, 20, 40, 60, 60, 60, 60, 60, 60, 300, 300]);
+    });
+  });
+
+  group('TunnelPolicy.shouldSkipColdDial', () {
+    test('a non-user caller waits for the timer', () {
+      expect(
+          TunnelPolicy.shouldSkipColdDial(
+              sinceFailedDial: const Duration(seconds: 3),
+              nextRetry: const Duration(seconds: 5),
+              bypassBackoff: false),
+          isTrue);
+      expect(
+          TunnelPolicy.shouldSkipColdDial(
+              sinceFailedDial: const Duration(seconds: 5),
+              nextRetry: const Duration(seconds: 5),
+              bypassBackoff: false),
+          isFalse);
+    });
+
+    test('no failure on record, or a bypass → dial', () {
+      expect(
+          TunnelPolicy.shouldSkipColdDial(
+              sinceFailedDial: null,
+              nextRetry: const Duration(seconds: 5),
+              bypassBackoff: false),
+          isFalse);
+      expect(
+          TunnelPolicy.shouldSkipColdDial(
+              sinceFailedDial: const Duration(seconds: 1),
+              nextRetry: const Duration(seconds: 60),
+              bypassBackoff: true),
+          isFalse);
+    });
+  });
+
+  group('TunnelPolicy.classifyProbeError', () {
+    test('timeout / refused / reset are told apart', () {
+      expect(TunnelPolicy.classifyProbeError(TimeoutException('x')), 'timeout');
+      expect(
+          TunnelPolicy.classifyProbeError(const SocketException(
+              'Connection refused',
+              osError: OSError('Connection refused', 111))),
+          'refused');
+      expect(
+          TunnelPolicy.classifyProbeError(
+              const SocketException('Connection reset by peer')),
+          'reset');
+      expect(
+          TunnelPolicy.classifyProbeError(const HttpException(
+              'Connection closed before full header was received')),
+          'reset');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Quick Connect (iroh) stayed down for minutes after a cellular dead zone and did not come back when service returned; with no downloaded tracks the app went silent while the notification still said "playing". Two drive logs from v0.35.0 were reconstructed line by line and the tunnel lifecycle audited; 17 findings were confirmed adversarially, two of them critical. The full write-up (timelines, root causes, fix plan, device script) is in a private report: https://claude.ai/code/artifact/1fb7da36-95d4-48f4-ba7f-b442d0be148d

**Root causes**

1. `handleNetworkChange` probed the loopback on every connectivity event / app resume **without reading the native status**. During a reconnect the shim fails every loopback request within a second, so the probe always failed, and a failing probe stopped the tunnel and started a fresh one with a single cold dial — replacing a supervisor that re-dials forever on the same port with one 33 s attempt (log: `resume probe failed` 15:08:50 → `tunnel start failed` 15:09:23, exactly 8 s relay wait + 25 s connect).
2. A failed cold dial was **terminal**: `tunnelPort` went null (every URL → `127.0.0.1:0`) and nothing retried. Only a transport-type change, an app resume, the banner's Retry, a playback error, a browse or a download re-enqueue could re-enter — none of which fire on a screen-off Android Auto drive.
3. The probe ran 0 s after the `network_change` nudge with a 6 s budget while iroh was still migrating paths, so every Wi-Fi↔cellular hand-off rebuilt a healthy tunnel (port + token rotation → audible player reload, stale art, killed downloads). Every rebuild in both logs was one of these.
4. Auto DJ never waited for the tunnel; an outage-drained queue ended in `stop()`, which set `_intentionalStop` and disarmed every later tunnel-back heal.

(The evening log's 5.5-minute silence turned out to be end-of-queue with Auto DJ off — v0.35.0 predates 46e53ba, already on master.)

## Phase 1 — Dart only (this PR)

- **`lib/singletons/tunnel_policy.dart`** (new): pure, unit-tested rules. Never probe or drop a reconnecting tunnel; probe a connected-reporting one twice (+3 s, +10 s) before acting; ≤1 hard rebuild per 60 s; retry 5/10/20/40/60 s then 5 min after a failed dial; a rejected pairing never re-dials on its own; a watchdog for a non-converging supervisor (120 s when the relay is known reachable, 5 min when the binary cannot say, never in a known dead zone).
- **`server_list.dart`**: single-flight `handleNetworkChange` around the policy (a Retry tap that lands mid-run keeps its user semantics); tunnel identity *and* status re-checked inside `_tunnelChain` before any drop; a retry timer so "no tunnel and nothing scheduled" is unreachable; a recently-failed gate so other callers (DJ picks re-fired every ~30 s, browse, downloads, playback errors) cannot queue cold dials past the backoff; launch dial bounded to 12 s with the skipped ping re-run on tunnel-up; lifecycle logging (`tunnel up port=… path=… in …ms (reason)`, every stop with reason, status edges, probe outcome + exception class).
- **`main.dart`**: every connectivity result logged, 1.5 s debounce, `[none]` cancels a pending run, Retry on the reconnecting banner too.
- **`audio_stuff.dart`**: an Auto DJ pick waits for the tunnel and is remembered when it can't; a queue that ends mid-outage **parks** (paused, play intent kept) instead of stopping, retries the pick immediately when the tunnel is in fact serving, and resumes from the park when the pick lands (resume is a property of the park, and the append is awaited before the seek); the park is released by any play/pause/skip/seek so it can never stop something the user started later; album-art URLs are rebound after a rebuild (downloaded items included); automatic resumes honour a 90 s interruption window; player state transitions and ≥3 s rebuffers are logged.
- **`cast_origin.dart`**: `rebindLoopbackArt` (pure, tested).
- **`iroh_tunnel.dart`**: optional lookups for the Phase 2 native symbols (`force_reconnect` / `drain_events` / `relay_online`), so the committed `.so` / xcframework keep working and Phase 2 slots in without Dart changes.

The iOS thaw case from 98d06c8 (native says connected on a dead QUIC connection) is preserved: both probes fail → hard rebuild, now backed by the retry loop.

**Deliberately unchanged:** an iroh playback error inside the ≤30 s window where the native status still says connected still takes the plain-HTTP retry walk (~35–45 s) before a ground-truth probe runs. Phase 2 (Rust: in-place reconnect on the same port, event-driven backoff, events ring, relay state) is designed and not started.

## Verification

- `flutter analyze`: clean apart from 17 pre-existing hints in unrelated files.
- `flutter test`: 404 pass, 42 new (`tunnel_policy_test`, `queue_end_action_test`, `rebind_loopback_art_test`).
- A three-lens review of the diff (lifecycle / playback / scenario replay) found 18 issues, all fixed before the first commit.
- **Smoke-tested on four targets, 17 scenarios, every recovery automatic** (details in the PR comments):
  - Android emulator vs demo.mstream.io: dead zone mid-track, Retry tap in airplane mode, unbuffered-track skip during an outage, queue end during an outage with Auto DJ, 10 s blip, launch mid-outage, steady state.
  - iOS simulator: launch / Auto DJ, 5-minute background then resume, wrong-secret pairing code.
  - Galaxy S25 over real cellular against the author's server: Wi-Fi→cellular hand-off, 70 s airplane mode, Retry tap, queue end inside the connected-but-dead window, Play after an outage-drained queue, cellular→Wi-Fi return.
  - iPhone X (iOS 15): suspension (iOS kills the loopback listener; both probes catch it and the tunnel is rebuilt), 4-minute Wi-Fi outage.
- Four defects found only by those rounds are fixed in dc858d6 and 1e065c9.

Not reproducible off a drive: a same-network signal fade with no transport event. The logging added here makes the next one readable line by line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
