### PR TITLE
fix(playback): the tunnel heal gives up on a verified path; downloads run two per server

### DIFF
--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -57,6 +57,10 @@ enum MediaToggleAction { play, pause, ignore }
 /// this trigger entirely.
 enum HealAction { run, rearm, drop }
 
+/// What to do after a tunnel-heal resume failed: try again later, or stop
+/// blaming the tunnel and let the failing track take the ordinary skip walk.
+enum ResumeFailureAction { rearm, skipTrack }
+
 class AudioPlayerHandler extends BaseAudioHandler
     with QueueHandler, SeekHandler {
   // ignore: close_sinks
@@ -354,7 +358,11 @@ class AudioPlayerHandler extends BaseAudioHandler
     // one's state, and that edge must not be lost.
     ServerManager().tunnelTransitions.listen((t) {
       if (t.from == IrohTunnelStatus.connected) return;
-      if (t.to == IrohTunnelStatus.connected) _onTunnelReconnected();
+      if (t.to == IrohTunnelStatus.connected) {
+        // A real edge: whatever verdict suspended the heal is stale now.
+        _healSuspended = false;
+        _onTunnelReconnected();
+      }
     });
     // Stop the service when playback reaches the end of the queue.
     _backendSubject.switchMap((b) => b.processingStateStream).listen((state) {
@@ -428,6 +436,8 @@ class AudioPlayerHandler extends BaseAudioHandler
         _httpRetries = 0;
         _networkStalled = false;
         _tunnelLoadFailures = 0;
+        _healResumeFailures = 0;
+        _healSuspended = false;
         // Only a DIFFERENT track reaching ready clears the local-copy retry
         // guard. Clearing it on every ready reopens the loop it exists to
         // stop: a corrupt-but-LOADABLE file (valid header, damaged tail)
@@ -1033,7 +1043,7 @@ class AudioPlayerHandler extends BaseAudioHandler
     if (itemServer != null &&
         itemServer.isIrohTransport &&
         ServerManager().tunnelServes(itemServer)) {
-      _noteTunnelLoadFailure(itemServer);
+      unawaited(_noteTunnelLoadFailure(itemServer));
     }
     // Non-iroh source failed → hand off to _recoverHttpError, which (with an
     // async connectivity probe) pauses-and-holds on a real outage, retries a
@@ -1052,13 +1062,43 @@ class AudioPlayerHandler extends BaseAudioHandler
   int _tunnelLoadFailures = 0;
   static const int _kTunnelFailuresBeforeProbe = 3;
 
-  void _noteTunnelLoadFailure(Server server) {
-    if (++_tunnelLoadFailures < _kTunnelFailuresBeforeProbe) return;
+  /// Returns true only when this failure triggered the probe AND the probe
+  /// cleared the path — the failures are the source's own.
+  Future<bool> _noteTunnelLoadFailure(Server server) async {
+    if (++_tunnelLoadFailures < _kTunnelFailuresBeforeProbe) return false;
     _tunnelLoadFailures = 0;
     appLog('[iroh] $_kTunnelFailuresBeforeProbe loads failed against a '
         'tunnel reporting connected — checking whether it really is');
-    unawaited(ServerManager().reverifyTunnel(server));
+    return ServerManager().reverifyTunnel(server);
   }
+
+  // Consecutive heal resumes that failed (reset by `ready`, like the load
+  // counter above): the heal's own bound, see healResumeFailureAction.
+  int _healResumeFailures = 0;
+  // Set when the heal hands a track to the skip walk: the path is fine and
+  // the failures are the sources' own, so the heal stays out — every park
+  // during the walk would otherwise re-trigger it (the idle transition is
+  // its own trigger), re-seeding each failing track twice more before the
+  // probe hands it off again. Lifted by a track loading, or by a real
+  // tunnel edge, whose verdict supersedes this one.
+  bool _healSuspended = false;
+  static const int kMaxHealResumeFailures = 6;
+
+  /// After a heal resume failed: keep re-arming while the path itself may be
+  /// the problem; hand the track to the skip walk once the probe has cleared
+  /// the path (the failures are the source's — an expired credential, a file
+  /// the server no longer has — and no amount of re-seeding fixes those); and
+  /// after [kMaxHealResumeFailures] regardless, so a probe that never ran
+  /// (rate-limited, or another one in flight) cannot keep the loop alive.
+  /// Before this the heal re-seeded the same track every ~14 s for as long as
+  /// a serving tunnel and an idle player coexisted, and its own "probe passed
+  /// — the failures were not the path" verdict changed nothing. Pure;
+  /// unit-tested.
+  static ResumeFailureAction healResumeFailureAction(
+          {required bool pathVerified, required int failures}) =>
+      pathVerified || failures >= kMaxHealResumeFailures
+          ? ResumeFailureAction.skipTrack
+          : ResumeFailureAction.rearm;
 
   // The TRACK whose local copy we already re-seeded for — identity, never an
   // index: a removal above the marked row slides a different track underneath
@@ -1296,6 +1336,9 @@ class AudioPlayerHandler extends BaseAudioHandler
       return;
     }
     _recoveringPlayback = true;
+    // Set when the retry's own reload threw: the walk continues from
+    // whenComplete, once the flag is released (see below).
+    Object? followUp;
     _switchChain = _switchChain.then((_) async {
       if (queue.value.isEmpty || !identical(_backend, _localBackend)) return;
       // No network → an outage: pause-and-hold and let onNetworkRegained resume
@@ -1334,15 +1377,31 @@ class AudioPlayerHandler extends BaseAudioHandler
         // Fresh URLs, not queue.value: a tunnel that rebuilt during the
         // backoff has a new port and token, and retrying the stale ones just
         // burns the bounded budget against addresses that cannot work.
-        await _localBackend.setSources(_queueWithFreshUrls(),
-            initialIndex: idx, initialPosition: pos);
+        try {
+          await _localBackend.setSources(_queueWithFreshUrls(),
+              initialIndex: idx, initialPosition: pos);
+        } catch (e) {
+          // A dead source can fail INSIDE setSources. The player's error
+          // event for it then lands while this recovery still holds the
+          // flag and is dropped as "already recovering", so nothing would
+          // follow this retry — on the rig the walk sat at retry 1 until
+          // the tunnel heal happened to re-seed (which it no longer does
+          // once it has handed a track to the walk). Carry on from here.
+          appLog('[play] retry $attempt did not load: $e');
+          followUp = e;
+          return;
+        }
         if (_playIntent) unawaited(_localBackend.play());
       } else {
         await _skipFailedTrack(error);
       }
     }).catchError((Object e) {
       castLog('http error recovery failed', error: e);
-    }).whenComplete(() => _recoveringPlayback = false);
+    }).whenComplete(() {
+      _recoveringPlayback = false;
+      final next = followUp;
+      if (next != null) _recoverHttpError(next);
+    });
   }
 
   // Resume after a queue-wide network stall when connectivity returns. Wired to
