### PR TITLE
feat(federation): Phase 4 — the isIroh / transport split

### DIFF
--- a/FEDERATION_PLAN.md
+++ b/FEDERATION_PLAN.md
@@ -212,54 +212,50 @@ through (`makeServerCall(useThisServer, …)`) and `POST
 the one place the webapp found a path-namespace collision, so verify it on a
 peer before deciding to keep the rows.
 
-### Phase 4 — the `isIroh` / transport split (blocks release on iroh)
+### Phase 4 — the `isIroh` / transport split ✅ done
 
-Bigger than "verify playback". A federated server has
-`connectionType == 'http'`, so **`isIroh` is false for it even when its parent
-is iroh** — and every site that asks "is this an iroh server?" in order to
-apply loopback handling will answer wrong for a peer of an iroh parent.
+Landed in two steps. The rebase of Phases 1–2 onto the launch/tunnel work
+found the first site in the manager itself: the tunnel target keyed on the
+browsed server's own type, so selecting a peer of an iroh parent *released*
+the parent's tunnel and every peer request resolved to the unroutable
+origin — browsing failed, not just playback. That commit added the
+primitives and moved the manager's tunnel decisions onto them; this phase
+covers everything else.
 
-There are ~29 `isIroh` call sites and they are asking two different questions:
+**The distinction, on the model.** `Server.transportServer` is the parent
+for a federated server and the server itself otherwise (null only for a
+peer whose parent is not linked); `isIrohTransport` asks whether requests
+for this server ride a loopback tunnel. `isIroh` stays the identity
+question — the pairing-code menu, the one-iroh cap, the edit form, the
+share block, the retry timer and the rotate-code path.
 
-- **"Is this server itself an iroh server?"** — config and identity: the
-  one-iroh-max rule, the pairing-code menu item, the edit form, the whole
-  tunnel lifecycle in `ServerManager`. These stay on `isIroh`, untouched.
-- **"Do this server's bytes travel over a loopback tunnel?"** — transport.
-  For a peer of an iroh parent the answer is *yes*, and these are wrong today.
+**The manager answers for the transport.** `tunnelAssignedTo`,
+`tunnelServes`, `awaitTunnelReady` and `reverifyTunnel` resolve the server
+they are handed to its transport, so every caller on the playback path —
+the load-failure recovery, the parked-track heal, the DJ gates, the Android
+Auto browse wait, downloads — is right with whichever server it holds.
 
-The fix is to make that distinction explicit on `Server` — a `transportServer`
-getter (`parentServer ?? this`) and an `isIrohTransport` built on it — then
-audit each site for which question it is asking. `getServerPaths` already
-computes exactly this as a local; it wants promoting to the model.
+**Sites moved to the transport question.** The queue's tunnel-follows-queue
+listener; `isIrohDJ` / `shouldDeferDJPick` / the parked-pick reverify; the
+art rebuild after a tunnel bind (`_withRebuiltArt`); `_phoneIsCastOrigin`;
+`cast_origin.irohServerFor` (returns the transport, so a peer track is
+relayed through `LocalMediaServer` like any tunnel track), `irohLoopbackUri`
+and `rebindLoopbackArt` (the parent's port + token); `downloads`' stale-port
+rotation; `makeServerCall`'s tunnel-drop retry. Queue restore and
+`Playlist.toMediaItem` re-origin a persisted art URL through
+`albumArtFileFromUrl`, which reads both URL shapes — a server's own
+`/album-art/<file>` and a peer's `…/peers/<id>/art/<file>`. The stream URL
+rebuild needed nothing: `buildServerStreamUrl` was already federation-aware,
+and the rebuild walks every queue item.
 
-Triage list for the transport half (from a grep — confirm per site, this is
-not a find-and-replace):
-
-| Site | Why it matters |
-|---|---|
-| `cast_origin.dart:23` `irohServerFor` | hands a DLNA renderer an unreachable `127.0.0.1` URL |
-| `audio_stuff.dart` ×5 (231, 890, 905, 1378, 2407) | URL rebinding and tunnel waits on the playback path |
-| `downloads.dart:231` | "only loopback URLs rotate this way" — a federated URL through an iroh parent IS one, and needs the same stale-port rotation |
-| `queue_store.dart:340`, `playlist.dart:89` | art URL rebinding |
-| `api.dart:148` | the retry-on-tunnel-drop branch in `makeServerCall` |
-| `auto_browse.dart:810` | tunnel-serving check |
-
-**Blast radius is bounded but the failure mode is nasty.** Only peers of an
-*iroh* parent are affected; with a plain HTTP parent every one of these sites
-answers correctly today. But iroh is the roaming transport, so it is a real
-configuration — and the symptom is that browsing works fine while playback,
-casting and downloads break in ways that do not point at federation.
-
-Treat this as **blocking release for iroh users**, not as cleanup. Phases 2
-and 3 are shippable against an HTTP parent without it.
-
-Also in this phase:
-
-- queue restore across a restart (a federated server must resolve by
-  localname before `QueueStore.init`)
-- downloads: `/media` and ranges are allowlisted and `_ensureDownloadDir` now
-  covers both entry points, so this should work once the URL is rewritten —
-  verify on a peer.
+**Verified** with `smoke/android/federation-rig.sh` in tunnel mode: a peer of
+a Quick Connect parent reconciles, browses and plays; the parent's tunnel
+survives selecting the peer and a switch to a standard server while a peer
+track plays; and after a relaunch the restored peer track plays on the
+parent's fresh port. Unit tests pin the extractor, the peer art rebind, and
+the queue-restore re-origin. Casting a peer track through the LAN relay is
+covered by the same code path as an iroh server's and is the one piece
+not run on a renderer.
 
 ### Phase 5 — optional: make Discover leads actionable
 

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -390,7 +390,7 @@ class AudioPlayerHandler extends BaseAudioHandler
         final dj = autoDJServer;
         final action = queueEndAction(
             onLocalBackend: identical(_backend, _localBackend),
-            isIrohDJ: dj != null && dj.isIroh,
+            isIrohDJ: dj != null && dj.isIrohTransport,
             djPickPending: _djPickPending,
             playIntent: _playIntent,
             tunnelServes: dj != null && ServerManager().tunnelServes(dj),
@@ -1016,7 +1016,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     final itemServer = failed == null ? null : _serverFor(failed);
     if (!badLocalCopy &&
         itemServer != null &&
-        itemServer.isIroh &&
+        itemServer.isIrohTransport &&
         !ServerManager().tunnelServes(itemServer)) {
       // The tunnel isn't live for this track's iroh server — point it there and
       // resume rather than skipping. (If it IS serving this server and the track
@@ -1031,7 +1031,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     // fires on a status TRANSITION that never comes. Count these; past a
     // couple, ask for ground truth.
     if (itemServer != null &&
-        itemServer.isIroh &&
+        itemServer.isIrohTransport &&
         ServerManager().tunnelServes(itemServer)) {
       _noteTunnelLoadFailure(itemServer);
     }
@@ -1550,7 +1550,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     final idx = _reviveSpot().index;
     final item = (idx >= 0 && idx < q.length) ? q[idx] : null;
     final server = item == null ? null : _serverFor(item);
-    if (server == null || !server.isIroh) return;
+    if (server == null || !server.isIrohTransport) return;
     if (!ServerManager().tunnelServes(server)) return;
     // Shares the error-time recovery's per-server budget so a flapping tunnel
     // (connected↔reconnecting) can't spin reloads against a dying server.
@@ -2630,11 +2630,12 @@ class AudioPlayerHandler extends BaseAudioHandler
     return sameStreamUrl(newId, m.id) ? m : m.copyWith(id: newId);
   }
 
-  /// Re-derive [m]'s album-art URL against the live tunnel (iroh items only;
-  /// downloaded items included). Same instance when nothing changes.
+  /// Re-derive [m]'s album-art URL against the live tunnel (items whose bytes
+  /// ride a tunnel — an iroh server's, or a federated peer's through its
+  /// parent; downloaded items included). Same instance when nothing changes.
   MediaItem _withRebuiltArt(MediaItem m) {
     final server = _serverFor(m);
-    if (server == null || !server.isIroh) return m;
+    if (server == null || !server.isIrohTransport) return m;
     return rebindLoopbackArt(m, server);
   }
 
@@ -2917,7 +2918,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     if (!isNetwork && localPath != null && File(localPath).existsSync()) {
       return true;
     }
-    return _serverFor(item)?.isIroh ?? false;
+    return _serverFor(item)?.isIrohTransport ?? false;
   }
 
   // True while the active cast backend streams the on-device visualizer: the
@@ -3087,7 +3088,8 @@ class AudioPlayerHandler extends BaseAudioHandler
     // of stopping (queueEndAction).
     final dj = autoDJServer!;
     if (shouldDeferDJPick(
-        isIroh: dj.isIroh, tunnelServes: ServerManager().tunnelServes(dj))) {
+        isIroh: dj.isIrohTransport,
+        tunnelServes: ServerManager().tunnelServes(dj))) {
       // Owed from THIS moment, not from when the wait gives up: a track that
       // ends inside the 12s wait (a short track, a seek to the end — seen on
       // a Galaxy: completed 11s after the top-up started) would otherwise
@@ -3395,7 +3397,9 @@ class AudioPlayerHandler extends BaseAudioHandler
         // Parked on this pick and the tunnel still claims to serve: ask for
         // ground truth now rather than waiting up to a minute for the idle
         // timeout to flip the status (see _retryPickAtQueueEnd).
-        if (_parkedForDJ && dj.isIroh && ServerManager().tunnelServes(dj)) {
+        if (_parkedForDJ &&
+            dj.isIrohTransport &&
+            ServerManager().tunnelServes(dj)) {
           unawaited(ServerManager().reverifyTunnel(dj));
         }
         return;

--- a/lib/media/auto_browse.dart
+++ b/lib/media/auto_browse.dart
@@ -864,7 +864,7 @@ class AutoApi {
     // would replace an instant error row with a 45s spinner on every browse
     // tap of an unreachable server. 12s is long enough for a tunnel that is
     // actually coming up and short enough to stay a car UI.
-    if (server.isIroh && !ServerManager().tunnelServes(server)) {
+    if (server.isIrohTransport && !ServerManager().tunnelServes(server)) {
       await ServerManager().awaitTunnelReady(
           server: server,
           timeout: const Duration(seconds: 12),

--- a/lib/media/cast_origin.dart
+++ b/lib/media/cast_origin.dart
@@ -16,11 +16,13 @@ import 'local_media_server.dart';
 /// which relays the bytes to the renderer from the phone's LAN address over the
 /// tunnel (Range forwarded, so seeking still works).
 
-/// The iroh [Server] a queued [item] belongs to, or null when the item isn't
-/// from an iroh server (a plain HTTP server's URLs are already routable).
+/// The iroh [Server] whose tunnel carries a queued [item]'s bytes — the item's
+/// own server, or the PARENT of a federated peer, whose URLs sit on the
+/// parent's loopback just the same — or null when the item's bytes don't ride
+/// a tunnel at all (a plain HTTP server's URLs are already routable).
 Server? irohServerFor(MediaItem item) {
   final s = ServerManager().byLocalname(item.extras?['server'] as String?);
-  return (s != null && s.isIroh) ? s : null;
+  return (s != null && s.isIrohTransport) ? s.transportServer : null;
 }
 
 /// Rebind a stored loopback iroh URL to [server]'s LIVE tunnel — current port +
@@ -30,10 +32,13 @@ Server? irohServerFor(MediaItem item) {
 /// ([irohProxyUri], for a renderer that can't reach loopback) or hand it to an
 /// on-device consumer that can (the visualizer transcoder).
 Uri irohLoopbackUri(Server server, String stored) {
+  // A federated peer has no port or token of its own: both live on the
+  // parent whose tunnel it rides, so resolve to that transport first.
+  final t = server.transportServer ?? server;
   final u = Uri.parse(stored);
-  final base = Uri.parse(server.effectiveBaseUrl); // http://127.0.0.1:<livePort>
+  final base = Uri.parse(t.effectiveBaseUrl); // http://127.0.0.1:<livePort>
   final q = Map<String, String>.from(u.queryParameters);
-  if (server.tunnelToken != null) q['__lt'] = server.tunnelToken!;
+  if (t.tunnelToken != null) q['__lt'] = t.tunnelToken!;
   return u.replace(
     scheme: base.scheme,
     host: base.host,
@@ -52,13 +57,15 @@ Uri irohLoopbackUri(Server server, String stored) {
 /// Without this, every tunnel rebuild left the queue's art on the dead port:
 /// "Error loading artUri … Connection refused" every ~30s for minutes.
 MediaItem rebindLoopbackArt(MediaItem item, Server server) {
-  if (!server.isIroh || server.tunnelPort == null) return item;
+  // The port and token to compare against are the TRANSPORT's: a peer's art
+  // URL is the parent's art proxy on the parent's loopback.
+  final t = server.transportServer;
+  if (t == null || !t.isIroh || t.tunnelPort == null) return item;
   bool stale(String? u) {
     if (u == null) return false;
     final p = Uri.tryParse(u);
     if (p == null || p.host != '127.0.0.1') return false;
-    return p.port != server.tunnelPort ||
-        p.queryParameters['__lt'] != server.tunnelToken;
+    return p.port != t.tunnelPort || p.queryParameters['__lt'] != t.tunnelToken;
   }
 
   final art = item.artUri?.toString();

--- a/lib/objects/playlist.dart
+++ b/lib/objects/playlist.dart
@@ -84,15 +84,17 @@ class PlaylistEntry {
     // For an iroh server that URL carries a previous session's loopback port +
     // token, so re-origin it against the live tunnel (mirrors queue_store); HTTP
     // servers keep the persisted URL (their host:port is durable).
+    // Transport, not identity: a federated peer of an iroh parent rides that
+    // parent's tunnel and its art URL (the parent's art proxy) goes stale the
+    // same way. albumArtFileFromUrl reads both URL shapes.
     String? artUrl = extrasMap['artUrl'] as String?;
     final server = ServerManager().byLocalname(extrasMap['server'] as String?);
-    if (artUrl != null && server != null && server.isIroh) {
-      final u = Uri.tryParse(artUrl);
-      if (u != null &&
-          u.pathSegments.length >= 2 &&
-          u.pathSegments.first == 'album-art') {
-        artUrl = buildAlbumArtUrl(server, u.pathSegments.sublist(1).join('/'),
-            compress: u.queryParameters['compress'] ?? 's');
+    if (artUrl != null && server != null && server.isIrohTransport) {
+      final file = albumArtFileFromUrl(artUrl);
+      if (file != null) {
+        artUrl = buildAlbumArtUrl(server, file,
+            compress:
+                Uri.tryParse(artUrl)?.queryParameters['compress'] ?? 's');
         extrasMap['artUrl'] = artUrl;
       }
     }

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -171,7 +171,8 @@ class ApiManager {
               'x-access-token': server.authToken ?? ''
             });
       http.Response response;
-      final bool isIroh = server.isIroh;
+      // Transport, not identity: a peer of an iroh parent rides that tunnel.
+      final bool isIroh = server.isIrohTransport;
       try {
         // For iroh, bound the request so a wedged tunnel fails fast instead of
         // hanging the global loading bar. HTTP gets a generous bound too — a

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -228,7 +228,9 @@ class DownloadManager {
     } catch (_) {
       return false; // server removed while the download lingered
     }
-    if (!server.isIroh) return false; // only loopback URLs rotate this way
+    // Only loopback URLs rotate this way — an iroh server's, or a federated
+    // peer's, whose download URL sits on its parent's loopback.
+    if (!server.isIrohTransport) return false;
 
     // Bring the tunnel up (rebuilds it if hard-down) and wait for a live port;
     // if it can't connect, this is a real failure.

--- a/lib/singletons/queue_store.dart
+++ b/lib/singletons/queue_store.dart
@@ -378,18 +378,19 @@ class QueueStore {
       id = (j['id'] as String?) ?? Uuid().v4();
     }
 
-    // For an iroh server the persisted artUrl carries the PREVIOUS session's
-    // ephemeral loopback port + token, so re-origin it against the current tunnel:
-    // pull the album-art file + compress out of the stale URL and rebuild via
-    // buildAlbumArtUrl (live effectiveBaseUrl/token). HTTP servers keep the URL.
+    // For a server whose bytes ride an iroh tunnel — its own, or its parent's
+    // for a federated peer — the persisted artUrl carries the PREVIOUS
+    // session's ephemeral loopback port + token, so re-origin it against the
+    // current tunnel: pull the album-art file + compress out of the stale URL
+    // and rebuild via buildAlbumArtUrl (live effectiveBaseUrl/token, and the
+    // peer's proxy prefix). HTTP servers keep the URL.
     String? artUrl = extras['artUrl'] as String?;
-    if (artUrl != null && server != null && server.isIroh) {
-      final u = Uri.tryParse(artUrl);
-      if (u != null &&
-          u.pathSegments.length >= 2 &&
-          u.pathSegments.first == 'album-art') {
-        artUrl = buildAlbumArtUrl(server, u.pathSegments.sublist(1).join('/'),
-            compress: u.queryParameters['compress'] ?? 's');
+    if (artUrl != null && server != null && server.isIrohTransport) {
+      final file = albumArtFileFromUrl(artUrl);
+      if (file != null) {
+        artUrl = buildAlbumArtUrl(server, file,
+            compress:
+                Uri.tryParse(artUrl)?.queryParameters['compress'] ?? 's');
         extras['artUrl'] = artUrl; // keep extras consistent (player panel / Auto)
       }
     }

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -662,8 +662,16 @@ class ServerManager {
 
   /// True when the single tunnel is currently assigned to [s] (regardless of its
   /// connection state) — i.e. [s] is the server we last (re)started it for.
-  bool tunnelAssignedTo(Server s) =>
-      s.isIroh && _activeTunnelCode != null && s.irohPairingCode == _activeTunnelCode;
+  ///
+  /// Answered for the TRANSPORT: a federated peer is served exactly when its
+  /// parent's tunnel is, so every caller may pass whichever server it holds.
+  bool tunnelAssignedTo(Server s) {
+    final t = s.transportServer;
+    return t != null &&
+        t.isIroh &&
+        _activeTunnelCode != null &&
+        t.irohPairingCode == _activeTunnelCode;
+  }
 
   /// True when the tunnel is assigned to [s] AND reports connected — i.e. [s]'s
   /// loopback is live right now.
@@ -1375,8 +1383,10 @@ class ServerManager {
       String caller = '?',
       bool bypassBackoff = false}) async {
     // Default to the browsed server; callers on the playback path pass the
-    // track's server (which the single tunnel may be serving instead).
-    final s = server ?? currentServer;
+    // track's server (which the single tunnel may be serving instead). Either
+    // way the wait is for the TRANSPORT's tunnel — a federated peer has none
+    // of its own and is ready exactly when its parent is.
+    final s = (server ?? currentServer)?.transportServer;
     if (!IrohTunnel.isSupported || s == null || !s.isIroh) return true;
     // A rejected cold dial leaves no native tunnel to report it; answer
     // before firing an ensure that would only re-dial into the rejection.
@@ -1428,8 +1438,12 @@ class ServerManager {
   /// [_remedyDeadTunnel] (kick in place when the binary can, else a hard
   /// rebuild rate-limited to one per minute). A passing probe means the tunnel
   /// is fine and the failures were the source's own problem, so nothing moves.
-  Future<void> reverifyTunnel(Server s) async {
-    if (!IrohTunnel.isSupported || !s.isIroh || _reverifying) return;
+  Future<void> reverifyTunnel(Server server) async {
+    // Probe the transport: a peer's failures happen on its parent's tunnel.
+    final s = server.transportServer;
+    if (!IrohTunnel.isSupported || s == null || !s.isIroh || _reverifying) {
+      return;
+    }
     if (_activeTunnelCode == null || s.tunnelPort == null) return;
     // Already known down: ensureActiveTunnel / awaitTunnelReady own that case
     // and this would only race them.

--- a/lib/util/stream_url.dart
+++ b/lib/util/stream_url.dart
@@ -163,6 +163,29 @@ String buildServerDownloadUrl(Server server, String path) {
 /// when null, matching [buildServerStreamUrl]) and the whole URL is
 /// percent-encoded. Assumes [Server.url] carries no trailing slash — the app's
 /// stored convention, shared with the stream-URL builder above.
+/// The `album_art_file` a stored art URL was built for, or null when [url] is
+/// not an art URL. Understands both shapes [buildAlbumArtUrl] produces: a
+/// server's own `/album-art/<file>` and a federated peer's
+/// `…/federation/peers/<id>/art/<file>`. Used to re-origin a persisted URL
+/// against the live tunnel: the file is the durable part, everything else is
+/// re-derived.
+String? albumArtFileFromUrl(String url) {
+  final u = Uri.tryParse(url);
+  if (u == null) return null;
+  final seg = u.pathSegments;
+  if (seg.length >= 2 && seg.first == 'album-art') {
+    return seg.sublist(1).join('/');
+  }
+  final art = seg.indexOf('art');
+  if (art >= 2 &&
+      art + 1 < seg.length &&
+      seg[art - 2] == 'peers' &&
+      seg.contains('federation')) {
+    return seg.sublist(art + 1).join('/');
+  }
+  return null;
+}
+
 String buildAlbumArtUrl(Server server, String artFile, {String compress = 's'}) {
   final String token =
       server.authToken == null ? '' : '&token=${server.authToken!}';

--- a/smoke/android/federation-rig.sh
+++ b/smoke/android/federation-rig.sh
@@ -108,6 +108,17 @@ if [ "$IROH" = 1 ]; then
   T=$(now_ts); tap $PICKER; sleep 1.5; tap 782 366; sleep 5
   wait_for_log_after "$T" '\[srv\] switched to ' 5 || fail "no switch away from the peer"
   if is_playing && [ "$(count_log 'tunnel stopped')" -eq 0 ]; then pass "tunnel kept for the queued peer track after switching to a standard server"; else fail "tunnel or playback lost after the switch ($(session_state))"; fi
+  # Phase 4: relaunch with the peer track queued. The parent's tunnel comes up on
+  # a FRESH port, so the restored peer URLs (stream through the parent's proxy,
+  # art through its art proxy) must be re-derived against it — or the track
+  # plays from a dead loopback port.
+  PORT1=$(applog | grep -oE 'tunnel up port=[0-9]+' | head -1 | grep -oE '[0-9]+$')
+  media_key pause; sleep 1; app_stop; logcat_clear; wake; app_start
+  wait_for_log '\[iroh\] tunnel up' 45 || fail "no tunnel after the relaunch"
+  PORT2=$(applog | grep -oE 'tunnel up port=[0-9]+' | head -1 | grep -oE '[0-9]+$')
+  if wait_for_log '\[play\] track [0-9]+/[0-9]+' 30; then
+    sleep 3; ensure_playing 15 && pass "restored peer track plays after a relaunch (port $PORT1 → $PORT2)" || { save_applog rig-relaunch; fail "restored peer track did not play on the fresh port ($(session_state))"; }
+  else save_applog rig-relaunch; fail "queue did not restore after the relaunch"; fi
 fi
 media_key pause; sleep 1
 save_applog federation-rig

--- a/test/media/rebind_loopback_art_test.dart
+++ b/test/media/rebind_loopback_art_test.dart
@@ -78,4 +78,48 @@ void main() {
       expect(identical(rebindLoopbackArt(item, _iroh()), item), isTrue);
     });
   });
+
+  group('a federated peer of an iroh parent', () {
+    // A peer's art URL is the parent's art proxy on the parent's loopback, so
+    // it goes stale with the parent's port + token and must be rebound to
+    // THEM — the peer itself has no tunnel, port or token of its own.
+    Server peerOf(Server parent) =>
+        Server('federated://home/3', null, null, null, 'peer-basement')
+          ..federationParent = 'home'
+          ..federationPeerId = 3
+          ..parentServer = parent;
+    const staleProxied =
+        'http://127.0.0.1:34113/api/v1/federation/peers/3/art/abc.jpeg'
+        '?compress=l&token=jwt&__lt=oldtok';
+
+    test('rebinds to the parent tunnel and keeps the proxied path', () {
+      final peer = peerOf(_iroh());
+      final out = rebindLoopbackArt(
+          _item(art: staleProxied, extraArt: staleProxied), peer);
+      expect(out.artUri!.port, 52345);
+      expect(out.artUri!.queryParameters['__lt'], 'newtok');
+      expect(out.artUri!.path, '/api/v1/federation/peers/3/art/abc.jpeg');
+      expect(Uri.parse(out.extras!['artUrl'] as String).port, 52345);
+    });
+
+    test('irohLoopbackUri resolves the parent port and token', () {
+      final peer = peerOf(_iroh());
+      final live = irohLoopbackUri(peer, staleProxied);
+      expect(live.port, 52345);
+      expect(live.queryParameters['__lt'], 'newtok');
+      expect(live.path, '/api/v1/federation/peers/3/art/abc.jpeg');
+    });
+
+    test('a peer of an HTTP parent is left alone', () {
+      final http = Server('https://music.example', null, null, 'jwt', 'home');
+      final item = _item(art: staleProxied);
+      expect(identical(rebindLoopbackArt(item, peerOf(http)), item), isTrue);
+    });
+
+    test('an unlinked peer is left alone', () {
+      final peer = peerOf(_iroh())..parentServer = null;
+      final item = _item(art: staleProxied);
+      expect(identical(rebindLoopbackArt(item, peer), item), isTrue);
+    });
+  });
 }

--- a/test/objects/federated_server_test.dart
+++ b/test/objects/federated_server_test.dart
@@ -207,6 +207,34 @@ void main() {
     });
   });
 
+  group('albumArtFileFromUrl', () {
+    // Queue restore and playlists re-origin a persisted art URL against the
+    // live tunnel by pulling the file out of it; a peer's URL is the parent's
+    // art proxy, a different shape with the same durable part.
+    test("reads a server's own /album-art URL", () {
+      expect(
+          albumArtFileFromUrl(
+              'http://127.0.0.1:4111/album-art/abc.jpeg?compress=l&token=t'),
+          'abc.jpeg');
+    });
+
+    test("reads a peer's proxied art URL", () {
+      expect(
+          albumArtFileFromUrl('http://127.0.0.1:4111/api/v1/federation/peers/3'
+              '/art/abc%20d.jpeg?compress=s&token=t&__lt=x'),
+          'abc d.jpeg');
+    });
+
+    test('anything else is not an art URL', () {
+      expect(albumArtFileFromUrl('http://127.0.0.1:4111/media/a.mp3'), isNull);
+      expect(
+          albumArtFileFromUrl(
+              'http://h/api/v1/federation/peers/3/stream/a.mp3'),
+          isNull);
+      expect(albumArtFileFromUrl('not a url at all ::'), isNull);
+    });
+  });
+
   group('album art', () {
     test('a peer cover goes through the art proxy with compress forwarded', () {
       final peer = _pair().peer;

--- a/test/singletons/queue_store_test.dart
+++ b/test/singletons/queue_store_test.dart
@@ -109,6 +109,49 @@ void main() {
       expect(restored.id, isNot(contains('STALE')));
     });
 
+    test('a federated peer of an iroh parent re-origins onto the parent tunnel',
+        () {
+      // The peer's URLs are the parent's proxies on the parent's loopback. A
+      // previous session's port + token are baked into both the stream id and
+      // the art URL; the restore must re-derive them against the LIVE tunnel
+      // (transport, not identity — the peer itself is not an iroh server).
+      final parent = Server('iroh://placeholder', null, null, 'ptok', 'home')
+        ..connectionType = 'iroh'
+        ..tunnelPort = 52345
+        ..tunnelToken = 'newtok';
+      final peer = Server('federated://home/3', null, null, null, 'peer-b')
+        ..federationParent = 'home'
+        ..federationPeerId = 3
+        ..parentServer = parent;
+      final original = MediaItem(
+        id: 'http://127.0.0.1:34113/api/v1/federation/peers/3/stream/a.mp3'
+            '?app_uuid=OLD&token=STALE&__lt=oldtok',
+        title: 'A',
+        extras: {
+          'server': 'peer-b',
+          'path': '/a.mp3',
+          'artUrl': 'http://127.0.0.1:34113/api/v1/federation/peers/3/art/x.jpg'
+              '?compress=l&token=STALE&__lt=oldtok',
+        },
+      );
+      final restored = QueueStore.itemFromJson(
+        roundTripJson(original),
+        resolveServer: (name) => name == 'peer-b' ? peer : null,
+      );
+      expect(restored, isNotNull);
+      expect(restored!.id,
+          startsWith('http://127.0.0.1:52345/api/v1/federation/peers/3/stream/a.mp3'));
+      expect(restored.id, contains('token=ptok'));
+      expect(restored.id, contains('__lt=newtok'));
+      expect(restored.id, isNot(contains('STALE')));
+      final art = Uri.parse(restored.extras!['artUrl'] as String);
+      expect(art.port, 52345);
+      expect(art.path, '/api/v1/federation/peers/3/art/x.jpg');
+      expect(art.queryParameters['compress'], 'l');
+      expect(art.queryParameters['__lt'], 'newtok');
+      expect(art.queryParameters['token'], 'ptok');
+    });
+
     test('returns null when the server is no longer configured', () {
       final original = MediaItem(
         id: 'http://host:3000/media/x',


### PR DESCRIPTION
Stacked on #129. Finishes the split the rebase commit there started: every place that asked "is this an iroh server?" for a **transport** reason now resolves through the server that actually carries the bytes, so a federated peer of a Quick Connect parent behaves like the tunnel-carried server it is. Identity sites (pairing-code menu, one-iroh cap, edit form, share block, retry/rotate paths) stay on `isIroh`.

## What changed

- **Manager helpers answer for the transport.** `tunnelAssignedTo`, `tunnelServes`, `awaitTunnelReady`, `reverifyTunnel` resolve the server they are handed to its transport, so every caller on the playback path (load-failure recovery, parked-track heal, DJ gates, Android Auto browse wait, downloads) is right with whichever server it holds.
- **Sites moved to `isIrohTransport`:** the DJ flags, the art rebuild after a tunnel bind, `_phoneIsCastOrigin`, the stale-port download rotation, `makeServerCall`'s tunnel-drop retry.
- **Casting:** `irohServerFor` returns the transport, so a peer track is relayed through `LocalMediaServer` like any tunnel track; `irohLoopbackUri` / `rebindLoopbackArt` rebind to the *parent's* port and token, which a peer does not have.
- **Queue restore and playlists:** a persisted art URL is re-originated through `albumArtFileFromUrl`, which reads both URL shapes (`/album-art/<file>` and `…/peers/<id>/art/<file>`). The old extractor knew only the first, so a restored peer's art kept a dead port.
- The stream-URL rebuild needed nothing: the builder was already federation-aware and the rebuild walks every item.

`FEDERATION_PLAN.md` Phase 4 marked done with the mechanism.

## Verification

| | Result |
|---|---|
| `flutter test` | 463 pass (+8: extractor, peer art rebind, queue-restore re-origin) |
| analyzer | 17-issue baseline |
| `smoke/android/federation-rig.sh`, tunnel mode | **11/11** — peer reconciled under the iroh parent, browsed, played through the proxies; tunnel kept while browsing the peer and after a switch to a standard server mid-track; **relaunch: the restored peer track plays again on the parent's fresh port (38365 → 38977)** |
| same script, HTTP mode | 7/7 |

Not run on a renderer: casting a peer track through the LAN relay — same code path as an iroh server's, now that `irohServerFor` returns the transport.

Phase 3 (capability gates: Auto DJ, rating, lyrics, share, torrent, manage-server rows, the Forget decision, `.m3u` check) is next and separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)