### PR TITLE
test(smoke): phone-clock log anchors; dead-zone accepts the post-kick watchdog rebuild

### DIFF
--- a/smoke/android/dead-zone.sh
+++ b/smoke/android/dead-zone.sh
@@ -13,25 +13,46 @@ log "order: $(cfg_order iroh)"; cfg_dj "$IROH"
 app_stop; logcat_clear; wake; app_start
 wait_for_log '\[iroh\] tunnel up' 20 || { fail "no tunnel at launch"; summary; exit 1; }
 PORT=$(applog | grep -oE 'tunnel up port=[0-9]+' | head -1 | grep -oE '[0-9]+$'); log "port $PORT"
-ensure_playing 20 || log "(not playing — continuing with the tunnel checks)"; sleep 5
-log "== hand-off: wifi off"; HO=$(now_hms); wifi disable
+# A PLAY key in the first seconds after a cold start is dropped (the session is not
+# the media-button target yet); the other scripts settle 12-15s before theirs.
+sleep 10; ensure_playing 20 || log "(not playing — continuing with the tunnel checks)"; sleep 5
+log "== hand-off: wifi off"; HO=$(now_ts); wifi disable
 wait_for_log_after "$HO" 'probe #[12] passed|reconnected: attempt' 45 && pass "hand-off: tunnel kept (probe passed)" || fail "hand-off: no probe pass within 45s"
-log "== outage 1: airplane ${OUTAGE}s"; airplane enable; sleep "$OUTAGE"; BACK=$(now_hms); airplane disable
+log "== outage 1: airplane ${OUTAGE}s"; airplane enable; sleep "$OUTAGE"; BACK=$(now_ts); airplane disable
 if wait_for_log_after "$BACK" 'reconnected: attempt' 90; then
   d=$(secs_between "$BACK" "$(ts_after "$BACK" 'reconnected: attempt')"); pass "outage 1: reconnected in place ${d}s after airplane off"
 else fail "outage 1: no in-place reconnect within 90s"; fi
 sleep 10
-log "== outage 2: Retry tap while reconnecting"; O2=$(now_hms); airplane enable
+log "== outage 2: Retry tap while reconnecting"; O2=$(now_ts); airplane enable
 wait_for_log_after "$O2" 'status connected → reconnecting' 75 || log "   (no reconnecting edge yet)"
 sleep 5; shot banner; tap $RETRY; sleep 3
 if wait_for_log 'kicking the tunnel in place \(retry-tap\)' 5; then pass "Retry kicked in place"; else fail "Retry did not kick (rebuild?)"; fi
-sleep 20; BACK=$(now_hms); airplane disable
-if wait_for_log_after "$BACK" 'reconnected: attempt' 90; then d=$(secs_between "$BACK" "$(ts_after "$BACK" 'reconnected: attempt')"); pass "outage 2: reconnected ${d}s after airplane off"; else fail "outage 2: no reconnect within 90s"; fi
-log "== return home: wifi on"; HOME_TS=$(now_hms); wifi enable
-# A migrating connection may fail both probes; the in-place kick that follows counts as recovery too.
-wait_for_log_after "$HOME_TS" 'probe #[12] passed|reconnected: attempt' 60 && pass "Wi-Fi return: tunnel serving ($(ts_after "$HOME_TS" 'probe #[12] passed|reconnected: attempt'))" || fail "Wi-Fi return: neither a probe pass nor a reconnect within 60s"
+sleep 20; BACK=$(now_ts); airplane disable
+# A Retry kick that lands inside the dead zone cannot take until service returns; if the
+# supervisor has not converged 45s after the kick, the post-kick watchdog rebuilds the
+# tunnel on a fresh port (rotating the stream URLs) — the designed fallback, not a bug.
+REC='reconnected: attempt|tunnel up .*\(rebuild/watchdog\)'
+if wait_for_log_after "$BACK" "$REC" 90; then
+  d=$(secs_between "$BACK" "$(ts_after "$BACK" "$REC")")
+  if applog | awk -v s="$BACK" '{ if (substr($1,1,12) >= s) print }' | grep -q 'rebuild/watchdog'; then
+    pass "outage 2: the post-kick watchdog rebuilt the tunnel ${d}s after airplane off (in place did not converge in 45s)"
+  else pass "outage 2: reconnected in place ${d}s after airplane off"; fi
+else fail "outage 2: neither an in-place reconnect nor the watchdog rebuild within 90s"; fi
+log "== return home: wifi on"; HOME_TS=$(now_ts); wifi enable
+# A connection that just moved from cellular to Wi-Fi may fail both probes; the in-place
+# kick that follows is the recovery then. Report the time and the path it took.
+after_home() { applog | awk -v s="$HOME_TS" '{ if (substr($1,1,12) >= s) print }'; }
+if wait_for_log_after "$HOME_TS" 'probe #[12] passed|reconnected: attempt' 60; then
+  d=$(secs_between "$HOME_TS" "$(ts_after "$HOME_TS" 'probe #[12] passed|reconnected: attempt')")
+  how=$(after_home | grep -oE 'probe #[12] (passed|failed) \([a-z 0-9]+|kicking the tunnel|reconnected: attempt [0-9]+ in [0-9.]+s' | tr '\n' ';')
+  pass "Wi-Fi return: tunnel serving ${d}s after wifi on [$how]"
+else fail "Wi-Fi return: neither a probe pass nor a reconnect within 60s"; fi
+log "player after the return: $(after_home | grep -E '\[play\]|rror' | sed 's/^[0-9:.]* //' | cut -c1-60 | tr '\n' ';')"
 save_applog dead-zone