@@ -1481,8 +1540,11 @@ class AudioPlayerHandler extends BaseAudioHandler
     required bool skipPending,
     required BackendProcessingState processingState,
     required bool queueEmpty,
+    bool healSuspended = false,
   }) {
     if (!onLocalBackend || intentionalStop || queueEmpty) return HealAction.drop;
+    // The probe has cleared the path and the skip walk owns the failures.
+    if (healSuspended) return HealAction.drop;
     // A recovery in flight will finish; re-check after it does.
     if (recovering || skipPending) return HealAction.rearm;
     // Not parked yet. It may still park (a load in flight can fail), and no
@@ -1534,6 +1596,7 @@ class AudioPlayerHandler extends BaseAudioHandler
       skipPending: _skipPending,
       processingState: _localBackend.processingState,
       queueEmpty: q.isEmpty,
+      healSuspended: _healSuspended,
     )) {
       case HealAction.drop:
         return;
@@ -1570,7 +1633,7 @@ class AudioPlayerHandler extends BaseAudioHandler
       // backend switch, a user play) may already have revived the player.
       if (_localBackend.processingState != BackendProcessingState.idle) return;
       await _reseedLocalAtSpot();
-    }).catchError((Object e) {
+    }).catchError((Object e) async {
       // appLog, not castLog: no cast is involved, and the incident log this
       // fix came from was tagged [cast] with no cast in sight.
       appLog('[play] tunnel-reconnect resume failed: $e');
@@ -1580,12 +1643,33 @@ class AudioPlayerHandler extends BaseAudioHandler
       // there oscillates 0↔1 and the ground-truth probe never fires. This
       // loop is the one that ran every 11s for the whole incident; it is
       // exactly the run of failures worth probing on.
-      _noteTunnelLoadFailure(server);
-      // Try again rather than leaving the player parked. Bounded by the
-      // tunnelServes gate, the 10s per-server cooldown and the single
-      // _tunnelHealRetry slot, so a flapping tunnel gets ~one attempt per
-      // 10-11s and a revived player fails the idle guard and stops.
-      _rearmTunnelHeal();
+      final pathVerified = await _noteTunnelLoadFailure(server);
+      switch (healResumeFailureAction(
+          pathVerified: pathVerified, failures: ++_healResumeFailures)) {
+        case ResumeFailureAction.rearm:
+          // Try again rather than leaving the player parked. Bounded by the
+          // tunnelServes gate, the 10s per-server cooldown, the single
+          // _tunnelHealRetry slot and the failure bound above, so a flapping
+          // tunnel gets ~one attempt per 10-11s and a revived player fails
+          // the idle guard and stops.
+          _rearmTunnelHeal();
+        case ResumeFailureAction.skipTrack:
+          // The tunnel is fine (or has had its chances): this track will not
+          // load through it, so it takes the ordinary skip walk — bounded by
+          // the queue length, ending in the outage-vs-bad-source decision —
+          // instead of being re-seeded forever.
+          appLog('[play] tunnel fine, track still fails — skipping it '
+              'instead of re-parking ($_healResumeFailures resumes failed); '
+              'heal suspended until a track loads');
+          _healResumeFailures = 0;
+          _healSuspended = true;
+          _skipPending = true;
+          _switchChain = _switchChain
+              .then((_) => _skipFailedTrack(e))
+              .catchError((Object e2) =>
+                  castLog('skip after a failed heal resume failed', error: e2))
+              .whenComplete(() => _skipPending = false);
+      }
     }).whenComplete(() => _recoveringPlayback = false);
   }
 

