### PR TITLE
feat(federation): Phase 3 — capability gates for federated peers

### DIFF
--- a/FEDERATION_PLAN.md
+++ b/FEDERATION_PLAN.md
@@ -197,20 +197,38 @@ for a federated server, keeping File Explorer / Albums / Artists / Recent /
 Local Files, plus a read-only note mirroring the webapp's left-nav
 explanation.
 
-### Phase 3 — capability gates
+### Phase 3 — capability gates ✅ done
 
-`isFederated` checks for: Auto DJ (picker + `toggleAutoDJ`), star rating, the
-lyrics badge, share, and the torrent panel. `manage_server.dart` offers
-federated rows nothing but "Forget" — no edit, no pairing code, no storage
-settings.
+Every surface whose route the federation allowlist refuses is gated on
+`isFederated`, at the track level where a peer's track can sit in a queue
+browsed from another server:
 
-**`.m3u` rows.** The webapp hides them on a peer (mStream 9dfc3bfb): its row
-handlers called local APIs with a peer path, which poisoned the breadcrumb or
-loaded a same-named *local* playlist. The app's equivalents thread the server
-through (`makeServerCall(useThisServer, …)`) and `POST
-/api/v1/file-explorer/m3u` is allowlisted, so it may well work — but this is
-the one place the webapp found a path-namespace collision, so verify it on a
-peer before deciding to keep the rows.
+- **Auto DJ.** The panel's server dropdown skips peers; the queue-header
+  toggle refuses a peer with a snack ("Auto DJ can't run on a shared
+  server"); CarPlay's toggle and the car's Shuffle All refuse with a log
+  line; and the handler's `setAutoDJ` action is the backstop for every entry
+  point. A peer cannot host the DJ — random-songs is off the allowlist and
+  its paths mean nothing to the parent.
+- **Track sheet.** No rating badge and no lyrics badge for a peer's track,
+  and no Add to playlist (the parent would store a path it cannot resolve).
+  Download stays. The metadata screen's lyrics chip is gated the same way.
+- **Share** blocks a queue of peer tracks with its own message, before the
+  iroh "no public URL" block.
+- **Torrent.** The add-torrent screen offers only the user's own servers.
+- **Car root.** A peer's root has no Shuffle All and no Playlists
+  (`AutoBrowse.rootTabs`, unit-tested).
+- **Manage servers.** A peer row shows its name, a hub icon and "via
+  <parent>" (or "No longer shared by <parent>"), and offers Info plus
+  Hide/Show; no Edit, no pairing code. **The Forget decision:** peers are the
+  parent admin's data, so a removed peer would come back on the next
+  reconcile. Hiding (`federationHidden`, persisted, honoured by the picker
+  and the car via `Server.isSelectable`) is the durable choice while the
+  parent lists it; Forget appears only once the parent has stopped listing
+  it (`federationMissing`). Hiding the browsed peer moves the browser to its
+  parent first.
+
+**`.m3u` rows** — verified on the rig with a playlist file in the peer's
+library (see the Phase 3 PR).
 
 ### Phase 4 — the `isIroh` / transport split ✅ done
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1998,5 +1998,18 @@
   "browserFederatedReadOnlyNote": "Playlists and ratings stay on your own",
   "@browserFederatedReadOnlyNote": {
     "description": "Subtitle of the note row explaining what a federated peer cannot do."
+  },
+  "federatedAutoDjUnavailable": "Auto DJ can't run on a shared server. Switch to one of your own servers first.",
+  "federatedShareUnavailable": "Tracks on a shared server can't be shared from here — they live in someone else's library.",
+  "federatedForget": "Forget",
+  "federatedHide": "Hide from the picker",
+  "federatedShow": "Show in the picker",
+  "federatedNoLongerListed": "No longer shared by {parent}",
+  "@federatedNoLongerListed": {
+    "placeholders": {
+      "parent": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3971,6 +3971,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Playlists and ratings stay on your own'**
   String get browserFederatedReadOnlyNote;
+
+  /// No description provided for @federatedAutoDjUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto DJ can\'t run on a shared server. Switch to one of your own servers first.'**
+  String get federatedAutoDjUnavailable;
+
+  /// No description provided for @federatedShareUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Tracks on a shared server can\'t be shared from here — they live in someone else\'s library.'**
+  String get federatedShareUnavailable;
+
+  /// No description provided for @federatedForget.
+  ///
+  /// In en, this message translates to:
+  /// **'Forget'**
+  String get federatedForget;
+
+  /// No description provided for @federatedHide.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide from the picker'**
+  String get federatedHide;
+
+  /// No description provided for @federatedShow.
+  ///
+  /// In en, this message translates to:
+  /// **'Show in the picker'**
+  String get federatedShow;
+
+  /// No description provided for @federatedNoLongerListed.
+  ///
+  /// In en, this message translates to:
+  /// **'No longer shared by {parent}'**
+  String federatedNoLongerListed(String parent);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2296,4 +2296,26 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get browserFederatedReadOnlyNote =>
       'Playlists and ratings stay on your own';
+
+  @override
+  String get federatedAutoDjUnavailable =>
+      'Auto DJ can\'t run on a shared server. Switch to one of your own servers first.';
+
+  @override
+  String get federatedShareUnavailable =>
+      'Tracks on a shared server can\'t be shared from here — they live in someone else\'s library.';
+
+  @override
+  String get federatedForget => 'Forget';
+
+  @override
+  String get federatedHide => 'Hide from the picker';
+
+  @override
+  String get federatedShow => 'Show in the picker';
+
+  @override
+  String federatedNoLongerListed(String parent) {
+    return 'No longer shared by $parent';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2268,4 +2268,26 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get browserFederatedReadOnlyNote =>
       'Playlists and ratings stay on your own';
+
+  @override
+  String get federatedAutoDjUnavailable =>
+      'Auto DJ can\'t run on a shared server. Switch to one of your own servers first.';
+
+  @override
+  String get federatedShareUnavailable =>
+      'Tracks on a shared server can\'t be shared from here — they live in someone else\'s library.';
+
+  @override
+  String get federatedForget => 'Forget';
+
+  @override
+  String get federatedHide => 'Hide from the picker';
+
+  @override
+  String get federatedShow => 'Show in the picker';
+
+  @override
+  String federatedNoLongerListed(String parent) {
+    return 'No longer shared by $parent';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2297,4 +2297,26 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get browserFederatedReadOnlyNote =>
       'Playlists and ratings stay on your own';
+
+  @override
+  String get federatedAutoDjUnavailable =>
+      'Auto DJ can\'t run on a shared server. Switch to one of your own servers first.';
+
+  @override
+  String get federatedShareUnavailable =>
+      'Tracks on a shared server can\'t be shared from here — they live in someone else\'s library.';
+
+  @override
+  String get federatedForget => 'Forget';
+
+  @override
+  String get federatedHide => 'Hide from the picker';
+
+  @override
+  String get federatedShow => 'Show in the picker';
+
+  @override
+  String federatedNoLongerListed(String parent) {
+    return 'No longer shared by $parent';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2296,4 +2296,26 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get browserFederatedReadOnlyNote =>
       'Playlists and ratings stay on your own';
+
+  @override
+  String get federatedAutoDjUnavailable =>
+      'Auto DJ can\'t run on a shared server. Switch to one of your own servers first.';
+
+  @override
+  String get federatedShareUnavailable =>
+      'Tracks on a shared server can\'t be shared from here — they live in someone else\'s library.';
+
+  @override
+  String get federatedForget => 'Forget';
+
+  @override
+  String get federatedHide => 'Hide from the picker';
+
+  @override
+  String get federatedShow => 'Show in the picker';
+
+  @override
+  String federatedNoLongerListed(String parent) {
+    return 'No longer shared by $parent';
+  }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2295,4 +2295,26 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get browserFederatedReadOnlyNote =>
       'Playlists and ratings stay on your own';
+
+  @override
+  String get federatedAutoDjUnavailable =>
+      'Auto DJ can\'t run on a shared server. Switch to one of your own servers first.';
+
+  @override
+  String get federatedShareUnavailable =>
+      'Tracks on a shared server can\'t be shared from here — they live in someone else\'s library.';
+
+  @override
+  String get federatedForget => 'Forget';
+
+  @override
+  String get federatedHide => 'Hide from the picker';
+
+  @override
+  String get federatedShow => 'Show in the picker';
+
+  @override
+  String federatedNoLongerListed(String parent) {
+    return 'No longer shared by $parent';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2191,4 +2191,26 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get browserFederatedReadOnlyNote =>
       'Playlists and ratings stay on your own';
+
+  @override
+  String get federatedAutoDjUnavailable =>
+      'Auto DJ can\'t run on a shared server. Switch to one of your own servers first.';
+
+  @override
+  String get federatedShareUnavailable =>
+      'Tracks on a shared server can\'t be shared from here — they live in someone else\'s library.';
+
+  @override
+  String get federatedForget => 'Forget';
+
+  @override
+  String get federatedHide => 'Hide from the picker';
+
+  @override
+  String get federatedShow => 'Show in the picker';
+
+  @override
+  String federatedNoLongerListed(String parent) {
+    return 'No longer shared by $parent';
+  }
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2307,4 +2307,26 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get browserFederatedReadOnlyNote =>
       'Playlists and ratings stay on your own';
+
+  @override
+  String get federatedAutoDjUnavailable =>
+      'Auto DJ can\'t run on a shared server. Switch to one of your own servers first.';
+
+  @override
+  String get federatedShareUnavailable =>
+      'Tracks on a shared server can\'t be shared from here — they live in someone else\'s library.';
+
+  @override
+  String get federatedForget => 'Forget';
+
+  @override
+  String get federatedHide => 'Hide from the picker';
+
+  @override
+  String get federatedShow => 'Show in the picker';
+
+  @override
+  String federatedNoLongerListed(String parent) {
+    return 'No longer shared by $parent';
+  }
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2290,4 +2290,26 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get browserFederatedReadOnlyNote =>
       'Playlists and ratings stay on your own';
+
+  @override
+  String get federatedAutoDjUnavailable =>
+      'Auto DJ can\'t run on a shared server. Switch to one of your own servers first.';
+
+  @override
+  String get federatedShareUnavailable =>
+      'Tracks on a shared server can\'t be shared from here — they live in someone else\'s library.';
+
+  @override
+  String get federatedForget => 'Forget';
+
+  @override
+  String get federatedHide => 'Hide from the picker';
+
+  @override
+  String get federatedShow => 'Show in the picker';
+
+  @override
+  String federatedNoLongerListed(String parent) {
+    return 'No longer shared by $parent';
+  }
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2310,4 +2310,26 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get browserFederatedReadOnlyNote =>
       'Playlists and ratings stay on your own';
+
+  @override
+  String get federatedAutoDjUnavailable =>
+      'Auto DJ can\'t run on a shared server. Switch to one of your own servers first.';
+
+  @override
+  String get federatedShareUnavailable =>
+      'Tracks on a shared server can\'t be shared from here — they live in someone else\'s library.';
+
+  @override
+  String get federatedForget => 'Forget';
+
+  @override
+  String get federatedHide => 'Hide from the picker';
+
+  @override
+  String get federatedShow => 'Show in the picker';
+
+  @override
+  String federatedNoLongerListed(String parent) {
+    return 'No longer shared by $parent';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2147,4 +2147,26 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get browserFederatedReadOnlyNote =>
       'Playlists and ratings stay on your own';
+
+  @override
+  String get federatedAutoDjUnavailable =>
+      'Auto DJ can\'t run on a shared server. Switch to one of your own servers first.';
+
+  @override
+  String get federatedShareUnavailable =>
+      'Tracks on a shared server can\'t be shared from here — they live in someone else\'s library.';
+
+  @override
+  String get federatedForget => 'Forget';
+
+  @override
+  String get federatedHide => 'Hide from the picker';
+
+  @override
+  String get federatedShow => 'Show in the picker';
+
+  @override
+  String federatedNoLongerListed(String parent) {
+    return 'No longer shared by $parent';
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -981,11 +981,11 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
           StreamBuilder<List<Server>>(
               stream: ServerManager().serverListStream,
               builder: (context, snapshot) {
-                // A peer the parent has stopped listing isn't selectable, so it
-                // doesn't count towards "is there more than one server here".
+                // A peer the parent has stopped listing, or one the user hid,
+                // isn't selectable, so it doesn't count towards "is there more
+                // than one server here".
                 final isVisible = snapshot.hasData &&
-                    snapshot.data!.where((s) => !s.federationMissing).length >
-                        1;
+                    snapshot.data!.where((s) => s.isSelectable).length > 1;
                 return Visibility(
                   visible: isVisible,
                   child: PopupMenuButton(
@@ -1024,10 +1024,11 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
                         final servers = ServerManager().serverList;
                         return <PopupMenuEntry<int>>[
                           for (final server in servers)
-                            // A peer its parent no longer lists stays in the
-                            // list so queued and downloaded tracks keep
-                            // resolving, but selecting it could only fail.
-                            if (!server.federationMissing)
+                            // A peer its parent no longer lists (or one the
+                            // user hid) stays in the list so queued and
+                            // downloaded tracks keep resolving, but is not
+                            // offered.
+                            if (server.isSelectable)
                               PopupMenuItem<int>(
                                 // The index into the FULL list — that is what
                                 // changeCurrentServer takes.

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -2563,6 +2563,14 @@ class AudioPlayerHandler extends BaseAudioHandler
         break;
       case 'setAutoDJ':
         final nextDJ = extras?['autoDJServer'] as Server?;
+        // Backstop for every entry point (panel, queue header, CarPlay, Auto):
+        // a federated peer cannot host the DJ — random-songs is off the
+        // federation allowlist and its paths mean nothing to the parent.
+        if (nextDJ != null && nextDJ.isFederated) {
+          appLog('[dj] ${nextDJ.localname} is a shared (federated) server — '
+              'Auto DJ ignored');
+          break;
+        }
         // A re-arm on the SAME server (a settings-screen rebuild, the queue
         // header toggling it back on) is not a new session. Only a real
         // change resets the session state — and only a real change is allowed

--- a/lib/media/auto_browse.dart
+++ b/lib/media/auto_browse.dart
@@ -18,6 +18,7 @@
 //      mirrors the same endpoints + parsing and returns plain DisplayItems
 //      (so playback can reuse queue_actions.playFromHere unchanged).
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show Platform;
@@ -247,7 +248,7 @@ class AutoBrowse {
       }
 
       if (parentMediaId == AudioService.browsableRootId) {
-        return _rootTabs(server);
+        return rootTabs(server);
       }
 
       final Uri? u = Uri.tryParse(parentMediaId);
@@ -421,6 +422,11 @@ class AutoBrowse {
       // Shuffle All: hand the library to the app's Auto-DJ from a clean queue —
       // infinite random play, reusing its working random-songs payload + top-up.
       if (u.host == 'shuffle') {
+        if (srv.isFederated) {
+          appLog('[auto] shuffle: ${srv.localname} is a shared server — '
+              'Auto DJ is not available there');
+          return;
+        }
         await handler.customAction('clearPlaylist');
         await handler.customAction('setAutoDJ', {'autoDJServer': srv});
         return;
@@ -556,8 +562,13 @@ class AutoBrowse {
 
   // ── tree nodes ──
 
-  static List<MediaItem> _rootTabs(Server server) {
+  /// The root of the car tree for [server]. A federated peer is read-only and
+  /// cannot host the DJ, so it has no Shuffle All (random-songs) and no
+  /// Playlists (every playlist route is off the federation allowlist).
+  @visibleForTesting
+  static List<MediaItem> rootTabs(Server server) {
     final String s = server.localname;
+    final bool federated = server.isFederated;
     // Albums/Artists open onto an A–Z letter index (category list), or — for a
     // small library — straight to album/artist rows. The album-art grid is
     // applied one level down on the album leaves (see _bucketView childStyle).
@@ -565,11 +576,15 @@ class AutoBrowse {
     return [
       // A playable quick-action: hand the whole library to Auto-DJ (infinite
       // shuffle). First, so it's the obvious "just play something" option.
-      MediaItem(
-          id: _id('shuffle', {'s': s}), title: 'Shuffle All', playable: true),
+      if (!federated)
+        MediaItem(
+            id: _id('shuffle', {'s': s}),
+            title: 'Shuffle All',
+            playable: true),
       _browse(_id('cat', {'s': s, 'k': 'recent'}), 'Recently Added'),
-      _browse(_id('cat', {'s': s, 'k': 'playlists'}), 'Playlists',
-          styleExtras: _listChildren),
+      if (!federated)
+        _browse(_id('cat', {'s': s, 'k': 'playlists'}), 'Playlists',
+            styleExtras: _listChildren),
       _browse(_id('cat', {'s': s, 'k': 'albums'}), 'Albums',
           styleExtras: _categoryListChildren),
       _browse(_id('cat', {'s': s, 'k': 'artists'}), 'Artists',

--- a/lib/native/carplay_bridge.dart
+++ b/lib/native/carplay_bridge.dart
@@ -131,6 +131,11 @@ class CarPlayBridge {
           appLog('[carplay] Auto DJ: no server to run it on');
           return null;
         }
+        if (server.isFederated) {
+          appLog('[carplay] Auto DJ: ${server.localname} is a shared server — '
+              'not available there');
+          return null;
+        }
         appLog('[carplay] Auto DJ → on (${server.localname})');
         // Not awaited: on an empty queue this starts random play, whose
         // play() future only completes when playback later pauses.

--- a/lib/objects/server.dart
+++ b/lib/objects/server.dart
@@ -95,6 +95,16 @@ class Server {
   // only when the user says so, or with the parent.
   bool federationMissing = false;
 
+  // The user hid this peer from the picker (and the car). Peers are the
+  // parent admin's data, so "remove" would only last until the next
+  // reconcile mirrored the list again — hiding is the durable choice, and it
+  // keeps queued and downloaded tracks resolving. Cleared with "Show".
+  bool federationHidden = false;
+
+  /// Whether the picker (and the car UI) may offer this server: not a peer
+  /// its parent no longer lists, and not one the user hid.
+  bool get isSelectable => !federationMissing && !federationHidden;
+
   // Runtime-only (never persisted): the live parent, linked by ServerManager
   // after the list loads and on every peer reconcile. Same contract as
   // [tunnelPort] — null means "not resolvable yet", and every accessor below
@@ -264,6 +274,7 @@ class Server {
             json['federationPeerId'] is int ? json['federationPeerId'] : null,
         federationPeerName = json['federationPeerName'] as String?,
         federationMissing = json['federationMissing'] == true,
+        federationHidden = json['federationHidden'] == true,
         serverVersion = json['serverVersion'] as String?,
         versionCheckedAt = json['versionCheckedAt'] is int
             ? DateTime.fromMillisecondsSinceEpoch(json['versionCheckedAt'])
@@ -297,6 +308,7 @@ class Server {
         'federationPeerId': federationPeerId,
         'federationPeerName': federationPeerName,
         'federationMissing': federationMissing,
+        'federationHidden': federationHidden,
         'serverVersion': serverVersion,
         'versionCheckedAt': versionCheckedAt?.millisecondsSinceEpoch
       };

--- a/lib/screens/add_torrent_screen.dart
+++ b/lib/screens/add_torrent_screen.dart
@@ -64,9 +64,13 @@ class _AddTorrentScreenState extends State<AddTorrentScreen> {
   @override
   void initState() {
     super.initState();
-    _servers = ServerManager().serverList;
+    // A federated peer cannot receive a torrent (every torrent route is off
+    // the federation allowlist), so only the user's own servers are offered.
+    _servers = ServerManager().serverList.where((s) => !s.isFederated).toList();
     final cur = ServerManager().currentServer;
-    _server = cur ?? (_servers.isNotEmpty ? _servers.first : null);
+    _server = (cur != null && !cur.isFederated)
+        ? cur
+        : (_servers.isNotEmpty ? _servers.first : null);
     if (_server != null) {
       _loadForServer(_server!);
     } else {

--- a/lib/screens/auto_dj.dart
+++ b/lib/screens/auto_dj.dart
@@ -733,7 +733,10 @@ class _AutoDJScreenState extends State<AutoDJScreen> {
   // ── Server picker (multi-server only, when enabled) ─────────────
 
   Widget _serverPickerTile(Server autoDJServer) {
-    final servers = ServerManager().serverList;
+    // A federated peer cannot host the DJ: random-songs is off the
+    // federation allowlist, and its paths mean nothing to the parent.
+    final servers =
+        ServerManager().serverList.where((s) => !s.isFederated).toList();
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
       child: DropdownButton<Server>(

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -704,8 +704,19 @@ class _BrowserState extends State<Browser> {
   // card height fell out of the screen WIDTH, which on a narrow phone (or at
   // a large text scale) squeezed the tile and label into less room than they
   // occupy and overflowed.
-  Widget _homeView(BuildContext context, List<DisplayItem> items) {
+  Widget _homeView(BuildContext context, List<DisplayItem> allItems) {
     final rows = <Widget>[];
+    // A note (a federated peer's "read-only server") is a full-width banner
+    // above the cards, never a card: it has no action and reads as a caption
+    // for the sections, not one of them.
+    final notes = allItems.where((it) => it.type == 'note').toList();
+    final items = allItems.where((it) => it.type != 'note').toList();
+    for (final note in notes) {
+      rows.add(Padding(
+        padding: EdgeInsets.only(bottom: _homeCardGap),
+        child: _homeNote(context, note),
+      ));
+    }
     for (var i = 0; i < items.length; i += 2) {
       final pair = items.skip(i).take(2).toList();
       rows.add(Padding(
@@ -730,6 +741,40 @@ class _BrowserState extends State<Browser> {
   }
 
   static const double _homeCardGap = 10;
+
+  Widget _homeNote(BuildContext context, DisplayItem note) {
+    final l = AppLocalizations.of(context);
+    return Material(
+      color: VelvetColors.card,
+      borderRadius: BorderRadius.circular(VelvetColors.radiusLarge),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(children: [
+          if (note.icon != null) ...[
+            Icon(note.icon!.icon, color: VelvetColors.textSecondary),
+            const SizedBox(width: 12),
+          ],
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(browserChromeLabel(l, note.name),
+                    style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                        color: VelvetColors.textPrimary)),
+                if (note.subtext != null)
+                  Text(browserChromeLabel(l, note.subtext!),
+                      style: TextStyle(
+                          fontSize: 13, color: VelvetColors.textSecondary)),
+              ],
+            ),
+          ),
+        ]),
+      ),
+    );
+  }
 
   Widget _homeCard(BuildContext context, List<DisplayItem> items, int i) {
     final l = AppLocalizations.of(context);
@@ -1034,8 +1079,7 @@ class _BrowserState extends State<Browser> {
                     // / scroll restore) is untouched. The execAction home
                     // menu is fixed section shortcuts, not content, so it
                     // is never filtered.
-                    final bool isHome = rawList.isNotEmpty &&
-                        rawList[0].type == 'execAction';
+                    final bool isHome = BrowserManager.isHomeList(rawList);
                     // Search state lives in BrowserManager (the top toolbar owns
                     // the field) and re-emits this list on every change, so
                     // reading it synchronously here re-filters live.

--- a/lib/screens/manage_server.dart
+++ b/lib/screens/manage_server.dart
@@ -199,7 +199,12 @@ class ManageServersScreen extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: () => _pushEdit(context, index),
+        // A federated peer has nothing to edit — its name, URL, credentials and
+        // storage are the parent's — so the row opens Info rather than a form
+        // whose Save would overwrite the synthetic record.
+        onTap: () => server.isFederated
+            ? _showServerInfo(context, index)
+            : _pushEdit(context, index),
         child: Container(
           decoration: BoxDecoration(
             border: Border(

--- a/lib/screens/manage_server.dart
+++ b/lib/screens/manage_server.dart
@@ -36,7 +36,7 @@ class ManageServersScreen extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(ServerManager().serverList[index].url,
+                  Text(ServerManager().serverList[index].displayName,
                       style: TextStyle(color: VelvetColors.textPrimary)),
                   const SizedBox(height: 16),
                   Text(l.manageServerDownloadFolder,
@@ -111,19 +111,39 @@ class ManageServersScreen extends StatelessWidget {
           case 'delete':
             _showDeleteDialog(context, index);
             break;
+          case 'hide':
+            ServerManager().setFederatedHidden(server, true);
+            break;
+          case 'show':
+            ServerManager().setFederatedHidden(server, false);
+            break;
         }
       },
       itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
         // Index 0 is already the default server, so omit the action.
-        if (index != 0)
+        if (index != 0 && server.isSelectable)
           _menuItem('default', Icons.arrow_upward_rounded, l.makeDefault),
         _menuItem('info', Icons.info_outline, l.info),
         // Re-share this iroh server's pairing QR so another device can pair.
         if (server.isIroh && server.irohPairingCode != null)
           _menuItem('pairingCode', Icons.qr_code_2, l.irohShowPairingCode),
-        _menuItem('edit', Icons.edit_outlined, l.edit),
-        _menuItem('delete', Icons.delete_outline, l.delete,
-            color: VelvetColors.error),
+        // A federated peer has nothing to edit — its name, transport and
+        // credentials are the parent's — and is the parent admin's data, so
+        // it can be hidden but not removed while the parent still lists it.
+        // Once the parent stops listing it, Forget drops the record.
+        if (!server.isFederated)
+          _menuItem('edit', Icons.edit_outlined, l.edit),
+        if (server.isFederated && !server.federationMissing)
+          server.federationHidden
+              ? _menuItem('show', Icons.visibility_outlined, l.federatedShow)
+              : _menuItem(
+                  'hide', Icons.visibility_off_outlined, l.federatedHide),
+        if (!server.isFederated)
+          _menuItem('delete', Icons.delete_outline, l.delete,
+              color: VelvetColors.error),
+        if (server.isFederated && server.federationMissing)
+          _menuItem('delete', Icons.delete_outline, l.federatedForget,
+              color: VelvetColors.error),
       ],
     );
   }
@@ -174,6 +194,7 @@ class ManageServersScreen extends StatelessWidget {
   // for the default server), the URL, a star marking the default, and the
   // ⋮ menu. Tapping the row opens the edit screen.
   Widget _serverRow(BuildContext context, Server server, int index) {
+    final l = AppLocalizations.of(context);
     final bool isDefault = index == 0;
     return Material(
       color: Colors.transparent,
@@ -196,22 +217,49 @@ class ManageServersScreen extends StatelessWidget {
                   borderRadius:
                       BorderRadius.circular(VelvetColors.radiusSmall),
                 ),
-                child: Icon(Icons.dns,
+                child: Icon(server.isFederated ? Icons.hub_outlined : Icons.dns,
                     color: isDefault
                         ? VelvetColors.primary
                         : VelvetColors.textSecondary),
               ),
               const SizedBox(width: 12),
               Expanded(
-                child: Text(
-                  server.url,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w600,
-                    color: VelvetColors.textPrimary,
-                  ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      server.displayName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                        // A hidden peer reads as parked, not gone.
+                        color: server.federationHidden
+                            ? VelvetColors.textSecondary
+                            : VelvetColors.textPrimary,
+                      ),
+                    ),
+                    // A peer names the server it is reached through — or the
+                    // one that stopped sharing it.
+                    if (server.isFederated)
+                      Text(
+                        server.federationMissing
+                            ? l.federatedNoLongerListed(
+                                server.parentServer?.displayName ??
+                                    server.federationParent ??
+                                    '')
+                            : l.serverPickerVia(
+                                server.parentServer?.displayName ??
+                                    server.federationParent ??
+                                    ''),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                            fontSize: 12, color: VelvetColors.textSecondary),
+                      ),
+                  ],
                 ),
               ),
               if (server.isIroh && server == ServerManager().currentServer)

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -75,7 +75,10 @@ class MetadataScreen extends StatelessWidget {
       // a rateable track: a local file has no server-side rating, and adding it
       // unconditionally would force an empty chip row to render for one.
       if (MediaItemRating.canRate(item)) MediaItemRating(item: item, size: 18),
-      if (extras['hasLyrics'] == true && lyricsServer != null && path != null)
+      if (extras['hasLyrics'] == true &&
+          lyricsServer != null &&
+          !lyricsServer.isFederated &&
+          path != null)
         _actionChip(
           Icons.lyrics_rounded,
           l.lyricsTitle,

--- a/lib/screens/share_playlist_dialog.dart
+++ b/lib/screens/share_playlist_dialog.dart
@@ -46,6 +46,14 @@ Future<void> showSharePlaylistDialog(BuildContext context) async {
           context, l.shareBlockedTitle, l.shareServerGoneBody(serverName));
       return;
     case _Shareable(:final server, :final filepaths):
+      // A federated peer's tracks live on someone else's server: the parent's
+      // share route cannot address them, and every share/playlist route is
+      // off the federation allowlist besides.
+      if (server.isFederated) {
+        await _alert(
+            context, l.shareBlockedTitle, l.federatedShareUnavailable);
+        return;
+      }
       // An iroh server has no public URL — a share link would point at a dead
       // loopback address — so block sharing its tracks with a clear message.
       if (server.isIroh) {

--- a/lib/singletons/browser_list.dart
+++ b/lib/singletons/browser_list.dart
@@ -13,6 +13,19 @@ import '../objects/server.dart';
 import '../theme/velvet_theme.dart';
 
 class BrowserManager {
+  /// Whether [list] is the home section list: its first row that is not a
+  /// note is a section shortcut. A federated peer's home leads with a
+  /// read-only note, and that must not demote it to a plain list — the home
+  /// treatment (card grid, the whole-server search field) is what makes the
+  /// sections usable.
+  static bool isHomeList(List<DisplayItem> list) {
+    for (final it in list) {
+      if (it.type == 'note') continue;
+      return it.type == 'execAction';
+    }
+    return false;
+  }
+
   final List<List<DisplayItem>> browserCache = [];
   final List<double> scrollCache = [];
   // 1:1 with browserCache. Drives whether the letter-scrub strip

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -1661,6 +1661,22 @@ class ServerManager {
     return null;
   }
 
+  /// Hide a peer from the picker (or show it again). Hiding the server that
+  /// is being browsed moves the browser to its parent first — the peer is
+  /// still addressable (queued tracks keep playing), it just stops being
+  /// offered.
+  Future<void> setFederatedHidden(Server s, bool hidden) async {
+    if (!s.isFederated || s.federationHidden == hidden) return;
+    s.federationHidden = hidden;
+    if (hidden && identical(s, currentServer)) {
+      final parent = s.parentServer;
+      final idx = parent == null ? -1 : serverList.indexOf(parent);
+      await changeCurrentServer(idx >= 0 ? idx : 0);
+    }
+    _serverListStream.sink.add(serverList);
+    await writeServerFile();
+  }
+
   /// Follow a parent's rename through to its peers. [Server.federationParent]
   /// stores the parent's localname, and the edit screen lets the user change
   /// it; without this the children would point at a name nothing answers to.

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
@@ -145,7 +146,7 @@ class ServerManager {
     syncInsecureTls();
 
     if (serverList.isNotEmpty) {
-      currentServer = serverList[0];
+      currentServer = firstSelectable(serverList);
       // An iroh default: bring its tunnel up BEFORE the browser queries it —
       // bounded: a cold dial in a dead zone takes up to ~43s and the retry
       // loop owns failures, so launch must not wait on it. The dial keeps
@@ -1575,7 +1576,7 @@ class ServerManager {
     } else if (!serverList.contains(currentServer)) {
       // The active server went — either it IS the one being removed, or it was
       // one of its peers, swept out with it.
-      currentServer = serverList[0];
+      currentServer = firstSelectable(serverList);
       // clear the browser
       BrowserManager().goToNavScreen();
       _currentServerStream.sink.add(currentServer);
@@ -1644,6 +1645,13 @@ class ServerManager {
       if (s.isFederated) s.parentServer = byLocalname(s.federationParent);
     }
   }
+
+  /// The default: the first server the picker would offer. A hidden or
+  /// no-longer-listed peer can sit at index 0 (Make Default, then hidden, or
+  /// the parent stopped sharing it), and opening on it would only 404.
+  @visibleForTesting
+  static Server firstSelectable(List<Server> servers) =>
+      servers.firstWhere((s) => s.isSelectable, orElse: () => servers.first);
 
   /// The federated servers reached through [parent].
   List<Server> federatedChildren(Server parent) => serverList
@@ -1720,15 +1728,38 @@ class ServerManager {
     }
 
     bool changed = false;
+    // Ids first, names second: a peer the admin removed and re-added comes
+    // back under a NEW row id (the plan's "peer ids are parent-side rowids"
+    // risk). Matching by id alone would flag the old record missing and mint
+    // a `-2` twin, stranding the queue and the download folder — so a listed
+    // id nobody holds is adopted by a child of the same name whose own id is
+    // no longer listed.
     final Set<int> listed = {};
+    final entries = <({int id, String name})>[];
     for (final p in peers) {
       if (p is! Map) continue;
       final id = p['id'];
       final name = p['name'];
       if (id is! int || name is! String || name.isEmpty) continue;
       listed.add(id);
-
-      final existing = _childByPeerId(parent, id);
+      entries.add((id: id, name: name));
+    }
+    for (final e in entries) {
+      final id = e.id;
+      final name = e.name;
+      var existing = _childByPeerId(parent, id);
+      if (existing == null) {
+        final orphan =
+            adoptablePeer(federatedChildren(parent), name, listed);
+        if (orphan != null) {
+          appLog('[federation] ${orphan.localname}: peer id '
+              '${orphan.federationPeerId} → $id (re-added on '
+              '${parent.localname})');
+          orphan.federationPeerId = id;
+          existing = orphan;
+          changed = true;
+        }
+      }
       if (existing == null) {
         final fresh = _newFederatedServer(parent, id, name);
         serverList.add(fresh);
@@ -1745,11 +1776,13 @@ class ServerManager {
       }
     }
 
+    Server? vanishedUnderUs;
     for (final child in federatedChildren(parent)) {
       final gone = !listed.contains(child.federationPeerId);
       if (gone != child.federationMissing) {
         child.federationMissing = gone;
         changed = true;
+        if (gone && identical(child, currentServer)) vanishedUnderUs = child;
       }
     }
 
@@ -1757,10 +1790,34 @@ class ServerManager {
     _linkFederatedParents();
     _serverListStream.sink.add(serverList);
     await writeServerFile();
+    // The peer being browsed stopped being shared: every request through the
+    // proxy is a 404 from here on, and the picker no longer offers it. Move
+    // the browser to the parent, the way Hide does.
+    if (vanishedUnderUs != null) {
+      appLog('[federation] ${vanishedUnderUs.localname} is no longer shared '
+          'by ${parent.localname} — leaving it for the parent');
+      final idx = serverList.indexOf(parent);
+      await changeCurrentServer(idx >= 0 ? idx : 0);
+    }
     // Capabilities for anything new or newly back: one /api through the proxy.
     for (final child in federatedChildren(parent)) {
       if (!child.federationMissing) unawaited(getServerPaths(child));
     }
+  }
+
+  /// Among [children] (one parent's peers), the record a listed peer named
+  /// [name] should re-use when no child holds its id: a child of that name
+  /// whose OWN id is not in [listed] — the admin removed and re-added it, and
+  /// the parent handed out a fresh row id. Null when nothing qualifies.
+  @visibleForTesting
+  static Server? adoptablePeer(
+      List<Server> children, String name, Set<int> listed) {
+    for (final c in children) {
+      if (c.federationPeerName == name && !listed.contains(c.federationPeerId)) {
+        return c;
+      }
+    }
+    return null;
   }
 
   /// A Server standing in for peer [id] of [parent], named [name].

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -426,9 +426,17 @@ class ServerManager {
       }
 
       // Peers are the parent's data, so only a parent reconciles them — and
-      // only when it says it has some (flags, never probes).
-      if (!server.isFederated && scoped?['federationBrowse'] == true) {
-        unawaited(refreshFederatedPeers(server));
+      // only when it says it has some (flags, never probes). The flag going
+      // OFF is information too: the parent removed its last peer, or switched
+      // federation off. Either way nothing we hold for it is reachable any
+      // more, so the peers we have are reconciled against an empty list —
+      // flagged missing, and the browser moved off one being browsed.
+      if (!server.isFederated) {
+        if (scoped?['federationBrowse'] == true) {
+          unawaited(refreshFederatedPeers(server));
+        } else if (scoped != null && federatedChildren(server).isNotEmpty) {
+          unawaited(_reconcilePeers(server, const []));
+        }
       }
     } catch (err) {
       if (throwErr) {
@@ -1726,7 +1734,12 @@ class ServerManager {
       appLog('[federation] peer list on ${parent.localname} failed: $err');
       return;
     }
+    await _reconcilePeers(parent, peers);
+  }
 
+  /// Fold the parent's peer list ([peers], possibly empty) into the servers
+  /// held for it. See [refreshFederatedPeers] for the rules.
+  Future<void> _reconcilePeers(Server parent, List peers) async {
     bool changed = false;
     // Ids first, names second: a peer the admin removed and re-added comes
     // back under a NEW row id (the plan's "peer ids are parent-side rowids"

--- a/lib/widgets/browser_toolbar.dart
+++ b/lib/widgets/browser_toolbar.dart
@@ -92,7 +92,7 @@ class _BrowserToolbarState extends State<BrowserToolbar> {
     // keeps logical focus through back/keyboard-dismiss and navigation (Flutter
     // even restores it on return to home), which left the preview stuck on.
     _navSub = BrowserManager().browserListStream.listen((list) {
-      final isHome = list.isNotEmpty && list[0].type == 'execAction';
+      final isHome = BrowserManager.isHomeList(list);
       if (!isHome && _homeSearchFocus.hasFocus) _homeSearchFocus.unfocus();
     });
   }
@@ -414,7 +414,7 @@ class _BrowserToolbarState extends State<BrowserToolbar> {
 
     // Home section list: the "search the whole server" field, plus a checkbox
     // dropdown that picks which categories the search queries (persisted).
-    final isHome = s.list.isNotEmpty && s.list[0].type == 'execAction';
+    final isHome = BrowserManager.isHomeList(s.list);
     if (isHome) {
       return Row(children: [
         const SizedBox(width: 8),

--- a/lib/widgets/queue_list.dart
+++ b/lib/widgets/queue_list.dart
@@ -17,6 +17,7 @@ import '../singletons/downloads.dart';
 import '../singletons/media.dart';
 import '../singletons/server_list.dart';
 import '../theme/velvet_theme.dart';
+import '../singletons/log_manager.dart';
 import '../util/media_format.dart';
 import '../util/image_cache.dart';
 import 'auto_dj_start_sheet.dart';
@@ -592,8 +593,21 @@ Future<void> toggleAutoDJ(BuildContext context) async {
   if (current == null) return;
   final handler = MediaManager().audioHandler;
   final messenger = ScaffoldMessenger.of(context);
+  // A shared (federated) server cannot run the DJ — its random-songs route
+  // is off the federation allowlist — so say so instead of a silent 403.
+  // Only ENABLING is refused: switching the DJ off while a peer is browsed
+  // (the `current == state` branch can never be a peer) must keep working.
+  void refusePeer() {
+    appLog('[dj] refused: ${current.localname} is a shared (federated) server');
+    messenger.showSnackBar(
+        SnackBar(content: Text(l.federatedAutoDjUnavailable)));
+  }
   final Server? state = handler.customState.valueOrNull?.autoDJState as Server?;
   if (state == null) {
+    if (current.isFederated) {
+      refusePeer();
+      return;
+    }
     // Nothing queued: the DJ has no cue to work from, so it needs a first
     // track before it means anything. With a queue this never runs — the DJ
     // reads what is already there, which is why the old standing "seed song"
@@ -611,6 +625,10 @@ Future<void> toggleAutoDJ(BuildContext context) async {
     handler.customAction('setAutoDJ', {'autoDJServer': null});
     messenger.showSnackBar(SnackBar(content: Text(l.autoDjDisabled)));
   } else {
+    if (current.isFederated) {
+      refusePeer();
+      return;
+    }
     handler.customAction('setAutoDJ', {'autoDJServer': current});
     messenger.showSnackBar(
         SnackBar(content: Text(l.autoDjEnabledFor(current.url))));

--- a/lib/widgets/track_actions_sheet.dart
+++ b/lib/widgets/track_actions_sheet.dart
@@ -278,8 +278,12 @@ class TrackActionsSheet extends StatelessWidget {
               await addToQueueEnd(item);
               _queuedToast();
             }),
-          if (isServerTrack) ...[
+          // Playlists live on the user's OWN server: adding a peer's path
+          // would store one the parent cannot resolve (and every playlist
+          // route is off the federation allowlist besides).
+          if (isServerTrack && item.server?.isFederated != true)
             action(Icons.playlist_add, l.trackAddToPlaylist, _addToPlaylist),
+          if (isServerTrack) ...[
             // downloadOneFile does its own progress/error snackbars, so no
             // toast here; referenceItem keeps the row's download badge live.
             action(
@@ -327,17 +331,21 @@ class _TrackBadges extends StatelessWidget {
     final m = item.metadata;
     final key = m?.musicalKey?.trim();
     final bpm = m?.bpm;
+    // A federated peer's tracks: no rating (rate-song is off the federation
+    // allowlist, and the rating would be someone else's anyway) and no lyrics
+    // badge (the lyrics route is off it too, so nothing could open them).
+    final federated = item.server?.isFederated == true;
     return Wrap(
       spacing: 8,
       runSpacing: 8,
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
-        _SheetRating(item: item),
+        if (!federated) _SheetRating(item: item),
         if (key != null && key.isNotEmpty)
           factBadge(Icons.piano, key),
         // A tempo of 0 is "the scanner found no BPM", not a 0-BPM song.
         if (bpm != null && bpm > 0) factBadge(Icons.speed, '$bpm BPM'),
-        if (m?.hasLyrics == true)
+        if (m?.hasLyrics == true && !federated)
           factBadge(Icons.lyrics_rounded, l.lyricsTitle),
       ],
     );

--- a/smoke/android/federation-rig.sh
+++ b/smoke/android/federation-rig.sh
@@ -89,10 +89,13 @@ json.dump([b]+L, open(dst,'w'))
 PY
 app_stop; cfg_write servers.json "$RIG/servers.json"; logcat_clear; wake; app_start
 wait_for_log '\[app\] default server ready' 30 || fail "default never published"
-for i in $(seq 1 30); do
+# The reconcile runs once the parent's capability refresh lands; over a
+# just-enabled Quick Connect the first dial can stall in the handshake for
+# ~13s once or twice before a retry lands, so allow a generous window.
+for i in $(seq 1 90); do
   cfg_read servers.json | python3 -c "import sys,json; sys.exit(0 if any(s.get('federationParent')=='$PARENT' for s in json.load(sys.stdin)) else 1)" && break; sleep 1
 done
-[ "$i" -lt 30 ] && pass "peer reconciled under $PARENT in ${i}s" || { save_applog rig-launch; fail "no peer entry after 30s"; summary; exit 1; }
+[ "$i" -lt 90 ] && pass "peer reconciled under $PARENT in ${i}s" || { save_applog rig-launch; fail "no peer entry after 90s"; summary; exit 1; }
 N=$(cfg_read servers.json | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
 PEER_Y=$((222 + 144 * (N - 1))) # picker rows: 222, 366, 510, … — the peer is listed last
 tap $PICKER; sleep 1.5; shot picker; tap 639 $PEER_Y; sleep 3

--- a/smoke/android/federation-rig.sh
+++ b/smoke/android/federation-rig.sh
@@ -122,4 +122,7 @@ if [ "$IROH" = 1 ]; then
 fi
 media_key pause; sleep 1
 save_applog federation-rig
+# SMOKE_RIG_KEEP=1: leave both servers running and the phone on the rig config
+# for checks done by hand afterwards (restore with cfg_restore + kill the nodes).
+if [ "${SMOKE_RIG_KEEP:-0}" = 1 ]; then trap - EXIT; log "kept: servers $NODES up, phone on the rig config, backup in $CFG_BACKUP"; fi
 summary

--- a/smoke/recipes/federation-lifecycle.md
+++ b/smoke/recipes/federation-lifecycle.md
@@ -1,0 +1,20 @@
+# Federation peer lifecycle (by hand, on the rig)
+
+Run `android/federation-rig.sh` with `SMOKE_RIG_KEEP=1` (HTTP mode is the
+reliable transport for these; the rig's just-enabled Quick Connect stalls its
+first dials), then drive the steps below against the kept servers. Admin calls
+use the rig user (`rig` / `rigpw`); a small helper with `tok`, `revoke_key`,
+`del_peer`, `add_peer`, `peer_list` lives in the session that ran it — the
+routes are `POST /api/v1/auth/login`, `DELETE /api/v1/admin/federation/keys/:id`
+(on A), `DELETE|POST /api/v1/admin/federation/peers[/:id]` (on B, the POST takes
+`{ticket}` from a fresh mint on A: `POST /api/v1/admin/federation/keys
+{name, vpaths:["demo"]}` → `.ticket`).
+
+| Step | Do | Expect (2026-09-02 results) |
+|---|---|---|
+| Key revoked on the peer | revoke A's key; browse + play the peer | browse fails fast (`db/album-songs → 502` in 54 ms, "Failed To Connect To Server"); a queued track falls back to its download; a failed auto-download raises the generic toast. A's log then repeats `usage flush failed for key id=1: FOREIGN KEY constraint failed` every 15 s — server bug. |
+| Peer removed and re-added (new row id) | `del_peer`, `add_peer`; switch to the parent | `[federation] peer-…: peer id 1 → 2 (re-added on rig-b)`, one record, downloads intact. B's first dial with the new key is rejected for ~60 s: A backs off an endpoint after 5 failed handshakes (`BACKOFF_MS`), and the revoked-key attempts count. |
+| Parent's last peer removed while browsed | `del_peer`; relaunch with the peer as the default | `default server ready: peer-…` → `[federation] … no longer shared by rig-b — leaving it for the parent` → `[srv] switched to rig-b`; a second relaunch opens on the first selectable server. Manage Servers: "No longer shared by …", row tap → Info, menu = Info + Forget; Forget drops the record and its queued tracks (`[queue] server … removed — dropping 6`), keeps the folder unless ticked. |
+| Peer offline, parent up | `kill` A's node; browse the peer | `album-songs → 502 (15108ms)` after B's dial deadline, then the error state; B's bridge recovers by itself once A is back. |
+| Cheap taps | search, Artists, Recent, airplane-mode play of a downloaded peer track | `db/artists → 200`, `db/recent/added → 200`, PLAYING from disk. Search needed the home-list fix (the note row hid the search field). |
+| Parent outage over Quick Connect, peer track streaming | tunnel-mode config, auto-download off, play, airplane 45 s | `status connected → reconnecting` at the idle timeout; buffer runs out → `[play] iroh recovery: tunnel not ready for peer-… — parked`; on reconnect `iroh tunnel back — resuming parked playback`, PLAYING within 1 s. |

--- a/test/media/auto_root_tabs_test.dart
+++ b/test/media/auto_root_tabs_test.dart
@@ -1,0 +1,30 @@
+// The car tree's root for a federated peer: read-only, no DJ. Shuffle All
+// hands the library to Auto DJ (random-songs, off the federation allowlist)
+// and Playlists lists routes the allowlist refuses, so a peer's root has
+// neither; a plain server keeps both.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/auto_browse.dart';
+import 'package:mstream_music/objects/server.dart';
+
+void main() {
+  List<String> titles(Server s) =>
+      AutoBrowse.rootTabs(s).map((m) => m.title).toList();
+
+  test('a plain server offers Shuffle All and Playlists', () {
+    final s = Server('https://music.example.com', null, null, 'jwt', 'home');
+    expect(titles(s), containsAll(['Shuffle All', 'Playlists', 'Albums']));
+  });
+
+  test('a federated peer offers neither', () {
+    final parent = Server('https://home.example.com', null, null, 'jwt', 'home');
+    final peer = Server('federated://home/3', null, null, null, 'peer-b')
+      ..federationParent = 'home'
+      ..federationPeerId = 3
+      ..parentServer = parent;
+    final t = titles(peer);
+    expect(t, isNot(contains('Shuffle All')));
+    expect(t, isNot(contains('Playlists')));
+    expect(t, containsAll(['Recently Added', 'Albums', 'Artists', 'Files']));
+  });
+}

--- a/test/objects/federated_server_test.dart
+++ b/test/objects/federated_server_test.dart
@@ -114,6 +114,31 @@ void main() {
     });
   });
 
+  group('selectable', () {
+    // Phase 3: the picker and the car offer a peer only while its parent
+    // still lists it and the user has not hidden it.
+    test('a listed, unhidden peer is selectable', () {
+      expect(_pair().peer.isSelectable, isTrue);
+    });
+
+    test('a peer the parent stopped listing is not', () {
+      expect((_pair().peer..federationMissing = true).isSelectable, isFalse);
+    });
+
+    test('a hidden peer is not, and the flag survives a round trip', () {
+      final peer = _pair().peer..federationHidden = true;
+      expect(peer.isSelectable, isFalse);
+      final back = Server.fromJson(peer.toJson());
+      expect(back.federationHidden, isTrue);
+      expect(back.isSelectable, isFalse);
+    });
+
+    test('a plain server is always selectable', () {
+      final s = Server('https://music.example.com', null, null, null, 'main');
+      expect(s.isSelectable, isTrue);
+    });
+  });
+
   group('credentials', () {
     test('a peer authenticates with the parent token, never its own', () {
       final p = _pair();

--- a/test/objects/federated_server_test.dart
+++ b/test/objects/federated_server_test.dart
@@ -6,6 +6,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/singletons/server_list.dart';
 import 'package:mstream_music/util/stream_url.dart';
 
 /// A parent + one peer of it, wired the way ServerManager wires them.
@@ -136,6 +137,49 @@ void main() {
     test('a plain server is always selectable', () {
       final s = Server('https://music.example.com', null, null, null, 'main');
       expect(s.isSelectable, isTrue);
+    });
+  });
+
+  group('reconcile helpers', () {
+    Server child(String name, int id) =>
+        Server('federated://home/$id', null, null, null, 'peer-$id')
+          ..federationParent = 'home'
+          ..federationPeerId = id
+          ..federationPeerName = name;
+
+    test('a re-added peer is adopted by its old record, by name', () {
+      // The admin removed "Basement" (id 3) and re-added it: the parent now
+      // lists id 7 under the same name and nobody holds 7.
+      final old = child('Basement', 3);
+      final other = child('Attic', 4);
+      expect(ServerManager.adoptablePeer([old, other], 'Basement', {7, 4}),
+          same(old));
+    });
+
+    test('a child whose id is still listed is never adopted', () {
+      // Two peers can share a name; the one the parent still lists stays.
+      final live = child('Basement', 3);
+      expect(ServerManager.adoptablePeer([live], 'Basement', {3, 7}), isNull);
+    });
+
+    test('a different name is never adopted', () {
+      expect(
+          ServerManager.adoptablePeer([child('Attic', 4)], 'Basement', {7}),
+          isNull);
+    });
+
+    test('the default skips a hidden or missing peer at index 0', () {
+      final parent = Server('https://home.example.com', null, null, 'j', 'home');
+      final hidden = child('Basement', 3)
+        ..parentServer = parent
+        ..federationHidden = true;
+      final missing = child('Attic', 4)
+        ..parentServer = parent
+        ..federationMissing = true;
+      expect(ServerManager.firstSelectable([hidden, missing, parent]),
+          same(parent));
+      // Nothing selectable at all: fall back to the first, never crash.
+      expect(ServerManager.firstSelectable([hidden]), same(hidden));
     });
   });
 

--- a/test/singletons/federated_nav_test.dart
+++ b/test/singletons/federated_nav_test.dart
@@ -5,6 +5,7 @@
 // this device's own downloads either way.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/objects/display_item.dart';
 import 'package:mstream_music/objects/server.dart';
 import 'package:mstream_music/singletons/browser_list.dart';
 import 'package:mstream_music/singletons/server_list.dart';
@@ -110,5 +111,26 @@ void main() {
     expect(_sections(), contains('playlists'));
     expect(_sections(), contains('rated'));
     expect(BrowserManager().browserList.any((i) => i.type == 'note'), isFalse);
+  });
+
+  group('BrowserManager.isHomeList', () {
+    DisplayItem row(String type) =>
+        DisplayItem(null, type, type, null, null, null);
+    test('a section list is home', () {
+      expect(BrowserManager.isHomeList([row('execAction'), row('execAction')]),
+          isTrue);
+    });
+    test("a peer's leading note does not demote its home", () {
+      // The toolbar's whole-server search and the card grid key on this; the
+      // note used to make a peer's home a plain list without the search.
+      expect(BrowserManager.isHomeList([row('note'), row('execAction')]),
+          isTrue);
+    });
+    test('anything else is not home', () {
+      expect(BrowserManager.isHomeList([row('file'), row('execAction')]),
+          isFalse);
+      expect(BrowserManager.isHomeList([row('note')]), isFalse);
+      expect(BrowserManager.isHomeList(const []), isFalse);
+    });
   });
 }


### PR DESCRIPTION
Stacked on #141 (Phase 4), which is stacked on #129. Every surface whose route the federation allowlist refuses is now gated on `isFederated`, at the track level where a peer's track can sit in a queue browsed from another server.

## What changed

- **Auto DJ.** The panel's server dropdown skips peers; the queue-header toggle refuses a peer with a snack and a log line (turning the DJ *off* while a peer is browsed still works); CarPlay's toggle and the car's Shuffle All refuse with a log line; the handler's `setAutoDJ` action is the backstop for every entry point.
- **Track sheet.** No rating badge, no lyrics badge and no Add to playlist for a peer's track — Download stays. The metadata screen's lyrics chip is gated the same way.
- **Share** blocks a queue of peer tracks with its own message, ahead of the iroh "no public URL" block.
- **Torrent.** The add-torrent screen offers only the user's own servers.
- **Car root.** A peer's root has no Shuffle All and no Playlists (`AutoBrowse.rootTabs`, now test-visible).
- **Manage servers.** A peer row shows its name, a hub icon and "via <parent>" (or "No longer shared by <parent>"), and offers Info plus Hide/Show — no Edit, no pairing code, no Delete.
- **The Forget decision.** Peers are the parent admin's data, so a removed peer would come back on the next reconcile. Hiding is the durable choice: `federationHidden` is persisted and honoured by the picker and the car through `Server.isSelectable`; hiding the browsed peer moves the browser to its parent first. Forget (delete) appears only once the parent has stopped listing the peer.
- Strings: six new keys; generated locale files regenerated.

`FEDERATION_PLAN.md` Phase 3 marked done.

## Verification

| | Result |
|---|---|
| `flutter test` | 469 pass (+6: `isSelectable` and the hidden flag's round trip; a peer's car root has neither Shuffle All nor Playlists) |
| analyzer | 17-issue baseline |
| `smoke/android/federation-rig.sh`, HTTP mode | 7/7 |
| by hand on the rig (Galaxy S25, screenshots in `smoke/out/`) | Auto DJ on the peer → the snack + `[dj] refused` in the log · peer track sheet → no rating/lyrics badge, no Add to playlist, Download present · Share Playlist → "Can't share this queue … live in someone else's library" · Add torrent → defaults to the parent · Manage Servers → peer row with hub icon and "via", menu = Make Default / Info / Hide; Hide dims the row, drops it from the picker and moves the browser to the parent (`[srv] switched to rig-b`); Show restores it · **`.m3u` on the peer**: File Explorer lists `mix.m3u`, opening it POSTs `file-explorer/m3u` through the proxy (200) and lists its entries, and an entry plays — keep the rows |

Noticed, not fixed here: the m3u listing shows the `#EXTM3U` header as a row on any server (pre-existing); and the rig's *freshly enabled* Quick Connect endpoint stalled the phone's first tunnel dials in the handshake (13 s each) in several runs — worth a look on the server side, independent of federation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)