### PR TITLE
feat(federation): direct access to a peer over its own tunnel (#143 step 4) + Quick Connect cap removal

### DIFF
--- a/FEDERATION_PLAN.md
+++ b/FEDERATION_PLAN.md
@@ -313,6 +313,54 @@ now; lifting it is a separate change.
 `for=<localname>` suffix, since two tunnels would otherwise be
 indistinguishable in a Diagnostics export.
 
+### Phase 7 — direct access: a peer over a tunnel of its own ✅ done
+
+The point of issue #143: a peer's bytes no longer cross the parent's home
+link twice, the peer stays usable while the parent is down, and there is one
+hop less latency. Server side: mStream#943 (guest tokens, the parent's
+`access` route, the `mstrfedg1:` guest ticket, `federationDirect` in the
+`/api` user block). App side, this phase.
+
+**The mode is the peer's own tunnel port.** `Server.isDirect` is true while
+the peer holds a `tunnelPort` of its own — the manager binds it when the
+peer's tunnel is up and clears it when that tunnel goes — and every accessor
+reads through it: `transportServer` is the peer itself, `effectiveBaseUrl`
+its loopback, `authToken` the guest token, `localTokenQuery` its own `__lt`,
+`apiUri` the plain path. The three URL builders take the plain `/media` and
+`/album-art` shapes for a direct peer and the parent's proxy shapes
+otherwise; `albumArtFileFromUrl` already read both. `ownsTunnel` (a Quick
+Connect server, or a direct peer) is the "has a tunnel of its own" question
+the manager and the strip ask; `isIroh` stays identity.
+
+**The manager.** A federated peer that is browsed or queued is a target of
+its own when its parent advertises `federationDirect`, nobody declined this
+session, and the parent still lists it — with the parent's tunnel kept as a
+target too until the peer is direct (the proxy serves meanwhile). The peer's
+handle keys by localname and dials with its guest ticket
+(`TunnelHandle.credentialFor`), fetched from the parent on demand
+(`GET …/peers/:id/access`, waiting for a Quick Connect parent's tunnel
+first) and recorded on the peer with its expiry. A tunnel that is up gets a
+fresh ticket swapped in place once three quarters of the lifetime is gone
+(`IrohTunnel.setCredential` — same port, the queued URLs survive; only
+upcoming items take the new token). A refused guest token is asked for
+again rather than treated as a re-pair: at the first dial through one forced
+refresh and a quick retry, on a running tunnel through the poll, on a browse
+401 at once. A parent that answers `direct: false` puts the peer on the
+proxy for the session. When a direct tunnel goes, the queued URLs are
+rebuilt against the parent.
+
+**What the user sees.** The strip follows a browsed direct peer's own
+tunnel; a peer handle that is still an attempt never puts Repair or Retry on
+the strip (the proxy is serving). Log lines: `[federation] <peer>: direct
+access issued/unchanged/no direct access`, the peer's own `[iroh] … for=<peer>`
+lifecycle with `mode=guest` in the native events.
+
+**Also in this phase: the one-Quick-Connect-server cap is gone.** The native
+layer keys tunnels by server and the manager runs one per server, so the
+add-server screen and its backstop no longer refuse a second Quick Connect
+server. A server that is neither browsed nor queued has no tunnel, so a phone
+with several paired servers still runs one most of the time.
+
 ### Phase 5 — optional: make Discover leads actionable
 
 `/api/v1/discovery/federation/similar` already returns `peer:{id,name}` on the

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1096,10 +1096,6 @@
   "@irohPairingBody": {
     "description": "Explainer under the pairing-code section header on the Quick Connect tab."
   },