--- a/lib/media/audio_stuff.dart
+++ b/lib/media/audio_stuff.dart
@@ -2744,19 +2744,23 @@ class AudioPlayerHandler extends BaseAudioHandler
   /// Whether an "upcoming only" rebuild really should leave the current item
   /// alone. The option exists to keep a track that is PLAYING from reloading
   /// mid-song (buffering counts; so does a finished queue, where there is
-  /// nothing upcoming and nothing to restart). A current item the backend is
-  /// not holding — idle after a failed load, never started — or one still
-  /// loading has nothing to protect and may be the very URL that needs the
-  /// change: a direct peer's renewed guest token, a tunnel that came up under
-  /// a parked player. Pure; unit-tested.
+  /// nothing upcoming and nothing to restart). Anything else has nothing to
+  /// protect and may be the very URL that needs the change — a direct peer's
+  /// renewed guest token, a tunnel that came up under a parked player, a
+  /// queue restored at launch and sitting paused on the parent's proxy URL
+  /// while the peer's own tunnel arrives: idle after a failed load, never
+  /// started, still loading, or loaded but paused (the reload keeps the
+  /// spot and stays paused, so nothing is heard). Pure; unit-tested.
   static bool protectsCurrentTrack(
-      {required bool upcomingOnly, required BackendProcessingState state}) {
+      {required bool upcomingOnly,
+      required BackendProcessingState state,
+      required bool playing}) {
     if (!upcomingOnly) return false;
     return switch (state) {
+      BackendProcessingState.completed => true,
       BackendProcessingState.ready ||
-      BackendProcessingState.buffering ||
-      BackendProcessingState.completed =>
-        true,
+      BackendProcessingState.buffering =>
+        playing,
       BackendProcessingState.idle || BackendProcessingState.loading => false,
     };
   }
