### PR TITLE
feat(ios): CarPlay — browse, play and queue the library from the car

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
+		CA9F2E7A3B1D4C5E6F708192 /* CarPlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9F2E7A3B1D4C5E6F708193 /* CarPlay.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -51,6 +52,8 @@
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		CA9F2E7A3B1D4C5E6F708193 /* CarPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlay.swift; sourceTree = "<group>"; };
+		CA9F2E7A3B1D4C5E6F708194 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -126,6 +129,8 @@
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
+				CA9F2E7A3B1D4C5E6F708193 /* CarPlay.swift */,
+				CA9F2E7A3B1D4C5E6F708194 /* Runner.entitlements */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -288,6 +293,7 @@
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
+				CA9F2E7A3B1D4C5E6F708192 /* CarPlay.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -386,6 +392,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				PRODUCT_BUNDLE_IDENTIFIER = mstream.music;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -565,8 +572,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				PRODUCT_BUNDLE_IDENTIFIER = mstream.music;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -587,6 +596,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				PRODUCT_BUNDLE_IDENTIFIER = mstream.music;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		CA9F2E7A3B1D4C5E6F708192 /* CarPlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9F2E7A3B1D4C5E6F708193 /* CarPlay.swift */; };
+		CA9F2E7A3B1D4C5E6F708195 /* Siri.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9F2E7A3B1D4C5E6F708196 /* Siri.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -54,6 +55,7 @@
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		CA9F2E7A3B1D4C5E6F708193 /* CarPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlay.swift; sourceTree = "<group>"; };
 		CA9F2E7A3B1D4C5E6F708194 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
+		CA9F2E7A3B1D4C5E6F708196 /* Siri.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Siri.swift; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
 				CA9F2E7A3B1D4C5E6F708193 /* CarPlay.swift */,
+				CA9F2E7A3B1D4C5E6F708196 /* Siri.swift */,
 				CA9F2E7A3B1D4C5E6F708194 /* Runner.entitlements */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
@@ -294,6 +297,7 @@
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
 				CA9F2E7A3B1D4C5E6F708192 /* CarPlay.swift in Sources */,
