### PR TITLE
fix(iroh): a standard default server is usable at launch while the queue's Quick Connect server dials

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'screens/album_detail_view.dart';
 import 'objects/display_item.dart';
 import 'native/carplay_bridge.dart';
 import 'singletons/server_list.dart';
+import 'singletons/tunnel_policy.dart';
 import 'objects/server.dart';
 import 'screens/about_screen.dart';
 import 'screens/auto_dj.dart';
@@ -580,10 +581,16 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
       initialData: ServerManager().tunnelStatus,
       builder: (context, snap) {
         final st = snap.data ?? IrohTunnelStatus.down;
-        // Show whenever the tunnel has a server to serve — including a background
-        // playback server while a non-iroh default is the selected server (the
-        // tunnel "follows playback").
-        if (!ServerManager().tunnelActive) {
+        // Only while the tunnel has a server to serve. Browsing the iroh
+        // server: every state. Browsing a standard server while the tunnel
+        // serves queued playback in the background: only the actionable
+        // states — a spinner over a server that is already usable reads as
+        // that server being unreachable (TunnelPolicy.showTunnelBanner).
+        if (!ServerManager().tunnelActive ||
+            !TunnelPolicy.showTunnelBanner(
+                status: st,
+                browsingTunnelServer:
+                    ServerManager().currentServer?.isIroh ?? false)) {
           return const SizedBox.shrink();
         }
         final l = AppLocalizations.of(context);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -576,10 +576,24 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
   // that we're on a slower relay path (the optimal direct path stays hidden, so
   // everyday use is clean). Hidden entirely for non-iroh servers. Plain English.
   Widget _tunnelBanner() {
-    return StreamBuilder<IrohTunnelStatus>(
-      stream: ServerManager().tunnelStatusStream,
-      initialData: ServerManager().tunnelStatus,
-      builder: (context, snap) {
+    // Re-evaluated on a server switch too, not only on tunnel events: whether
+    // the strip belongs on screen depends on which server is being browsed
+    // (a "Reconnecting…" strip used to outlive a switch to a standard server
+    // until the tunnel's next status change).
+    return StreamBuilder<Server?>(
+      stream: ServerManager().currentServerStream,
+      initialData: ServerManager().currentServer,
+      builder: (context, _) => StreamBuilder<IrohTunnelStatus>(
+        stream: ServerManager().tunnelStatusStream,
+        initialData: ServerManager().tunnelStatus,
+        builder: _tunnelBannerBody,
+      ),
+    );
+  }
+
+  Widget _tunnelBannerBody(
+      BuildContext context, AsyncSnapshot<IrohTunnelStatus> snap) {
+    {
         final st = snap.data ?? IrohTunnelStatus.down;
         // Only while the tunnel has a server to serve. Browsing the iroh
         // server: every state. Browsing a standard server while the tunnel
@@ -653,8 +667,7 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
                       style: TextStyle(color: VelvetColors.primary)),
                 ));
         }
-      },
-    );
+    }
   }
 
   // Thin iroh status strip — matches the migration banner's Material + padding +

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -138,12 +138,21 @@ class ServerManager {
 
     if (serverList.isNotEmpty) {
       currentServer = serverList[0];
-      // Bring up the tunnel for an iroh default server BEFORE the browser queries
-      // it — bounded: a cold dial in a dead zone takes up to ~43s and the retry
-      // loop owns failures now, so launch must not wait on it. The dial keeps
-      // running on the chain; the first browse/playback awaits the tunnel itself.
-      await ensureActiveTunnel(reason: 'launch', bypassBackoff: true)
-          .timeout(const Duration(seconds: 12), onTimeout: () {});
+      // An iroh default: bring its tunnel up BEFORE the browser queries it —
+      // bounded: a cold dial in a dead zone takes up to ~43s and the retry
+      // loop owns failures, so launch must not wait on it. The dial keeps
+      // running on the chain; the first browse/playback awaits the tunnel
+      // itself. A standard default needs nothing and must not wait on the
+      // chain either (a queued iroh server's dial may already be running on it).
+      if (currentServer!.isIroh) {
+        await ensureActiveTunnel(reason: 'launch', bypassBackoff: true)
+            .timeout(const Duration(seconds: 12), onTimeout: () {});
+      }
+      // Publish the default to the UI now: it is usable as soon as it is
+      // known. Everything below is background tunnel work for the queue and
+      // used to hold the browser (blank panel, "Connecting…") for up to 12s.
+      BrowserManager().goToNavScreen();
+      _currentServerStream.sink.add(currentServer);
       // Pre-warm the saved queue's iroh server (if it's a DIFFERENT server) in the
       // BACKGROUND — without selecting it — so the queue restores against a live
       // tunnel instead of a dead loopback port. The default stays selected; this
@@ -158,8 +167,6 @@ class ServerManager {
               server: rs, caller: 'launch', extendWhileDialing: false);
         }
       }