-  "irohOneServerLimit": "Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.",
-  "@irohOneServerLimit": {
-    "description": "Shown on the iroh add-server tab when an iroh server already exists (only one is allowed)."
-  },
   "irohPairingCodeLabel": "Pairing code",
   "@irohPairingCodeLabel": {
     "description": "Text field label for the iroh pairing code (add-server iroh tab and the re-pair sheet)."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2742,12 +2742,6 @@ abstract class AppLocalizations {
   /// **'Enable Remote Access on the server, then paste its pairing code or scan the QR.'**
   String get irohPairingBody;
 
-  /// Shown on the iroh add-server tab when an iroh server already exists (only one is allowed).
-  ///
-  /// In en, this message translates to:
-  /// **'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.'**
-  String get irohOneServerLimit;
-
   /// Text field label for the iroh pairing code (add-server iroh tab and the re-pair sheet).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1585,10 +1585,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
-  String get irohOneServerLimit =>
-      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
-
-  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1565,10 +1565,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
-  String get irohOneServerLimit =>
-      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
-
-  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1583,10 +1583,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
-  String get irohOneServerLimit =>
-      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
-
-  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1583,10 +1583,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
-  String get irohOneServerLimit =>
-      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
-
-  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1584,10 +1584,6 @@ class AppLocalizationsIt extends AppLocalizations {
       'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
-  String get irohOneServerLimit =>
-      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
-
-  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1517,10 +1517,6 @@ class AppLocalizationsJa extends AppLocalizations {
       'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
-  String get irohOneServerLimit =>
-      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
-
-  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1599,10 +1599,6 @@ class AppLocalizationsPl extends AppLocalizations {
       'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
-  String get irohOneServerLimit =>
-      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
-
-  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1580,10 +1580,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
-  String get irohOneServerLimit =>
-      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
-
-  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1603,10 +1603,6 @@ class AppLocalizationsRu extends AppLocalizations {
       'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
-  String get irohOneServerLimit =>
-      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
-
-  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1486,10 +1486,6 @@ class AppLocalizationsZh extends AppLocalizations {
       'Enable Remote Access on the server, then paste its pairing code or scan the QR.';
 
   @override
-  String get irohOneServerLimit =>
-      'Only one peer-to-peer (iroh) server is supported. Remove the existing one to connect a different server.';
-
-  @override
   String get irohPairingCodeLabel => 'Pairing code';
 
   @override

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -306,14 +306,15 @@ class AudioPlayerHandler extends BaseAudioHandler
     // stays selected — and, with more than one tunnel server queued, keeps
     // all of them reachable.
     queue.listen((items) {
-      final transports = <String, Server>{};
+      // The item's OWN server, not its transport: a federated peer's songs
+      // ride its parent's tunnel on the proxy path and the peer's own once it
+      // is direct, and the manager is where that decision lives.
+      final servers = <String, Server>{};
       for (final it in items) {
-        // A federated peer's songs ride its parent's tunnel: that is the
-        // server to keep connected, not the peer (which has no tunnel).
-        final s = _serverFor(it)?.transportServer;
-        if (s != null && s.isIroh) transports[s.localname] = s;
+        final s = _serverFor(it);
+        if (s != null) servers[s.localname] = s;
       }
-      ServerManager().setQueueIrohServers(transports.values);
+      ServerManager().setQueueIrohServers(servers.values);
       // Keep-queue-offline: sweep every queue change for tracks to download.
       // No-op unless the setting is on; DownloadManager dedupes (in-flight,
       // once-per-session, already-on-disk). Lives here — not main.dart — so

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -2629,7 +2629,12 @@ class AudioPlayerHandler extends BaseAudioHandler
   /// Downloaded items are left alone — they play from the local copy, so their
   /// URL is irrelevant.
   MediaItem _withRebuiltUrl(MediaItem m) {
-    if (m.extras?['localPath'] != null) return m;
+    // A downloaded copy plays from disk, so its URL is irrelevant — while the
+    // file is there. One that vanished (storage cleared, the folder pruned)
+    // falls back to the stored URL at load time, so it is rebuilt like a
+    // streaming item; left alone it would carry a dead port or, for a
+    // direct peer, an expired guest token.
+    if (hasLocalCopy(m)) return m;
     final path = m.extras?['path'] as String?;
     final server = _serverFor(m);
     if (path == null || server == null) return m; // local-only / unknown server
@@ -2644,6 +2649,32 @@ class AudioPlayerHandler extends BaseAudioHandler
     final server = _serverFor(m);
     if (server == null || !server.isIrohTransport) return m;
     return rebindLoopbackArt(m, server);
+  }
+
+  /// Whether [m] plays from a downloaded copy that is actually on disk.
+  static bool hasLocalCopy(MediaItem m) {
+    final localPath = m.extras?['localPath'];
+    return localPath is String && File(localPath).existsSync();
+  }
+
+  /// Whether an "upcoming only" rebuild really should leave the current item
+  /// alone. The option exists to keep a track that is PLAYING from reloading
+  /// mid-song (buffering counts; so does a finished queue, where there is
+  /// nothing upcoming and nothing to restart). A current item the backend is
+  /// not holding — idle after a failed load, never started — or one still
+  /// loading has nothing to protect and may be the very URL that needs the
+  /// change: a direct peer's renewed guest token, a tunnel that came up under
+  /// a parked player. Pure; unit-tested.
+  static bool protectsCurrentTrack(
+      {required bool upcomingOnly, required BackendProcessingState state}) {
+    if (!upcomingOnly) return false;
+    return switch (state) {
+      BackendProcessingState.ready ||
+      BackendProcessingState.buffering ||
+      BackendProcessingState.completed =>
+        true,
+      BackendProcessingState.idle || BackendProcessingState.loading => false,
+    };
   }
 
   /// The URI the CURRENT item actually plays from: the downloaded file when
@@ -2688,7 +2719,13 @@ class AudioPlayerHandler extends BaseAudioHandler
     // everything and wants the LOGICAL spot instead.
     final cur = (_backend.currentIndex ?? 0).clamp(0, q.length - 1);
 
-    if (upcomingOnly) {
+    final protectCurrent = protectsCurrentTrack(
+        upcomingOnly: upcomingOnly, state: _backend.processingState);
+    if (upcomingOnly && !protectCurrent) {
+      appLog('[queue] upcoming-only rebuild widened to the current track '
+          '(${_backend.processingState.name})');
+    }
+    if (protectCurrent) {
       final rebuilt = <MediaItem>[];
       bool changed = false;
       for (int i = 0; i < q.length; i++) {

--- a/lib/objects/direct_access.dart
+++ b/lib/objects/direct_access.dart
@@ -1,0 +1,74 @@
+// What a parent hands out for reaching one of its federated peers DIRECTLY —
+// `GET /api/v1/federation/peers/:id/access` (mStream#943). Pure parsing, so
+// the shape the app depends on is pinned by a unit test instead of by a
+// two-server rig.
+//
+// The parent answers one of three ways, and the app treats them differently:
+//   direct: true   — a guest token the peer minted for the parent's key, the
+//                    peer's endpoint ticket, and both packaged as a
+//                    `mstrfedg1:` ticket for the native dial → go direct;
+//   direct: false  — the peer will not mint (an older build, or federation
+//                    switched off there) → the proxy path is all there is;
+//   anything else  — a malformed 200 → transient, try again later.
+
+class DirectAccess {
+  const DirectAccess({
+    required this.endpointTicket,
+    required this.endpointId,
+    required this.guestToken,
+    required this.ticket,
+    required this.expiresAt,
+  });
+
+  /// The peer's iroh EndpointTicket (routing info, not a secret).
+  final String endpointTicket;
+
+  /// The peer's endpoint id (a public key), or null when the parent could
+  /// not read the ticket. Lets a later step notice one peer listed by two
+  /// parents.
+  final String? endpointId;
+
+  /// The guest JWT: what every request to the peer carries in the ordinary
+  /// token slots (`x-access-token`, `?token=`).
+  final String guestToken;
+
+  /// The `mstrfedg1:` envelope of endpoint ticket + guest token — what the
+  /// native dial (and the in-place credential swap) takes, verbatim.
+  final String ticket;
+
+  /// When the guest token expires (UTC). The parent re-mints past three
+  /// quarters of the lifetime; the app asks again on the same schedule.
+  final DateTime expiresAt;
+
+  /// Null when the parent answered `direct: false`. Throws [FormatException]
+  /// on a 200 that is missing fields, which callers treat as transient —
+  /// unlike a refusal, which holds for the session.
+  static DirectAccess? fromJson(Map json) {
+    if (json['direct'] != true) return null;
+    final t = json['endpointTicket'];
+    final g = json['guestToken'];
+    final d = json['directTicket'];
+    final e = json['expiresAt'];
+    if (t is! String ||
+        t.isEmpty ||
+        g is! String ||
+        g.isEmpty ||
+        d is! String ||
+        !d.startsWith('mstrfedg') ||
+        e is! String) {
+      throw const FormatException('direct access payload is missing fields');
+    }
+    final expiresAt = DateTime.tryParse(e);
+    if (expiresAt == null) {
+      throw const FormatException('direct access expiresAt is not a date');
+    }
+    final id = json['endpointId'];
+    return DirectAccess(
+      endpointTicket: t,
+      endpointId: id is String && id.isNotEmpty ? id : null,
+      guestToken: g,
+      ticket: d,
+      expiresAt: expiresAt.toUtc(),
+    );
+  }
+}

--- a/lib/objects/server.dart
+++ b/lib/objects/server.dart
@@ -56,6 +56,12 @@ class Server {
   //                                  flag's real payload is "this server
   //                                  VERSION has the route" (mStream #762)
   bool? discoveryPathAvailable;
+  //   federationDirectAvailable    — this server hands its devices DIRECT
+  //                                  access to its federated peers (the
+  //                                  `access` route, mStream#943); read on
+  //                                  the PARENT, decides whether a peer of
+  //                                  it is worth dialing directly
+  bool? federationDirectAvailable;
 
   // authentication is optional (mstream servers can be public OR private)
   String? username;
@@ -113,20 +119,52 @@ class Server {
 
   bool get isFederated => federationParent != null;
 
-  /// The server whose transport carries this server's bytes: the parent for a
-  /// federated server, itself for everything else. Null only for a federated
-  /// server whose parent is not linked yet (nothing can be addressed then).
+  // ─── Direct access (issue #143) ─────────────────────────────────────
+  // Runtime-only, never persisted. The parent hands out a guest ticket for
+  // the peer's federation endpoint (`GET /api/v1/federation/peers/:id/access`);
+  // with it the peer gets a tunnel of its OWN and stops riding the parent's
+  // proxies — its bytes no longer cross the parent's home link twice, and it
+  // stays usable while the parent is down. The proxy path stays the
+  // fallback: an older peer, a refused mint, a failed dial.
+  //
+  // What decides the mode is [tunnelPort] on the peer ITSELF ([isDirect]):
+  // ServerManager binds it when the peer's own tunnel is up and clears it
+  // when that tunnel goes, and every accessor below reads through it — so a
+  // peer flips between the two URL shapes exactly when its tunnel does.
+  String? directTicket; // the `mstrfedg1:` envelope — what the native dial takes
+  String? directGuestToken; // the JWT inside it — what URLs carry as ?token=
+  String? directEndpointId;
+  DateTime? directExpiresAt;
+  DateTime? directFetchedAt;
+  // The parent answered `direct: false` (an older peer, or federation
+  // switched off there), or refused to mint anything fresh for a token the
+  // peer rejected: the proxy is all there is this session.
+  bool directDenied = false;
+
+  /// True while this peer is reached over a tunnel of its own.
+  bool get isDirect => isFederated && tunnelPort != null;
+
+  /// Whether requests for this server ride a loopback tunnel of ITS OWN: a
+  /// Quick Connect server always, a federated peer while it is direct.
+  /// ([isIroh] stays the identity question — the pairing-code menu, the edit
+  /// form, the repair sheet.)
+  bool get ownsTunnel => isIroh || isDirect;
+
+  /// The server whose transport carries this server's bytes: the parent for
+  /// a federated server on the proxy path, itself for everything else — a
+  /// direct peer included. Null only for a federated server whose parent is
+  /// not linked yet (nothing can be addressed then).
   ///
   /// Two different questions hide behind "is this an iroh server?": identity
-  /// (the pairing-code menu, the one-iroh cap, the edit form — [isIroh]) and
-  /// transport (does a request for it ride a loopback tunnel, and whose —
-  /// [isIrohTransport]). A peer of an iroh parent answers no to the first and
-  /// yes to the second.
-  Server? get transportServer => isFederated ? parentServer : this;
+  /// ([isIroh]) and transport (does a request for it ride a loopback tunnel,
+  /// and whose — [isIrohTransport]). A peer of an iroh parent answers no to
+  /// the first and yes to the second; a direct peer answers no and yes too,
+  /// on its own tunnel.
+  Server? get transportServer => isFederated && !isDirect ? parentServer : this;
 
   /// True when requests for this server travel over an iroh loopback tunnel —
-  /// its own, or its parent's for a federated server.
-  bool get isIrohTransport => transportServer?.isIroh == true;
+  /// its own, or its parent's for a federated server on the proxy path.
+  bool get isIrohTransport => transportServer?.ownsTunnel == true;
 
   /// What to call this server in the UI: a peer's name, or the URL that
   /// identifies every other kind of server.
@@ -177,12 +215,17 @@ class Server {
   /// (`/api/…`, `/art/…`, `/stream/…`). Meaningless unless [isFederated].
   String get federationPrefix => '/api/v1/federation/peers/$federationPeerId';
 
-  /// The token that authenticates requests for this server. A federated server
-  /// has none of its own: the proxy runs normal local-user auth on the PARENT,
-  /// and the peer beyond it is reached with the parent's federation key, which
-  /// never leaves the parent. Read this — not [jwt] — for anything that ends up
-  /// on the wire.
-  String? get authToken => isFederated ? parentServer?.jwt : jwt;
+  /// The token that authenticates requests for this server. A federated
+  /// server on the proxy path has none of its own: the proxy runs normal
+  /// local-user auth on the PARENT, and the peer beyond it is reached with
+  /// the parent's federation key, which never leaves the parent. A direct
+  /// peer carries the guest token the peer minted — a JWT the peer's wall
+  /// reads from the ordinary slots. Read this — not [jwt] — for anything
+  /// that ends up on the wire.
+  String? get authToken {
+    if (!isFederated) return jwt;
+    return isDirect ? directGuestToken : parentServer?.jwt;
+  }
 
   /// The base origin to use for requests/streams right now. A federated server
   /// borrows its parent's, which is what makes an iroh parent work for free —
@@ -192,8 +235,10 @@ class Server {
   /// active); for HTTP it's [url]. Before an iroh tunnel is up, or before a
   /// federated server's parent is linked, this is [_unroutable].
   String get effectiveBaseUrl {
-    if (isFederated) return parentServer?.effectiveBaseUrl ?? _unroutable;
-    return isIroh ? 'http://127.0.0.1:${tunnelPort ?? 0}' : url;
+    if (isFederated && !isDirect) {
+      return parentServer?.effectiveBaseUrl ?? _unroutable;
+    }
+    return ownsTunnel ? 'http://127.0.0.1:${tunnelPort ?? 0}' : url;
   }
 
   /// Query suffix authenticating a loopback request to the iroh tunnel
@@ -203,8 +248,8 @@ class Server {
   /// loopback, and the browse proxy forwards no query params onward, so the
   /// loopback token can't ride through to the peer.
   String get localTokenQuery {
-    if (isFederated) return parentServer?.localTokenQuery ?? '';
-    return (isIroh && tunnelToken != null) ? '&__lt=$tunnelToken' : '';
+    if (isFederated && !isDirect) return parentServer?.localTokenQuery ?? '';
+    return (ownsTunnel && tunnelToken != null) ? '&__lt=$tunnelToken' : '';
   }
 
   /// Resolve [location] against [effectiveBaseUrl], adding the loopback token for
@@ -214,13 +259,13 @@ class Server {
   /// then defers to the parent — so an iroh parent's `__lt` is applied once, to
   /// the outer loopback URL, and the peer sees only the proxied path.
   Uri apiUri(String location) {
-    if (isFederated) {
+    if (isFederated && !isDirect) {
       final parent = parentServer;
       if (parent == null) return Uri.parse(_unroutable);
       return parent.apiUri('$federationPrefix/api$location');
     }
     final u = Uri.parse(effectiveBaseUrl).resolve(location);
-    if (!isIroh || tunnelToken == null) return u;
+    if (!ownsTunnel || tunnelToken == null) return u;
     return u.replace(queryParameters: {
       ...u.queryParameters,
       '__lt': tunnelToken!,
@@ -267,6 +312,9 @@ class Server {
         discoveryPathAvailable = json['discoveryPathAvailable'] is bool
             ? json['discoveryPathAvailable']
             : null,
+        federationDirectAvailable = json['federationDirectAvailable'] is bool
+            ? json['federationDirectAvailable']
+            : null,
         connectionType = json['connectionType'] as String? ?? 'http',
         irohPairingCode = json['irohPairingCode'] as String?,
         federationParent = json['federationParent'] as String?,
@@ -302,6 +350,7 @@ class Server {
         'discoveryP2pAvailable': discoveryP2pAvailable,
         'federationDiscoveryAvailable': federationDiscoveryAvailable,
         'discoveryPathAvailable': discoveryPathAvailable,
+        'federationDirectAvailable': federationDirectAvailable,
         'connectionType': connectionType,
         'irohPairingCode': irohPairingCode,
         'federationParent': federationParent,

--- a/lib/screens/add_server.dart
+++ b/lib/screens/add_server.dart
@@ -1387,8 +1387,7 @@ class MyCustomFormState extends State<MyCustomForm> {
         _irohSignedInReady = !isPublic;
       });
       if (isPublic) {
-        // No credentials needed — save immediately (the form pops on success;
-        // the one-iroh cap backstop in _saveIrohServer clears state otherwise).
+        // No credentials needed — save immediately (the form pops on success).
         showGlobalSnack(l.connectionSuccessful);
         await _saveIrohServer(code: code, port: port, jwt: '');
       } else {
@@ -1511,12 +1510,6 @@ class MyCustomFormState extends State<MyCustomForm> {
   // the live tunnel adopted as the active connection, then switch to it.
   Future<void> _saveIrohServer(
       {required String code, required int port, required String jwt}) async {
-    // Backstop the one-iroh-server cap (the tab UI normally blocks reaching here).
-    if (ServerManager().hasIrohServer) {
-      if (mounted) setState(() => _irohSaving = false);
-      _showIrohResult(false, AppLocalizations.of(context).irohOneServerLimit);
-      return;
-    }
     final id = code.hashCode.toUnsigned(32).toRadixString(16);
     final username = _irohPublic ? '' : _irohUserCtrl.text;
     final password = _irohPublic ? '' : _irohPassCtrl.text;
@@ -1553,15 +1546,9 @@ class MyCustomFormState extends State<MyCustomForm> {
   Future<void> _connectDiscovered(DiscoveredServer server) async {
     final l = AppLocalizations.of(context);
     if (_connectingId != null) return; // one pairing at a time
-    // The manual paste/scan Test dials the SAME single native tunnel; two
-    // concurrent dials hand one flow the other's port and it silently binds
-    // the wrong server. The tiles and the Test button also disable while the
-    // sibling flow runs — this is the backstop.
+    // One pairing at a time: the tiles and the Test button also disable
+    // while the sibling flow runs — this is the backstop.
     if (_irohTesting) return;
-    if (ServerManager().hasIrohServer) {
-      _showIrohResult(false, l.irohOneServerLimit);
-      return;
-    }
     if (!IrohTunnel.isSupported) {
       _showIrohResult(false, l.irohAndroidOnly);
       return;
@@ -1571,8 +1558,8 @@ class MyCustomFormState extends State<MyCustomForm> {
       _showIrohResult(false, l.lanUnreachable);
       return;
     }
-    // A leftover tunnel from a paste/scan test would collide (single native
-    // tunnel) — drop it first.
+    // A leftover tunnel from a paste/scan test is not this server's — drop
+    // it first.
     if (_irohPort != null && !_irohSaved) {
       _stopTestTunnel();
       _irohPort = null;
@@ -1862,29 +1849,6 @@ class MyCustomFormState extends State<MyCustomForm> {
               const SizedBox(height: 16),
               Text(
                 l.irohAndroidOnly,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                    color: VelvetColors.textSecondary, fontSize: 14, height: 1.4),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-    // One iroh server max (a single native tunnel). If one's already configured,
-    // show why instead of the pairing UI.
-    if (ServerManager().hasIrohServer) {
-      return SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(28, 40, 28, 28),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(Icons.hub_outlined,
-                  size: 40, color: VelvetColors.textSecondary),
-              const SizedBox(height: 16),
-              Text(
-                l.irohOneServerLimit,
                 textAlign: TextAlign.center,
                 style: TextStyle(
                     color: VelvetColors.textSecondary, fontSize: 14, height: 1.4),

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io' show File;
 
 import './file_explorer.dart';
@@ -204,6 +205,11 @@ class ApiManager {
       appLog('[api] $getOrPost $location → ${response.statusCode} '
           '(${sw.elapsedMilliseconds}ms)');
 
+      // A direct peer refusing our guest token: the parent can hand out a
+      // fresh one, and the tunnel keeps its port meanwhile.
+      if (response.statusCode == 401 && server.isDirect) {
+        unawaited(ServerManager().onDirectAuthRejected(server));
+      }
       if (response.statusCode > 299) {
         throw Exception('Server Call Failed');
       }

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'package:mstream_music/singletons/file_explorer.dart';
 
 import '../objects/server.dart';
+import '../objects/direct_access.dart';
 import './api.dart';
 import './app_messenger.dart';
 import './browser_list.dart';
@@ -36,9 +37,11 @@ class ServerManager {
   // is a second entry here, not a second copy of the lifecycle.
   final Map<String, TunnelHandle> _tunnels = {};
 
-  // The transports the play queue references (pushed by the audio handler on
-  // every queue edit), and the release timers for the ones it let go of.
-  final Map<String, Server> _queueIrohServers = {};
+  // The servers the play queue references (pushed by the audio handler on
+  // every queue edit) — held as the item's own server, not its transport,
+  // because a federated peer's transport changes with its mode — and the
+  // release timers for the ones it let go of.
+  final Map<String, Server> _queueServers = {};
   final Map<String, Timer> _queueReleaseTimers = {};
 
   // ── Manager-wide reconnect bookkeeping (the rules live in tunnel_policy.dart) ──
@@ -140,6 +143,9 @@ class ServerManager {
                 reason: 'launch', bypassBackoff: true)
             .timeout(const Duration(seconds: 12), onTimeout: () {});
       }
+      // A federated default worth dialing directly gets its own tunnel next
+      // to the parent's; nothing else changes here.
+      unawaited(ensureTunnels(reason: 'launch'));
       // Publish the default to the UI now: it is usable as soon as it is
       // known. Everything below is background tunnel work for the queue and
       // used to hold the browser (blank panel, "Connecting…") for up to 12s.
@@ -171,17 +177,7 @@ class ServerManager {
   }
 
 
-  /// True when an iroh server is already configured. Only one is supported (a
-  /// single native tunnel), so the add-server flow gates a second one.
-  bool get hasIrohServer => serverList.any((s) => s.isIroh);
-
   Future<void> addServer(Server newServer) async {
-    // One iroh server max (single tunnel). The add-server UI blocks this; this is
-    // the code-level backstop so no other path can add a second.
-    if (newServer.isIroh && hasIrohServer) {
-      showGlobalSnack('Only one iroh server is supported.');
-      return;
-    }
     serverList.add(newServer);
 
     if (currentServer == null) {
@@ -310,18 +306,17 @@ class ServerManager {
   }
 
   Future<void> getServerPaths(Server server, {bool throwErr = false}) async {
-    // Whatever actually carries this server's bytes. A federated server has no
-    // transport of its own — it rides the parent's, so a peer of an iroh
-    // server has to wait on the PARENT's tunnel, not its own (it has none).
-    final transport = server.isFederated ? server.parentServer : server;
+    // Whatever actually carries this server's bytes: the parent's tunnel for
+    // a federated peer on the proxy path, the peer's own once it is direct.
+    final transport = server.transportServer;
     // A federated server whose parent isn't linked yet can't be addressed at
     // all; every URL would resolve to the unroutable origin.
     if (transport == null) {
       if (throwErr) throw Exception('federation parent not linked');
       return;
     }
-    // An iroh server can only be reached through its live tunnel.
-    if (transport.isIroh && transport.tunnelPort == null) {
+    // A tunnel server can only be reached through its live tunnel.
+    if (transport.ownsTunnel && transport.tunnelPort == null) {
       // At launch this fires for the ACTIVE server too: loadServerList pings
       // every server as soon as the list is read, and the tunnel is still
       // dialling. Skipping meant its capabilities and — since the version
@@ -361,6 +356,7 @@ class ServerManager {
       final bool? prevDiscovery = server.discoveryAvailable;
       final bool? prevDiscoveryP2p = server.discoveryP2pAvailable;
       final bool? prevFedDiscovery = server.federationDiscoveryAvailable;
+      final bool? prevFedDirect = server.federationDirectAvailable;
       final bool? prevDiscoveryPath = server.discoveryPathAvailable;
       final prevVersion = server.serverVersion;
 
@@ -411,8 +407,14 @@ class ServerManager {
           server.discoveryAvailable != prevDiscovery ||
           server.discoveryP2pAvailable != prevDiscoveryP2p ||
           server.federationDiscoveryAvailable != prevFedDiscovery ||
+          server.federationDirectAvailable != prevFedDirect ||
           server.discoveryPathAvailable != prevDiscoveryPath) {
         unawaited(writeServerFile());
+      }
+      // The parent just started offering direct access: any peer of it that
+      // is browsed or queued is worth a tunnel of its own right away.
+      if (server.federationDirectAvailable == true && prevFedDirect != true) {
+        unawaited(ensureTunnels(reason: 'direct-available'));
       }
 
       // Peers are the parent's data, so only a parent reconciles them — and
@@ -480,6 +482,8 @@ class ServerManager {
         features is Map && features['discoveryP2p'] == true;
     server.federationDiscoveryAvailable =
         user is Map && user['federationDiscovery'] == true;
+    server.federationDirectAvailable =
+        user is Map && user['federationDirect'] == true;
     // /api carries no discoveryPath. It was only ever a "this server VERSION
     // has the sonic-path route" gate, and mStream #934 records that it is
     // identical to `discovery` on every build carrying that code.
@@ -512,6 +516,7 @@ class ServerManager {
     server.discoveryAvailable = res['discovery'] == true;
     server.discoveryP2pAvailable = res['discoveryP2p'] == true;
     server.federationDiscoveryAvailable = res['federationDiscovery'] == true;
+    server.federationDirectAvailable = res['federationDirect'] == true;
     server.discoveryPathAvailable = res['discoveryPath'] == true;
     return res;
   }
@@ -615,17 +620,65 @@ class ServerManager {
   //  6. Handles are independent: one server's cold dial never delays
   //     another's, and a decision about one never stops another.
 
-  /// The transports that need a tunnel right now.
+  /// The transports that need a tunnel right now: for every referenced
+  /// server (browsed, or holding queued tracks) the Quick Connect server
+  /// itself, or — for a federated peer — the peer's own tunnel when it is
+  /// worth dialing directly, plus the parent's while the peer is not direct
+  /// yet (and whenever it is not), since the proxy path serves until then.
   Set<Server> _tunnelTargets() {
     final out = <Server>{};
-    final c = currentServer?.transportServer;
-    if (c != null && c.isIroh) out.add(c);
-    for (final q in _queueIrohServers.values) {
-      final t = q.transportServer;
-      if (t != null && t.isIroh) out.add(t);
+    void add(Server? referenced) {
+      if (referenced == null) return;
+      if (referenced.isFederated) {
+        if (_directWanted(referenced)) out.add(referenced);
+        final parent = referenced.parentServer;
+        // The parent's tunnel carries the proxy path until the peer is
+        // direct, and the access call whenever the peer's guest ticket has
+        // to be fetched again (stale, or refused by the peer).
+        if (parent != null &&
+            parent.isIroh &&
+            (!referenced.isDirect ||
+                _directTicketStale(referenced) ||
+                _directRefused(referenced))) {
+          out.add(parent);
+        }
+        return;
+      }
+      if (referenced.isIroh) out.add(referenced);
+    }
+
+    add(currentServer);
+    for (final q in _queueServers.values) {
+      add(q);
     }
     return out;
   }
+
+  /// Whether [peer] should have a tunnel of its own: its parent offers
+  /// direct access (the `federationDirect` flag), nobody declined for this
+  /// peer this session, and the parent still lists it.
+  bool _directWanted(Server peer) {
+    final parent = peer.parentServer;
+    return IrohTunnel.isSupported &&
+        parent != null &&
+        parent.federationDirectAvailable == true &&
+        !peer.directDenied &&
+        !peer.federationMissing;
+  }
+
+  /// The peer's own tunnel is up but its supervisor gave up on the guest
+  /// token (the peer answered "NO"): a refresh through the parent is due.
+  bool _directRefused(Server peer) {
+    final h = _tunnels[peer.localname];
+    return h != null &&
+        h.assigned &&
+        _nativeStatusOf(h) == IrohTunnelStatus.rejected;
+  }
+
+  bool _directTicketStale(Server peer) => TunnelPolicy.directTicketStale(
+      fetchedAt: peer.directFetchedAt,
+      expiresAt: peer.directExpiresAt,
+      now: DateTime.now());
 
   bool _isTarget(Server transport) =>
       _tunnelTargets().any((t) => t.localname == transport.localname);
@@ -643,8 +696,12 @@ class ServerManager {
   Server? _bannerTarget() => bannerTargetAmong(
         browsed: currentServer?.transportServer,
         background: [
+          // A peer's handle that is still an ATTEMPT (dialing, or refused)
+          // serves nothing yet — the proxy does — so its state is not the
+          // user's problem and must not put Repair/Retry on the strip.
           for (final h in _tunnels.values)
-            (server: h.server, status: _effectiveStatus(h)),
+            if (!h.server.isFederated || h.server.isDirect)
+              (server: h.server, status: _effectiveStatus(h)),
         ],
       );
 
@@ -668,24 +725,23 @@ class ServerManager {
   void setQueueIrohServers(Iterable<Server> servers) {
     final next = <String, Server>{};
     for (final s in servers) {
-      final t = s.transportServer;
-      if (t != null && t.isIroh) next[t.localname] = t;
+      if (s.isIroh || s.isFederated) next[s.localname] = s;
     }
     var changed = false;
     for (final e in next.entries) {
       _queueReleaseTimers.remove(e.key)?.cancel();
-      if (!_queueIrohServers.containsKey(e.key)) {
-        _queueIrohServers[e.key] = e.value;
+      if (!_queueServers.containsKey(e.key)) {
+        _queueServers[e.key] = e.value;
         changed = true;
       }
     }
-    for (final name in _queueIrohServers.keys.toList()) {
+    for (final name in _queueServers.keys.toList()) {
       if (next.containsKey(name) || _queueReleaseTimers.containsKey(name)) {
         continue;
       }
       _queueReleaseTimers[name] = Timer(TunnelTiming.queueReleaseGrace, () {
         _queueReleaseTimers.remove(name);
-        final was = _queueIrohServers.remove(name);
+        final was = _queueServers.remove(name);
         if (was == null) return;
         appLog('[iroh] queue no longer references ${was.localname} — '
             'releasing its tunnel');
@@ -707,7 +763,9 @@ class ServerManager {
   /// parent's tunnel is, so every caller may pass whichever server it holds.
   bool tunnelAssignedTo(Server s) {
     final h = _handleFor(s);
-    return h != null && h.assigned && h.code == h.server.irohPairingCode;
+    return h != null &&
+        h.assigned &&
+        h.code == TunnelHandle.credentialFor(h.server);
   }
 
   /// True when the tunnel for [s] is assigned AND reports connected — i.e.
@@ -752,7 +810,14 @@ class ServerManager {
     // A cold dial answered "NO": no native tunnel exists to say so, but the
     // strip must offer Repair, not Retry.
     if (h.startRejected && h.nativeKey == null) return IrohTunnelStatus.rejected;
-    return _nativeStatusOf(h);
+    final native = _nativeStatusOf(h);
+    // A direct peer whose supervisor gave up on a refused guest token is
+    // being refreshed from the parent (_maintainDirect), not re-paired:
+    // "reconnecting" is what the user should read.
+    if (h.server.isFederated && native == IrohTunnelStatus.rejected) {
+      return IrohTunnelStatus.reconnecting;
+    }
+    return native;
   }
 
   // Logged once: the reason the native tunnel is unavailable while a server
@@ -807,7 +872,9 @@ class ServerManager {
       {bool verify = false,
       String reason = 'ensure',
       bool bypassBackoff = false}) {
-    if (!IrohTunnel.isSupported || !transport.isIroh) return Future.value();
+    if (!IrohTunnel.isSupported || !(transport.isIroh || transport.isFederated)) {
+      return Future.value();
+    }
     final h = _handleOf(transport);
     h.pendingEnsures++;
     _startStatusPolling();
@@ -821,10 +888,9 @@ class ServerManager {
   Future<void> _ensureHandle(
       TunnelHandle h, bool verify, String reason, bool bypassBackoff) async {
     final s = h.server;
-    final code = s.irohPairingCode;
-    if (code == null) return;
     final name = s.localname;
-    if (h.assigned && h.code == code) {
+    String? credential = TunnelHandle.credentialFor(s);
+    if (h.assigned && credential != null && h.code == credential) {
       // Already wired up. The supervisor handles transient drops itself; only
       // rebuild on a verify when it's fully down (a reconnecting/rejected
       // tunnel is left alone — restarting wouldn't help).
@@ -855,6 +921,31 @@ class ServerManager {
       if (h.retryTimer == null && !h.startRejected) _scheduleRetry(h);
       return;
     }
+    if (s.isFederated && !h.assigned) {
+      // A peer's credential comes from its parent and expires: fetch it when
+      // missing, stale, or the one the peer refused. Behind the gates above
+      // on purpose — a parent that keeps failing is asked on the retry
+      // ladder, not on every reconcile. (A tunnel that is UP refreshes in
+      // place instead — _maintainDirect.)
+      if (credential == null ||
+          _directTicketStale(s) ||
+          credential == h.refusedCredential) {
+        final outcome = await _refreshDirectAccess(s,
+            force: credential != null && credential == h.refusedCredential);
+        credential = TunnelHandle.credentialFor(s);
+        if (credential == null || credential == h.refusedCredential) {
+          // Declined, unreachable, or the same refused token: the proxy
+          // serves; a transient failure gets the retry ladder.
+          if (outcome != DirectAccessOutcome.denied && _directWanted(s)) {
+            h.lastFailedDialAt = DateTime.now();
+            _scheduleRetry(h, note: ' — waiting for a guest token');
+          }
+          return;
+        }
+      }
+    }
+    if (credential == null) return;
+    final code = credential;
     // A dead (verify) or re-paired tunnel is replaced: drop the old one first
     // (a start under a key that is still running returns its stale port).
     // NB: no cast fallback here. A renderer reaches a tunnel server through
@@ -908,10 +999,13 @@ class ServerManager {
       // casting: the cast backends re-resolve each track against the live
       // tunnel at load time (irohProxyUri), and a mid-session reload clobbers
       // the Cast SDK's own suspend/resume recovery.
+      // A direct peer's proxy URLs still work while its own tunnel comes
+      // up, so only UPCOMING items move over — the playing track keeps its
+      // stream instead of reloading mid-song.
       unawaited(MediaManager()
           .audioHandler
           .customAction('rebuildTranscodeUrls',
-              const {'upcomingOnly': false, 'auto': true})
+              {'upcomingOnly': s.isFederated, 'auto': true})
           .catchError((Object e) {
         // Reaching here should now be rare: the handler runs this rebuild
         // on the same chain as every other local-backend load, so a
@@ -930,7 +1024,23 @@ class ServerManager {
       h.startRejected = '$e'.contains('rejected');
       appLog('[iroh] tunnel start failed after ${sw.elapsedMilliseconds}ms '
           '($reason): $e for=$name');
-      if (h.startRejected) {
+      if (h.startRejected && s.isFederated) {
+        // A refused GUEST token is not a pairing problem: it expired or its
+        // key was rotated, and the parent is where a fresh one comes from.
+        // Ask once; a new ticket gets a quick retry, a refusal to mint puts
+        // the peer on the proxy for the session, anything else waits for
+        // the ladder.
+        h.refusedCredential = code;
+        h.startRejected = false;
+        final outcome = await _refreshDirectAccess(s, force: true);
+        if (outcome == DirectAccessOutcome.issued) {
+          _scheduleRetry(h,
+              delay: TunnelTiming.retryAfterNetworkReturn,
+              note: ' — fresh guest token');
+        } else if (outcome != DirectAccessOutcome.denied) {
+          _scheduleRetry(h, note: ' — guest token refused, refresh pending');
+        }
+      } else if (h.startRejected) {
         h.cancelRetry();
       } else {
         final next = TunnelPolicy.retryAfterFailedDial(
@@ -964,12 +1074,25 @@ class ServerManager {
   /// Stop [h]'s native tunnel and forget its assignment. ONLY from inside
   /// its chain (invariant 3).
   void _stopHandleTunnel(TunnelHandle h, String reason) {
-    if (h.nativeKey != null) {
+    final had = h.nativeKey != null;
+    if (had) {
       appLog('[iroh] tunnel stopped ($reason) port=${h.port} '
           'for=${h.server.localname}');
       IrohTunnel.instance.stop(h.nativeKey!);
     }
     h.clearRuntime();
+    // A direct peer just went back to the proxy path: every queued URL on
+    // its old loopback is dead, so rebuild them against the parent (which
+    // rebuilds again when its own tunnel binds, if it has one).
+    if (had && h.server.isFederated) {
+      unawaited(MediaManager()
+          .audioHandler
+          .customAction('rebuildTranscodeUrls',
+              const {'upcomingOnly': false, 'auto': true})
+          .catchError((Object e) {
+        appLog('[iroh] URL rebuild after the direct tunnel went failed: $e');
+      }));
+    }
   }
 
   /// Nothing references [h]'s server any more: stop its tunnel on its chain
@@ -1349,6 +1472,185 @@ class ServerManager {
   /// connection instead of the tunnel. Returns WHY it failed, classified by
   /// [TunnelPolicy.classifyProbeError], because "refused", "reset" and
   /// "timeout" are three different tunnel states.
+  // ── Direct access to federated peers (issue #143) ──
+  //
+  // The parent hands out a guest ticket per peer (GET …/peers/:id/access —
+  // objects/direct_access.dart); the peer's handle dials it like a pairing
+  // code, on the federation ALPN. The ticket expires daily: a tunnel that is
+  // up gets the new one swapped in place (same port, same queued URLs), a
+  // refused one is asked for again rather than treated as a re-pair, and a
+  // parent that declines puts the peer on the proxy for the session.
+
+  /// Ask [peer]'s parent for direct access and record the answer on the
+  /// peer. Waits (bounded) for the parent's own tunnel first when the
+  /// parent is a Quick Connect server — the access call rides it.
+  Future<DirectAccessOutcome> _refreshDirectAccess(Server peer,
+      {bool force = false}) async {
+    final parent = peer.parentServer;
+    final id = peer.federationPeerId;
+    if (parent == null || id == null) return DirectAccessOutcome.failed;
+    final name = peer.localname;
+    if (parent.isIroh && !tunnelServes(parent)) {
+      // The parent is a target while this peer's ticket is due (see
+      // _tunnelTargets), so nothing releases it under the call; it may just
+      // not have been dialed yet.
+      unawaited(ensureTunnelFor(parent, reason: 'direct-access'));
+      await awaitTunnelReady(
+          server: parent,
+          timeout: const Duration(seconds: 12),
+          extendWhileDialing: false,
+          caller: 'direct-access');
+      if (!tunnelServes(parent)) {
+        appLog('[federation] $name: direct access needs ${parent.localname}\'s '
+            'tunnel, which is not up');
+        return DirectAccessOutcome.failed;
+      }
+    }
+    try {
+      final response = await http.get(
+        parent.apiUri('/api/v1/federation/peers/$id/access'
+            '${force ? '?refresh=1' : ''}'),
+        headers: {'x-access-token': parent.authToken ?? ''},
+      ).timeout(const Duration(seconds: 20));
+      if (response.statusCode != 200) {
+        appLog('[federation] $name: direct access on ${parent.localname} -> '
+            'HTTP ${response.statusCode}');
+        return DirectAccessOutcome.failed;
+      }
+      final body = jsonDecode(response.body);
+      if (body is! Map) return DirectAccessOutcome.failed;
+      final access = DirectAccess.fromJson(body);
+      if (access == null) {
+        peer.directDenied = true;
+        appLog('[federation] $name: no direct access '
+            '(${body['reason'] ?? 'declined'}) — staying on '
+            '${parent.localname}\'s proxy');
+        return DirectAccessOutcome.denied;
+      }
+      final changed = access.ticket != peer.directTicket;
+      peer.directDenied = false;
+      if (changed) {
+        // The staleness clock starts at the fetch of a NEW ticket only: the
+        // same one handed out again would otherwise look fresh again.
+        peer
+          ..directTicket = access.ticket
+          ..directGuestToken = access.guestToken
+          ..directEndpointId = access.endpointId
+          ..directExpiresAt = access.expiresAt
+          ..directFetchedAt = DateTime.now();
+      }
+      appLog('[federation] $name: direct access '
+          '${changed ? 'issued' : 'unchanged'}, expires '
+          '${access.expiresAt.toIso8601String()}');
+      return changed ? DirectAccessOutcome.issued : DirectAccessOutcome.unchanged;
+    } on FormatException catch (e) {
+      appLog('[federation] $name: direct access answer unreadable: $e');
+      return DirectAccessOutcome.failed;
+    } catch (e) {
+      appLog('[federation] $name: direct access failed: $e');
+      return DirectAccessOutcome.failed;
+    }
+  }
+
+  /// Poll-time upkeep for a direct peer's tunnel: re-fetch a ticket past
+  /// three quarters of its life and swap it in place, and treat a supervisor
+  /// that gave up on a refused token as "refresh it" — rate-limited, since a
+  /// refresh is a round trip through the parent.
+  void _maintainDirect(TunnelHandle h) {
+    final s = h.server;
+    if (!s.isFederated || !h.assigned || h.directRefreshing) return;
+    final refused = _nativeStatusOf(h) == IrohTunnelStatus.rejected;
+    final stale = _directTicketStale(s);
+    if (!refused && !stale) return;
+    // Rate-limit ATTEMPTS after a refusal, and only FAILED attempts for a
+    // stale ticket — a renewal that worked must not delay the next one. A
+    // ticket that has already run out (the parent was unreachable at the
+    // scheduled point) is urgent: every request is failing, so ask on the
+    // short gap.
+    final expiresAt = s.directExpiresAt;
+    final expired = expiresAt != null && !DateTime.now().isBefore(expiresAt);
+    final gap = _since(refused ? h.directRefreshedAt : h.directRefreshFailedAt);
+    final minGap = refused || expired
+        ? TunnelTiming.directRefusedRetryGap
+        : TunnelTiming.directRefreshMinGap;
+    if (gap != null && gap < minGap) return;
+    unawaited(_refreshDirectCredential(h,
+        force: refused, why: refused ? 'refused' : 'stale'));
+  }
+
+  /// Fetch a fresh ticket for a peer whose tunnel is up and hand it to the
+  /// native side in place — same port, same token, the queued URLs survive;
+  /// only upcoming items take the new guest token. A parent that declines
+  /// releases the tunnel (the proxy takes over); a swap the native side
+  /// refuses (a different endpoint id) rebuilds instead.
+  Future<void> _refreshDirectCredential(TunnelHandle h,
+      {required bool force, required String why}) async {
+    final s = h.server;
+    final name = s.localname;
+    h.directRefreshing = true;
+    h.directRefreshedAt = DateTime.now();
+    try {
+      final before = s.directTicket;
+      var outcome = await _refreshDirectAccess(s, force: force);
+      if (outcome == DirectAccessOutcome.unchanged && !force) {
+        // The parent's own cache is not due for a re-mint yet: make it.
+        outcome = await _refreshDirectAccess(s, force: true);
+      }
+      if (!h.assigned || h.nativeKey == null) return;
+      switch (outcome) {
+        case DirectAccessOutcome.denied:
+          appLog('[iroh] direct access withdrawn ($why) — back to the proxy '
+              'for=$name');
+          await _releaseHandle(h, 'direct-withdrawn');
+          return;
+        case DirectAccessOutcome.failed:
+        case DirectAccessOutcome.unchanged:
+          h.directRefreshFailedAt = DateTime.now();
+          return; // try again after the gap
+        case DirectAccessOutcome.issued:
+          break;
+      }
+      final ticket = s.directTicket;
+      if (ticket == null || ticket == before) return;
+      try {
+        IrohTunnel.instance.setCredential(h.nativeKey!, ticket);
+        h.code = ticket;
+        h.refusedCredential = null;
+        h.directRefreshFailedAt = null;
+        appLog('[iroh] guest credential refreshed in place ($why) for=$name');
+        // The parent's tunnel was kept up for the access call; drop it if
+        // nothing else wants it.
+        unawaited(ensureTunnels(reason: 'direct-refreshed'));
+        unawaited(MediaManager()
+            .audioHandler
+            .customAction('rebuildTranscodeUrls',
+                const {'upcomingOnly': true, 'auto': true})
+            .catchError((Object e) {
+          appLog('[iroh] URL rebuild after the credential refresh failed: $e');
+        }));
+      } on IrohTunnelException catch (e) {
+        appLog('[iroh] credential swap refused (${e.message}) — rebuilding '
+            'for=$name');
+        await _hardRebuild(h,
+            code: h.code, port: h.port, reason: 'credential', user: true);
+      }
+    } finally {
+      h.directRefreshing = false;
+    }
+  }
+
+  /// The browse layer saw a 401 from a direct peer: its guest token is no
+  /// longer honoured (expired early, or the key was rotated). Refresh it now
+  /// rather than at the next scheduled point.
+  Future<void> onDirectAuthRejected(Server server) async {
+    if (!server.isDirect) return;
+    final h = _tunnels[server.localname];
+    if (h == null || h.directRefreshing) return;
+    final gap = _since(h.directRefreshedAt);
+    if (gap != null && gap < TunnelTiming.directRefusedRetryGap) return;
+    await _refreshDirectCredential(h, force: true, why: '401');
+  }
+
   Future<({bool ok, String reason, int ms})> _probeTunnel(Server s) async {
     final sw = Stopwatch()..start();
     final client = HttpClient()
@@ -1430,6 +1732,7 @@ class ServerManager {
     for (final line in _drainNativeEventsOf(h)) {
       appLog('[iroh-native] $line for=$name');
     }
+    _maintainDirect(h);
     // Watchdog: a supervisor that is not converging although the relay is
     // reachable (or a kick that did not take) gets a fresh endpoint. Never in
     // a dead zone — see TunnelPolicy.shouldEscalate — and never more than one
@@ -1494,7 +1797,7 @@ class ServerManager {
     // federated peer has none of its own and is ready exactly when its
     // parent is.
     final s = (server ?? currentServer)?.transportServer;
-    if (!IrohTunnel.isSupported || s == null || !s.isIroh) return true;
+    if (!IrohTunnel.isSupported || s == null || !s.ownsTunnel) return true;
     final h = _handleOf(s);
     // A rejected cold dial leaves no native tunnel to report it; answer
     // before firing an ensure that would only re-dial into the rejection.
@@ -1541,7 +1844,7 @@ class ServerManager {
   Future<void> reverifyTunnel(Server server) async {
     // Probe the transport: a peer's failures happen on its parent's tunnel.
     final s = server.transportServer;
-    if (!IrohTunnel.isSupported || s == null || !s.isIroh) return;
+    if (!IrohTunnel.isSupported || s == null || !s.ownsTunnel) return;
     final h = _tunnels[s.localname];
     if (h == null || h.reverifying || !h.assigned) return;
     // Already known down: ensureTunnelFor / awaitTunnelReady own that case
@@ -1672,7 +1975,7 @@ class ServerManager {
     // it on the next edit, but do it now).
     for (final gone in [removeThisServer, ...orphans]) {
       _queueReleaseTimers.remove(gone.localname)?.cancel();
-      _queueIrohServers.remove(gone.localname);
+      _queueServers.remove(gone.localname);
     }
 
     if (serverList.isEmpty) {
@@ -1967,6 +2270,7 @@ class ServerManager {
     server.discoveryAvailable = false;
     server.discoveryP2pAvailable = false;
     server.federationDiscoveryAvailable = false;
+    server.federationDirectAvailable = false; // a peer's own peers are out of reach
     server.discoveryPathAvailable = false;
     server.playlists.clear();
   }
@@ -2062,4 +2366,19 @@ class ServerManager {
   Stream<Server?> get currentServerStream => _currentServerStream.stream;
 
   Stream<List<Server>> get serverListStream => _serverListStream.stream;
+}
+
+/// What asking the parent for a peer's direct access came to.
+enum DirectAccessOutcome {
+  /// A ticket the peer did not hold before (first fetch, or a fresh mint).
+  issued,
+
+  /// The parent handed out the ticket the peer already holds.
+  unchanged,
+
+  /// The parent said `direct: false`: the proxy is all there is.
+  denied,
+
+  /// Unreachable, an HTTP error, or an unreadable answer: try again later.
+  failed,
 }

--- a/lib/singletons/tunnel_handle.dart
+++ b/lib/singletons/tunnel_handle.dart
@@ -36,8 +36,27 @@ class TunnelHandle {
           ? transport.irohPairingCode!
           : transport.localname;
 
+  /// The credential a transport dials with: a Quick Connect server's pairing
+  /// code, or the `mstrfedg1:` guest ticket the parent handed out for a
+  /// federated peer — null until it has (the proxy serves meanwhile).
+  static String? credentialFor(Server transport) =>
+      transport.isIroh ? transport.irohPairingCode : transport.directTicket;
+
   /// The key the running native tunnel was started under; null when none.
   String? nativeKey;
+
+  // ── Direct peers only ──
+  /// A guest ticket the peer refused: not dialed again until the parent
+  /// hands out a different one.
+  String? refusedCredential;
+
+  /// Last refresh ATTEMPT through this handle, the last one that came back
+  /// empty-handed (the parent unreachable, or nothing new to hand out — what
+  /// the poll rate-limits), and whether one is in flight — the poll must not
+  /// stack them.
+  DateTime? directRefreshedAt;
+  DateTime? directRefreshFailedAt;
+  bool directRefreshing = false;
 
   /// The credential the running tunnel was started with, and its loopback
   /// port + token. Mirrored onto [Server.tunnelPort] / [Server.tunnelToken],
@@ -101,7 +120,7 @@ class TunnelHandle {
   /// Whether this is still the tunnel a probe was taken against — the
   /// re-check every probe consequence runs inside the chain before acting.
   bool sameTunnel(String? c, int? p) =>
-      c != null && code == c && port == p && server.irohPairingCode == c;
+      c != null && code == c && port == p && credentialFor(server) == c;
 
   /// Record a started (or adopted) tunnel.
   void bind(
@@ -152,7 +171,7 @@ int statusSeverity(IrohTunnelStatus s) => switch (s) {
 Server? bannerTargetAmong(
     {required Server? browsed,
     required List<({Server server, IrohTunnelStatus status})> background}) {
-  if (browsed != null && browsed.isIroh) return browsed;
+  if (browsed != null && browsed.ownsTunnel) return browsed;
   Server? worst;
   var worstRank = -1;
   for (final b in background) {

--- a/lib/singletons/tunnel_policy.dart
+++ b/lib/singletons/tunnel_policy.dart
@@ -89,6 +89,18 @@ class TunnelTiming {
   /// 2026-09-02) and cost a full rebuild seconds later.
   static const Duration queueReleaseGrace = Duration(seconds: 10);
 
+  /// A direct peer's guest ticket is re-fetched once this fraction of its
+  /// life is gone — the parent re-mints past the same point — so the token in
+  /// flight never runs out mid-session.
+  static const double directRefreshAt = 0.75;
+
+  /// After a refresh that came back empty-handed (the parent unreachable, or
+  /// nothing new to hand out), how long before the poll asks again for a
+  /// stale ticket; a successful refresh resets it, so a short-lived ticket
+  /// is renewed on schedule. A refused token has its own shorter gap.
+  static const Duration directRefreshMinGap = Duration(minutes: 5);
+  static const Duration directRefusedRetryGap = Duration(seconds: 60);
+
   /// How long after an audio-focus interruption began an auto rebuild must not
   /// resume playback. A window, not a flag: Android never delivers the `end`
   /// for a permanent loss (6 begins, 0 ends across the two drive logs).
@@ -256,6 +268,19 @@ class TunnelPolicy {
     if (browsingTunnelServer) return true;
     return status == IrohTunnelStatus.rejected ||
         status == IrohTunnelStatus.down;
+  }
+
+  /// Whether a direct peer's guest ticket should be fetched again: nothing
+  /// fetched, a life that already ended, or more than
+  /// [TunnelTiming.directRefreshAt] of it gone. Pure; unit-tested.
+  static bool directTicketStale(
+      {required DateTime? fetchedAt,
+      required DateTime? expiresAt,
+      required DateTime now}) {
+    if (fetchedAt == null || expiresAt == null) return true;
+    final life = expiresAt.difference(fetchedAt);
+    if (life <= Duration.zero) return true;
+    return now.difference(fetchedAt) >= life * TunnelTiming.directRefreshAt;
   }
 
   /// Delay before retry number [attempt] (0-based) after a failed cold dial.

--- a/lib/util/stream_url.dart
+++ b/lib/util/stream_url.dart
@@ -63,13 +63,15 @@ String buildServerStreamUrl(Server server, String path) {
   final tm = TranscodeManager();
   final String token =
       server.authToken == null ? '' : '&token=${server.authToken!}';
-  // A federated server's tracks live on a peer, reached through the parent's
-  // byte proxy (which forwards Range, so seeking still works). /transcode is
-  // off the federation allowlist entirely — there is no transcode branch to
-  // take here, and transcodeAvailable is pinned false for these servers so the
-  // check below would land on /media regardless. Explicit anyway: the endpoint
-  // differs, not just the flag.
-  if (server.isFederated) {
+  // A federated server's tracks live on a peer. On the proxy path they come
+  // through the parent's byte proxy (which forwards Range, so seeking still
+  // works); a DIRECT peer serves /media itself over its own tunnel, with the
+  // guest token in the ordinary slot, so it takes the plain branch below.
+  // /transcode is off the federation allowlist either way — there is no
+  // transcode branch to take, and transcodeAvailable is pinned false for
+  // these servers so the check below lands on /media regardless. Explicit
+  // for the proxy anyway: the endpoint differs, not just the flag.
+  if (server.isFederated && !server.isDirect) {
     return '${server.effectiveBaseUrl}${server.federationPrefix}/stream$p'
         '?app_uuid=${Uuid().v4()}$token${server.localTokenQuery}';
   }
@@ -143,7 +145,7 @@ String buildServerDownloadUrl(Server server, String path) {
     if (element.isEmpty) continue;
     p += '/${Uri.encodeComponent(element)}';
   }
-  final String base = server.isFederated
+  final String base = server.isFederated && !server.isDirect
       ? '${server.effectiveBaseUrl}${server.federationPrefix}/stream$p'
       : '${server.effectiveBaseUrl}/media$p';
   final parts = <String>[
@@ -192,8 +194,10 @@ String buildAlbumArtUrl(Server server, String artFile, {String compress = 's'}) 
   // The art proxy takes the file as ONE path segment — the peer serves
   // /album-art/:file, a single hash name — and forwards only `compress`.
   // encodeComponent, not encodeFull: the segment is escaped exactly once, the
-  // way the webapp's peerArtUrl does it.
-  if (server.isFederated) {
+  // way the webapp's peerArtUrl does it. A direct peer serves /album-art
+  // itself, so it takes the plain shape below (which albumArtFileFromUrl
+  // reads as well).
+  if (server.isFederated && !server.isDirect) {
     return '${server.effectiveBaseUrl}${server.federationPrefix}'
         '/art/${Uri.encodeComponent(artFile)}'
         '?compress=$compress$token${server.localTokenQuery}';

--- a/test/media/rebuild_scope_test.dart
+++ b/test/media/rebuild_scope_test.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/media/audio_stuff.dart';
+import 'package:mstream_music/media/playback_backend.dart';
+
+void main() {
+  group('AudioPlayerHandler.protectsCurrentTrack', () {
+    test('a playing or buffering track is left alone by an upcoming-only rebuild', () {
+      for (final s in [BackendProcessingState.ready, BackendProcessingState.buffering, BackendProcessingState.completed]) {
+        expect(AudioPlayerHandler.protectsCurrentTrack(upcomingOnly: true, state: s), isTrue, reason: '$s');
+      }
+    });
+
+    test('an idle or still-loading current track is rebuilt too (its URL may be the stale one)', () {
+      for (final s in [BackendProcessingState.idle, BackendProcessingState.loading]) {
+        expect(AudioPlayerHandler.protectsCurrentTrack(upcomingOnly: true, state: s), isFalse, reason: '$s');
+      }
+    });
+
+    test('a full rebuild never protects', () {
+      for (final s in BackendProcessingState.values) {
+        expect(AudioPlayerHandler.protectsCurrentTrack(upcomingOnly: false, state: s), isFalse);
+      }
+    });
+  });
+
+  group('AudioPlayerHandler.hasLocalCopy', () {
+    test('true only while the downloaded file is actually on disk', () async {
+      final dir = await Directory.systemTemp.createTemp('mstream-copy');
+      final f = File('${dir.path}/track.mp3')..writeAsStringSync('x');
+      MediaItem item(String? lp) => MediaItem(id: 'http://127.0.0.1:1/media/a.mp3', title: 'a', extras: {'path': '/a.mp3', 'localPath': lp});
+      expect(AudioPlayerHandler.hasLocalCopy(item(f.path)), isTrue);
+      f.deleteSync();
+      expect(AudioPlayerHandler.hasLocalCopy(item(f.path)), isFalse, reason: 'a vanished copy is not a copy');
+      expect(AudioPlayerHandler.hasLocalCopy(item(null)), isFalse);
+      expect(AudioPlayerHandler.hasLocalCopy(MediaItem(id: 'x', title: 'x')), isFalse);
+      dir.deleteSync(recursive: true);
+    });
+  });
+}

--- a/test/objects/direct_access_test.dart
+++ b/test/objects/direct_access_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/objects/direct_access.dart';
+import 'package:mstream_music/singletons/tunnel_policy.dart';
+
+void main() {
+  group('DirectAccess.fromJson', () {
+    final ok = {
+      'direct': true,
+      'endpointTicket': 'endpointabc',
+      'endpointId': 'ca24f6e9',
+      'guestToken': 'eyJhbGciOiJIUzI1NiJ9.eyJmZWRlcmF0aW9uR3Vlc3QiOnRydWV9.sig',
+      'expiresAt': '2026-09-05T20:00:00.000Z',
+      'directTicket': 'mstrfedg1:eyJ0IjoiZW5kcG9pbnRhYmMiLCJnIjoiZXlKIn0',
+    };
+
+    test('parses the parent\'s access answer', () {
+      final a = DirectAccess.fromJson(ok)!;
+      expect(a.endpointTicket, 'endpointabc');
+      expect(a.endpointId, 'ca24f6e9');
+      expect(a.guestToken, startsWith('eyJ'));
+      expect(a.ticket, startsWith('mstrfedg1:'));
+      expect(a.expiresAt, DateTime.utc(2026, 9, 5, 20));
+    });
+
+    test('a refusal is null, not an error', () {
+      expect(DirectAccess.fromJson({'direct': false, 'reason': 'older build'}), isNull);
+      expect(DirectAccess.fromJson({}), isNull);
+    });
+
+    test('a null endpoint id is allowed (no native module on the parent)', () {
+      expect(DirectAccess.fromJson({...ok, 'endpointId': null})!.endpointId, isNull);
+    });
+
+    test('a malformed 200 throws, so it is retried rather than remembered', () {
+      for (final broken in [
+        {...ok}..remove('guestToken'),
+        {...ok, 'directTicket': 'mstrfed1:not-a-guest-ticket'},
+        {...ok, 'expiresAt': 'soon'},
+        {...ok, 'endpointTicket': ''},
+      ]) {
+        expect(() => DirectAccess.fromJson(broken), throwsFormatException);
+      }
+    });
+  });
+
+  group('TunnelPolicy.directTicketStale', () {
+    final fetched = DateTime.utc(2026, 9, 5, 0);
+    final expires = DateTime.utc(2026, 9, 6, 0); // a day
+
+    test('fresh for the first three quarters of its life, stale after', () {
+      expect(
+          TunnelPolicy.directTicketStale(
+              fetchedAt: fetched, expiresAt: expires, now: fetched.add(const Duration(hours: 17))),
+          isFalse);
+      expect(
+          TunnelPolicy.directTicketStale(
+              fetchedAt: fetched, expiresAt: expires, now: fetched.add(const Duration(hours: 18))),
+          isTrue);
+      expect(
+          TunnelPolicy.directTicketStale(
+              fetchedAt: fetched, expiresAt: expires, now: expires.add(const Duration(hours: 1))),
+          isTrue);
+    });
+
+    test('nothing fetched, or a life that already ended, is stale', () {
+      expect(TunnelPolicy.directTicketStale(fetchedAt: null, expiresAt: null, now: fetched), isTrue);
+      expect(TunnelPolicy.directTicketStale(fetchedAt: fetched, expiresAt: fetched, now: fetched), isTrue);
+    });
+  });
+}

--- a/test/objects/federated_server_test.dart
+++ b/test/objects/federated_server_test.dart
@@ -327,4 +327,68 @@ void main() {
           'https://home.example.com/album-art/abc123.jpg?compress=s&token=PARENT-JWT');
     });
   });
+
+  group('direct access (issue #143)', () {
+    test('a peer is direct exactly while it holds a tunnel port of its own', () {
+      final (parent: parent, peer: peer) = _pair();
+      expect(peer.isDirect, isFalse);
+      expect(peer.ownsTunnel, isFalse);
+      expect(peer.transportServer, same(parent));
+      expect(peer.isIrohTransport, isFalse, reason: 'an HTTP parent has no tunnel');
+
+      peer
+        ..tunnelPort = 40123
+        ..tunnelToken = 'peerlt'
+        ..directGuestToken = 'GUEST-JWT';
+      expect(peer.isDirect, isTrue);
+      expect(peer.ownsTunnel, isTrue);
+      expect(peer.transportServer, same(peer));
+      expect(peer.isIrohTransport, isTrue);
+      expect(peer.isIroh, isFalse, reason: 'identity stays federated');
+    });
+
+    test('direct: own loopback, own __lt, the guest token — never the parent\'s', () {
+      final (parent: parent, peer: peer) = _pair(iroh: true, tunnelPort: 5001, tunnelToken: 'parentlt');
+      expect(parent.effectiveBaseUrl, 'http://127.0.0.1:5001');
+      peer
+        ..tunnelPort = 40123
+        ..tunnelToken = 'peerlt'
+        ..directGuestToken = 'GUEST-JWT';
+      expect(peer.effectiveBaseUrl, 'http://127.0.0.1:40123');
+      expect(peer.authToken, 'GUEST-JWT');
+      expect(peer.localTokenQuery, '&__lt=peerlt');
+      final u = peer.apiUri('/api/v1/db/albums');
+      expect(u.toString(), 'http://127.0.0.1:40123/api/v1/db/albums?__lt=peerlt');
+      expect(u.toString(), isNot(contains('federation')));
+      expect(u.toString(), isNot(contains('parentlt')));
+    });
+
+    test('proxy: the parent\'s everything, as before', () {
+      final (parent: parent, peer: peer) = _pair(iroh: true, tunnelPort: 5001, tunnelToken: 'parentlt');
+      peer.directGuestToken = 'GUEST-JWT'; // held but unused without a tunnel
+      expect(peer.isDirect, isFalse);
+      expect(peer.authToken, parent.jwt);
+      expect(peer.effectiveBaseUrl, 'http://127.0.0.1:5001');
+      expect(peer.apiUri('/api/v1/db/albums').toString(),
+          'http://127.0.0.1:5001/api/v1/federation/peers/3/api/api/v1/db/albums?__lt=parentlt');
+    });
+
+    test('the direct material is runtime-only; the parent\'s flag persists', () {
+      final peer = _pair().peer
+        ..directTicket = 'mstrfedg1:x'
+        ..directGuestToken = 'g'
+        ..directDenied = true
+        ..tunnelPort = 1;
+      final back = Server.fromJson(peer.toJson());
+      expect(back.directTicket, isNull);
+      expect(back.directGuestToken, isNull);
+      expect(back.directDenied, isFalse);
+      expect(back.tunnelPort, isNull);
+      expect(back.isDirect, isFalse);
+
+      final parent = _pair().parent..federationDirectAvailable = true;
+      expect(Server.fromJson(parent.toJson()).federationDirectAvailable, isTrue);
+      expect(Server.fromJson({'url': 'https://x', 'localname': 'x'}).federationDirectAvailable, isNull);
+    });
+  });
 }

--- a/test/singletons/tunnel_handle_test.dart
+++ b/test/singletons/tunnel_handle_test.dart
@@ -60,6 +60,44 @@ void main() {
     });
   });
 
+  group('direct peers', () {
+    Server peerOf(Server parent) => Server('federated://home/3', null, null, null, 'peer-x')
+      ..federationParent = 'home'
+      ..federationPeerId = 3
+      ..parentServer = parent;
+
+    test('a peer keys by localname and dials with its guest ticket', () {
+      final peer = peerOf(_http('home'));
+      expect(TunnelHandle.keyFor(peer), 'peer-x');
+      expect(TunnelHandle.credentialFor(peer), isNull, reason: 'nothing until the parent hands one out');
+      peer.directTicket = 'mstrfedg1:abc';
+      expect(TunnelHandle.credentialFor(peer), 'mstrfedg1:abc');
+      expect(TunnelHandle.credentialFor(_iroh('qc', 'mstr1:code')), 'mstr1:code');
+    });
+
+    test('binding a peer handle makes the peer direct; clearing it puts it back on the proxy', () {
+      final parent = _http('home');
+      final peer = peerOf(parent);
+      expect(peer.transportServer, same(parent));
+      final h = TunnelHandle(peer)
+        ..bind(key: 'peer-x', credential: 'mstrfedg1:abc', localPort: 5000, localToken: 'lt');
+      expect(peer.isDirect, isTrue);
+      expect(peer.transportServer, same(peer));
+      expect(peer.isIrohTransport, isTrue);
+      expect(h.sameTunnel('mstrfedg1:abc', 5000), isFalse, reason: 'the server holds no ticket yet');
+      peer.directTicket = 'mstrfedg1:abc';
+      expect(h.sameTunnel('mstrfedg1:abc', 5000), isTrue);
+      h.clearRuntime();
+      expect(peer.isDirect, isFalse);
+      expect(peer.transportServer, same(parent));
+    });
+
+    test('the strip follows a browsed direct peer over its own tunnel', () {
+      final peer = peerOf(_http('home'))..tunnelPort = 5000;
+      expect(bannerTargetAmong(browsed: peer.transportServer, background: const []), same(peer));
+    });
+  });
+
   group('bannerTargetAmong', () {
     final qc = _iroh('qc', 'mstr1:a');
     final other = _iroh('other', 'mstr1:b');

--- a/test/util/stream_url_direct_test.dart
+++ b/test/util/stream_url_direct_test.dart
@@ -1,0 +1,66 @@
+// A federated peer reached DIRECTLY (issue #143) serves /media and
+// /album-art itself over a tunnel of its own, with the guest token in the
+// ordinary token slot; on the proxy path the same peer's URLs go through the
+// parent. The flip is the peer's own tunnel port, nothing else.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/singletons/transcode.dart';
+import 'package:mstream_music/util/stream_url.dart';
+
+({Server parent, Server peer}) _pair() {
+  final parent = Server('https://home.example.com', 'alice', 'secret', 'PARENT-JWT', 'home');
+  final peer = Server('federated://home/3', null, null, null, 'peer-basement')
+    ..federationParent = 'home'
+    ..federationPeerId = 3
+    ..federationPeerName = 'Basement'
+    ..parentServer = parent
+    ..transcodeAvailable = false;
+  return (parent: parent, peer: peer);
+}
+
+void main() {
+  setUp(() => TranscodeManager().transcodeOn = false);
+
+  test('proxy path: stream, download and art go through the parent', () {
+    final peer = _pair().peer;
+    expect(buildServerStreamUrl(peer, '/Music/a.mp3'),
+        startsWith('https://home.example.com/api/v1/federation/peers/3/stream/Music/a.mp3?app_uuid='));
+    expect(buildServerStreamUrl(peer, '/Music/a.mp3'), contains('&token=PARENT-JWT'));
+    expect(buildServerDownloadUrl(peer, '/Music/a.mp3'),
+        'https://home.example.com/api/v1/federation/peers/3/stream/Music/a.mp3?token=PARENT-JWT');
+    expect(buildAlbumArtUrl(peer, 'abc.jpg', compress: 'm'),
+        'https://home.example.com/api/v1/federation/peers/3/art/abc.jpg?compress=m&token=PARENT-JWT');
+  });
+
+  test('direct: the peer\'s own loopback, /media and /album-art, the guest token, the peer\'s __lt', () {
+    final peer = _pair().peer
+      ..tunnelPort = 40123
+      ..tunnelToken = 'peerlt'
+      ..directGuestToken = 'GUEST-JWT';
+    expect(peer.isDirect, isTrue);
+    final stream = buildServerStreamUrl(peer, '/Music/a.mp3');
+    expect(stream, startsWith('http://127.0.0.1:40123/media/Music/a.mp3?app_uuid='));
+    expect(stream, contains('&token=GUEST-JWT'));
+    expect(stream, endsWith('&__lt=peerlt'));
+    expect(stream, isNot(contains('PARENT-JWT')));
+    expect(stream, isNot(contains('federation')));
+    expect(buildServerDownloadUrl(peer, '/Music/a.mp3'),
+        'http://127.0.0.1:40123/media/Music/a.mp3?token=GUEST-JWT&__lt=peerlt');
+    final art = buildAlbumArtUrl(peer, 'abc.jpg', compress: 'l');
+    expect(art, 'http://127.0.0.1:40123/album-art/abc.jpg?compress=l&token=GUEST-JWT&__lt=peerlt');
+    expect(albumArtFileFromUrl(art), 'abc.jpg', reason: 'the extractor reads the plain shape');
+  });
+
+  test('losing the tunnel puts the same peer back on the proxy shapes', () {
+    final peer = _pair().peer
+      ..tunnelPort = 40123
+      ..tunnelToken = 'peerlt'
+      ..directGuestToken = 'GUEST-JWT';
+    peer.tunnelPort = null;
+    peer.tunnelToken = null;
+    expect(peer.isDirect, isFalse);
+    expect(buildServerStreamUrl(peer, '/Music/a.mp3'), contains('/api/v1/federation/peers/3/stream/'));
+    expect(buildServerStreamUrl(peer, '/Music/a.mp3'), contains('&token=PARENT-JWT'));
+  });
+}


### PR DESCRIPTION
Step 4 of #143, with the one-Quick-Connect-server cap removal folded in. Server side is mStream#943 (merged); native layer #148; multi-tunnel manager #149.

## What changes

A federated peer whose parent advertises direct access (`federationDirect` in the parent's `/api` user block) now gets a tunnel of its own. The manager asks the parent for the peer's guest ticket (`GET /api/v1/federation/peers/:id/access`), dials the peer's federation endpoint with it (the `mstrfedg1:` ticket, `mode=guest` on the native side), and the peer's URLs move to its own loopback with the guest token: `/media` and `/album-art` straight from the peer, `apiUri` the plain path. No proxy hop, and the peer keeps playing and browsing while the parent is down. The proxy path stays the fallback for an older peer, a declined mint, or a failed dial.

**The mode is the peer's own tunnel port.** `Server.isDirect` is true exactly while the peer holds a `tunnelPort` of its own (the manager binds and clears it with the tunnel), and every accessor reads through it. `ownsTunnel` (a Quick Connect server, or a direct peer) is the "has a tunnel of its own" question the manager and the strip ask; `isIroh` stays identity (the pairing menu, the repair sheet).

**Manager.** A browsed or queued peer is a tunnel target of its own when its parent offers direct access, nobody declined this session, and the parent still lists it; the parent's tunnel stays a target while the peer is not direct yet and whenever the peer's ticket has to come through it again. The ticket fetch sits behind the existing backoff gates (a failing parent is asked on the retry ladder, not on every reconcile). The queue listener now reports item servers rather than transports, since a peer's transport changes with its mode.

**Ticket lifecycle.** Fetched on demand; renewed in place once 75 % of its life is gone (`IrohTunnel.setCredential`, same port, the queued URLs survive; only upcoming items take the new token). A stale-but-unchanged answer forces the parent to re-mint. Only failed attempts are rate-limited (5 min), an expired ticket retries on the 60 s gap, and a parent that comes back after an outage is asked within a minute. A refused guest token is asked for again rather than treated as a re-pair: at the first dial through one forced refresh and a quick retry, on a running tunnel through the poll, on a browse 401 at once. `direct: false` puts the peer on the proxy for the session. When a direct tunnel goes, the queued URLs are rebuilt against the parent. A peer handle that is still an attempt never puts Repair/Retry on the strip (the proxy is serving).

**Cap removal.** The native layer keys tunnels by server and the manager runs one per server, so the add-server screen and its backstop no longer refuse a second Quick Connect server. The unused l10n string is gone too.

## Tests

504 pass (16 new): `direct_access_test.dart` (parse ok/declined/malformed, staleness boundaries), `stream_url_direct_test.dart` (both URL shapes and the flip), `federated_server_test.dart` (direct-mode accessors, runtime-only fields, the persisted parent flag), `tunnel_handle_test.dart` (`credentialFor`, bind/clear flips the mode, the strip follows a direct peer).

## Verified on the Galaxy S25 (two-server rig, `MSTREAM_TEST_FED_GUEST_TTL_MS=180000`, parent over LAN HTTP)

- Ticket issued 70 ms after the switch to the peer; peer tunnel up (`path=direct`, `mode=guest`) after one 13 s handshake stall on the first dial; upcoming queue items rebuilt onto `127.0.0.1:<peer port>/media/...` with the guest token and the peer's own `__lt`.
- Three renewals in place at 75 % (the third through a parent restarted with an empty cache), one `tunnel up` for the whole session: port kept.
- Parent process killed: a freshly queued peer album streams from the peer's loopback (`state → ready` in 0.2 s, PLAYING), and browsing back into the album answers `POST /api/v1/file-explorer → 200` over the direct tunnel; the peer logged zero rejected tokens.
- The existing rig (`federation-rig.sh`) passes 7/7 twice on this build.

## Observations (not regressions, not fixed here)

- The first guest dial stalled in the handshake for 10 s once or twice before landing (the retry ladder covered it): the same first-dial stall as mStream#940, now on the federation endpoint. The peer logs nothing for it.
- The keep-queue-offline downloader starts every track of a queued album at once; a federated peer caps a key at 3 concurrent streams (guests share it), so the rest get 429 and retry later, and a burst can compete with the player's own stream. Predates this PR (the proxy path counts under the same key).
- A downloaded item whose local copy vanishes behind the app's back falls back to its stored URL, which can carry an expired guest token (rebuilds skip downloaded items). Re-deriving the URL at load time would close it; same class as a stale `__lt` after a tunnel rebuild.

## Next

Step 5: a direct-mode flag for `smoke/android/federation-rig.sh` (parent killed mid-track, key revoked, short TTL renewal), replacing the hand-run script used above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