@@ -2804,10 +2808,13 @@ class AudioPlayerHandler extends BaseAudioHandler
     final cur = (_backend.currentIndex ?? 0).clamp(0, q.length - 1);
 
     final protectCurrent = protectsCurrentTrack(
-        upcomingOnly: upcomingOnly, state: _backend.processingState);
+        upcomingOnly: upcomingOnly,
+        state: _backend.processingState,
+        playing: _backend.playing);
     if (upcomingOnly && !protectCurrent) {
       appLog('[queue] upcoming-only rebuild widened to the current track '
-          '(${_backend.processingState.name})');
+          '(${_backend.processingState.name}'
+          '${_backend.playing ? '' : ', paused'})');
     }
     if (protectCurrent) {
       final rebuilt = <MediaItem>[];

--- a/lib/singletons/downloads.dart
+++ b/lib/singletons/downloads.dart
@@ -122,6 +122,11 @@ class DownloadManager {
               await AutoDownloadLedger()
                   .record(dt.serverName!, dt.dataPath!, dt.localPath!);
               await _enforceAutoDownloadCap();
+              // A slot just freed: pull the next unmarked track in. The
+              // queue patch above usually re-sweeps too; this makes sure of
+              // it when the patch changed nothing.
+              unawaited(autoDownloadQueue(
+                  MediaManager().audioHandler.queue.value));
             }
           }
           break;
@@ -348,21 +353,44 @@ class DownloadManager {
     return items.sublist(start, end > items.length ? items.length : end);
   }
 
+  /// With [slotsFor], at most that many candidates per server are picked (and
+  /// marked) in one sweep; the rest stay unmarked, so the next sweep — every
+  /// queue change, every landing — picks them up as transfers finish.
   static List<MediaItem> autoDownloadCandidates(
       List<MediaItem> items, Set<String> attempted,
-      {required bool Function(String path) fileExists}) {
+      {required bool Function(String path) fileExists,
+      int Function(String server)? slotsFor}) {
     final out = <MediaItem>[];
+    final used = <String, int>{};
     for (final m in items) {
       final server = m.extras?['server'] as String?;
       final path = m.extras?['path'] as String?;
       if (server == null || path == null) continue;
       final localPath = m.extras?['localPath'] as String?;
       if (localPath != null && fileExists(localPath)) continue;
-      if (!attempted.add(server + path)) continue;
+      if (attempted.contains(server + path)) continue;
+      if (slotsFor != null) {
+        final taken = used[server] ?? 0;
+        if (taken >= slotsFor(server)) continue; // unmarked: a later sweep
+        used[server] = taken + 1;
+      }
+      attempted.add(server + path);
       out.add(m);
     }
     return out;
   }
+
+  /// How many keep-queue-offline transfers may run against one server at
+  /// once. A queued album used to fire every track together: a federated
+  /// peer caps a key at 3 concurrent streams (guests share it), so most came
+  /// back 429 to retry in another burst, and the burst competed with the
+  /// player's own stream; a small self-hosted server is not happier about
+  /// 26 range requests either. Manual downloads are not held back.
+  static const int kAutoDownloadParallel = 2;
+
+  // In-flight keys are `<serverName><filepath>`, and paths start with '/'.
+  int _inFlightFor(String server) =>
+      _inFlight.where((k) => k.startsWith('$server/')).length;
 
   /// Keep-queue-offline sweep: enqueue a download for every queued server
   /// track not yet on disk. Fired on every queue change (audio_stuff._init)