-      BrowserManager().goToNavScreen();
-      _currentServerStream.sink.add(currentServer);
       for (var s in serverList) {
         getServerPaths(s);
       }
@@ -440,13 +447,38 @@ class ServerManager {
   // This holds the iroh server the queue currently references (pushed by the
   // audio handler on queue changes); null when no queued song is from it.
   Server? _queueIrohServer;
+  // Pending release of _queueIrohServer (see setQueueIrohServer).
+  Timer? _queueReleaseTimer;
 
   /// Record the iroh server the play queue references ([s]), or null when no
   /// queued song is from an iroh server. No-op when unchanged; otherwise
   /// re-evaluates the tunnel target. Called by the audio handler on queue changes.
+  ///
+  /// A null is applied after [TunnelTiming.queueReleaseGrace], not at once:
+  /// the handler's initial empty queue, a restore and a clear-then-refill all
+  /// pass through "nothing from the iroh server queued" for a moment, and an
+  /// immediate release tore a launch tunnel down mid-dial (a full rebuild —
+  /// new port, reloaded URLs — seconds later). A server arriving inside the
+  /// grace period simply cancels the release.
   void setQueueIrohServer(Server? s) {
     final next = (s != null && s.isIroh) ? s : null;
+    if (next != null) {
+      _queueReleaseTimer?.cancel();
+      _queueReleaseTimer = null;
+    }
     if (next?.localname == _queueIrohServer?.localname) return;
+    if (next == null) {
+      _queueReleaseTimer ??= Timer(TunnelTiming.queueReleaseGrace, () {
+        _queueReleaseTimer = null;
+        final was = _queueIrohServer;
+        if (was == null) return;
+        appLog('[iroh] queue no longer references ${was.localname} — '
+            'releasing the tunnel');
+        _queueIrohServer = null;
+        unawaited(ensureActiveTunnel(reason: 'queue-server'));
+      });
+      return;
+    }
     _queueIrohServer = next;
     // No backoff bypass: this fires from the launch queue restore as well as
     // from a user queuing songs, and a bypass here re-dialed a REJECTED code

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -276,11 +276,27 @@ class ServerManager {
   Future<void> changeCurrentServer(int currentServerIndex) async {
     currentServer = serverList[currentServerIndex];
     _currentServerStream.sink.add(currentServer);
-    // Bring the tunnel up for the newly-active iroh server (or tear it down when
-    // switching to HTTP) before the browser queries it.
-    await ensureActiveTunnel(reason: 'server-switch', bypassBackoff: true);
+    await _settleTunnelForSwitch('server-switch');
+  }
+
+  /// After [currentServer] changed: reset the browser onto it and point the
+  /// tunnel where it now belongs. An iroh server is brought up BEFORE the
+  /// browser queries it. A standard server needs no tunnel, so the browser
+  /// resets at once — the old server's stack must not sit under the new
+  /// header, and it must not wait on the chain, where a cold dial for the
+  /// queue's iroh server may be running; the ensure (keep the tunnel for the
+  /// queue, or release it) runs behind.
+  Future<void> _settleTunnelForSwitch(String reason) async {
+    final s = currentServer!;
+    if (!s.isIroh) {
+      BrowserManager().goToNavScreen();
+      unawaited(getServerPaths(s));
+      unawaited(ensureActiveTunnel(reason: reason, bypassBackoff: true));
+      return;
+    }
+    await ensureActiveTunnel(reason: reason, bypassBackoff: true);
     BrowserManager().goToNavScreen();
-    unawaited(getServerPaths(currentServer!));
+    unawaited(getServerPaths(s));
   }
 
   Future<void> getServerPaths(Server server, {bool throwErr = false}) async {
@@ -1424,8 +1440,7 @@ class ServerManager {
     // changeCurrentServer().
     currentServer = s;
     _currentServerStream.sink.add(currentServer);
-    await ensureActiveTunnel(reason: 'make-default', bypassBackoff: true);
-    BrowserManager().goToNavScreen();
+    await _settleTunnelForSwitch('make-default');
 
     // Persist the new order so serverList[0] — the default loaded on the
     // next launch — is this server. Without this the choice was lost on

--- a/lib/singletons/tunnel_policy.dart
+++ b/lib/singletons/tunnel_policy.dart
@@ -82,6 +82,13 @@ class TunnelTiming {
   /// Bound on a queue-end park waiting for the tunnel to come back.
   static const Duration parkMax = Duration(minutes: 30);
 
+  /// How long a queue that stops referencing the iroh server keeps the tunnel
+  /// before it is released. A restore, a clear-then-refill and the handler's
+  /// initial empty queue all pass through "no iroh song queued" for a moment;
+  /// releasing at once tore a fresh launch tunnel down mid-dial (Galaxy S25,
+  /// 2026-09-02) and cost a full rebuild seconds later.
+  static const Duration queueReleaseGrace = Duration(seconds: 10);
+
   /// How long after an audio-focus interruption began an auto rebuild must not
   /// resume playback. A window, not a flag: Android never delivers the `end`
   /// for a permanent loss (6 begins, 0 ends across the two drive logs).
@@ -234,6 +241,21 @@ class TunnelPolicy {
         ? TunnelTiming.reconnectingWatchdog
         : TunnelTiming.reconnectingWatchdogBlind;
     return (notConnectedFor ?? Duration.zero) >= ceiling;
+  }
+
+  /// Whether the tunnel status strip belongs on screen. Browsing the iroh
+  /// server: every state (it is the server on screen). Browsing another
+  /// server while the tunnel serves queued playback in the background: only
+  /// the actionable states — a rejected code (Repair) and a hard-down tunnel
+  /// (Retry). "Connecting…" / "Reconnecting…" spinners over a standard server
+  /// that is already usable read as that server being unreachable.
+  static bool showTunnelBanner({
+    required IrohTunnelStatus status,
+    required bool browsingTunnelServer,
+  }) {
+    if (browsingTunnelServer) return true;
+    return status == IrohTunnelStatus.rejected ||
+        status == IrohTunnelStatus.down;
   }
 
   /// Delay before retry number [attempt] (0-based) after a failed cold dial.

--- a/test/singletons/tunnel_policy_test.dart
+++ b/test/singletons/tunnel_policy_test.dart
@@ -198,6 +198,48 @@ void main() {
     });
   });
 
+  group('TunnelPolicy.showTunnelBanner', () {
+    test('browsing the iroh server shows every state', () {
+      for (final st in IrohTunnelStatus.values) {
+        expect(
+            TunnelPolicy.showTunnelBanner(
+                status: st, browsingTunnelServer: true),
+            isTrue,
+            reason: '$st');
+      }
+    });
+
+    // The regression: a standard default with the queue on the Quick Connect
+    // server showed "Connecting to server…" over a browser that was usable.
+    test('a background playback tunnel shows only the actionable states', () {
+      expect(
+          TunnelPolicy.showTunnelBanner(
+              status: IrohTunnelStatus.connecting, browsingTunnelServer: false),
+          isFalse);
+      expect(
+          TunnelPolicy.showTunnelBanner(
+              status: IrohTunnelStatus.reconnecting,
+              browsingTunnelServer: false),
+          isFalse);
+      expect(
+          TunnelPolicy.showTunnelBanner(
+              status: IrohTunnelStatus.connected, browsingTunnelServer: false),
+          isFalse);
+      expect(
+          TunnelPolicy.showTunnelBanner(
+              status: IrohTunnelStatus.down, browsingTunnelServer: false),
+          isTrue);
+      expect(
+          TunnelPolicy.showTunnelBanner(
+              status: IrohTunnelStatus.rejected, browsingTunnelServer: false),
+          isTrue);
+    });
+
+    test('the queue release grace is long enough to cover a restore', () {
+      expect(TunnelTiming.queueReleaseGrace, const Duration(seconds: 10));
+    });
+  });
+
   group('TunnelPolicy.shouldEscalate', () {
     bool esc({
       IrohTunnelStatus native = IrohTunnelStatus.reconnecting,


### PR DESCRIPTION
## Summary

Reported on Android: with the personal server paired twice (HTTPS as the default, Quick Connect second) and the saved queue on the Quick Connect one, reopening the app showed "Connecting to server…" and a blank browser for seconds before anything loaded. With the Quick Connect server as the default it was fine.

Three causes, all visible in the launch log of the unfixed build:

1. **The UI waited on tunnel work it didn't need.** `loadServerList` published the current server only after a launch ensure (queued on the chain behind the dial the queue restore had already started) and an explicit wait for the queue server's tunnel. A standard default is now published as soon as it is known; only an iroh default still waits for its own tunnel first (that path is unchanged and re-checked).
2. **A transient empty queue tore the launch tunnel down.** The audio handler's initial empty-queue event cleared the queue's iroh server mid-dial, so the tunnel that had just come up was stopped as "no target" and rebuilt seconds later, and the launch wait ran its full 12 s. `setQueueIrohServer(null)` now applies after a 10 s grace (`TunnelTiming.queueReleaseGrace`); a server arriving inside it cancels the release.
3. **The banner meant the wrong server.** "Connecting…" showed for a background playback tunnel over a standard server that was already usable. `TunnelPolicy.showTunnelBanner`: every state while browsing the iroh server; only the actionable ones (rejected → Repair, down → Retry) while browsing another server. Unit-tested.

## Review pass: two more of the same family (second commit)

4. **Switching to a standard server** (`changeCurrentServer` / `makeDefault`) reset the browser only after the tunnel ensure, so with a cold dial holding the chain the old server's stack sat under the new header. A standard server now resets the browser first and lets the ensure run behind; an iroh server still comes up before the browser queries it.
5. **The tunnel strip outlived a server switch**: it re-evaluated only on tunnel events, so "Reconnecting to server… Retry" stayed on screen over the standard server until the tunnel's next state change. It now also rebuilds on the current-server stream.

## Verification (Galaxy S25, the author's server paired both ways)

| Default server | Before | After |
|---|---|---|
| HTTPS, queue on Quick Connect | "Connecting to server…" over an empty browser at 1.6 s, blank panel through 5 s, tunnel up → torn down → rebuilt, queue restored at 14 s | Home grid + server URL at 1.2 s, no banner, one background dial, queue restored at 5.5 s |
| Quick Connect | works | unchanged: dials first (3.3 s), then browser + queue |
| Quick Connect default, airplane mode until reconnecting, then switch to HTTPS | home grid under the HTTPS header but "Reconnecting to server… Retry" still showing | home grid, no strip |

`flutter test`: 427 pass (new banner-policy tests). Analyzer clean on the touched files.

Trade-off worth knowing: while browsing a standard server, a *reconnecting* background tunnel no longer shows a strip; playback of queued Quick Connect tracks still recovers on its own (PR #134), and the Repair / Retry strips for the two hard states remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