-ports=$(applog | grep -oE 'tunnel up port=[0-9]+' | sort -u | wc -l | tr -d ' ')
-if [ "$ports" -le 1 ]; then pass "same port throughout"; else fail "$ports distinct ports (a rebuild happened)"; fi
-if [ "$(count_log 'stream URLs rebuilt')" -eq 0 ]; then pass "no URL rebuild"; else fail "stream URLs rebuilt during the round"; fi
+# After the launch dial, every tunnel must be an in-place reconnect (same port) or the
+# post-kick watchdog's rebuild; stream URLs may only be rebuilt by that rebuild.
+dials=$(applog | grep -E 'tunnel up port=' | tail -n +2 | grep -vcE '\(rebuild/watchdog\)' | tr -d ' ')
+wd=$(count_log 'tunnel up .*\(rebuild/watchdog\)'); urls=$(count_log 'stream URLs rebuilt')
+if [ "$dials" -eq 0 ]; then pass "no unexplained rebuild (${wd} watchdog rebuild(s))"; else fail "$dials tunnel dial(s) that were neither the launch nor the watchdog"; fi
+if [ "$urls" -le "$wd" ]; then pass "stream URLs rebuilt only by the watchdog ($urls)"; else fail "stream URLs rebuilt ${urls}× with $wd watchdog rebuild(s)"; fi
 summary