+				CA9F2E7A3B1D4C5E6F708195 /* Siri.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Flutter
+import Intents
 import UIKit
 
 @main
@@ -15,6 +16,7 @@ import UIKit
   /// isolates would split the audio state.
   private(set) var engine: FlutterEngine!
   private(set) var carPlay: CarPlayBridge!
+  private(set) var siri: SiriMediaHandler!
 
   override func application(
     _ application: UIApplication,
@@ -26,7 +28,16 @@ import UIKit
     GeneratedPluginRegistrant.register(with: engine)
     self.engine = engine
     carPlay = CarPlayBridge(messenger: engine.binaryMessenger)
+    siri = SiriMediaHandler(bridge: carPlay)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  /// SiriKit media intents are handled in-app (iOS 14+): "play <X> on
+  /// mStream" resolves against the library and plays through the audio
+  /// handler, with the app launched in the background if it was not running.
+  override func application(_ application: UIApplication, handlerFor intent: INIntent) -> Any? {
+    if intent is INPlayMediaIntent { return siri }
+    return nil
   }
 
   // Keep downloaded music out of iCloud backups: it's re-fetchable from the

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2,12 +2,30 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+@objc class AppDelegate: FlutterAppDelegate {
+  static var shared: AppDelegate { UIApplication.shared.delegate as! AppDelegate }
+
+  /// The one Flutter engine, owned by the app rather than by the phone
+  /// window's view controller. CarPlay can launch the app with no phone scene
+  /// at all (phone locked, icon tapped on the car display), and the Dart side
+  /// — audio_service handler, servers, the Quick Connect tunnel — must be up
+  /// for that. The phone scene attaches a FlutterViewController to this engine
+  /// whenever it connects (SceneDelegate); the CarPlay scene talks to it over
+  /// a method channel (CarPlay.swift). Never create a second engine: two Dart
+  /// isolates would split the audio state.
+  private(set) var engine: FlutterEngine!
+  private(set) var carPlay: CarPlayBridge!
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     excludeDownloadsFromBackup()
+    let engine = FlutterEngine(name: "mstream")
+    engine.run(withEntrypoint: nil)
+    GeneratedPluginRegistrant.register(with: engine)
+    self.engine = engine
+    carPlay = CarPlayBridge(messenger: engine.binaryMessenger)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
@@ -25,9 +43,5 @@ import UIKit
     var values = URLResourceValues()
     values.isExcludedFromBackup = true
     try? media.setResourceValues(values)
-  }
-
-  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
-    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/ios/Runner/CarPlay.swift
+++ b/ios/Runner/CarPlay.swift
@@ -1,0 +1,305 @@
+import CarPlay
+import Flutter
+import UIKit
+
+/// The CarPlay scene. CarPlay hands us an interface controller; everything the
+/// car shows comes from the Dart browse tree (lib/media/auto_browse.dart — the
+/// same tree Android Auto renders) over the `mstream/carplay` method channel
+/// (lib/native/carplay_bridge.dart). Now Playing is CarPlay's own template,
+/// fed by the MPNowPlayingInfoCenter / remote-command state audio_service
+/// already publishes.
+class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
+  func templateApplicationScene(
+    _ templateApplicationScene: CPTemplateApplicationScene,
+    didConnect interfaceController: CPInterfaceController
+  ) {
+    AppDelegate.shared.carPlay.attach(interfaceController)
+  }
+
+  func templateApplicationScene(
+    _ templateApplicationScene: CPTemplateApplicationScene,
+    didDisconnectInterfaceController interfaceController: CPInterfaceController
+  ) {
+    AppDelegate.shared.carPlay.detach()
+  }
+}
+
+/// Lives for the whole process (created with the engine in AppDelegate), so it
+/// is there whether the car connects before or after the Dart side is ready.
+final class CarPlayBridge: NSObject {
+  /// Audio apps get a template stack this deep (root included); a deep Files
+  /// tree would overflow it, so at the limit the top level is swapped instead
+  /// of the push failing.
+  static let maxDepth = 5
+
+  private let channel: FlutterMethodChannel
+  private let art = CarPlayArtLoader()
+  private var interfaceController: CPInterfaceController?
+  private var rootTemplate: CPListTemplate?
+  private var dartReady = false
+  private var observingNowPlaying = false
+
+  init(messenger: FlutterBinaryMessenger) {
+    channel = FlutterMethodChannel(name: "mstream/carplay", binaryMessenger: messenger)
+    super.init()
+    channel.setMethodCallHandler { [weak self] call, result in
+      switch call.method {
+      case "ready":
+        // Dart booted and registered its handler: (re)load the root. On a
+        // CarPlay-only cold launch the car connected seconds before this.
+        self?.dartReady = true
+        NSLog("[carplay] dart ready (car connected: %d)", self?.interfaceController == nil ? 0 : 1)
+        self?.loadRoot()
+        result(nil)
+      default:
+        #if DEBUG
+        if self?.handleDebug(call, result: result) == true { return }
+        #endif
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  #if DEBUG
+  /// Test hooks (debug builds only), driven from Dart's `ext.mstream.carplay`
+  /// service extension: the Simulator's CarPlay window does not take
+  /// synthetic taps, so automated runs select rows through the same handlers a
+  /// real tap would invoke.
+  private func handleDebug(_ call: FlutterMethodCall, result: @escaping FlutterResult) -> Bool {
+    switch call.method {
+    case "debugState":
+      let ic = interfaceController
+      let top = ic?.topTemplate
+      var state: [String: Any] = [
+        "connected": ic != nil,
+        "dartReady": dartReady,
+        "depth": ic?.templates.count ?? 0,
+        "top": top.map { String(describing: type(of: $0)) } ?? "none",
+      ]
+      if let list = top as? CPListTemplate {
+        state["title"] = list.title ?? ""
+        state["items"] = list.sections.flatMap { $0.items }.map {
+          ($0 as? CPListItem)?.text ?? String(describing: $0)
+        }
+      }
+      result(state)
+    case "debugTap":
+      guard let ic = interfaceController, let list = ic.topTemplate as? CPListTemplate else {
+        result(FlutterError(code: "no-list", message: "top template is not a list", details: nil))
+        return true
+      }
+      let index = call.arguments as? Int ?? 0
+      let items = list.sections.flatMap { $0.items }
+      guard index < items.count, let item = items[index] as? CPListItem, let handler = item.handler else {
+        result(FlutterError(code: "no-item", message: "no tappable row \(index) of \(items.count)", details: nil))
+        return true
+      }
+      handler(item) { result(nil) }
+    case "debugBack":
+      guard let ic = interfaceController else { result(nil); return true }
+      ic.popTemplate(animated: false) { _, _ in result(nil) }
+    case "debugUpNext":
+      showQueue()
+      result(nil)
+    default:
+      return false
+    }
+    return true
+  }
+  #endif
+
+  // MARK: - Scene attach / detach
+
+  func attach(_ ic: CPInterfaceController) {
+    interfaceController = ic
+    let root = CPListTemplate(title: "mStream", sections: [])
+    root.emptyViewTitleVariants = ["Loading…"]
+    root.emptyViewSubtitleVariants = ["Starting mStream"]
+    rootTemplate = root
+    ic.setRootTemplate(root, animated: false, completion: nil)
+    configureNowPlaying()
+    NSLog("[carplay] connected (dart ready: %d)", dartReady ? 1 : 0)
+    if dartReady { loadRoot() }
+  }
+
+  func detach() {
+    NSLog("[carplay] disconnected")
+    interfaceController = nil
+    rootTemplate = nil
+  }
+
+  // MARK: - Templates
+
+  private func loadRoot() {
+    guard let root = rootTemplate else { return }
+    invoke("getChildren", "root") { [weak self] payload in
+      guard let self = self, let root = self.rootTemplate, root === self.rootTemplate else { return }
+      let rows = payload as? [[String: Any]] ?? []
+      root.emptyViewTitleVariants = ["Nothing to show"]
+      root.emptyViewSubtitleVariants = ["Open mStream on your phone and add a server"]
+      root.updateSections([CPListSection(items: self.listItems(rows))])
+      NSLog("[carplay] root: %d rows", rows.count)
+    }
+  }
+
+  private func browse(id: String, title: String, completion: @escaping () -> Void) {
+    invoke("getChildren", id) { [weak self] payload in
+      guard let self = self, let ic = self.interfaceController else { completion(); return }
+      let rows = payload as? [[String: Any]] ?? []
+      let template = CPListTemplate(
+        title: title, sections: [CPListSection(items: self.listItems(rows))])
+      template.emptyViewTitleVariants = ["Nothing here"]
+      self.push(template, on: ic, completion: completion)
+    }
+  }
+
+  private func play(id: String, completion: @escaping () -> Void) {
+    invoke("play", id) { [weak self] _ in
+      guard let self = self, let ic = self.interfaceController else { completion(); return }
+      let nowPlaying = CPNowPlayingTemplate.shared
+      if ic.topTemplate === nowPlaying {
+        completion()
+      } else {
+        self.push(nowPlaying, on: ic, completion: completion)
+      }
+    }
+  }
+
+  private func push(_ template: CPTemplate, on ic: CPInterfaceController,
+                    completion: @escaping () -> Void) {
+    if ic.templates.count >= CarPlayBridge.maxDepth {
+      NSLog("[carplay] template stack at %d — replacing the top level", ic.templates.count)
+      ic.popTemplate(animated: false) { _, _ in
+        ic.pushTemplate(template, animated: true) { _, _ in completion() }
+      }
+    } else {
+      ic.pushTemplate(template, animated: true) { _, _ in completion() }
+    }
+  }
+
+  /// Rows the Dart side serialised (CarPlayBridge.encodeItem): id, title,
+  /// subtitle, artUri, playable, notice.
+  private func listItems(_ rows: [[String: Any]]) -> [CPListItem] {
+    let capped = rows.prefix(CPListTemplate.maximumItemCount)
+    return capped.map { row in
+      let id = row["id"] as? String ?? ""
+      let title = row["title"] as? String ?? ""
+      let subtitle = row["subtitle"] as? String
+      let playable = row["playable"] as? Bool ?? false
+      let notice = row["notice"] as? Bool ?? false
+      let item = CPListItem(text: title, detailText: subtitle)
+      item.accessoryType = (playable || notice) ? .none : .disclosureIndicator
+      if notice { item.isEnabled = false }
+      if let uri = row["artUri"] as? String, let url = URL(string: uri) {
+        art.load(url) { image in item.setImage(image) }
+      }
+      item.handler = { [weak self] _, done in
+        guard let self = self, !notice else { done(); return }
+        if playable {
+          self.play(id: id, completion: done)
+        } else {
+          self.browse(id: id, title: title, completion: done)
+        }
+      }
+      return item
+    }
+  }
+
+  // MARK: - Now Playing (Up Next = the queue)
+
+  private func configureNowPlaying() {
+    let nowPlaying = CPNowPlayingTemplate.shared
+    nowPlaying.isUpNextButtonEnabled = true
+    nowPlaying.upNextTitle = "Queue"
+    if !observingNowPlaying {
+      nowPlaying.add(self)
+      observingNowPlaying = true
+    }
+  }
+
+  private func showQueue() {
+    invoke("getQueue", nil) { [weak self] payload in
+      guard let self = self, let ic = self.interfaceController,
+        let dict = payload as? [String: Any]
+      else { return }
+      let rows = dict["items"] as? [[String: Any]] ?? []
+      let current = dict["index"] as? Int ?? -1
+      let items = rows.prefix(CPListTemplate.maximumItemCount).enumerated().map {
+        (index, row) -> CPListItem in
+        let item = CPListItem(
+          text: row["title"] as? String ?? "", detailText: row["subtitle"] as? String)
+        item.isPlaying = index == current
+        if let uri = row["artUri"] as? String, let url = URL(string: uri) {
+          self.art.load(url) { image in item.setImage(image) }
+        }
+        item.handler = { [weak self] _, done in
+          self?.invoke("skipToQueueItem", index) { _ in
+            // Back to Now Playing, which is one level down.
+            self?.interfaceController?.popTemplate(animated: true, completion: nil)
+            done()
+          }
+        }
+        return item
+      }
+      let template = CPListTemplate(title: "Queue", sections: [CPListSection(items: items)])
+      template.emptyViewTitleVariants = ["The queue is empty"]
+      self.push(template, on: ic) {}
+    }
+  }
+
+  // MARK: - Channel
+
+  /// Swift → Dart. Results land on the main thread; a Dart-side failure is
+  /// logged and delivered as nil so the car never hangs on a spinner.
+  private func invoke(_ method: String, _ arguments: Any?,
+                      completion: @escaping (Any?) -> Void) {
+    channel.invokeMethod(method, arguments: arguments) { result in
+      if let error = result as? FlutterError {
+        NSLog("[carplay] %@ failed: %@ %@", method, error.code, error.message ?? "")
+        completion(nil)
+      } else if let sentinel = result as? NSObject, sentinel === FlutterMethodNotImplemented {
+        NSLog("[carplay] %@: Dart side not ready", method)
+        completion(nil)
+      } else {
+        completion(result)
+      }
+    }
+  }
+}
+
+extension CarPlayBridge: CPNowPlayingTemplateObserver {
+  func nowPlayingTemplateUpNextButtonTapped(_ nowPlayingTemplate: CPNowPlayingTemplate) {
+    showQueue()
+  }
+}
+
+/// Album art for list rows: fetched straight from the URL the Dart side hands
+/// over (they self-authenticate — a token in the query, or the loopback tunnel
+/// port), downscaled to CarPlay's row size, cached for the session.
+final class CarPlayArtLoader {
+  private let cache = NSCache<NSString, UIImage>()
+  private let session = URLSession(configuration: .ephemeral)
+
+  func load(_ url: URL, into apply: @escaping (UIImage) -> Void) {
+    let key = url.absoluteString as NSString
+    if let cached = cache.object(forKey: key) {
+      apply(cached)
+      return
+    }
+    session.dataTask(with: url) { [weak self] data, _, _ in
+      guard let data = data, let raw = UIImage(data: data) else { return }
+      let image = CarPlayArtLoader.fit(raw, into: CPListItem.maximumImageSize)
+      self?.cache.setObject(image, forKey: key)
+      DispatchQueue.main.async { apply(image) }
+    }.resume()
+  }
+
+  private static func fit(_ image: UIImage, into size: CGSize) -> UIImage {
+    guard image.size.width > size.width || image.size.height > size.height else { return image }
+    let scale = min(size.width / image.size.width, size.height / image.size.height)
+    let target = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+    return UIGraphicsImageRenderer(size: target).image { _ in
+      image.draw(in: CGRect(origin: .zero, size: target))
+    }
+  }
+}

--- a/ios/Runner/CarPlay.swift
+++ b/ios/Runner/CarPlay.swift
@@ -1,5 +1,6 @@
 import CarPlay
 import Flutter
+import MediaPlayer
 import UIKit
 
 /// The CarPlay scene. CarPlay hands us an interface controller; everything the
@@ -38,6 +39,10 @@ final class CarPlayBridge: NSObject {
   private var rootTemplate: CPListTemplate?
   private var dartReady = false
   private var observingNowPlaying = false
+  /// shuffle / repeat ("none" | "all" | "one") / Auto DJ, as last pushed by Dart.
+  private var modes: (shuffle: Bool, repeat: String, autoDJ: Bool) = (false, "none", false)
+  /// The Now Playing buttons' actions in display order (the debug hook presses them).
+  private var nowPlayingActions: [() -> Void] = []
 
   init(messenger: FlutterBinaryMessenger) {
     channel = FlutterMethodChannel(name: "mstream/carplay", binaryMessenger: messenger)
@@ -50,6 +55,15 @@ final class CarPlayBridge: NSObject {
         self?.dartReady = true
         NSLog("[carplay] dart ready (car connected: %d)", self?.interfaceController == nil ? 0 : 1)
         self?.loadRoot()
+        result(nil)
+      case "modes":
+        if let m = call.arguments as? [String: Any] {
+          self?.modes = (
+            m["shuffle"] as? Bool ?? false,
+            m["repeat"] as? String ?? "none",
+            m["autoDJ"] as? Bool ?? false)
+          self?.applyModes()
+        }
         result(nil)
       default:
         #if DEBUG
@@ -75,6 +89,7 @@ final class CarPlayBridge: NSObject {
         "dartReady": dartReady,
         "depth": ic?.templates.count ?? 0,
         "top": top.map { String(describing: type(of: $0)) } ?? "none",
+        "modes": ["shuffle": modes.shuffle, "repeat": modes.repeat, "autoDJ": modes.autoDJ],
       ]
       if let list = top as? CPListTemplate {
         state["title"] = list.title ?? ""
@@ -100,6 +115,14 @@ final class CarPlayBridge: NSObject {
       ic.popTemplate(animated: false) { _, _ in result(nil) }
     case "debugUpNext":
       showQueue()
+      result(nil)
+    case "debugButton":
+      let index = call.arguments as? Int ?? 0
+      guard index < nowPlayingActions.count else {
+        result(FlutterError(code: "no-button", message: "no Now Playing button \(index)", details: nil))
+        return true
+      }
+      nowPlayingActions[index]()
       result(nil)
     default:
       return false
@@ -215,6 +238,34 @@ final class CarPlayBridge: NSObject {
       nowPlaying.add(self)
       observingNowPlaying = true
     }
+    applyModes()
+  }
+
+  /// Shuffle, repeat and Auto DJ on the Now Playing screen. CarPlay draws the
+  /// two system buttons from the remote command center's current shuffle /
+  /// repeat types (audio_service never sets those on iOS, so this does), and
+  /// Auto DJ is an image button whose selected state mirrors the app's.
+  private func applyModes() {
+    let center = MPRemoteCommandCenter.shared()
+    center.changeShuffleModeCommand.currentShuffleType = modes.shuffle ? .items : .off
+    center.changeRepeatModeCommand.currentRepeatType =
+      modes.repeat == "one" ? .one : (modes.repeat == "all" ? .all : .off)
+    guard interfaceController != nil else { return }
+    let shuffle = CPNowPlayingShuffleButton { [weak self] _ in self?.toggle("toggleShuffle") }
+    let repeatButton = CPNowPlayingRepeatButton { [weak self] _ in self?.toggle("cycleRepeat") }
+    let djImage = UIImage(systemName: "sparkles") ?? UIImage()
+    let autoDJ = CPNowPlayingImageButton(image: djImage) { [weak self] _ in self?.toggle("toggleAutoDJ") }
+    autoDJ.isSelected = modes.autoDJ
+    nowPlayingActions = [
+      { [weak self] in self?.toggle("toggleShuffle") },
+      { [weak self] in self?.toggle("cycleRepeat") },
+      { [weak self] in self?.toggle("toggleAutoDJ") },
+    ]
+    CPNowPlayingTemplate.shared.updateNowPlayingButtons([shuffle, repeatButton, autoDJ])
+  }
+
+  private func toggle(_ method: String) {
+    invoke(method, nil) { _ in }
   }
 
   private func showQueue() {

--- a/ios/Runner/CarPlay.swift
+++ b/ios/Runner/CarPlay.swift
@@ -254,11 +254,12 @@ final class CarPlayBridge: NSObject {
     center.changeShuffleModeCommand.currentShuffleType = modes.shuffle ? .items : .off
     center.changeRepeatModeCommand.currentRepeatType =
       modes.repeat == "one" ? .one : (modes.repeat == "all" ? .all : .off)
-    guard interfaceController != nil else { return }
+    guard let ic = interfaceController else { return }
     let shuffle = CPNowPlayingShuffleButton { [weak self] _ in self?.toggle("toggleShuffle") }
     let repeatButton = CPNowPlayingRepeatButton { [weak self] _ in self?.toggle("cycleRepeat") }
-    let djImage = UIImage(systemName: "sparkles") ?? UIImage()
-    let autoDJ = CPNowPlayingImageButton(image: djImage) { [weak self] _ in self?.toggle("toggleAutoDJ") }
+    let autoDJ = CPNowPlayingImageButton(image: autoDJImage(for: ic)) { [weak self] _ in
+      self?.toggle("toggleAutoDJ")
+    }
     autoDJ.isSelected = modes.autoDJ
     nowPlayingActions = [
       { [weak self] in self?.toggle("toggleShuffle") },
@@ -270,6 +271,43 @@ final class CarPlayBridge: NSObject {
 
   private func toggle(_ method: String) {
     invoke(method, nil) { _ in }
+  }
+
+  /// The app's Auto DJ control is a text pill. CarPlay's Now Playing has no
+  /// text button type — every custom button is an image button, capped at
+  /// CPNowPlayingButtonMaximumImageSize — so the label is rendered into the
+  /// image. Rendered at the car display's own scale: the display uses the
+  /// bitmap's pixels as-is, so a 3x bitmap came out cropped to its top-left
+  /// corner (the letter "A" of a two-line "Auto DJ"). A template image, so
+  /// CarPlay tints it and draws the selected-state pill behind it.
+  private var autoDJImageCache: (scale: CGFloat, image: UIImage)?
+  private func autoDJImage(for ic: CPInterfaceController) -> UIImage {
+    let scale = max(1, ic.carTraitCollection.displayScale)
+    if let cached = autoDJImageCache, cached.scale == scale { return cached.image }
+    let size = CPNowPlayingButtonMaximumImageSize
+    NSLog("[carplay] button image %.0fx%.0f @%.0fx", size.width, size.height, scale)
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = scale
+    let paragraph = NSMutableParagraphStyle()
+    paragraph.alignment = .center
+    let text = NSAttributedString(
+      string: "DJ",
+      attributes: [
+        .font: UIFont.systemFont(ofSize: min(20, size.height * 0.6), weight: .bold),
+        .foregroundColor: UIColor.white,
+        .paragraphStyle: paragraph,
+      ])
+    let bounds = text.boundingRect(
+      with: CGSize(width: size.width, height: .greatestFiniteMagnitude),
+      options: [.usesLineFragmentOrigin], context: nil)
+    let image = UIGraphicsImageRenderer(size: size, format: format).image { _ in
+      let origin = CGPoint(x: 0, y: max(0, (size.height - bounds.height) / 2))
+      text.draw(
+        with: CGRect(origin: origin, size: CGSize(width: size.width, height: bounds.height)),
+        options: [.usesLineFragmentOrigin], context: nil)
+    }.withRenderingMode(.alwaysTemplate)
+    autoDJImageCache = (scale, image)
+    return image
   }
 
   private func showQueue() {

--- a/ios/Runner/CarPlay.swift
+++ b/ios/Runner/CarPlay.swift
@@ -62,6 +62,10 @@ final class CarPlayBridge: NSObject {
             m["shuffle"] as? Bool ?? false,
             m["repeat"] as? String ?? "none",
             m["autoDJ"] as? Bool ?? false)
+          // CarPlay's play/pause button reads this, not the playback rate;
+          // audio_service only sets it on macOS.
+          MPNowPlayingInfoCenter.default().playbackState =
+            (m["playing"] as? Bool ?? false) ? .playing : .paused
           self?.applyModes()
         }
         result(nil)

--- a/ios/Runner/CarPlay.swift
+++ b/ios/Runner/CarPlay.swift
@@ -120,6 +120,14 @@ final class CarPlayBridge: NSObject {
     case "debugUpNext":
       showQueue()
       result(nil)
+    case "debugArtist":
+      showArtist()
+      result(nil)
+    case "debugSiri":
+      // Dry-run of the Siri handler minus speech: resolve the phrase, then
+      // handle the resolved items exactly as Siri would.
+      let query = call.arguments as? String ?? ""
+      AppDelegate.shared.siri.dryRun(query: query) { summary in result(summary) }
     case "debugButton":
       let index = call.arguments as? Int ?? 0
       guard index < nowPlayingActions.count else {
@@ -238,6 +246,8 @@ final class CarPlayBridge: NSObject {
     let nowPlaying = CPNowPlayingTemplate.shared
     nowPlaying.isUpNextButtonEnabled = true
     nowPlaying.upNextTitle = "Queue"
+    // Tapping the artist name opens that artist's albums.
+    nowPlaying.isAlbumArtistButtonEnabled = true
     if !observingNowPlaying {
       nowPlaying.add(self)
       observingNowPlaying = true
@@ -310,6 +320,24 @@ final class CarPlayBridge: NSObject {
     return image
   }
 
+  /// The current track's artist → that artist's albums (a browse push).
+  private func showArtist() {
+    invoke("artistNode", nil) { [weak self] payload in
+      guard let self = self, let node = payload as? [String: Any],
+        let id = node["id"] as? String, let title = node["title"] as? String
+      else {
+        NSLog("[carplay] artist button: no artist for the current track")
+        return
+      }
+      self.browse(id: id, title: title) {}
+    }
+  }
+
+  /// Swift → Dart for other native callers (Siri).
+  func call(_ method: String, _ arguments: Any?, completion: @escaping (Any?) -> Void) {
+    invoke(method, arguments, completion: completion)
+  }
+
   private func showQueue() {
     invoke("getQueue", nil) { [weak self] payload in
       guard let self = self, let ic = self.interfaceController,
@@ -363,6 +391,10 @@ final class CarPlayBridge: NSObject {
 extension CarPlayBridge: CPNowPlayingTemplateObserver {
   func nowPlayingTemplateUpNextButtonTapped(_ nowPlayingTemplate: CPNowPlayingTemplate) {
     showQueue()
+  }
+
+  func nowPlayingTemplateAlbumArtistButtonTapped(_ nowPlayingTemplate: CPNowPlayingTemplate) {
+    showArtist()
   }
 }
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -54,9 +54,20 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
+		<true/>
 		<key>UISceneConfigurations</key>
 		<dict>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>CPTemplateApplicationScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>CarPlay</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).CarPlaySceneDelegate</string>
+				</dict>
+			</array>
 			<key>UIWindowSceneSessionRoleApplication</key>
 			<array>
 				<dict>
@@ -66,8 +77,6 @@
 					<string>flutter</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>
@@ -76,8 +85,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -23,6 +23,12 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSSiriUsageDescription</key>
+	<string>Play your music by voice: "Hey Siri, play &lt;song, album or artist&gt; on mStream."</string>
+	<key>INIntentsSupported</key>
+	<array>
+		<string>INPlayMediaIntent</string>
+	</array>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>mStream does not use the microphone</string>
 	<key>NSCameraUsageDescription</key>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.carplay-audio</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.developer.carplay-audio</key>
 	<true/>
+	<key>com.apple.developer.siri</key>
+	<true/>
 </dict>
 </plist>

--- a/ios/Runner/SceneDelegate.swift
+++ b/ios/Runner/SceneDelegate.swift
@@ -1,6 +1,63 @@
 import Flutter
 import UIKit
 
+/// The phone window. Builds its own window around a FlutterViewController on
+/// the app-owned engine (no storyboard: the storyboard would create a second,
+/// implicit engine) and registers that engine for scene life-cycle events by
+/// hand — with UIApplicationSupportsMultipleScenes on (a CarPlay requirement)
+/// Flutter no longer does that automatically.
 class SceneDelegate: FlutterSceneDelegate {
+  override func scene(
+    _ scene: UIScene, willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard let windowScene = scene as? UIWindowScene else { return }
+    let engine = AppDelegate.shared.engine!
+    let window = UIWindow(windowScene: windowScene)
+    if engine.viewController == nil {
+      window.rootViewController = FlutterViewController(engine: engine, nibName: nil, bundle: nil)
+      _ = registerSceneLifeCycle(with: engine)
+    } else {
+      // iPad "New Window": the engine already renders in another window and a
+      // second FlutterViewController on one engine is not supported. Show why,
+      // and ask the system to take this window down again.
+      window.rootViewController = AlreadyOpenViewController()
+      UIApplication.shared.requestSceneSessionDestruction(session, options: nil, errorHandler: nil)
+    }
+    self.window = window
+    window.makeKeyAndVisible()
+    super.scene(scene, willConnectTo: session, options: connectionOptions)
+  }
 
+  override func sceneDidDisconnect(_ scene: UIScene) {
+    super.sceneDidDisconnect(scene)
+    guard let engine = AppDelegate.shared.engine,
+      window?.rootViewController is FlutterViewController
+    else { return }
+    _ = unregisterSceneLifeCycle(with: engine)
+    // Let go of the view controller so the next phone scene can attach a fresh
+    // one; the engine — and the music — keep running.
+    engine.viewController = nil
+  }
+}
+
+/// Placeholder for a second phone window (iPad multitasking).
+final class AlreadyOpenViewController: UIViewController {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemBackground
+    let label = UILabel()
+    label.text = "mStream is already open in another window."
+    label.textAlignment = .center
+    label.numberOfLines = 0
+    label.textColor = .secondaryLabel
+    label.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(label)
+    NSLayoutConstraint.activate([
+      label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+      label.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 24),
+      label.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -24),
+    ])
+  }
 }

--- a/ios/Runner/Siri.swift
+++ b/ios/Runner/Siri.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Intents
+
+/// "Hey Siri, play <X> on mStream." SiriKit media intent, handled in-app
+/// (AppDelegate.application(_:handlerFor:)). Resolution is the browse tree's
+/// search over the `mstream/carplay` channel — tracks, then albums, then
+/// artists — and the chosen node plays through the same path a CarPlay tap
+/// uses, so Auto DJ, the Quick Connect tunnel and offline copies all apply.
+final class SiriMediaHandler: NSObject, INPlayMediaIntentHandling {
+  private let bridge: CarPlayBridge
+  /// Siri may ask for up to this many candidates; the first is what plays.
+  private static let maxCandidates = 5
+
+  init(bridge: CarPlayBridge) {
+    self.bridge = bridge
+  }
+
+  // MARK: - INPlayMediaIntentHandling
+
+  func resolveMediaItems(
+    for intent: INPlayMediaIntent,
+    with completion: @escaping ([INPlayMediaMediaItemResolutionResult]) -> Void
+  ) {
+    let search = intent.mediaSearch
+    let query = [search?.mediaName, search?.albumName, search?.artistName]
+      .compactMap { $0 }.first { !$0.isEmpty } ?? ""
+    guard !query.isEmpty else {
+      NSLog("[siri] resolve: nothing to search for")
+      completion([INPlayMediaMediaItemResolutionResult.unsupported()])
+      return
+    }
+    bridge.call("searchMedia", query) { payload in
+      let rows = payload as? [[String: Any]] ?? []
+      let items = rows.prefix(SiriMediaHandler.maxCandidates).compactMap(SiriMediaHandler.mediaItem)
+      NSLog("[siri] resolve(\"%@\"): %d candidates", query, items.count)
+      if items.isEmpty {
+        completion([INPlayMediaMediaItemResolutionResult.unsupported()])
+      } else {
+        completion(INPlayMediaMediaItemResolutionResult.successes(with: items))
+      }
+    }
+  }
+
+  func handle(intent: INPlayMediaIntent, completion: @escaping (INPlayMediaIntentResponse) -> Void) {
+    guard let item = intent.mediaItems?.first, let id = item.identifier else {
+      NSLog("[siri] handle: no media item")
+      completion(INPlayMediaIntentResponse(code: .failure, userActivity: nil))
+      return
+    }
+    NSLog("[siri] handle: %@", item.title ?? id)
+    bridge.call("playMedia", id) { _ in
+      completion(INPlayMediaIntentResponse(code: .success, userActivity: nil))
+    }
+  }
+
+  // MARK: - Helpers
+
+  private static func mediaItem(_ row: [String: Any]) -> INMediaItem? {
+    guard let id = row["id"] as? String, let title = row["title"] as? String else { return nil }
+    let type: INMediaItemType
+    switch row["kind"] as? String {
+    case "album": type = .album
+    case "artist": type = .artist
+    case "track": type = .song
+    default: type = .music
+    }
+    return INMediaItem(identifier: id, title: title, type: type, artwork: nil, artist: row["subtitle"] as? String)
+  }
+
+  #if DEBUG
+  /// The Siri flow without speech: resolve `query`, then handle the resolved
+  /// items the way Siri would. Reports the candidate titles and the response.
+  func dryRun(query: String, completion: @escaping ([String: Any]) -> Void) {
+    let search = INMediaSearch(
+      mediaType: .music, sortOrder: .unknown, mediaName: query, artistName: nil, albumName: nil,
+      genreNames: nil, moodNames: nil, releaseDate: nil, reference: .unknown, mediaIdentifier: nil)
+    let intent = INPlayMediaIntent(
+      mediaItems: nil, mediaContainer: nil, playShuffled: nil, playbackRepeatMode: .unknown,
+      resumePlayback: nil, playbackQueueLocation: .unknown, playbackSpeed: nil, mediaSearch: search)
+    bridge.call("searchMedia", query) { payload in
+      let rows = payload as? [[String: Any]] ?? []
+      let items = rows.prefix(SiriMediaHandler.maxCandidates).compactMap(SiriMediaHandler.mediaItem)
+      self.resolveMediaItems(for: intent) { results in
+        guard !items.isEmpty else {
+          completion(["candidates": [], "resolutions": results.count, "response": "not found"])
+          return
+        }
+        let resolved = INPlayMediaIntent(
+          mediaItems: items, mediaContainer: nil, playShuffled: nil, playbackRepeatMode: .unknown,
+          resumePlayback: nil, playbackQueueLocation: .unknown, playbackSpeed: nil, mediaSearch: search)
+        self.handle(intent: resolved) { response in
+          completion([
+            "candidates": items.map { "\($0.type.rawValue):\($0.title ?? "")" },
+            "resolutions": results.count,
+            "response": response.code.rawValue,
+          ])
+        }
+      }
+    }
+  }
+  #endif
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:rxdart/rxdart.dart';
 import 'screens/browser.dart';
 import 'screens/album_detail_view.dart';
 import 'objects/display_item.dart';
+import 'native/carplay_bridge.dart';
 import 'singletons/server_list.dart';
 import 'objects/server.dart';
 import 'screens/about_screen.dart';
@@ -71,6 +72,18 @@ void main() {
   ));
 }
 
+/// See the runApp call site: on iOS the phone window can arrive long after
+/// the engine started (CarPlay-only launch). Polling is fine — it is a rare
+/// path and nothing else is waiting.
+Future<void> _implicitViewReady() async {
+  final dispatcher = WidgetsBinding.instance.platformDispatcher;
+  if (dispatcher.implicitView != null) return;
+  appLog('[app] no window yet (CarPlay-only launch?) — UI waits for the phone scene');
+  while (dispatcher.implicitView == null) {
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+  }
+}
+
 Future<void> _startApp() async {
   WidgetsFlutterBinding.ensureInitialized();
   // Full flavor only: route API HTTPS through an override that accepts a
@@ -95,6 +108,9 @@ Future<void> _startApp() async {
   // so Android Auto cover art works on any build (not just VARIANT=play ones).
   await initAutoArt();
   await MediaManager().start();
+  // CarPlay: serve the browse tree + queue to the Swift scene, and tell it Dart
+  // is up (the car may have connected before main() ran). iOS only.
+  await CarPlayBridge.init();
   // Download status/progress listener. Here — not the widget's initState — so
   // HEADLESS boots (media resumption, Android Auto) also track completions:
   // the keep-queue-offline sweep runs from the handler's queue listener in
@@ -114,6 +130,11 @@ Future<void> _startApp() async {
   // ThemeData and any direct VelvetColors lookups stay in sync.
   // combineLatest2 (rxdart) merges the two streams into one record so a
   // single StreamBuilder drives both; locale == null follows the device.
+  // A CarPlay-only launch (phone locked, icon tapped on the car) has no phone
+  // window yet, and runApp needs one. Everything above — audio handler,
+  // servers, tunnel, CarPlay bridge — is already up and serving the car; the
+  // UI waits for the phone scene to attach.
+  await _implicitViewReady();
   runApp(StreamBuilder<(AppTheme, Locale?, int?)>(
     stream: Rx.combineLatest3(
       SettingsManager().themeStream,

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -2977,6 +2977,11 @@ class AudioPlayerHandler extends BaseAudioHandler
         MediaAction.seekBackward,
         // Lets Google Assistant route "play <X> on mStream" to playFromSearch.
         MediaAction.playFromSearch,
+        // Enables the OS shuffle / repeat remote commands (lock screen,
+        // CarPlay's Now Playing draws its shuffle and repeat buttons from
+        // them). Both handler methods exist and are safe headless.
+        MediaAction.setShuffleMode,
+        MediaAction.setRepeatMode,
       },
       shuffleMode: shuffle,
       repeatMode: repeat,

--- a/lib/media/auto_browse.dart
+++ b/lib/media/auto_browse.dart
@@ -131,6 +131,55 @@ class AutoBrowse {
   /// list); tapping it yields no children. CarPlay reads it to disable the row.
   static const String noticeId = '$_scheme://notice';
 
+  /// The browse node for [artist] on the server [localname] (its albums) —
+  /// what CarPlay's Now Playing artist button opens.
+  static String artistId(String localname, String artist) =>
+      _id('artist', {'s': localname, 'v': artist});
+
+  /// What kind of node an id is: track, album, artist, shuffle, … (the id's
+  /// host), or null for anything outside our scheme.
+  static String? nodeKind(String id) {
+    final u = Uri.tryParse(id);
+    return (u != null && u.scheme == _scheme) ? u.host : null;
+  }
+
+  /// Plays a node of any playable kind — a track (its container from that
+  /// point), an album or an artist (first album) from the top, shuffle. The
+  /// Siri "play `<X>` on mStream" handler lands here with whatever [search]
+  /// result was chosen. Never throws.
+  static Future<void> playNode(String id) async {
+    try {
+      await ServerManager().ensureLoaded();
+      final Uri? u = Uri.tryParse(id);
+      if (u == null || u.scheme != _scheme) return;
+      switch (u.host) {
+        case 'track':
+        case 'shuffle':
+        case 'resume':
+          await play(id);
+          return;
+      }
+      final qp = u.queryParameters;
+      final Server? srv = _serverForId(qp['s']);
+      final String? v = qp['v'];
+      if (srv == null || v == null) return;
+      List<DisplayItem> songs = const [];
+      if (u.host == 'album') {
+        songs = await AutoApi.albumSongs(srv, v);
+      } else if (u.host == 'artist') {
+        final album = _firstNamed(await AutoApi.artistAlbums(srv, v));
+        if (album != null) songs = await AutoApi.albumSongs(srv, album);
+      }
+      if (songs.isEmpty) {
+        appLog('[auto] playNode($id): nothing playable');
+        return;
+      }
+      await playFromHere(songs, 0);
+    } catch (e) {
+      appLog('[auto] playNode($id) failed: $e');
+    }
+  }
+
   // Short-lived per-server cache of the full albums/artists lists, so A–Z
   // bucket drill-ins reuse the parent tab's fetch instead of re-GETting the
   // whole library on every letter tap.

--- a/lib/media/auto_browse.dart
+++ b/lib/media/auto_browse.dart
@@ -20,6 +20,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io' show Platform;
 
 import 'package:audio_service/audio_service.dart';
 import 'package:http/http.dart' as http;
@@ -111,6 +112,9 @@ Future<void> initAutoArt() async {
 /// items ("Invalid album art uri") but loads a local content:// one — the
 /// provider downloads + caches the bytes.
 String _artContentUri(String remoteUrl) {
+  // CarPlay's Swift side fetches the remote URL itself (CarPlayArtLoader);
+  // content:// is Android's ArtContentProvider.
+  if (Platform.isIOS) return remoteUrl;
   final authority = _artAuthority ??
       '${isPlayBuild ? 'mstream.music' : 'mstream.music.plus'}.art';
   return Uri(
@@ -123,6 +127,10 @@ String _artContentUri(String remoteUrl) {
 
 /// Android Auto browse + playback for the active mStream server.
 class AutoBrowse {
+  /// The id every informational row carries (no server, load failed, empty
+  /// list); tapping it yields no children. CarPlay reads it to disable the row.
+  static const String noticeId = '$_scheme://notice';
+
   // Short-lived per-server cache of the full albums/artists lists, so A–Z
   // bucket drill-ins reuse the parent tab's fetch instead of re-GETting the
   // whole library on every letter tap.
@@ -703,7 +711,7 @@ class AutoBrowse {
   /// A non-playable informational row (no server / load error). Tapping it
   /// returns no children (the id isn't in our scheme).
   static MediaItem _notice(String title, String subtitle) => MediaItem(
-        id: '$_scheme://notice',
+        id: noticeId,
         title: title,
         artist: subtitle,
         playable: false,

--- a/lib/native/carplay_bridge.dart
+++ b/lib/native/carplay_bridge.dart
@@ -74,6 +74,34 @@ class CarPlayBridge {
         appLog('[carplay] skipToQueueItem($index)');
         await MediaManager().audioHandler.skipToQueueItem(index);
         return null;
+      case 'artistNode':
+        // The Now Playing artist button: the current track's artist on the
+        // server it came from, as the browse node of that artist's albums.
+        final item = MediaManager().audioHandler.mediaItem.value;
+        final artist = item?.artist;
+        final server = item?.extras?['server'] as String?;
+        if (item == null || artist == null || artist.isEmpty || server == null) {
+          return null;
+        }
+        return {'id': AutoBrowse.artistId(server, artist), 'title': artist};
+      // ── Siri: "play <X> on mStream". Resolution is the browse tree's search
+      // (tracks, then albums, then artists); the chosen node plays through
+      // the same path a car tap would.
+      case 'searchMedia':
+        final query = (call.arguments as String).trim();
+        final items = await AutoBrowse.search(query);
+        final rows = items
+            .where((m) => m.id != AutoBrowse.noticeId)
+            .map((m) => {...encodeItem(m), 'kind': AutoBrowse.nodeKind(m.id)})
+            .toList();
+        appLog('[siri] search("$query"): ${rows.length} results');
+        return rows;
+      case 'playMedia':
+        final id = call.arguments as String;
+        appLog('[siri] play($id)');
+        // Not awaited: play() futures complete when playback later pauses.
+        unawaited(AutoBrowse.playNode(id));
+        return null;
       // ── Now Playing buttons: the same toggles as the player panel and the
       // queue header, so the car and the phone never disagree on what a tap
       // means. The new state reaches the car through the modes push below.
@@ -115,7 +143,9 @@ class CarPlayBridge {
 
   /// Debug builds only: `ext.mstream.carplay` on the VM service, so a test
   /// run can drive the car's templates (the Simulator's CarPlay window takes
-  /// no synthetic taps). Params: `action=state|tap|back|upnext|button`, `index=<row or button>`.
+  /// no synthetic taps). Params:
+  /// `action=state|tap|back|upnext|button|artist|siri`, `index=<row or button>`,
+  /// `query=<siri phrase>`.
   static void _registerDebugExtension() {
     developer.registerExtension('ext.mstream.carplay',
         (String method, Map<String, String> params) async {
@@ -128,6 +158,9 @@ class CarPlayBridge {
           'upnext' => await _channel.invokeMethod<dynamic>('debugUpNext'),
           'button' => await _channel.invokeMethod<dynamic>(
               'debugButton', int.parse(params['index'] ?? '0')),
+          'artist' => await _channel.invokeMethod<dynamic>('debugArtist'),
+          'siri' => await _channel.invokeMethod<dynamic>(
+              'debugSiri', params['query'] ?? ''),
           _ => await _channel.invokeMethod<dynamic>('debugState'),
         };
         return developer.ServiceExtensionResponse.result(

--- a/lib/native/carplay_bridge.dart
+++ b/lib/native/carplay_bridge.dart
@@ -1,0 +1,113 @@
+import 'dart:async' show unawaited;
+import 'dart:convert';
+import 'dart:developer' as developer;
+import 'dart:io' show Platform;
+
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter/services.dart';
+
+import '../media/auto_browse.dart';
+import '../singletons/log_manager.dart';
+import '../singletons/media.dart';
+
+/// CarPlay ⇄ Dart. The Swift CarPlay scene (ios/Runner/CarPlay.swift) renders
+/// whatever this hands back: the browse tree Android Auto already uses
+/// (AutoBrowse — headless-safe, never throws), serialised as plain maps, plus
+/// the live queue for the Now Playing screen's "Queue" list. Playback itself
+/// goes through the audio handler like every other entry point, so CarPlay
+/// gets Auto DJ, the Quick Connect tunnel and the offline copies for free.
+class CarPlayBridge {
+  static const MethodChannel _channel = MethodChannel('mstream/carplay');
+
+  /// What Swift asks for as the top level; mapped onto audio_service's root.
+  static const String rootId = 'root';
+
+  static bool _started = false;
+
+  /// Registers the handler and tells the native side Dart is up (it may have
+  /// been showing "Loading…" to the car since before main() ran). iOS only;
+  /// a no-op everywhere else and when the binary has no bridge.
+  static Future<void> init() async {
+    if (!Platform.isIOS || _started) return;
+    _started = true;
+    _channel.setMethodCallHandler(_handle);
+    if (kDebugMode) _registerDebugExtension();
+    try {
+      await _channel.invokeMethod<void>('ready');
+    } on MissingPluginException {
+      // No CarPlay scene in this binary (tests, a stripped build): nothing to drive.
+    } catch (e) {
+      appLog('[carplay] ready handshake failed: $e');
+    }
+  }
+
+  static Future<dynamic> _handle(MethodCall call) async {
+    switch (call.method) {
+      case 'getChildren':
+        final id = call.arguments as String;
+        final items = await AutoBrowse.children(
+            id == rootId ? AudioService.browsableRootId : id);
+        appLog('[carplay] children($id): ${items.length}');
+        return items.map(encodeItem).toList();
+      case 'play':
+        final id = call.arguments as String;
+        appLog('[carplay] play($id)');
+        // Fire-and-forget: the handler's play() future completes only when
+        // playback later pauses or stops (just_audio semantics), and the car
+        // wants the row's completion — and its Now Playing screen — at once.
+        // AutoBrowse.play logs its own failures.
+        unawaited(AutoBrowse.play(id));
+        return null;
+      case 'getQueue':
+        final handler = MediaManager().audioHandler;
+        return {
+          'items': handler.queue.value.map(encodeItem).toList(),
+          'index': handler.playbackState.value.queueIndex ?? -1,
+        };
+      case 'skipToQueueItem':
+        final index = call.arguments as int;
+        appLog('[carplay] skipToQueueItem($index)');
+        await MediaManager().audioHandler.skipToQueueItem(index);
+        return null;
+      default:
+        throw MissingPluginException('${call.method} is not a CarPlay method');
+    }
+  }
+
+  /// Debug builds only: `ext.mstream.carplay` on the VM service, so a test
+  /// run can drive the car's templates (the Simulator's CarPlay window takes
+  /// no synthetic taps). Params: `action=state|tap|back|upnext`, `index=<row>`.
+  static void _registerDebugExtension() {
+    developer.registerExtension('ext.mstream.carplay',
+        (String method, Map<String, String> params) async {
+      try {
+        final action = params['action'] ?? 'state';
+        final dynamic r = switch (action) {
+          'tap' => await _channel.invokeMethod<dynamic>(
+              'debugTap', int.parse(params['index'] ?? '0')),
+          'back' => await _channel.invokeMethod<dynamic>('debugBack'),
+          'upnext' => await _channel.invokeMethod<dynamic>('debugUpNext'),
+          _ => await _channel.invokeMethod<dynamic>('debugState'),
+        };
+        return developer.ServiceExtensionResponse.result(
+            jsonEncode({'ok': true, 'result': r}));
+      } catch (e) {
+        return developer.ServiceExtensionResponse.result(
+            jsonEncode({'ok': false, 'error': '$e'}));
+      }
+    });
+  }
+
+  /// The subset of a MediaItem the car needs, as plain values. `notice` marks
+  /// AutoBrowse's informational rows (no server, load failed, empty list) so
+  /// the car shows them disabled instead of as a broken folder.
+  static Map<String, Object?> encodeItem(MediaItem m) => {
+        'id': m.id,
+        'title': m.title,
+        'subtitle': m.artist ?? m.album,
+        'artUri': m.artUri?.toString(),
+        'playable': m.playable ?? true,
+        'notice': m.id == AutoBrowse.noticeId,
+      };
+}

--- a/lib/native/carplay_bridge.dart
+++ b/lib/native/carplay_bridge.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show unawaited;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:io' show Platform;
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import '../media/auto_browse.dart';
 import '../singletons/log_manager.dart';
 import '../singletons/media.dart';
+import '../singletons/server_list.dart';
 
 /// CarPlay ⇄ Dart. The Swift CarPlay scene (ios/Runner/CarPlay.swift) renders
 /// whatever this hands back: the browse tree Android Auto already uses
@@ -24,6 +25,8 @@ class CarPlayBridge {
   static const String rootId = 'root';
 
   static bool _started = false;
+  static StreamSubscription<dynamic>? _playbackSub;
+  static StreamSubscription<dynamic>? _customSub;
 
   /// Registers the handler and tells the native side Dart is up (it may have
   /// been showing "Loading…" to the car since before main() ran). iOS only;
@@ -35,6 +38,7 @@ class CarPlayBridge {
     if (kDebugMode) _registerDebugExtension();
     try {
       await _channel.invokeMethod<void>('ready');
+      _watchModes();
     } on MissingPluginException {
       // No CarPlay scene in this binary (tests, a stripped build): nothing to drive.
     } catch (e) {
@@ -70,6 +74,40 @@ class CarPlayBridge {
         appLog('[carplay] skipToQueueItem($index)');
         await MediaManager().audioHandler.skipToQueueItem(index);
         return null;
+      // ── Now Playing buttons: the same toggles as the player panel and the
+      // queue header, so the car and the phone never disagree on what a tap
+      // means. The new state reaches the car through the modes push below.
+      case 'toggleShuffle':
+        final handler = MediaManager().audioHandler;
+        final on = handler.playbackState.value.shuffleMode ==
+            AudioServiceShuffleMode.all;
+        appLog('[carplay] shuffle → ${on ? 'off' : 'on'}');
+        await handler.setShuffleMode(
+            on ? AudioServiceShuffleMode.none : AudioServiceShuffleMode.all);
+        return null;
+      case 'cycleRepeat':
+        final handler = MediaManager().audioHandler;
+        final next = nextRepeatMode(handler.playbackState.value.repeatMode);
+        appLog('[carplay] repeat → ${next.name}');
+        await handler.setRepeatMode(next);
+        return null;
+      case 'toggleAutoDJ':
+        final handler = MediaManager().audioHandler;
+        if (handler.autoDJServer != null) {
+          appLog('[carplay] Auto DJ → off');
+          unawaited(handler.customAction('setAutoDJ', {'autoDJServer': null}));
+          return null;
+        }
+        final server = ServerManager().currentServer;
+        if (server == null) {
+          appLog('[carplay] Auto DJ: no server to run it on');
+          return null;
+        }
+        appLog('[carplay] Auto DJ → on (${server.localname})');
+        // Not awaited: on an empty queue this starts random play, whose
+        // play() future only completes when playback later pauses.
+        unawaited(handler.customAction('setAutoDJ', {'autoDJServer': server}));
+        return null;
       default:
         throw MissingPluginException('${call.method} is not a CarPlay method');
     }
@@ -77,7 +115,7 @@ class CarPlayBridge {
 
   /// Debug builds only: `ext.mstream.carplay` on the VM service, so a test
   /// run can drive the car's templates (the Simulator's CarPlay window takes
-  /// no synthetic taps). Params: `action=state|tap|back|upnext`, `index=<row>`.
+  /// no synthetic taps). Params: `action=state|tap|back|upnext|button`, `index=<row or button>`.
   static void _registerDebugExtension() {
     developer.registerExtension('ext.mstream.carplay',
         (String method, Map<String, String> params) async {
@@ -88,6 +126,8 @@ class CarPlayBridge {
               'debugTap', int.parse(params['index'] ?? '0')),
           'back' => await _channel.invokeMethod<dynamic>('debugBack'),
           'upnext' => await _channel.invokeMethod<dynamic>('debugUpNext'),
+          'button' => await _channel.invokeMethod<dynamic>(
+              'debugButton', int.parse(params['index'] ?? '0')),
           _ => await _channel.invokeMethod<dynamic>('debugState'),
         };
         return developer.ServiceExtensionResponse.result(
@@ -98,6 +138,61 @@ class CarPlayBridge {
       }
     });
   }
+
+  /// Pushes shuffle / repeat / Auto DJ to the car whenever one changes (and
+  /// once on start): CarPlay draws its shuffle and repeat buttons from the
+  /// remote command center's mode types, which the Swift side sets from this.
+  static void _watchModes() {
+    final handler = MediaManager().audioHandler;
+    _playbackSub ??= handler.playbackState
+        .map((s) => (s.shuffleMode, s.repeatMode))
+        .distinct()
+        .listen((_) => _pushModes());
+    _customSub ??= handler.customState.listen((_) => _pushModes());
+    _pushModes();
+  }
+
+  static Future<void> _pushModes() async {
+    final handler = MediaManager().audioHandler;
+    final state = handler.playbackState.value;
+    try {
+      await _channel.invokeMethod<void>(
+          'modes',
+          encodeModes(
+              shuffle: state.shuffleMode == AudioServiceShuffleMode.all,
+              repeat: state.repeatMode,
+              autoDJ: handler.autoDJServer != null));
+    } catch (e) {
+      appLog('[carplay] modes push failed: $e');
+    }
+  }
+
+  /// The repeat button's cycle: off → all → one → off (the player panel's
+  /// order; 'group' has no meaning here and is treated as 'all').
+  static AudioServiceRepeatMode nextRepeatMode(AudioServiceRepeatMode m) =>
+      switch (m) {
+        AudioServiceRepeatMode.none => AudioServiceRepeatMode.all,
+        AudioServiceRepeatMode.all ||
+        AudioServiceRepeatMode.group =>
+          AudioServiceRepeatMode.one,
+        AudioServiceRepeatMode.one => AudioServiceRepeatMode.none,
+      };
+
+  /// What the car is told about the three toggles.
+  static Map<String, Object?> encodeModes({
+    required bool shuffle,
+    required AudioServiceRepeatMode repeat,
+    required bool autoDJ,
+  }) =>
+      {
+        'shuffle': shuffle,
+        'repeat': switch (repeat) {
+          AudioServiceRepeatMode.one => 'one',
+          AudioServiceRepeatMode.all || AudioServiceRepeatMode.group => 'all',
+          AudioServiceRepeatMode.none => 'none',
+        },
+        'autoDJ': autoDJ,
+      };
 
   /// The subset of a MediaItem the car needs, as plain values. `notice` marks
   /// AutoBrowse's informational rows (no server, load failed, empty list) so

--- a/lib/native/carplay_bridge.dart
+++ b/lib/native/carplay_bridge.dart
@@ -145,7 +145,7 @@ class CarPlayBridge {
   static void _watchModes() {
     final handler = MediaManager().audioHandler;
     _playbackSub ??= handler.playbackState
-        .map((s) => (s.shuffleMode, s.repeatMode))
+        .map((s) => (s.shuffleMode, s.repeatMode, s.playing))
         .distinct()
         .listen((_) => _pushModes());
     _customSub ??= handler.customState.listen((_) => _pushModes());
@@ -161,7 +161,8 @@ class CarPlayBridge {
           encodeModes(
               shuffle: state.shuffleMode == AudioServiceShuffleMode.all,
               repeat: state.repeatMode,
-              autoDJ: handler.autoDJServer != null));
+              autoDJ: handler.autoDJServer != null,
+              playing: state.playing));
     } catch (e) {
       appLog('[carplay] modes push failed: $e');
     }
@@ -178,11 +179,15 @@ class CarPlayBridge {
         AudioServiceRepeatMode.one => AudioServiceRepeatMode.none,
       };
 
-  /// What the car is told about the three toggles.
+  /// What the car is told about the three toggles, plus whether playback is
+  /// running: CarPlay's Now Playing draws its play/pause button from
+  /// MPNowPlayingInfoCenter.playbackState, which audio_service sets only on
+  /// macOS, so the Swift side sets it from this.
   static Map<String, Object?> encodeModes({
     required bool shuffle,
     required AudioServiceRepeatMode repeat,
     required bool autoDJ,
+    required bool playing,
   }) =>
       {
         'shuffle': shuffle,
@@ -192,6 +197,7 @@ class CarPlayBridge {
           AudioServiceRepeatMode.none => 'none',
         },
         'autoDJ': autoDJ,
+        'playing': playing,
       };
 
   /// The subset of a MediaItem the car needs, as plain values. `notice` marks

--- a/test/native/carplay_bridge_test.dart
+++ b/test/native/carplay_bridge_test.dart
@@ -5,6 +5,7 @@ import 'package:mstream_music/native/carplay_bridge.dart';
 
 void main() {
   _modesTests();
+  _artistTests();
   group('CarPlayBridge.encodeItem', () {
     test('a browse node: not playable, not a notice, no art', () {
       const m = MediaItem(
@@ -88,6 +89,24 @@ void _modesTests() {
               autoDJ: false,
               playing: false)['repeat'],
           'none');
+    });
+  });
+}
+
+void _artistTests() {
+  group('AutoBrowse.artistId / nodeKind', () {
+    test('artist node id round-trips through nodeKind', () {
+      final id = AutoBrowse.artistId('iroh-demo', 'Color Out');
+      expect(id, startsWith('mstreamauto://artist?'));
+      expect(Uri.parse(id).queryParameters, {'s': 'iroh-demo', 'v': 'Color Out'});
+      expect(AutoBrowse.nodeKind(id), 'artist');
+    });
+
+    test('kinds of the ids the search tree mints; foreign ids are null', () {
+      expect(AutoBrowse.nodeKind('mstreamauto://track?s=a&p=%2Fx.mp3'), 'track');
+      expect(AutoBrowse.nodeKind('mstreamauto://album?s=a&v=EP'), 'album');
+      expect(AutoBrowse.nodeKind('https://demo/stream/1'), isNull);
+      expect(AutoBrowse.nodeKind('not a uri at all'), isNull);
     });
   });
 }

--- a/test/native/carplay_bridge_test.dart
+++ b/test/native/carplay_bridge_test.dart
@@ -69,15 +69,24 @@ void _modesTests() {
     test('plain values for the car', () {
       expect(
           CarPlayBridge.encodeModes(
-              shuffle: true, repeat: AudioServiceRepeatMode.one, autoDJ: false),
-          {'shuffle': true, 'repeat': 'one', 'autoDJ': false});
+              shuffle: true,
+              repeat: AudioServiceRepeatMode.one,
+              autoDJ: false,
+              playing: true),
+          {'shuffle': true, 'repeat': 'one', 'autoDJ': false, 'playing': true});
       expect(
           CarPlayBridge.encodeModes(
-              shuffle: false, repeat: AudioServiceRepeatMode.group, autoDJ: true),
-          {'shuffle': false, 'repeat': 'all', 'autoDJ': true});
+              shuffle: false,
+              repeat: AudioServiceRepeatMode.group,
+              autoDJ: true,
+              playing: false),
+          {'shuffle': false, 'repeat': 'all', 'autoDJ': true, 'playing': false});
       expect(
           CarPlayBridge.encodeModes(
-              shuffle: false, repeat: AudioServiceRepeatMode.none, autoDJ: false)['repeat'],
+              shuffle: false,
+              repeat: AudioServiceRepeatMode.none,
+              autoDJ: false,
+              playing: false)['repeat'],
           'none');
     });
   });

--- a/test/native/carplay_bridge_test.dart
+++ b/test/native/carplay_bridge_test.dart
@@ -4,6 +4,7 @@ import 'package:mstream_music/media/auto_browse.dart';
 import 'package:mstream_music/native/carplay_bridge.dart';
 
 void main() {
+  _modesTests();
   group('CarPlayBridge.encodeItem', () {
     test('a browse node: not playable, not a notice, no art', () {
       const m = MediaItem(
@@ -46,6 +47,38 @@ void main() {
       final e = CarPlayBridge.encodeItem(m);
       expect(e['notice'], isTrue);
       expect(e['playable'], isFalse);
+    });
+  });
+}
+
+void _modesTests() {
+  group('CarPlayBridge.nextRepeatMode', () {
+    test('cycles off → all → one → off, like the player panel', () {
+      expect(CarPlayBridge.nextRepeatMode(AudioServiceRepeatMode.none),
+          AudioServiceRepeatMode.all);
+      expect(CarPlayBridge.nextRepeatMode(AudioServiceRepeatMode.all),
+          AudioServiceRepeatMode.one);
+      expect(CarPlayBridge.nextRepeatMode(AudioServiceRepeatMode.one),
+          AudioServiceRepeatMode.none);
+      expect(CarPlayBridge.nextRepeatMode(AudioServiceRepeatMode.group),
+          AudioServiceRepeatMode.one);
+    });
+  });
+
+  group('CarPlayBridge.encodeModes', () {
+    test('plain values for the car', () {
+      expect(
+          CarPlayBridge.encodeModes(
+              shuffle: true, repeat: AudioServiceRepeatMode.one, autoDJ: false),
+          {'shuffle': true, 'repeat': 'one', 'autoDJ': false});
+      expect(
+          CarPlayBridge.encodeModes(
+              shuffle: false, repeat: AudioServiceRepeatMode.group, autoDJ: true),
+          {'shuffle': false, 'repeat': 'all', 'autoDJ': true});
+      expect(
+          CarPlayBridge.encodeModes(
+              shuffle: false, repeat: AudioServiceRepeatMode.none, autoDJ: false)['repeat'],
+          'none');
     });
   });
 }

--- a/test/native/carplay_bridge_test.dart
+++ b/test/native/carplay_bridge_test.dart
@@ -1,0 +1,51 @@
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/auto_browse.dart';
+import 'package:mstream_music/native/carplay_bridge.dart';
+
+void main() {
+  group('CarPlayBridge.encodeItem', () {
+    test('a browse node: not playable, not a notice, no art', () {
+      const m = MediaItem(
+          id: 'mstreamauto://cat?s=demo&k=albums', title: 'Albums', playable: false);
+      expect(CarPlayBridge.encodeItem(m), {
+        'id': 'mstreamauto://cat?s=demo&k=albums',
+        'title': 'Albums',
+        'subtitle': null,
+        'artUri': null,
+        'playable': false,
+        'notice': false,
+      });
+    });
+
+    test('a track: playable by default, art as a plain URL string', () {
+      final m = MediaItem(
+          id: 'https://demo/stream/1',
+          title: 'Hear The Cry',
+          artist: 'Selfless',
+          album: 'Album',
+          artUri: Uri.parse('https://demo/art/1.jpg?token=abc'));
+      final e = CarPlayBridge.encodeItem(m);
+      expect(e['playable'], isTrue);
+      expect(e['subtitle'], 'Selfless');
+      expect(e['artUri'], 'https://demo/art/1.jpg?token=abc');
+      expect(e['notice'], isFalse);
+    });
+
+    test('subtitle falls back to the album when there is no artist', () {
+      const m = MediaItem(id: 'x', title: 'T', album: 'The Album');
+      expect(CarPlayBridge.encodeItem(m)['subtitle'], 'The Album');
+    });
+
+    test('the notice row is flagged so the car disables it', () {
+      final m = MediaItem(
+          id: AutoBrowse.noticeId,
+          title: 'Nothing here',
+          artist: 'This list is empty',
+          playable: false);
+      final e = CarPlayBridge.encodeItem(m);
+      expect(e['notice'], isTrue);
+      expect(e['playable'], isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

CarPlay support for the approved audio entitlement. The car gets the same library tree Android Auto renders, playback goes through the audio handler like every other entry point (Auto DJ, the Quick Connect tunnel and offline copies come for free), and Now Playing is CarPlay's own template fed by what audio_service already publishes.

**One app-owned Flutter engine.** CarPlay can launch the app with no phone scene at all (phone locked, icon tapped on the car display), so the engine now starts in `AppDelegate` and the phone `SceneDelegate` attaches a `FlutterViewController` to it when the phone scene connects. It registers the engine for scene life-cycle events explicitly: with `UIApplicationSupportsMultipleScenes` on (a CarPlay requirement) Flutter no longer does that automatically (checked in the engine source). The storyboard is dropped from the scene manifest, since it would have created a second, implicit engine. An iPad "New Window" gets a placeholder and is closed again.

**CarPlay scene** (`ios/Runner/CarPlay.swift`): root list, drill-down lists with cover art fetched by `URLSession` (art URLs self-authenticate), the audio-app template stack capped at 5 (the top level is swapped instead of the push failing), Now Playing via `CPNowPlayingTemplate`, and a Queue list behind its Up Next button with tap-to-skip.

**Dart bridge** (`lib/native/carplay_bridge.dart`, channel `mstream/carplay`): serves `AutoBrowse.children` / `play` unchanged, plus the live queue and `skipToQueueItem`. On iOS the tree hands over the plain art URL instead of Android's `content://` wrapper. `play` is fire-and-forget: the handler's play future completes only when playback later pauses, and the car wants the row's completion (and its Now Playing screen) at once — found on the simulator, where Now Playing never appeared before this.

**Debug hook**: `ext.mstream.carplay` (VM-service extension, debug builds only) taps rows, goes back, opens Up Next and reports the template state, because the Simulator's CarPlay window accepts no synthetic input. Its Swift half is compiled only under `DEBUG`, which the Runner Debug configuration now defines.

**Signing**: `Runner.entitlements` with `com.apple.developer.carplay-audio` and `CODE_SIGN_ENTITLEMENTS` on the Runner target. Simulator builds need nothing else; device builds need a manually created provisioning profile with the CarPlay capability (automatic signing cannot mint one).

## Verification — iOS Simulator (Xcode 26.6), CarPlay display, demo.mstream.io over Quick Connect

| # | Scenario | Result |
|---|---|---|
| 1 | App icon on the CarPlay home screen; tap → root list (Shuffle All, Recently Added, Playlists, Albums, Artists, Files) | ✅ `[carplay] connected (dart ready: 1)`, `root: 6 rows` |
| 2 | Albums → 11 albums with cover art over the tunnel → album → 6 tracks → tap a track | ✅ `[carplay] play(…)` → queue loaded, `[play] play` → **Now Playing** with track / artist / album, transport and the Queue button |
| 3 | Up Next → Queue list (art + subtitles) → tap row 2 | ✅ `[carplay] skipToQueueItem(2)` → `track 3/6: Ghosts`, popped back |
| 4 | Shuffle All | ✅ `play(mstreamauto://shuffle…)` → queue cleared, Auto DJ picks, Now Playing |
| 5 | Recently Added / Playlists / Artists / Files | ✅ 20+ tracks / 6 playlists / 3 artists / 3 folders |
| 6 | Depth guard: Files → folder → folder → track (Now Playing at depth 5) → Up Next | ✅ `template stack at 5 — replacing the top level`, Queue shown at depth 5 |
| 7 | **Headless cold launch**: app terminated, icon tapped on the car display | ✅ `[carplay] connected (dart ready: 0)` → `dart ready (car connected: 1)` → tunnel up → root rendered → queue restored, phone still on the springboard |
| 8 | Phone UI opened on that CarPlay-launched process | ✅ full UI, mini-player showing the restored track |
| 9 | Phone scene life-cycle with the manual registration (HOME → reopen) | ✅ `[iroh] network change (resume)` → probe passed |

`flutter test`: all pass (new: `test/native/carplay_bridge_test.dart`). Analyzer clean on the touched files.

## Device testing — needs one thing from the account holder

Xcode's automatic signing cannot include the CarPlay entitlement. In the developer portal: enable **CarPlay Audio App** on the `mstream.music` App ID, create a **Development** provisioning profile for it with the test iPhones' UDIDs and your development certificate, download it, and I'll switch the Runner target to manual signing with that profile for the device build. Then test with the Toyota, or Apple's CarPlay Simulator app (Additional Tools for Xcode).

## Follow-ups (not in this PR)

- Now Playing buttons for shuffle / repeat / Auto DJ (`CPNowPlayingShuffleButton` etc.).
- Album art from servers with self-signed certificates (the Swift loader trusts only valid certs; the Dart HTTP override does not apply to it).
- `CPTabBarTemplate` (4 tabs) instead of the single root list, once the root nodes settle.
- `Main.storyboard` is now unused (dropped from the manifest) and can be deleted from the project in a cleanup.
- The iPad second-window placeholder path is untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
