### PR TITLE
fix(audio): a late Bluetooth PAUSE no longer un-pauses onto the phone speaker

### DIFF
--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -17,6 +17,7 @@ import 'chromecast_playback_backend.dart';
 import 'local_media_server.dart';
 import 'auto_browse.dart';
 import 'cast_origin.dart' show rebindLoopbackArt;
+import 'output_devices.dart' show isExternalOutput;
 import 'cast_log.dart';
 import 'cast_target.dart';
 import '../native/iroh_tunnel.dart';
@@ -45,6 +46,10 @@ import '../util/stream_url.dart';
 /// or retry the pick right now when the tunnel is serving and the earlier
 /// failure was transient. See [AudioPlayerHandler.queueEndAction].
 enum QueueEndAction { stop, park, retryPick }
+
+/// What a media-button toggle (play/pause key) does — see
+/// [AudioPlayerHandler.mediaToggleAction].
+enum MediaToggleAction { play, pause, ignore }
 
 /// An [AudioHandler] for playing a list of podcast episodes.
 /// What [AudioPlayerHandler.healAction] decided the tunnel heal should do:
@@ -235,7 +240,23 @@ class AudioPlayerHandler extends BaseAudioHandler
         // actually playing.
         if (!identical(_backend, _localBackend)) return;
         appLog('[audio] output disconnected — pausing');
+        _outputLostAt = DateTime.now();
         unawaited(pause());