--- a/smoke/android/switch-during-outage.sh
+++ b/smoke/android/switch-during-outage.sh
@@ -18,12 +18,12 @@ wait_for_log '\[iroh\] tunnel up' 20 || { fail "tunnel did not come up at launch
 sleep 2; tap $ALBUMS; sleep 3; shot before-outage
 airplane enable
 if wait_for_log 'status connected → reconnecting' 75; then pass "supervisor reconnecting after the drop"; else fail "no reconnecting edge within 75s"; fi
-tap $PICKER; sleep 1.5; TAP=$(now_hms); tap $ROW2; sleep 0.7; shot after-switch-0.7s; sleep 3; shot after-switch-3.7s
+tap $PICKER; sleep 1.5; TAP=$(now_ts); tap $ROW2; sleep 0.7; shot after-switch-0.7s; sleep 3; shot after-switch-3.7s
 if wait_for_log "\[srv\] switched to $STD" 5; then
   d=$(secs_between "$TAP" "$(first_ts "\[srv\] switched to $STD")")
   if lt "$d" 2.0; then pass "switch logged ${d}s after the tap"; else fail "switch logged ${d}s after the tap"; fi
 else fail "no '[srv] switched to $STD' line"; fi
-BACK=$(now_hms); airplane disable
+BACK=$(now_ts); airplane disable
 wait_for_log_after "$BACK" 'reconnected: attempt|tunnel up' 60 && pass "tunnel back after service returned" || fail "tunnel not back within 60s"
 save_applog switch; log "inspect $OUT/after-switch-*.png: standard server header, home grid, no 'Reconnecting…' strip"
 summary

--- a/smoke/lib.sh
+++ b/smoke/lib.sh
@@ -50,15 +50,15 @@ wait_for_log() { # <regex> <timeout s> → 0 when the line appears
 }
 # Like wait_for_log, but only a line stamped at/after <HH:MM:SS> counts (an
 # earlier match from launch or a previous outage must not satisfy a later check).
-wait_for_log_after() { # <since HH:MM:SS> <regex> <timeout s>
+wait_for_log_after() { # <since, from now_ts> <regex> <timeout s>
   local since="$1" pat="$2" t="${3:-30}" i=0 ts
   while [ "$i" -lt "$t" ]; do
-    ts=$(applog | grep -E "$pat" | awk -v s="$since" '{ if (substr($1,1,8) >= s) { print substr($1,1,12); exit } }')
+    ts=$(applog | grep -E "$pat" | awk -v s="$since" '{ if (substr($1,1,12) >= s) { print substr($1,1,12); exit } }')
     [ -n "$ts" ] && return 0
     sleep 1; i=$((i+1))
   done; return 1
 }
-ts_after() { applog | grep -E "$2" | awk -v s="$1" '{ if (substr($1,1,8) >= s) { print substr($1,1,12); exit } }'; }
+ts_after() { applog | grep -E "$2" | awk -v s="$1" '{ if (substr($1,1,12) >= s) { print substr($1,1,12); exit } }'; }
 first_ts() { applog | grep -E "$1" | head -1 | cut -c1-12; }
 last_ts()  { applog | grep -E "$1" | tail -1 | cut -c1-12; }
 count_log() { applog | grep -cE "$1"; }
@@ -72,7 +72,12 @@ print(round(s(b)-s(a),1) if a and b else '')
 PY
 }
 lt() { python3 -c "import sys; sys.exit(0 if float(sys.argv[1]) < float(sys.argv[2]) else 1)" "$1" "$2"; }
-now_hms() { date '+%H:%M:%S'; }
+# Anchor for wait_for_log_after / ts_after: the PHONE's clock (logcat stamps
+# lines with it; the Mac's can differ by a second) to the millisecond, so a
+# line logged in the same second as the anchor is never taken for a reaction
+# to it (first dead-zone run: the outage-2 reconnect satisfied the Wi-Fi return).
+now_ts()  { adbx shell date '+%H:%M:%S.%N' | tr -d '\r' | cut -c1-12; }
+now_hms() { now_ts; }
 
 shot()      { adbx exec-out screencap -p > "$OUT/$1.png" 2>/dev/null; log "shot $1"; }
 tap()       { adbx shell input tap "$1" "$2"; }

--- a/smoke/recipes/commute-quick-connect-default.md
+++ b/smoke/recipes/commute-quick-connect-default.md
@@ -9,6 +9,9 @@ The end-to-end check of the tunnel work (PRs #133, #134) on the real carrier.
 **Pass.**
 - No manual Retry needed; playback resumes on its own after every gap.
 - In the export: every gap ends with `reconnected: attempt N` on the same port as `tunnel up port=…` at launch, and `stream URLs rebuilt` does not appear.
+  One exception: after a Retry tap inside a dead zone, `tunnel up … (rebuild/watchdog)` on a new port 45 s after the tap is the designed fallback.
+- Arriving on Wi-Fi: after `network change (connectivity:wifi)`, note the `probe #1` / `probe #2` pair. Both timing out then `kicking the tunnel in place`
+  is the known ~17 s gap (2 of 3 returns so far); a `probe #2 passed` means the connection healed on its own. These pairs decide whether a one-probe kick is worth it.
 - Auto DJ picks that landed during a gap show `pick landed — resuming the parked queue`.
 
 **Capture.** Diagnostics › Share at the end of the drive. Note any moment the app felt stalled and the clock time.


### PR DESCRIPTION
## Summary

Follow-up to #138 after reading the first full run's logs closely.

- **Log anchors come from the phone's clock with millisecond precision** (`now_ts`). They were the Mac's `date` at one-second precision compared against logcat stamps: the "Wi-Fi return" step of the first run passed on the outage-2 reconnect line stamped in the same second as the anchor. That row in #138's table was a false pass; the Wi-Fi return had not been observed.
- **dead-zone runs with playback active**: a PLAY key within seconds of a cold start is dropped (the session is not yet the media-button target), so the script settles 10 s first like the other scripts do.
- **dead-zone accepts the designed fallback for outage 2**: a Retry kick inside the dead zone cannot take until service returns, and 45 s after the kick the post-kick watchdog rebuilds the tunnel on a fresh port. The trailing checks now fail only on a dial that is neither the launch nor the watchdog, or on stream URLs rebuilt beyond the watchdog's.
- The Wi-Fi return step reports the seconds to service, the probe/kick path it took, and any player lines after it.

## Run (Galaxy S25, `SMOKE_OUTAGE_S=60`, playing)

| Step | Result |
|---|---|
| hand-off Wi-Fi → cellular | kept, probe passed |
| outage 1 | in place, 23.3 s after airplane off |
| outage 2, Retry tap | kicked in place; watchdog rebuild 24.8 s after airplane off, playback reloaded at the same track |
| Wi-Fi return | probe #1 timeout → probe #2 timeout → kick → reconnected in 0.0 s; serving 23.2 s after the wifi command; no player event |
| rebuilds | only the watchdog's |

🤖 Generated with [Claude Code](https://claude.com/claude-code)