@@ -376,7 +404,21 @@ class DownloadManager {
   // once per change instead of on every queue emission / advance.
   int _lastClippedLogged = 0;
 
-  Future<void> autoDownloadQueue(List<MediaItem> items) async {
+  // Sweeps run one at a time. They fire on every queue emission — a new
+  // queue emits several times in a row — and two running at once each read
+  // the in-flight set before the other's enqueues have landed, so a queue's
+  // birth started three transfers instead of two (measured on the rig: three
+  // tasks plus the player's stream on a peer's 3-stream cap → eight 429s in
+  // the first seven seconds, none afterwards).
+  Future<void> _sweepChain = Future.value();
+
+  Future<void> autoDownloadQueue(List<MediaItem> items) {
+    final run = _sweepChain.then((_) => _autoDownloadQueue(items));
+    _sweepChain = run.catchError((_) {});
+    return run;
+  }
+
+  Future<void> _autoDownloadQueue(List<MediaItem> items) async {
     if (!SettingsManager().offlineQueue) return;
     final wifiOnly = SettingsManager().offlineQueueWifiOnly;
     // Only fetch what the cap actually allows on disk. Tracks outside the
@@ -397,7 +439,8 @@ class DownloadManager {
       }
     }
     for (final m in autoDownloadCandidates(window, _autoAttempted,
-        fileExists: (p) => File(p).existsSync())) {
+        fileExists: (p) => File(p).existsSync(),
+        slotsFor: (server) => kAutoDownloadParallel - _inFlightFor(server))) {
       await downloadOneFile(m.id, m.extras!['server'], m.extras!['path'],
           requiresWiFi: wifiOnly, auto: true, quiet: true);
     }

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -1841,17 +1841,21 @@ class ServerManager {
   /// [_remedyDeadTunnel] (kick in place when the binary can, else a hard
   /// rebuild rate-limited to one per minute). A passing probe means the tunnel
   /// is fine and the failures were the source's own problem, so nothing moves.
-  Future<void> reverifyTunnel(Server server) async {
+  ///
+  /// Returns true only when the probe ran and passed (the path is fine, the
+  /// failures were the source's own); false when it was remedied or not
+  /// probed at all.
+  Future<bool> reverifyTunnel(Server server) async {
     // Probe the transport: a peer's failures happen on its parent's tunnel.
     final s = server.transportServer;
-    if (!IrohTunnel.isSupported || s == null || !s.ownsTunnel) return;
+    if (!IrohTunnel.isSupported || s == null || !s.ownsTunnel) return false;
     final h = _tunnels[s.localname];
-    if (h == null || h.reverifying || !h.assigned) return;
+    if (h == null || h.reverifying || !h.assigned) return false;
     // Already known down: ensureTunnelFor / awaitTunnelReady own that case
     // and this would only race them.
-    if (!tunnelServes(s)) return;
+    if (!tunnelServes(s)) return false;
     final gap = _since(h.lastHardRebuildAt);
-    if (gap != null && gap < TunnelTiming.hardRebuildMinGap) return;
+    if (gap != null && gap < TunnelTiming.hardRebuildMinGap) return false;
     h.reverifying = true;
     try {
       final code = h.code;
@@ -1860,18 +1864,19 @@ class ServerManager {
       if (r.ok) {
         appLog('[iroh] tunnel probe passed (${r.reason}, ${r.ms}ms) — '
             'the failures were not the path for=${s.localname}');
-        return;
+        return true;
       }
       if (!tunnelServes(s)) {
         appLog('[iroh] probe failed (${r.reason}) but the supervisor '
             'noticed meanwhile — leaving it for=${s.localname}');
-        return;
+        return false;
       }
       appLog('[iroh] tunnel says connected but the probe failed '
           '(${r.reason}, ${r.ms}ms) after repeated load failures '
           'for=${s.localname}');
       await _remedyDeadTunnel(h,
           code: code, port: port, reason: 'reverify', user: false);
+      return false;
     } finally {
       h.reverifying = false;
     }

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -1001,7 +1001,11 @@ class ServerManager {
       // the Cast SDK's own suspend/resume recovery.
       // A direct peer's proxy URLs still work while its own tunnel comes
       // up, so only UPCOMING items move over — the playing track keeps its
-      // stream instead of reloading mid-song.
+      // stream instead of reloading mid-song (a paused or idle one moves
+      // too; see protectsCurrentTrack). And a peer that just went direct no
+      // longer needs its parent's tunnel unless the parent is browsed or
+      // queued itself: reconcile now rather than at the next queue edit.
+      if (s.isFederated) unawaited(ensureTunnels(reason: 'direct-up'));
       unawaited(MediaManager()
           .audioHandler
           .customAction('rebuildTranscodeUrls',
@@ -1098,9 +1102,24 @@ class ServerManager {
   /// Nothing references [h]'s server any more: stop its tunnel on its chain
   /// and drop the handle — unless an ensure is queued behind the stop, in
   /// which case something wants it back and the handle stays to serve that.
+  /// Queued URLs that still ride the dropped loopback are rebuilt: a peer's
+  /// tracks left on their parent's proxy port when the peer went direct
+  /// (the playing one is left alone on the bind on purpose, and reloads at
+  /// its spot here — a short gap instead of a dead source and a retry);
+  /// otherwise a no-op. (Federated handles rebuild in _stopHandleTunnel.)
   Future<void> _releaseHandle(TunnelHandle h, String reason) =>
       _mutateHandle(h, reason, () {
+        final carried = h.nativeKey != null && !h.server.isFederated;
         _stopHandleTunnel(h, reason);
+        if (carried) {
+          unawaited(MediaManager()
+              .audioHandler
+              .customAction('rebuildTranscodeUrls',
+                  const {'upcomingOnly': false, 'auto': true})
+              .catchError((Object e) {
+            appLog('[iroh] URL rebuild after the release failed: $e');
+          }));
+        }
         h.cancelRetry();
         if (identical(_tunnels[h.server.localname], h) &&
             h.pendingEnsures == 0) {

--- a/test/media/rebuild_scope_test.dart
+++ b/test/media/rebuild_scope_test.dart
@@ -8,20 +8,25 @@ import 'package:mstream_music/media/playback_backend.dart';
 void main() {
   group('AudioPlayerHandler.protectsCurrentTrack', () {
     test('a playing or buffering track is left alone by an upcoming-only rebuild', () {
-      for (final s in [BackendProcessingState.ready, BackendProcessingState.buffering, BackendProcessingState.completed]) {
-        expect(AudioPlayerHandler.protectsCurrentTrack(upcomingOnly: true, state: s), isTrue, reason: '$s');
+      for (final s in [BackendProcessingState.ready, BackendProcessingState.buffering]) {
+        expect(AudioPlayerHandler.protectsCurrentTrack(upcomingOnly: true, state: s, playing: true), isTrue, reason: '$s');
       }
+      expect(AudioPlayerHandler.protectsCurrentTrack(upcomingOnly: true, state: BackendProcessingState.completed, playing: false), isTrue);
     });
 
-    test('an idle or still-loading current track is rebuilt too (its URL may be the stale one)', () {
+    test('a paused, idle or still-loading current track is rebuilt too (its URL may be the stale one)', () {
+      // A queue restored at launch sits ready-but-paused on the parent's
+      // proxy URL while the peer's own tunnel arrives; the reload keeps the
+      // spot and stays paused.
+      expect(AudioPlayerHandler.protectsCurrentTrack(upcomingOnly: true, state: BackendProcessingState.ready, playing: false), isFalse);
       for (final s in [BackendProcessingState.idle, BackendProcessingState.loading]) {
-        expect(AudioPlayerHandler.protectsCurrentTrack(upcomingOnly: true, state: s), isFalse, reason: '$s');
+        expect(AudioPlayerHandler.protectsCurrentTrack(upcomingOnly: true, state: s, playing: true), isFalse, reason: '$s');
       }
     });
 
     test('a full rebuild never protects', () {
       for (final s in BackendProcessingState.values) {
-        expect(AudioPlayerHandler.protectsCurrentTrack(upcomingOnly: false, state: s), isFalse);
+        expect(AudioPlayerHandler.protectsCurrentTrack(upcomingOnly: false, state: s, playing: true), isFalse);
       }
     });
   });

--- a/test/media/tunnel_heal_action_test.dart
+++ b/test/media/tunnel_heal_action_test.dart
@@ -9,6 +9,7 @@ HealAction act({
   bool skipPending = false,
   BackendProcessingState processingState = BackendProcessingState.idle,
   bool queueEmpty = false,
+  bool healSuspended = false,
 }) =>
     AudioPlayerHandler.healAction(
       onLocalBackend: onLocalBackend,
@@ -17,12 +18,22 @@ HealAction act({
       skipPending: skipPending,
       processingState: processingState,
       queueEmpty: queueEmpty,
+      healSuspended: healSuspended,
     );
 
 void main() {
   group('AudioPlayerHandler.healAction', () {
     test('parked player with tracks queued → run', () {
       expect(act(), HealAction.run);
+    });
+
+    // After a hand-off the skip walk owns the failures: every park during it
+    // used to re-trigger the heal (the idle transition is its own trigger),
+    // re-seeding each failing track twice more before the probe handed it
+    // off again — ~35 s per track instead of ~3 s.
+    test('suspended after a hand-off → drop, even when parked', () {
+      expect(act(healSuspended: true), HealAction.drop);
+      expect(act(healSuspended: true, processingState: BackendProcessingState.loading), HealAction.drop);
     });
 
     // The regression this exists for. The heal's original trigger was a single
@@ -81,6 +92,30 @@ void main() {
               onLocalBackend: false,
               processingState: BackendProcessingState.loading),
           HealAction.drop);
+    });
+  });
+
+  group('AudioPlayerHandler.healResumeFailureAction', () {
+    ResumeFailureAction act({bool pathVerified = false, int failures = 1}) =>
+        AudioPlayerHandler.healResumeFailureAction(
+            pathVerified: pathVerified, failures: failures);
+
+    test('a resume that failed with no verdict yet → rearm', () {
+      expect(act(), ResumeFailureAction.rearm);
+      expect(act(failures: 2), ResumeFailureAction.rearm);
+    });
+
+    // The loop this exists for: an expired guest token (or a rotated secret)
+    // made every load fail against a tunnel that was perfectly fine, the
+    // probe said so, and the heal re-seeded the same track every ~14s anyway.
+    test('the probe cleared the path → the track takes the skip walk', () {
+      expect(act(pathVerified: true), ResumeFailureAction.skipTrack);
+      expect(act(pathVerified: true, failures: 1), ResumeFailureAction.skipTrack);
+    });
+
+    test('with no verdict, the bound alone ends it', () {
+      expect(act(failures: AudioPlayerHandler.kMaxHealResumeFailures - 1), ResumeFailureAction.rearm);
+      expect(act(failures: AudioPlayerHandler.kMaxHealResumeFailures), ResumeFailureAction.skipTrack);
     });
   });
 }

--- a/test/singletons/auto_download_test.dart
+++ b/test/singletons/auto_download_test.dart
@@ -79,6 +79,30 @@ void main() {
           1);
     });
 
+    test('a per-server slot budget picks — and marks — only what fits', () {
+      final attempted = <String>{};
+      final q = [item('/a'), item('/b'), item('/c'), item('/x', server: 's2')];
+      final first = DownloadManager.autoDownloadCandidates(q, attempted,
+          fileExists: missing, slotsFor: (s) => s == 's1' ? 1 : 2);
+      expect(first.map((m) => m.extras!['path']), ['/a', '/x']);
+      expect(attempted, {'s1/a', 's2/x'}, reason: 'the ones left out stay unmarked');
+      // The next sweep, with a slot free again, takes the next in order.
+      final second = DownloadManager.autoDownloadCandidates(q, attempted,
+          fileExists: missing, slotsFor: (s) => s == 's1' ? 1 : 0);
+      expect(second.map((m) => m.extras!['path']), ['/b']);
+      // No slots → nothing picked, nothing marked.
+      expect(DownloadManager.autoDownloadCandidates(q, attempted, fileExists: missing, slotsFor: (_) => 0), isEmpty);
+      expect(attempted, {'s1/a', 's2/x', 's1/b'});
+    });
+
+    test('already-attempted and on-disk tracks do not consume a slot', () {
+      final attempted = {'s1/a'};
+      final q = [item('/a'), item('/d', localPath: '/disk/d'), item('/b'), item('/c')];
+      final picked = DownloadManager.autoDownloadCandidates(q, attempted,
+          fileExists: onDisk, slotsFor: (_) => 1);
+      expect(picked.map((m) => m.extras!['path']), ['/b']);
+    });
+
     test('duplicate copies of one track in the same sweep pick once', () {
       final picked = DownloadManager.autoDownloadCandidates(
           [item('/a.mp3'), item('/a.mp3')], <String>{},


### PR DESCRIPTION
Stacked on #150 (the two observations from its verification that were not fixed there). Both were found on the two-server rig with an expired guest token, but neither is specific to federation: a Quick Connect server whose token died, or a queued album on any small server, hits the same paths.

## 1. The tunnel heal loop now terminates

When every load fails against a tunnel that is up (an expired or rotated credential, files the server no longer has), the heal re-seeded the same track every ~14 s for as long as a serving tunnel and an idle player coexisted. Its own ground-truth probe said "the failures were not the path" and nothing acted on it, and the ordinary retry-then-skip walk never got a turn because every park re-triggered the heal.

- `ServerManager.reverifyTunnel` returns its verdict (true = the probe ran and passed).
- After a failed heal resume, `healResumeFailureAction` decides: re-arm while the path may still be the problem; hand the track to the skip walk once the probe has cleared the path, and after six failed resumes regardless (a probe that never ran cannot keep the loop alive).
- A hand-off suspends the heal (`healAction` → drop) until a track loads or a real tunnel edge arrives, so the walk runs at the ordinary pace instead of two heal cycles per track.

## 2. Keep-queue-offline downloads two at a time per server

A queued album fired every track at once. A federated peer caps a key at 3 concurrent streams (guests share it), so most came back 429 to retry in another burst, and the burst competed with the player's own stream; a small self-hosted server is not happier about 26 range requests either.

- `autoDownloadCandidates` takes a per-server slot budget and marks only what it returns; the rest stay unmarked and enqueue as transfers land (a landing re-sweeps).
- `kAutoDownloadParallel = 2`; manual downloads are not held back.
- Sweeps are serialized: they fire on every queue emission, and two running at once each read the in-flight set before the other's enqueues landed (measured: three transfers at a queue's birth → eight 429s in the first seven seconds, none afterwards).

## Tests

514 pass (6 new): `healResumeFailureAction`, the suspended heal, the slot budget and its marking.

## Galaxy S25 verification

Two-server rig, 3-minute guest TTL, keep-queue-offline off unless noted. The full release suite (both rig modes, launch matrix, switch, media resumption, dead zone) is running on the phone overnight; its table follows as a comment.

| Scenario | Result |
|---|---|
| Expired token, parent dead: 3 failed resumes → probe clears the path → hand-off | PASS, heal stays out of the rest of the walk |
| Same, before the retry fix | the walk sat at retry 1 (found and fixed in this PR) |
| Parent back: renewal → widened rebuild → playing again | PASS, 1 s after the renewal |
| Queued album with keep-queue-offline on | 0 stream-cap rejections at the queue's birth (was 23, then 8 before the sweeps were serialized), 26/26 landed |
| Key revoked on the peer (rig) | app alive 75 s later, 1 access line, 0 heal resumes, playback parked |
| iOS simulator, same rig | direct tunnel on the first dial, playback and browse with the parent dead, two in-place renewals |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
