### PR TITLE
test(smoke): device smoke suite — Android + iOS scripts, manual recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,5 @@ l10n_untranslated.txt
 # Hidden root-level dev screenshots: visualizer / UI verification shots get
 # saved as `.<name>.png` during development. Local scratch, not the app.
 /.*.png
+# smoke-test artifacts (screenshots, logs, device config backups)
+smoke/out/

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -153,6 +153,8 @@ class ServerManager {
       // used to hold the browser (blank panel, "Connecting…") for up to 12s.
       BrowserManager().goToNavScreen();
       _currentServerStream.sink.add(currentServer);
+      // Timing marker for the smoke scripts (smoke/android/launch-matrix.sh).
+      appLog('[app] default server ready: ${currentServer!.localname}');
       // Pre-warm the saved queue's iroh server (if it's a DIFFERENT server) in the
       // BACKGROUND — without selecting it — so the queue restores against a live
       // tunnel instead of a dead loopback port. The default stays selected; this
@@ -288,6 +290,7 @@ class ServerManager {
   /// queue, or release it) runs behind.
   Future<void> _settleTunnelForSwitch(String reason) async {
     final s = currentServer!;
+    appLog('[srv] switched to ${s.localname} ($reason)');
     if (!s.isIroh) {
       BrowserManager().goToNavScreen();
       unawaited(getServerPaths(s));

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -1,0 +1,58 @@
+# Smoke tests
+
+Device-level checks for the things unit tests cannot see: the Quick Connect
+tunnel under real network churn, Bluetooth in the car, launch and server
+switching, CarPlay, background playback. Two kinds:
+
+- **Scripts** (`android/`, `ios/`, `run-android.sh`): repeatable, assert on the
+  app's own log lines, drop screenshots and the filtered log in `out/`.
+- **Recipes** (`recipes/`): the tests that need a car, a commute, a head unit
+  or an hour of pocket time. Each says what to do, what pass looks like, and
+  what evidence to capture.
+
+## Prerequisites
+
+- Android: a device or emulator over USB with the debug `.plus.dev` build
+  (`sed -i '' 's/applicationIdSuffix ".plus"$/applicationIdSuffix ".plus.dev"/' android/app/build.gradle`,
+  `flutter build apk --debug --flavor full --target-platform android-arm64`, then revert
+  build.gradle), the personal server paired **both** ways (standard + Quick Connect),
+  and for the Bluetooth test a paired headset. Wireless debugging dies with the radios —
+  use USB.
+- iOS: a booted simulator with `flutter build ios --simulator --debug`; the CarPlay
+  round needs the Simulator GUI (I/O › External Displays › CarPlay) and one click.
+- Screen coordinates default to a Galaxy S25 (1080×2340); override with the
+  `SMOKE_*_XY` variables named at the top of each script for other phones.
+
+## Running
+
+```bash
+smoke/run-android.sh                      # whole Android suite (soak: 120 min)
+SMOKE_SOAK_MIN=10 smoke/run-android.sh    # quick version
+smoke/android/dead-zone.sh                # one scenario
+smoke/ios/carplay-round.sh                # simulator CarPlay, prompts for the click
+```
+
+Every script prints `PASS`/`FAIL`/`SKIP` lines and a summary, exits non-zero on
+a FAIL, and restores any device config it changed (server order, Auto DJ
+target) on exit, including on Ctrl-C. Nothing prints pairing codes or tokens.
+
+| Script | What it proves | Time |
+|---|---|---|
+| `android/session-actions.sh` | shuffle/repeat advertised to the OS (lock screen, Auto, CarPlay) | 15 s |
+| `android/launch-matrix.sh` | a standard default is usable at once; a Quick Connect default dials first; one dial, no teardown churn | 40 s |
+| `android/switch-during-outage.sh` | switching to the standard server mid-outage resets the browser at once, no strip | 3 min |
+| `android/media-resumption.sh` | headless boot on a PLAY key after a force-kill | 1 min |
+| `android/bt-late-pause.sh` | the car-off late PAUSE is ignored | 1 min |
+| `android/dead-zone.sh` | hand-off, 75 s outage, Retry tap, Wi-Fi return — all in place | 5 min |
+| `android/playback-soak.sh` | screen-off playback survives (Samsung app-sleep) | 2 h |
+| `android/cast-through-rebuild.sh` | opt-in (`SMOKE_CAST=1`, plays on a TV): cast + tunnel disturbance | 2 min |
+| `ios/sim-launch.sh` | app-owned engine boots, UI renders, resume reaches Dart | 1 min |
+| `ios/carplay-round.sh` | the whole CarPlay template flow, buttons, artist, Siri dry-run, depth guard | 2 min |
+
+## Reading a failure
+
+The scripts assert on log markers the app writes for exactly this purpose:
+`[app] default server ready`, `[srv] switched to`, `[iroh] tunnel up`,
+`reconnected: attempt`, `kicking the tunnel in place`, `output disconnected —
+pausing`, `media button toggle ignored`. On a real phone the same lines are in
+Diagnostics › Share, which is how the drive recipes are read afterwards.

--- a/smoke/android/bt-late-pause.sh
+++ b/smoke/android/bt-late-pause.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# The car-off race: the head unit's late PAUSE arrives after the audio link
+# dropped. Stand-ins: `svc bluetooth disable` (the drop) and a PAUSE media key
+# through the system dispatcher (the AVRCP command). Needs a Bluetooth headset
+# connected (A2DP active) — pair one and connect it first.
+#   SMOKE_BT_ROW_XY   first "Paired devices" row in Settings › Bluetooth, used to reconnect (default "343 998")
+source "$(dirname "$0")/../lib.sh"; pick_device
+BTROW=${SMOKE_BT_ROW_XY:-"343 998"}
+reconnect_headset() {
+  bluetooth enable; sleep 8
+  adbx shell am start -a android.settings.BLUETOOTH_SETTINGS >/dev/null 2>&1; sleep 4; tap $BTROW; sleep 10; key KEYCODE_BACK
+  bt_connected && log "headset reconnected ($(a2dp_route))" || log "headset NOT reconnected — reconnect it by hand"
+}
+trap 'reconnect_headset' EXIT
+bt_connected || { skip "no Bluetooth headset connected"; trap - EXIT; summary; exit; }
+app_stop; logcat_clear; wake; app_start; sleep 15
+ensure_playing 20 || { save_applog bt-launch; log "session: $(session_state) route: $(a2dp_route)"; fail "did not start playing (see $OUT/bt-launch.log)"; summary; exit 1; }
+sleep 5; log "route: $(a2dp_route)"
+log "== drop"; bluetooth disable
+wait_for_log 'output disconnected — pausing' 15 && pass "drop paused the app" || fail "no becoming-noisy pause"
+sleep 6; media_key pause; sleep 3
+if wait_for_log 'media button toggle ignored' 3; then pass "late PAUSE ignored"; else fail "late PAUSE not ignored"; fi
+n=$(applog | awk '/output disconnected/{f=1} f && /\[play\] play$/' | wc -l | tr -d ' ')
+[ "$n" -eq 0 ] && pass "no play after the drop (state $(session_state))" || fail "playback resumed after the drop"
+save_applog bt
+summary

--- a/smoke/android/cast-through-rebuild.sh
+++ b/smoke/android/cast-through-rebuild.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Casting from the Quick Connect server while its tunnel is disturbed. Plays
+# audio on the renderer (a TV) — run it when that is acceptable. Wi-Fi is
+# toggled off for 40s (the renderer and the tunnel both drop), then back on:
+# the tunnel must reconnect and the cast must either survive or fall back to
+# the phone cleanly (no silent dead cast). The outcome is read from the log —
+# check $OUT/cast.log by hand for the cast lines.
+#   SMOKE_CAST_ICON_XY  app-bar cast icon (default "863 187")
+#   SMOKE_CAST_ROW_XY   the renderer's row in the sheet (default "363 1638", second row)
+source "$(dirname "$0")/../lib.sh"; pick_device; cfg_backup
+ICON=${SMOKE_CAST_ICON_XY:-"863 187"}; ROW=${SMOKE_CAST_ROW_XY:-"363 1638"}
+trap 'wifi enable; cfg_restore' EXIT
+log "order: $(cfg_order iroh)"
+app_stop; logcat_clear; wake; app_start
+wait_for_log '\[iroh\] tunnel up' 20 || { fail "no tunnel at launch"; summary; exit 1; }
+media_key play; sleep 5; tap $ICON; sleep 5; shot cast-sheet; tap $ROW; sleep 15; shot casting
+wifi disable; sleep 40; wifi enable
+wait_for_log 'reconnected: attempt|tunnel up' 90 && pass "tunnel back after Wi-Fi returned" || fail "tunnel not back"
+sleep 15; shot after; save_applog cast
+log "read $OUT/cast.log for the cast outcome (survived / fell back to the phone)"
+summary

--- a/smoke/android/dead-zone.sh
+++ b/smoke/android/dead-zone.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Quick Connect dead-zone round on cellular (the drive): Wi-Fi → cellular
+# hand-off, a 75s airplane-mode outage, the banner's Retry during a second
+# outage, Wi-Fi return. Checks the reconnects happen IN PLACE (same port, no
+# rebuild) and within a bounded time of service returning.
+#   SMOKE_RETRY_XY   the banner's Retry button (default "948 516", Galaxy S25)
+#   SMOKE_OUTAGE_S   outage length (default 75)
+source "$(dirname "$0")/../lib.sh"; pick_device; cfg_backup
+IROH=$(localname_of iroh); [ -n "$IROH" ] || { skip "needs a Quick Connect server"; summary; exit; }
+RETRY=${SMOKE_RETRY_XY:-"948 516"}; OUTAGE=${SMOKE_OUTAGE_S:-75}
+trap 'airplane disable; wifi enable; cfg_restore' EXIT
+log "order: $(cfg_order iroh)"; cfg_dj "$IROH"
+app_stop; logcat_clear; wake; app_start
+wait_for_log '\[iroh\] tunnel up' 20 || { fail "no tunnel at launch"; summary; exit 1; }
+PORT=$(applog | grep -oE 'tunnel up port=[0-9]+' | head -1 | grep -oE '[0-9]+$'); log "port $PORT"
+ensure_playing 20 || log "(not playing — continuing with the tunnel checks)"; sleep 5
+log "== hand-off: wifi off"; HO=$(now_hms); wifi disable
+wait_for_log_after "$HO" 'probe #[12] passed|reconnected: attempt' 45 && pass "hand-off: tunnel kept (probe passed)" || fail "hand-off: no probe pass within 45s"
+log "== outage 1: airplane ${OUTAGE}s"; airplane enable; sleep "$OUTAGE"; BACK=$(now_hms); airplane disable
+if wait_for_log_after "$BACK" 'reconnected: attempt' 90; then
+  d=$(secs_between "$BACK" "$(ts_after "$BACK" 'reconnected: attempt')"); pass "outage 1: reconnected in place ${d}s after airplane off"
+else fail "outage 1: no in-place reconnect within 90s"; fi
+sleep 10
+log "== outage 2: Retry tap while reconnecting"; O2=$(now_hms); airplane enable
+wait_for_log_after "$O2" 'status connected → reconnecting' 75 || log "   (no reconnecting edge yet)"
+sleep 5; shot banner; tap $RETRY; sleep 3
+if wait_for_log 'kicking the tunnel in place \(retry-tap\)' 5; then pass "Retry kicked in place"; else fail "Retry did not kick (rebuild?)"; fi
+sleep 20; BACK=$(now_hms); airplane disable
+if wait_for_log_after "$BACK" 'reconnected: attempt' 90; then d=$(secs_between "$BACK" "$(ts_after "$BACK" 'reconnected: attempt')"); pass "outage 2: reconnected ${d}s after airplane off"; else fail "outage 2: no reconnect within 90s"; fi
+log "== return home: wifi on"; HOME_TS=$(now_hms); wifi enable
+# A migrating connection may fail both probes; the in-place kick that follows counts as recovery too.
+wait_for_log_after "$HOME_TS" 'probe #[12] passed|reconnected: attempt' 60 && pass "Wi-Fi return: tunnel serving ($(ts_after "$HOME_TS" 'probe #[12] passed|reconnected: attempt'))" || fail "Wi-Fi return: neither a probe pass nor a reconnect within 60s"
+save_applog dead-zone
+ports=$(applog | grep -oE 'tunnel up port=[0-9]+' | sort -u | wc -l | tr -d ' ')
+if [ "$ports" -le 1 ]; then pass "same port throughout"; else fail "$ports distinct ports (a rebuild happened)"; fi
+if [ "$(count_log 'stream URLs rebuilt')" -eq 0 ]; then pass "no URL rebuild"; else fail "stream URLs rebuilt during the round"; fi
+summary

--- a/smoke/android/launch-matrix.sh
+++ b/smoke/android/launch-matrix.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Launch matrix: the app is reopened with the standard server as default, then
+# with the Quick Connect server as default. Checks (from the app log):
+#   standard default   → the default is published to the browser within 2s and
+#                        BEFORE any tunnel comes up (the queue's Quick Connect
+#                        server dials in the background)
+#   Quick Connect default → its tunnel comes up, then the browser
+#   both               → at most one dial in the first 12s, no "no-target"
+#                        teardown (the tunnel-built-then-torn-down churn)
+# Needs one Quick Connect and one standard server on the device.
+source "$(dirname "$0")/../lib.sh"; pick_device; cfg_backup
+IROH=$(localname_of iroh); STD=$(localname_of standard)
+if [ -z "$IROH" ] || [ -z "$STD" ]; then skip "needs one Quick Connect and one standard server"; summary; exit; fi
+
+run_case() { # <name> <iroh|standard>
+  local name="$1" order="$2"
+  log "== $name (order: $(cfg_order "$order"))"
+  app_stop; logcat_clear; wake; app_start; sleep 12; shot "$name-12s"; save_applog "$name"
+  local started ready up; started=$(first_ts '\[app\] mStream '); ready=$(first_ts '\[app\] default server ready'); up=$(first_ts '\[iroh\] tunnel up')
+  local d_ready d_up; d_ready=$(secs_between "$started" "$ready"); d_up=$(secs_between "$started" "$up")
+  log "   started→default ready ${d_ready:-?}s · started→tunnel up ${d_up:-never}s"
+  if [ "$order" = standard ]; then
+    if [ -n "$d_ready" ] && lt "$d_ready" 2.0; then pass "$name: default published in ${d_ready}s"; else fail "$name: default published in ${d_ready:-?}s (limit 2s)"; fi
+    if [ -n "$d_up" ]; then
+      if lt "$d_ready" "$d_up"; then pass "$name: published before the tunnel came up"; else fail "$name: the browser waited for the tunnel"; fi
+    else log "   (no Quick Connect dial in this launch — the saved queue is not on $IROH)"; fi
+  else
+    if [ -n "$d_up" ] && lt "$d_ready" 15; then pass "$name: tunnel up in ${d_up}s, default published at ${d_ready}s"; else fail "$name: tunnel up ${d_up:-never}, default ready ${d_ready:-never}"; fi
+  fi
+  local ups stops; ups=$(count_log '\[iroh\] tunnel up'); stops=$(count_log 'tunnel stopped \(no-target')
+  if [ "$ups" -le 1 ]; then pass "$name: $ups dial(s)"; else fail "$name: $ups dials in 12s"; fi
+  if [ "$stops" -eq 0 ]; then pass "$name: no no-target teardown"; else fail "$name: $stops no-target teardown(s)"; fi
+}
+run_case standard-default standard
+run_case quickconnect-default iroh
+summary

--- a/smoke/android/media-resumption.sh
+++ b/smoke/android/media-resumption.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Headless resume: the app's process is killed (the way the OS reclaims it —
+# NOT `am force-stop`, which puts an app in Android's stopped state where no
+# media key may start it), then a PLAY media key arrives (a headset button /
+# the car). The service must boot without the UI, restore the saved queue,
+# and play — with the Quick Connect tunnel dialed behind it.
+source "$(dirname "$0")/../lib.sh"; pick_device
+app_stop; logcat_clear; wake; app_start; sleep 15; ensure_playing 20 || log "(could not start playback before the kill)"; sleep 3; is_playing && media_key pause; sleep 2
+key KEYCODE_HOME; sleep 2; PID=$(app_pid); adbx shell "run-as $PKG kill -9 $PID" 2>/dev/null; sleep 3
+[ -z "$(app_pid)" ] && log "process $PID killed" || { fail "could not kill the process"; summary; exit 1; }
+logcat_clear; log "== PLAY key with the app dead"; media_key play
+if wait_for_log '\[app\] mStream ' 20; then pass "service booted headless"; else fail "no boot within 20s"; fi
+if wait_for_log '\[play\] play' 30; then pass "playback started ($(session_state))"; else fail "no play within 30s"; fi
+wait_for_log '\[play\] track ' 30 && pass "queue restored: $(applog | grep -oE '\[play\] track [0-9]+/[0-9]+: .*' | head -1)" || fail "no track line"
+save_applog resumption
+summary

--- a/smoke/android/playback-soak.sh
+++ b/smoke/android/playback-soak.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Screen-off playback soak (Samsung app-sleep, Doze): play, screen off, poll
+# every minute — the process must survive and the session stay PLAYING.
+#   SMOKE_SOAK_MIN   minutes (default 120)
+source "$(dirname "$0")/../lib.sh"; pick_device
+MIN=${SMOKE_SOAK_MIN:-120}
+trap 'wake' EXIT
+[ -n "$(app_pid)" ] || { wake; app_start; sleep 12; }
+logcat_clear
+ensure_playing 20 || { save_applog soak-start; fail "did not start playing ($(session_state))"; summary; exit 1; }
+PID0=$(app_pid); key KEYCODE_SLEEP; log "screen off, soaking ${MIN} min (pid $PID0)"
+i=0; bad=0
+while [ "$i" -lt "$MIN" ]; do
+  sleep 60; i=$((i+1))
+  st=$(session_state); pid=$(app_pid)
+  log "  +${i}m pid=${pid:-dead} $st"
+  if [ "$pid" != "$PID0" ] || ! echo "$st" | grep -q PLAYING; then bad=$((bad+1)); fi
+done
+[ "$bad" -eq 0 ] && pass "survived ${MIN} min screen-off, PLAYING at every poll" || fail "$bad bad poll(s) (restart or not playing)"
+n=$(count_log '\[play\] pause'); [ "$n" -eq 0 ] && pass "no unexpected pause" || fail "$n pause line(s) during the soak"
+save_applog soak; summary

--- a/smoke/android/session-actions.sh
+++ b/smoke/android/session-actions.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# The media session must advertise SET_REPEAT_MODE and SET_SHUFFLE_MODE (the
+# lock-screen / Android Auto / CarPlay shuffle-repeat controls hang off them).
+source "$(dirname "$0")/../lib.sh"; pick_device
+[ -n "$(app_pid)" ] || { wake; app_start; sleep 12; }
+ACTIONS=$(adbx shell dumpsys media_session 2>/dev/null | grep -A12 "$PKG" | grep -m1 -oE 'actions=[0-9]+' | cut -d= -f2)
+[ -n "$ACTIONS" ] || { fail "no media session for $PKG"; summary; exit 1; }
+log "actions bitmask: $ACTIONS"
+python3 -c "import sys; a=int(sys.argv[1]); sys.exit(0 if a & (1<<18) else 1)" "$ACTIONS" && pass "SET_REPEAT_MODE advertised" || fail "SET_REPEAT_MODE missing"
+python3 -c "import sys; a=int(sys.argv[1]); sys.exit(0 if a & (1<<21) else 1)" "$ACTIONS" && pass "SET_SHUFFLE_MODE advertised" || fail "SET_SHUFFLE_MODE missing"
+summary

--- a/smoke/android/switch-during-outage.sh
+++ b/smoke/android/switch-during-outage.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Switch to the standard server while the Quick Connect tunnel is reconnecting
+# (airplane mode). Checks: the switch is logged within 2s of the tap (the
+# browser reset does not wait on the tunnel chain) and the screenshots show
+# the standard server's home grid with NO tunnel strip. The strip and the
+# browser are visual — eyeball $OUT/after-switch-*.png.
+#   SMOKE_ALBUMS_XY        Albums tile          (default "281 1030", Galaxy S25 1080x2340)
+#   SMOKE_PICKER_XY        app-bar server picker (default "1007 187")
+#   SMOKE_PICKER_ROW2_XY   second row of the picker (default "782 366")
+source "$(dirname "$0")/../lib.sh"; pick_device; cfg_backup
+IROH=$(localname_of iroh); STD=$(localname_of standard)
+if [ -z "$IROH" ] || [ -z "$STD" ]; then skip "needs one Quick Connect and one standard server"; summary; exit; fi
+ALBUMS=${SMOKE_ALBUMS_XY:-"281 1030"}; PICKER=${SMOKE_PICKER_XY:-"1007 187"}; ROW2=${SMOKE_PICKER_ROW2_XY:-"782 366"}
+trap 'airplane disable; cfg_restore' EXIT
+log "order: $(cfg_order iroh)"
+app_stop; logcat_clear; wake; app_start
+wait_for_log '\[iroh\] tunnel up' 20 || { fail "tunnel did not come up at launch"; summary; exit 1; }
+sleep 2; tap $ALBUMS; sleep 3; shot before-outage
+airplane enable
+if wait_for_log 'status connected → reconnecting' 75; then pass "supervisor reconnecting after the drop"; else fail "no reconnecting edge within 75s"; fi
+tap $PICKER; sleep 1.5; TAP=$(now_hms); tap $ROW2; sleep 0.7; shot after-switch-0.7s; sleep 3; shot after-switch-3.7s
+if wait_for_log "\[srv\] switched to $STD" 5; then
+  d=$(secs_between "$TAP" "$(first_ts "\[srv\] switched to $STD")")
+  if lt "$d" 2.0; then pass "switch logged ${d}s after the tap"; else fail "switch logged ${d}s after the tap"; fi
+else fail "no '[srv] switched to $STD' line"; fi
+BACK=$(now_hms); airplane disable
+wait_for_log_after "$BACK" 'reconnected: attempt|tunnel up' 60 && pass "tunnel back after service returned" || fail "tunnel not back within 60s"
+save_applog switch; log "inspect $OUT/after-switch-*.png: standard server header, home grid, no 'Reconnecting…' strip"
+summary

--- a/smoke/ios/carplay-round.sh
+++ b/smoke/ios/carplay-round.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# CarPlay round on the iOS Simulator, driven through the app's debug hook
+# (`ext.mstream.carplay`, debug builds only). The Simulator's CarPlay window
+# takes no synthetic input, so ONE thing is manual: when prompted, click the
+# mStream icon in the "… – CarPlay" window. Everything after that is scripted:
+# root, Albums → album → track → Now Playing, Queue + skip, the three Now
+# Playing buttons, the artist button, a Siri dry-run, the 5-deep guard.
+#   SMOKE_SIM_UDID   booted simulator (default: the first booted iPhone)
+#   SMOKE_APP        Runner.app (default build/ios/iphonesimulator/Runner.app; SMOKE_BUILD=1 builds it)
+set -u
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"; OUT="${SMOKE_OUT:-$ROOT/smoke/out/$(date +%Y%m%d-%H%M%S)-carplay-round}"; mkdir -p "$OUT"
+PASS=0; FAIL=0
+log(){ echo "$(date '+%H:%M:%S') $*" | tee -a "$OUT/run.log"; }; pass(){ PASS=$((PASS+1)); log "PASS  $*"; }; fail(){ FAIL=$((FAIL+1)); log "FAIL  $*"; }
+UDID="${SMOKE_SIM_UDID:-$(xcrun simctl list devices booted | grep -oE '[0-9A-F-]{36}' | head -1)}"
+[ -n "$UDID" ] || { echo "no booted simulator"; exit 2; }
+APP="${SMOKE_APP:-$ROOT/build/ios/iphonesimulator/Runner.app}"
+if [ "${SMOKE_BUILD:-0}" = 1 ]; then (cd "$ROOT" && flutter build ios --simulator --debug | tail -1); fi
+[ -d "$APP" ] || { echo "no $APP (set SMOKE_BUILD=1)"; exit 2; }
+PORT=48123; VM="http://127.0.0.1:$PORT/"
+xcrun simctl terminate "$UDID" mstream.music 2>/dev/null; xcrun simctl install "$UDID" "$APP"
+xcrun simctl launch "$UDID" mstream.music --vm-service-port=$PORT --disable-service-auth-codes >/dev/null; sleep 10
+ISO=$(curl -s --max-time 5 "${VM}getVM" | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['isolates'][0]['id'])")
+ISOQ=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$ISO")
+cpx(){ local extra=""; if [ -n "${2:-}" ]; then case "$1" in siri) extra="&query=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$2")";; *) extra="&index=$2";; esac; fi
+  curl -s --max-time 40 "${VM}ext.mstream.carplay?isolateId=${ISOQ}&action=$1${extra}" | python3 -c "import sys,json
+raw=sys.stdin.read()
+try:
+    d=json.loads(raw); r=d.get('result', d); print(json.dumps(r if isinstance(r,(dict,list)) else d, ensure_ascii=False))
+except Exception: print('{}')"; }
+field(){ python3 -c "import sys,json; d=json.loads(sys.argv[1]); v=d
+for k in sys.argv[2].split('.'): v=v.get(k) if isinstance(v,dict) else None
+print('' if v is None else v)" "$1" "$2"; }
+shot(){ xcrun simctl io "$UDID" screenshot --display external "$OUT/$1.png" >/dev/null 2>&1; }
+# open the CarPlay display if the Simulator GUI is up
+osascript -e 'tell application "System Events" to tell process "Simulator" to click menu item "CarPlay" of menu "External Displays" of menu item "External Displays" of menu "I/O" of menu bar 1' >/dev/null 2>&1 &
+sleep 3; kill %1 2>/dev/null
+echo; echo ">>> Click the mStream icon in the Simulator's CarPlay window now (waiting up to 3 min)"; echo
+i=0; while [ $i -lt 180 ]; do [ "$(field "$(cpx state)" connected)" = "True" ] && break; sleep 2; i=$((i+2)); done
+[ "$(field "$(cpx state)" connected)" = "True" ] || { fail "CarPlay scene never connected"; log "== $PASS pass, $FAIL fail"; exit 1; }
+S=$(cpx state); echo "$S" | grep -q '"Shuffle All"' && pass "root list" || fail "root list: $S"; shot root
+cpx tap 3 >/dev/null; sleep 3; S=$(cpx state); [ "$(field "$S" title)" = "Albums" ] && pass "Albums ($(echo "$S" | grep -o '"items": \[[^]]*' | tr -cd ',' | wc -c | tr -d ' ') rows)" || fail "Albums: $S"; shot albums
+cpx tap 0 >/dev/null; sleep 3; S=$(cpx state); [ "$(field "$S" depth)" = "3" ] && pass "album opened: $(field "$S" title)" || fail "album: $S"
+cpx tap 0 >/dev/null; sleep 6; S=$(cpx state); [ "$(field "$S" top)" = "CPNowPlayingTemplate" ] && pass "track played → Now Playing" || fail "Now Playing: $S"; shot nowplaying
+cpx upnext >/dev/null; sleep 3; S=$(cpx state); [ "$(field "$S" title)" = "Queue" ] && pass "Up Next → Queue" || fail "Queue: $S"; shot queue
+cpx tap 1 >/dev/null; sleep 3; S=$(cpx state); [ "$(field "$S" top)" = "CPNowPlayingTemplate" ] && pass "queue row → skip, back on Now Playing" || fail "after skip: $S"
+cpx button 0 >/dev/null; sleep 2; [ "$(field "$(cpx state)" modes.shuffle)" = "True" ] && pass "shuffle on" || fail "shuffle"
+cpx button 1 >/dev/null; sleep 2; [ "$(field "$(cpx state)" modes.repeat)" = "all" ] && pass "repeat → all" || fail "repeat"
+cpx button 1 >/dev/null; sleep 2; cpx button 1 >/dev/null; sleep 2; cpx button 0 >/dev/null; sleep 2
+dj0=$(field "$(cpx state)" modes.autoDJ); cpx button 2 >/dev/null; sleep 3; dj1=$(field "$(cpx state)" modes.autoDJ); [ "$dj0" != "$dj1" ] && pass "Auto DJ toggled ($dj0 → $dj1)" || fail "Auto DJ did not toggle"; cpx button 2 >/dev/null; sleep 2; shot buttons
+cpx artist >/dev/null; sleep 4; S=$(cpx state); [ "$(field "$S" depth)" = "5" ] && pass "artist button → $(field "$S" title)" || fail "artist: $S"
+R=$(cpx siri "Color Out"); [ "$(field "$R" response)" = "4" ] && pass "Siri dry-run: $(echo "$R" | grep -o '"candidates": \[[^]]*\]' | cut -c1-80)" || fail "Siri: $R"
+sleep 4; cpx upnext >/dev/null; sleep 3; S=$(cpx state); [ "$(field "$S" depth)" = "5" ] && [ "$(field "$S" title)" = "Queue" ] && pass "depth guard held the stack at 5" || fail "depth guard: $S"
+xcrun simctl spawn "$UDID" log show --last 5m --predicate 'process == "Runner"' --style compact 2>/dev/null | grep -E "\[carplay\]|\[siri\]|flutter: \[play\]" | sed 's/^.*Runner\[[0-9]*:[0-9a-f]*\] //; s/(Flutter) flutter: //; s/(Foundation) //' > "$OUT/carplay.log"
+log "== carplay-round: $PASS pass, $FAIL fail — artifacts in $OUT"; [ "$FAIL" -eq 0 ]

--- a/smoke/ios/sim-launch.sh
+++ b/smoke/ios/sim-launch.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# iOS Simulator launch + life-cycle: the app boots from the app-owned engine,
+# the phone UI renders, and a background/foreground cycle reaches Dart
+# (the manual scene registration). Also the headless check: with the app
+# terminated, Dart must still boot when the CarPlay scene launches it — that
+# part needs a click, so it lives in carplay-round.sh.
+set -u
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"; OUT="${SMOKE_OUT:-$ROOT/smoke/out/$(date +%Y%m%d-%H%M%S)-sim-launch}"; mkdir -p "$OUT"
+PASS=0; FAIL=0; log(){ echo "$(date '+%H:%M:%S') $*" | tee -a "$OUT/run.log"; }; pass(){ PASS=$((PASS+1)); log "PASS  $*"; }; fail(){ FAIL=$((FAIL+1)); log "FAIL  $*"; }
+UDID="${SMOKE_SIM_UDID:-$(xcrun simctl list devices booted | grep -oE '[0-9A-F-]{36}' | head -1)}"; [ -n "$UDID" ] || { echo "no booted simulator"; exit 2; }
+APP="${SMOKE_APP:-$ROOT/build/ios/iphonesimulator/Runner.app}"; [ -d "$APP" ] || { echo "no $APP"; exit 2; }
+applog(){ xcrun simctl spawn "$UDID" log show --start "$1" --predicate 'process == "Runner"' --style compact 2>/dev/null | grep -E "flutter: \[" | sed 's/^\(.\{19\}\).*flutter: /\1 /'; }
+xcrun simctl terminate "$UDID" mstream.music 2>/dev/null; xcrun simctl install "$UDID" "$APP"
+M=$(date '+%Y-%m-%d %H:%M:%S'); xcrun simctl launch "$UDID" mstream.music >/dev/null; sleep 15
+L=$(applog "$M"); echo "$L" > "$OUT/launch.log"
+echo "$L" | grep -q '\[app\] mStream ' && pass "Dart booted" || fail "no boot line"
+echo "$L" | grep -q '\[app\] default server ready' && pass "default server published" || fail "default never published"
+xcrun simctl io "$UDID" screenshot "$OUT/phone.png" >/dev/null 2>&1
+M2=$(date '+%Y-%m-%d %H:%M:%S'); xcrun simctl launch "$UDID" com.apple.Preferences >/dev/null; sleep 3; xcrun simctl launch "$UDID" mstream.music >/dev/null; sleep 6
+applog "$M2" | grep -q 'network change (resume)' && pass "resume reached Dart after a background cycle" || fail "no resume event"
+log "== sim-launch: $PASS pass, $FAIL fail — artifacts in $OUT"; [ "$FAIL" -eq 0 ]

--- a/smoke/lib.sh
+++ b/smoke/lib.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Shared helpers for the Android smoke scripts. Source me; do not run.
+#
+#   ADB               path to adb (default: ~/Library/Android/sdk/platform-tools/adb)
+#   SMOKE_ADB_SERIAL  device serial (default: the first attached device)
+#   SMOKE_PKG         package id (default: mstream.music.plus.dev — the debug .plus.dev build)
+#   SMOKE_OUT         artifact dir (default: smoke/out/<timestamp>-<script>)
+#
+# Every script writes screenshots + the filtered app log to $OUT and prints
+# PASS / FAIL / SKIP lines followed by a summary; the exit code is non-zero on
+# any FAIL. Scripts that touch the device's server config back it up first and
+# restore it on exit (including Ctrl-C). Pairing codes / tokens are never
+# printed — only localnames.
+set -u
+SMOKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADB="${ADB:-$HOME/Library/Android/sdk/platform-tools/adb}"
+PKG="${SMOKE_PKG:-mstream.music.plus.dev}"
+ACT="${SMOKE_ACTIVITY:-com.example.mstream_music.MainActivity}"
+SERIAL="${SMOKE_ADB_SERIAL:-}"
+SCRIPT_NAME="$(basename "${0:-smoke}" .sh)"
+OUT="${SMOKE_OUT:-$SMOKE_ROOT/out/$(date +%Y%m%d-%H%M%S)-$SCRIPT_NAME}"
+mkdir -p "$OUT"
+PASS=0; FAIL=0; SKIP=0
+
+adbx() { if [ -n "$SERIAL" ]; then "$ADB" -s "$SERIAL" "$@"; else "$ADB" "$@"; fi; }
+pick_device() {
+  if [ -z "$SERIAL" ]; then SERIAL=$("$ADB" devices | awk 'NR>1 && $2=="device"{print $1; exit}'); fi
+  [ -n "$SERIAL" ] || { echo "no Android device attached"; exit 2; }
+  adbx shell pm list packages 2>/dev/null | grep -q "^package:$PKG$" || { echo "$PKG is not installed on $SERIAL"; exit 2; }
+  log "device: $SERIAL  package: $PKG"
+}
+log()  { echo "$(date '+%H:%M:%S') $*" | tee -a "$OUT/run.log"; }
+pass() { PASS=$((PASS+1)); log "PASS  $*"; }
+fail() { FAIL=$((FAIL+1)); log "FAIL  $*"; }
+skip() { SKIP=$((SKIP+1)); log "SKIP  $*"; }
+summary() { log "== $SCRIPT_NAME: $PASS pass, $FAIL fail, $SKIP skip — artifacts in $OUT"; [ "$FAIL" -eq 0 ]; }
+
+app_pid()      { adbx shell pidof "$PKG" 2>/dev/null | tr -d '\r '; }
+app_start()    { adbx shell am start -n "$PKG/$ACT" >/dev/null; }
+app_stop()     { adbx shell am force-stop "$PKG"; }
+logcat_clear() { adbx logcat -c; }
+# The app's own log lines (Flutter prints) since the last logcat_clear, as "HH:MM:SS.mmm [tag] …".
+applog() {
+  adbx logcat -d -v time 2>/dev/null | grep "I/flutter" | sed 's/^[0-9-]* //; s/ I\/flutter ( [0-9]*): / /'
+}
+wait_for_log() { # <regex> <timeout s> → 0 when the line appears
+  local pat="$1" t="${2:-30}" i=0
+  while [ "$i" -lt "$t" ]; do applog | grep -qE "$pat" && return 0; sleep 1; i=$((i+1)); done
+  return 1
+}
+# Like wait_for_log, but only a line stamped at/after <HH:MM:SS> counts (an
+# earlier match from launch or a previous outage must not satisfy a later check).
+wait_for_log_after() { # <since HH:MM:SS> <regex> <timeout s>
+  local since="$1" pat="$2" t="${3:-30}" i=0 ts
+  while [ "$i" -lt "$t" ]; do
+    ts=$(applog | grep -E "$pat" | awk -v s="$since" '{ if (substr($1,1,8) >= s) { print substr($1,1,12); exit } }')
+    [ -n "$ts" ] && return 0
+    sleep 1; i=$((i+1))
+  done; return 1
+}
+ts_after() { applog | grep -E "$2" | awk -v s="$1" '{ if (substr($1,1,8) >= s) { print substr($1,1,12); exit } }'; }
+first_ts() { applog | grep -E "$1" | head -1 | cut -c1-12; }
+last_ts()  { applog | grep -E "$1" | tail -1 | cut -c1-12; }
+count_log() { applog | grep -cE "$1"; }
+secs_between() { # <ts a> <ts b> → seconds (b - a), empty if either is missing
+  python3 - "$1" "$2" <<'PY'
+import sys
+def s(t):
+    h,m,r=t.split(':'); return int(h)*3600+int(m)*60+float(r)
+a,b=sys.argv[1],sys.argv[2]
+print(round(s(b)-s(a),1) if a and b else '')
+PY
+}
+lt() { python3 -c "import sys; sys.exit(0 if float(sys.argv[1]) < float(sys.argv[2]) else 1)" "$1" "$2"; }
+now_hms() { date '+%H:%M:%S'; }
+
+shot()      { adbx exec-out screencap -p > "$OUT/$1.png" 2>/dev/null; log "shot $1"; }
+tap()       { adbx shell input tap "$1" "$2"; }
+key()       { adbx shell input keyevent "$1"; }
+airplane()  { adbx shell cmd connectivity airplane-mode "$1" >/dev/null; log "airplane $1"; }
+wifi()      { adbx shell svc wifi "$1"; log "wifi $1"; }
+bluetooth() { adbx shell svc bluetooth "$1" >/dev/null; log "bluetooth $1"; }
+media_key() { adbx shell cmd media_session dispatch "$1" >/dev/null 2>&1; log "media key: $1"; }
+wake()      { adbx shell input keyevent KEYCODE_WAKEUP; }
+bt_connected() { adbx shell dumpsys bluetooth_manager 2>/dev/null | grep -m1 -E "ConnectionState:" | grep -q STATE_CONNECTED; }
+a2dp_route()   { adbx shell dumpsys audio 2>/dev/null | grep -m1 -oE 'Devices: (bt_a2dp|speaker)[^ ]*'; }
+session_state() { adbx shell dumpsys media_session 2>/dev/null | grep -A8 "$PKG" | grep -m1 -oE 'state=[A-Z_]+\([0-9]\)'; }
+is_playing() { session_state | grep -q PLAYING; }
+# Start playback if it is not running. A PLAY media key reaches the app as a
+# play/pause TOGGLE (audio_service), so it must never be sent to a playing app.
+ensure_playing() { # <timeout s> → 0 when PLAYING
+  local t="${1:-15}" i=0
+  is_playing && return 0
+  media_key play
+  while [ "$i" -lt "$t" ]; do is_playing && return 0; sleep 1; i=$((i+1)); done
+  return 1
+}
+
+# ── device config (servers.json / auto_dj.json), backed up + restored on exit ──
+CFG_BACKUP=""
+cfg_read()  { adbx shell "run-as $PKG cat app_flutter/$1"; }
+cfg_write() { adbx push "$2" /data/local/tmp/smoke-cfg >/dev/null
+              adbx shell "run-as $PKG sh -c 'cat /data/local/tmp/smoke-cfg > app_flutter/$1'; rm /data/local/tmp/smoke-cfg"; }
+cfg_backup() {
+  CFG_BACKUP="$OUT/cfg-backup"; mkdir -p "$CFG_BACKUP"
+  for f in servers.json auto_dj.json; do cfg_read "$f" > "$CFG_BACKUP/$f"; done
+  trap cfg_restore EXIT
+}
+cfg_restore() {
+  [ -n "$CFG_BACKUP" ] || return 0
+  app_stop
+  for f in servers.json auto_dj.json; do [ -s "$CFG_BACKUP/$f" ] && cfg_write "$f" "$CFG_BACKUP/$f"; done
+  rm -rf "$CFG_BACKUP"; CFG_BACKUP=""
+  log "device config restored"
+}
+# Put the Quick Connect server ("iroh") or the standard server ("standard") first; prints the order.
+cfg_order() {
+  python3 - "$CFG_BACKUP/servers.json" "$1" "$OUT/servers-ordered.json" <<'PY'
+import json,sys
+src,first,dst=sys.argv[1:]
+L=json.load(open(src)); iroh=[s for s in L if s.get('connectionType')=='iroh']; rest=[s for s in L if s.get('connectionType')!='iroh']
+out=(iroh+rest) if first=='iroh' else (rest+iroh)
+json.dump(out,open(dst,'w')); print(' '.join(s['localname'] for s in out))
+PY
+  cfg_write servers.json "$OUT/servers-ordered.json"; rm -f "$OUT/servers-ordered.json"
+}
+cfg_dj() { # point Auto DJ at a localname
+  python3 - "$CFG_BACKUP/auto_dj.json" "$1" "$OUT/auto_dj.json" <<'PY'
+import json,sys
+src,name,dst=sys.argv[1:]; d=json.load(open(src)); d['enabledServer']=name; json.dump(d,open(dst,'w'))
+PY
+  cfg_write auto_dj.json "$OUT/auto_dj.json"; rm -f "$OUT/auto_dj.json"
+}
+localname_of() { # iroh|standard → localname from the backup
+  python3 -c "
+import json,sys
+L=json.load(open(sys.argv[1])); kind=sys.argv[2]
+m=[s for s in L if (s.get('connectionType')=='iroh')==(kind=='iroh')]
+print(m[0]['localname'] if m else '')" "$CFG_BACKUP/servers.json" "$1"
+}
+save_applog() { applog > "$OUT/$1.log"; }

--- a/smoke/lib.sh
+++ b/smoke/lib.sh
@@ -80,7 +80,14 @@ key()       { adbx shell input keyevent "$1"; }
 airplane()  { adbx shell cmd connectivity airplane-mode "$1" >/dev/null; log "airplane $1"; }
 wifi()      { adbx shell svc wifi "$1"; log "wifi $1"; }
 bluetooth() { adbx shell svc bluetooth "$1" >/dev/null; log "bluetooth $1"; }
-media_key() { adbx shell cmd media_session dispatch "$1" >/dev/null 2>&1; log "media key: $1"; }
+# Media keys go through the input pipeline (KEYCODE_MEDIA_*), which the
+# session manager routes to the app's registered media button receiver even
+# when the app is paused or dead. `cmd media_session dispatch` only reaches a
+# session that is currently the media-button session (i.e. played recently).
+media_key() { # play | pause | play-pause
+  local code; case "$1" in play) code=126;; pause) code=127;; *) code=85;; esac
+  adbx shell input keyevent "$code"; log "media key: $1"
+}
 wake()      { adbx shell input keyevent KEYCODE_WAKEUP; }
 bt_connected() { adbx shell dumpsys bluetooth_manager 2>/dev/null | grep -m1 -E "ConnectionState:" | grep -q STATE_CONNECTED; }
 a2dp_route()   { adbx shell dumpsys audio 2>/dev/null | grep -m1 -oE 'Devices: (bt_a2dp|speaker)[^ ]*'; }

--- a/smoke/recipes/README.md
+++ b/smoke/recipes/README.md
@@ -1,0 +1,16 @@
+# Manual recipes
+
+Real-world runs the scripts cannot do. Do them with the debug `.plus.dev` build
+(Android) or a profile build (iOS) so the log is complete, and export
+Diagnostics › Share afterwards — the log lines named under "pass" are what to
+look for. Recipes, in the order they are worth running:
+
+1. [commute-quick-connect-default.md](commute-quick-connect-default.md)
+2. [commute-lan-default.md](commute-lan-default.md)
+3. [garage-cold-start.md](garage-cold-start.md)
+4. [ignition-off.md](ignition-off.md)
+5. [pocket-hour.md](pocket-hour.md)
+6. [carplay-in-car.md](carplay-in-car.md)
+7. [android-auto-dhu.md](android-auto-dhu.md)
+8. [lock-screen-controls.md](lock-screen-controls.md)
+9. [server-removed-while-playing.md](server-removed-while-playing.md)

--- a/smoke/recipes/android-auto-dhu.md
+++ b/smoke/recipes/android-auto-dhu.md
@@ -1,0 +1,7 @@
+# Android Auto with the desktop head unit
+
+Not installed on this Mac yet: SDK Manager › SDK Tools › "Android Auto Desktop Head Unit emulator" installs it under `$ANDROID_SDK/extras/google/auto/`. On the phone: Android Auto › developer settings › "Start head unit server", then `adb forward tcp:5277 tcp:5277` and run `desktop-head-unit`.
+
+**Do.** Force-kill the app first (cold bind). Browse the root, Albums, an album, play; use the Assistant: "play <album> on mStream". Then airplane mode for 60 s mid-browse.
+
+**Pass.** Cold bind renders the tree without the app UI (`[auto] getChildren` lines with no `[app]` UI lines before them is fine). Lists during the outage show the notice rows ("Couldn't load"), never blank. Playback recovers after service returns.

--- a/smoke/recipes/carplay-in-car.md
+++ b/smoke/recipes/carplay-in-car.md
@@ -1,0 +1,12 @@
+# CarPlay in the car
+
+Needs the device build signed with the CarPlay+Siri provisioning profile.
+
+**Do.**
+1. Phone locked, app not running, plug in (or connect wirelessly). Tap mStream on the car display.
+2. Browse Albums → an album → a track. Check artwork on Now Playing, the shuffle / repeat / DJ buttons, Queue, and the artist name as a button.
+3. "Hey Siri, play <an album you have> on mStream." Then a song, then an artist, then something you don't have.
+4. Unplug, wait a minute, plug back in.
+5. With the Quick Connect server as default, drive through a dead zone while browsing.
+
+**Pass.** Root list within a few seconds of the tap (cold launch, no phone UI). Artwork on Now Playing (the simulator never draws it; the car must). Siri resolves the three and says it can't find the fourth. Reconnect restores the last screen or the root. During a dead zone the lists show notice rows, never a permanent spinner; playback recovers by itself.

--- a/smoke/recipes/commute-lan-default.md
+++ b/smoke/recipes/commute-lan-default.md
@@ -1,0 +1,13 @@
+# Commute with the LAN server as default, queue on Quick Connect
+
+The configuration fixed in PR #137, never driven. The standard server becomes unreachable the moment you leave the house while the queue keeps streaming through the tunnel.
+
+**Setup.** Standard (LAN) server first in the list, Quick Connect second, a queue that was started from the Quick Connect server.
+
+**Do.** Open the app at home (browser should be up at once, no strip), play, drive away. At some point away from home, open the browser and tap a section on the LAN server; then switch to the Quick Connect server with the picker and browse.
+
+**Pass.**
+- At launch: home grid within a second, no "Connecting to server…" strip.
+- Away from home: playback continues; the LAN server shows a clear failure, not a spinner or a blank panel.
+- The picker switch to Quick Connect works immediately; the strip appears only if that tunnel is actually reconnecting.
+- Export: `[app] default server ready` within 2 s of `mStream … started`, one `tunnel up … (queue-server)`, no `tunnel stopped (no-target`.

--- a/smoke/recipes/commute-quick-connect-default.md
+++ b/smoke/recipes/commute-quick-connect-default.md
@@ -1,0 +1,14 @@
+# Commute with the Quick Connect server as default
+
+The end-to-end check of the tunnel work (PRs #133, #134) on the real carrier.
+
+**Setup.** Quick Connect server first in the server list, Auto DJ on it, keep-queue-offline as you normally run it. Start playback at home on Wi-Fi.
+
+**Do.** Drive the usual route: the Wi-Fi → cellular hand-off leaving the house, every dead zone, the return. Do not touch the app unless something is wrong; if you do tap Retry, note the time.
+
+**Pass.**
+- No manual Retry needed; playback resumes on its own after every gap.
+- In the export: every gap ends with `reconnected: attempt N` on the same port as `tunnel up port=…` at launch, and `stream URLs rebuilt` does not appear.
+- Auto DJ picks that landed during a gap show `pick landed — resuming the parked queue`.
+
+**Capture.** Diagnostics › Share at the end of the drive. Note any moment the app felt stalled and the clock time.

--- a/smoke/recipes/garage-cold-start.md
+++ b/smoke/recipes/garage-cold-start.md
@@ -1,0 +1,11 @@
+# Cold start with no service
+
+**Setup.** Quick Connect server as default. Kill the app. Stand where there is no signal (garage, basement).
+
+**Do.** Open the app, wait 20 s, walk or drive to signal.
+
+**Pass.**
+- Browser home grid usable within a second (the strip shows "Connecting…", that is fine — you are on the Quick Connect server).
+- Mini-player fills in within 12 s of launch even with no service (the queue restores parked).
+- Once service arrives: `retry #N` in the export leads to `tunnel up`, then `iroh tunnel back — resuming parked playback` if you had pressed play.
+- Never a `tunnel start failed` without a `retry #… in …s` after it.

--- a/smoke/recipes/ignition-off.md
+++ b/smoke/recipes/ignition-off.md
@@ -1,0 +1,7 @@
+# Ignition off with music playing (five cycles)
+
+The late-PAUSE race fixed in PR #135, in the real car.
+
+**Do.** Five times: play over the car's Bluetooth, turn the ignition off, wait 20 s, listen. Then start the car again and check playback resumes the way you expect from that head unit.
+
+**Pass.** Silence after every ignition-off. Export: each cycle shows `output disconnected — pausing`, and if the head unit sent its late PAUSE, `media button toggle ignored — output lost Ns ago`. No `[play] play` between the disconnect and the next time you touch the app or the car turns on.

--- a/smoke/recipes/lock-screen-controls.md
+++ b/smoke/recipes/lock-screen-controls.md
@@ -1,0 +1,7 @@
+# Lock-screen shuffle and repeat
+
+New since the handler advertises `setShuffleMode` / `setRepeatMode`.
+
+**Do.** Play, lock the phone. Android: expand the media notification and the lock-screen player; iOS: lock screen and Control Center. Toggle shuffle and cycle repeat where offered; check the app agrees when unlocked.
+
+**Pass.** The controls appear where the OS offers them, each toggle is reflected in the app's player panel, and the app's own toggles are reflected back within a second. `smoke/android/session-actions.sh` covers the advertised half automatically.

--- a/smoke/recipes/pocket-hour.md
+++ b/smoke/recipes/pocket-hour.md
@@ -1,0 +1,5 @@
+# An hour in the pocket, then play
+
+iOS suspension and Android Doze. **Do.** Pause, lock the phone, leave it for an hour, unlock, open the app, press play.
+
+**Pass.** Playing within a few seconds. iOS export: `probe #1 failed (refused` → `kicking the tunnel in place (resume)` → `listener re-bound` → `reconnected: attempt 1`. Android export: either nothing (the tunnel survived) or a single in-place reconnect. No `tunnel stopped`, no `stream URLs rebuilt`.

--- a/smoke/recipes/server-removed-while-playing.md
+++ b/smoke/recipes/server-removed-while-playing.md
@@ -1,0 +1,5 @@
+# Server removed while its queue is playing
+
+**Do.** Play from the Quick Connect server, then remove that server in Manage servers.
+
+**Pass.** Playback stops or skips to the next playable item cleanly, the tunnel is released (`tunnel stopped (no-target/remove-server)`), the browser lands on the remaining default, no crash, no lingering strip. Re-add the server by pairing again; the queue can be rebuilt.

--- a/smoke/run-android.sh
+++ b/smoke/run-android.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Runs the Android suite in order and prints one summary. Skip the long soak
+# with SMOKE_SOAK_MIN=10; the cast test is opt-in (SMOKE_CAST=1) because it
+# plays audio on a TV.
+cd "$(dirname "$0")" || exit 2
+mkdir -p out
+scripts="android/session-actions.sh android/launch-matrix.sh android/switch-during-outage.sh android/media-resumption.sh android/bt-late-pause.sh android/dead-zone.sh android/playback-soak.sh"
+[ "${SMOKE_CAST:-0}" = 1 ] && scripts="$scripts android/cast-through-rebuild.sh"
+summary=""
+for s in $scripts; do
+  echo; echo "########## $s"
+  if bash "$s"; then r=ok; else r=FAIL; fi
+  summary="$summary
+$(printf '%-36s %s' "$s" "$r")"
+done
+echo; echo "== suite$summary"


### PR DESCRIPTION
## Summary

`smoke/`: the device-level checks unit tests cannot see, as repeatable scripts plus recipes for what needs a car, a commute or a head unit. Stacked on #137 (it asserts the launch and switch behaviour fixed there) — the base retargets to master once that merges.

- **`lib.sh`** — adb helpers (filtered app log, wait-for-a-line-newer-than, screenshots, taps, airplane / Wi-Fi / Bluetooth / media keys), device config backup + restore on exit. Never prints pairing codes or tokens.
- **`android/`** — `session-actions` (shuffle/repeat advertised to the OS), `launch-matrix` (standard vs Quick Connect default: publish timing, one dial, no teardown churn), `switch-during-outage`, `media-resumption` (headless boot on a PLAY key after the process is killed), `bt-late-pause` (the car-off race), `dead-zone` (hand-off, 75 s outage, Retry tap, Wi-Fi return, same port, no rebuild), `playback-soak` (screen off), `cast-through-rebuild` (opt-in — plays on a TV). `run-android.sh` runs the suite; `SMOKE_SOAK_MIN` shortens the 2 h soak.
- **`ios/`** — `sim-launch` (app-owned engine boots, default published, resume reaches Dart), `carplay-round` (root → album → track → Now Playing, Queue + skip, the three buttons, artist, Siri dry-run, depth guard, through the debug hook; one click on the car display is the only manual step).
- **`recipes/`** — the two commutes, garage cold start, ignition-off ×5, pocket hour, CarPlay in the car, Android Auto DHU, lock-screen controls, server removed while playing: setup, steps, what pass looks like, which log lines to read in the Diagnostics export.
- Two log markers for the scripts: `[app] default server ready` after the launch publish, `[srv] switched to` on a server switch.

Screen coordinates default to a Galaxy S25 (1080×2340) and are overridable per script.

## First run (Galaxy S25, iPhone 17 Pro simulator)

| Script | Result | Notes |
|---|---|---|
| `android/session-actions` | 2/2 | shuffle + repeat advertised |
| `android/launch-matrix` | 7/7 | standard default published in 0.5 s before the tunnel; Quick Connect default 3.7 s dial then publish; one dial, no teardown |
| `android/switch-during-outage` | 3/3 | switch logged 0.5 s after the tap; screenshots: home grid, no strip |
| `android/media-resumption` | 3/3 | dead process booted headless ~1 s after the PLAY key, queue restored |
| `android/bt-late-pause` | 3/3 | drop paused, late PAUSE ignored, stayed paused |
| `android/dead-zone` | 7/7 | hand-off kept; outage 1 reconnected in place 9.6 s after airplane off; Retry kicked in place; Wi-Fi return recovered; same port; no URL rebuild |
| `android/playback-soak` (10 min) | 2/2 | PLAYING at every poll, same pid |
| `android/cast-through-rebuild` | not run | opt-in: plays on the family-room TV |
| `ios/sim-launch` | 3/3 | boot, default published, resume reached Dart |
| `ios/carplay-round` | not run here | needs one click on the car display; every step in it was run by hand earlier today |

Three things the first pass taught, now built into the scripts: a PLAY media key is a play/pause *toggle* for the app, so scripts check the session state before sending one; `am force-stop` puts an app into Android's stopped state where no media key can start it (the resumption test kills the process instead); `cmd media_session dispatch` only reaches a session that played recently, so media keys go through `input keyevent`.

One product observation from `dead-zone`: after the cellular → Wi-Fi return, a connection only seconds old failed both liveness probes and the in-place kick then reconnected it in 0.2 s — about 16 s of dead tunnel. Now that a kick is that cheap, kicking after the first timed-out probe on a hand-off is a candidate tweak (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