+      });
+      session.devicesChangedEventStream.listen((event) {
+        // A new output the user can hear (earbuds after the car, the car
+        // again) makes the next toggle theirs again. The built-in speaker
+        // "appearing" is only the route falling back and keeps the window.
+        final added = event.devicesAdded
+            .where((d) => d.isOutput && isExternalOutput(d.type))
+            .map((d) => d.type.name)
+            .toList();
+        if (added.isEmpty) return;
+        if (_outputLostAt != null) {
+          appLog('[audio] output connected (${added.join(', ')}) — '
+              'media toggles are live again');
+        }
+        _outputLostAt = null;
       });
     } catch (e) {
       appLog('[audio] audio session configure failed: $e');
@@ -1825,6 +1846,10 @@ class AudioPlayerHandler extends BaseAudioHandler
   Timer? _parkTimer;
   // When an audio-focus interruption began (see the session listener).
   DateTime? _interruptedAt;
+  // When the audio output went away (becoming-noisy: the car's Bluetooth, a
+  // headset); null once a new output appears or the user plays in the app.
+  // Gates media-button toggles — see click().
+  DateTime? _outputLostAt;
   BackendProcessingState? _lastLoggedProcState;
   DateTime? _bufferingSince;
 
@@ -2004,6 +2029,12 @@ class AudioPlayerHandler extends BaseAudioHandler
   /// server's problem, not the path's; stop retrying after this many.
   static const int kMaxDeferredPickFailures = 5;
 
+  /// After an output loss, how long a media-button toggle that would start
+  /// playback is treated as the old output's late PAUSE rather than the
+  /// user's request. Head units keep their remote-control link up for a few
+  /// seconds after the audio link drops (11s in the drive log).
+  static const Duration kOutputLostToggleWindow = Duration(seconds: 30);
+
   /// Whether play() must re-seed the local player instead of issuing a bare
   /// backend.play(): just_audio parked idle (a playback error tears the
   /// platform player down) with tracks still queued, so a bare play() would
@@ -2072,6 +2103,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     _playIntent = true;
     _intentionalStop = false;
     _interruptedAt = null; // the user wants audio; an old interruption is moot
+    _outputLostAt = null; // …and wherever it comes out is their choice now
     if (_parkedForDJ) {
       // The user pressed play on a parked queue end: leave the park (a pick
       // landing later appends without hijacking them) and replay the last
@@ -2114,6 +2146,50 @@ class AudioPlayerHandler extends BaseAudioHandler
     _playIntent = false;
     _releasePark(); // their intent wins; a landing pick appends only
     return _backend.pause();
+  }
+
+  /// Media buttons. audio_service folds every external PLAY / PAUSE /
+  /// PLAY_PAUSE / HEADSETHOOK key into this one toggle (only its own
+  /// notification buttons carry an explicit play or pause), so a head unit's
+  /// explicit PAUSE on ignition-off reaches us as "toggle". That PAUSE rides
+  /// the remote-control link, which outlives the audio link by seconds; when
+  /// it lands after the audio drop has already paused us, the toggle used to
+  /// un-pause onto the phone's own speaker (drive log 2026-08-31: output
+  /// disconnected 19:23:38, play 19:23:49). Inside the window after an output
+  /// loss, a toggle that would START playback is ignored; a new output device
+  /// or the user's own play in the app ends the window early. Playing → pause
+  /// is always honoured.
+  @override
+  Future<void> click([MediaButton button = MediaButton.media]) async {
+    if (button != MediaButton.media) return super.click(button);
+    final lost = _outputLostAt;
+    final sinceLost = lost == null ? null : DateTime.now().difference(lost);
+    switch (mediaToggleAction(
+        playing: playbackState.valueOrNull?.playing ?? false,
+        sinceOutputLost: sinceLost)) {
+      case MediaToggleAction.pause:
+        appLog('[audio] media button → pause');
+        await pause();
+      case MediaToggleAction.play:
+        appLog('[audio] media button → play');
+        await play();
+      case MediaToggleAction.ignore:
+        appLog('[audio] media button toggle ignored — output lost '
+            '${sinceLost!.inSeconds}s ago (a late PAUSE from the old output)');
+    }
+  }
+
+  /// Pure: what a media-button toggle does. [sinceOutputLost] is null when no
+  /// output has been lost, or a new one has appeared since.
+  static MediaToggleAction mediaToggleAction({
+    required bool playing,
+    required Duration? sinceOutputLost,
+  }) {
+    if (playing) return MediaToggleAction.pause;
+    if (sinceOutputLost != null && sinceOutputLost < kOutputLostToggleWindow) {
+      return MediaToggleAction.ignore;
+    }
+    return MediaToggleAction.play;
   }
 
   @override

--- a/lib/media/output_devices.dart
+++ b/lib/media/output_devices.dart
@@ -1,0 +1,30 @@
+// audio_session marks its device API @experimental. Its shape has been stable
+// across 0.1.x → 0.2.x, and this is the one place that names the enum, so the
+// warning is silenced here rather than sprinkled through the audio handler.
+// ignore_for_file: experimental_member_use
+import 'package:audio_session/audio_session.dart' show AudioDeviceType;
+
+/// An output a person plugs in or pairs — the ones whose arrival means the
+/// next media-button toggle is theirs again (see AudioPlayerHandler.click).
+/// The built-in speaker "appearing" after a Bluetooth drop is only the route
+/// falling back and must not count.
+bool isExternalOutput(AudioDeviceType t) => switch (t) {
+      AudioDeviceType.wiredHeadset ||
+      AudioDeviceType.wiredHeadphones ||
+      AudioDeviceType.lineAnalog ||
+      AudioDeviceType.lineDigital ||
+      AudioDeviceType.bluetoothA2dp ||
+      AudioDeviceType.bluetoothSco ||
+      AudioDeviceType.bluetoothLe ||
+      AudioDeviceType.usbAudio ||
+      AudioDeviceType.dock ||
+      AudioDeviceType.hdmi ||
+      AudioDeviceType.hdmiArc ||
+      AudioDeviceType.displayPort ||
+      AudioDeviceType.hearingAid ||
+      AudioDeviceType.carAudio ||
+      AudioDeviceType.auxLine ||
+      AudioDeviceType.airPlay =>
+        true,
+      _ => false,
+    };

--- a/test/media/media_toggle_test.dart
+++ b/test/media/media_toggle_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/audio_stuff.dart';
+
+void main() {
+  group('AudioPlayerHandler.mediaToggleAction', () {
+    MediaToggleAction act({bool playing = false, Duration? sinceOutputLost}) =>
+        AudioPlayerHandler.mediaToggleAction(
+            playing: playing, sinceOutputLost: sinceOutputLost);
+
+    test('playing → pause, whatever happened to the output', () {
+      expect(act(playing: true), MediaToggleAction.pause);
+      expect(act(playing: true, sinceOutputLost: const Duration(seconds: 5)),
+          MediaToggleAction.pause);
+    });
+
+    test('paused with no output loss on record → play', () {
+      expect(act(), MediaToggleAction.play);
+    });
+
+    // The regression this exists for: the car's explicit PAUSE arrives after
+    // the audio link has already dropped and paused us, and audio_service
+    // hands it over as a toggle — which used to un-pause onto the speaker.
+    test('paused inside the window after an output loss → ignore', () {
+      expect(act(sinceOutputLost: const Duration(seconds: 11)),
+          MediaToggleAction.ignore);
+      expect(act(sinceOutputLost: const Duration(seconds: 29)),
+          MediaToggleAction.ignore);
+    });
+
+    test('the window is 30s', () {
+      expect(AudioPlayerHandler.kOutputLostToggleWindow,
+          const Duration(seconds: 30));
+      expect(act(sinceOutputLost: const Duration(seconds: 30)),
+          MediaToggleAction.play);
+      expect(act(sinceOutputLost: const Duration(minutes: 5)),
+          MediaToggleAction.play);
+    });
+  });
+}

--- a/test/media/output_devices_test.dart
+++ b/test/media/output_devices_test.dart
@@ -1,0 +1,33 @@
+// ignore_for_file: experimental_member_use
+import 'package:audio_session/audio_session.dart' show AudioDeviceType;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/output_devices.dart';
+
+void main() {
+  group('isExternalOutput', () {
+    test('things a person pairs or plugs in end the toggle window', () {
+      for (final t in [
+        AudioDeviceType.bluetoothA2dp,
+        AudioDeviceType.bluetoothLe,
+        AudioDeviceType.wiredHeadphones,
+        AudioDeviceType.usbAudio,
+        AudioDeviceType.carAudio,
+      ]) {
+        expect(isExternalOutput(t), isTrue, reason: '$t');
+      }
+    });
+
+    test('the built-in speaker falling back does not', () {
+      for (final t in [
+        AudioDeviceType.builtInSpeaker,
+        AudioDeviceType.builtInEarpiece,
+        AudioDeviceType.builtInSpeakerSafe,
+        AudioDeviceType.telephony,
+        AudioDeviceType.remoteSubmix,
+        AudioDeviceType.unknown,
+      ]) {
+        expect(isExternalOutput(t), isFalse, reason: '$t');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Turn the car off and, occasionally, the music carries on from the phone's own speaker. This is not the revive-path bug fixed in 9635fc44 (that fix is in v0.35.0 and works), and it is not the device dropping the "audio becoming noisy" event.

**Root cause.** audio_service 0.18 folds every external PLAY / PAUSE / PLAY_PAUSE / HEADSETHOOK key into `click(MediaButton.media)`, whose default toggles on `playbackState.playing`; only its own notification buttons carry an explicit play or pause. A head unit sends an explicit PAUSE on ignition off over the remote-control link, which outlives the audio link by seconds. When that PAUSE lands after the audio drop has already paused the app, the toggle un-pauses it — onto the speaker. Before-or-after is a race, hence "occasionally". The 2026-08-31 drive log has it:

```
19:23:38 [audio] output disconnected — pausing
19:23:38 [play] pause
19:23:49 [play] play          ← the toggle
19:30:53 [play] pause         ← the user, from the speaker
```

**Fix.** `AudioPlayerHandler.click()` is overridden: inside a 30 s window after an output loss, a toggle that would START playback is ignored (and logged); playing → pause is always honoured; a new external output (audio_session's device-change stream) or the user's own play in the app ends the window early. The in-app controls and the notification buttons are untouched. The rule is a pure function (`mediaToggleAction`) with tests; the device-type list lives in `output_devices.dart` so the plugin's `@experimental` warning is scoped to one file.

## Verification (Galaxy S25, Android 16, Bluetooth headset)

The head unit was stood in for with `svc bluetooth disable` (the audio drop) and `cmd media_session dispatch pause` (the late PAUSE, through the same media-session dispatcher AVRCP uses).

**Unfixed build — reproduced:**
```
08:52:39 [play] play                                   (over A2DP)
08:52:47 [audio] output disconnected — pausing          (bluetooth off)
08:52:53 [play] play                                   (PAUSE key 6 s later → speaker, state PLAYING)
```

**Fixed build:**

| # | Scenario | Result |
|---|---|---|
| 1 | Play over A2DP via media key | ✅ `media button → play` |
| 2 | Bluetooth off, PAUSE key at +5 s | ✅ `toggle ignored — output lost 5s ago`, state PAUSED, silent |
| 3 | Second toggle at +15 s | ✅ ignored |
| 4 | Bluetooth on + headset reconnect, then play | ✅ `output connected (bluetoothSco) — media toggles are live again` → `media button → play` over A2DP |
| 5 | PAUSE key while playing | ✅ `media button → pause` |
| 6 | Reverse order: PAUSE key first, then Bluetooth off; play key 34 s after the loss | ✅ stays paused; the late play (outside the window) plays, as designed |

`flutter test`: 416 pass. Analyzer: no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
