### PR TITLE
rust: iroh-only reproduction of the same-NAT hairpin path stall (hand-off to iroh)

### DIFF
--- a/rust/iroh-hairpin-repro/Cargo.toml
+++ b/rust/iroh-hairpin-repro/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "iroh-hairpin-repro"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Two hosts behind one NAT: the dialer selects a hairpinned reflexive path that only works one way"
+
+[dependencies]
+iroh = "1"
+iroh-tickets = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+anyhow = "1"
+
+[profile.release]
+opt-level = "z"
+lto = "thin"
+strip = true

--- a/rust/iroh-hairpin-repro/README.md
+++ b/rust/iroh-hairpin-repro/README.md
@@ -1,0 +1,85 @@
+# iroh: a same-NAT dialer selects a hairpinned reflexive path that only works one way
+
+Two hosts behind one home router. The server's `EndpointAddr` (and so its
+ticket) carries its LAN address **and** the NAT-reflexive public addresses
+iroh learned through the relays. A dialer on the same LAN selects a "direct"
+path to one of the reflexive addresses: the router hairpins the first packet
+back in with its own LAN address as the source, the server's handshake flight
+makes it back through that NAT state, the dialer's `connect()` resolves and it
+opens its first stream — and nothing it sends after that reaches the server.
+The server's `Connecting` never completes; the dialer sits on the dead path for
+as long as it waits, with a working relay path available the whole time.
+
+Two binaries, only `iroh` + `iroh-tickets` + `tokio` as dependencies.
+
+## Run
+
+Host A (behind the NAT):
+
+```bash
+cargo run --release --bin server
+# prints its relay, each direct address tagged LAN / NAT-reflexive, and TICKET=…
+```
+
+Host B, a **second machine behind the same NAT** (a laptop on the same Wi-Fi;
+or an Android phone via `adb shell`, see below):
+
+```bash
+cargo run --release --bin client -- <ticket> 5            # the ticket as advertised
+cargo run --release --bin client -- <ticket> 5 --lan-only # the same ticket without the reflexive addresses
+```
+
+Each attempt binds a fresh endpoint, dials, opens the first bi-stream, writes
+5 bytes and waits 10 s for the server's `OK` — the shape of a first connection
+between two peers.
+
+Android as host B: `cargo ndk -t arm64-v8a --platform 26 build --release --bin client`,
+then `adb push target/aarch64-linux-android/release/client /data/local/tmp/hairpin-client`
+and `adb shell /data/local/tmp/hairpin-client <ticket> 5`.
+
+## What we see (iroh 1.0.0 both sides; macOS server, Android arm64 client, one home router)
+
+Server:
+
+```
+direct: 73.60.222.134:58294  [NAT-reflexive]
+direct: 73.60.222.134:62054  [NAT-reflexive]
+direct: 192.168.1.120:58294  [LAN]
+[14:20:30.218] incoming from Ip(192.168.1.1:47257)          ← the ROUTER's LAN address
+[14:21:00.222] STALL: handshake from Ip(192.168.1.1:47257) not complete after 30s
+…
+[14:21:33.027] incoming from Ip(192.168.1.204:40839)         ← the phone's own address
+[14:21:33.035] connected in 0.01s … paths=direct*
+[14:21:33.035] handshake OK in 0.01s (5 bytes from the client)
+```
+
+Client, the ticket as advertised — **4 of 5 attempts stalled**:
+
+```
+attempt 1: STALL — connected in 0.02s, no reply to the first stream in 10s; selected path=direct
+attempt 2: STALL — connected in 0.13s, no reply to the first stream in 10s; selected path=direct
+attempt 3: STALL — connected in 0.03s, no reply to the first stream in 10s; selected path=direct
+attempt 4: STALL — connected in 0.01s, no reply to the first stream in 10s; selected path=direct
+attempt 5: OK — connected in 0.01s, reply in 0.02s, selected path=direct
+```
+
+Client, `--lan-only` — **0 of 5 stalled** (four direct, one relay). Same-host
+control from the server's machine: 0 of 3.
+
+The two reflexive addresses have different mapped ports for the same local
+port: this router hands out a mapping per destination. Whether it hairpins a
+flow for one packet or for a few seconds does not matter to the point:
+
+- a path whose only evidence is one hairpinned round trip is selected over a
+  LAN candidate and over the relay, without the reverse direction ever being
+  validated;
+- once that path stops delivering, the connection stays on it instead of
+  falling back to the relay, which is up and was used to learn the peer.
+
+## Workaround we shipped
+
+The server builds its tickets from an `EndpointAddr` holding only the direct
+addresses present on its own interfaces (holepunching still discovers the
+reflexive ones through the relay). That is what `--lan-only` simulates on the
+dialing side. mStream#956 for the server-side change; the app-side trace that
+found it is in `../iroh_tunnel`.

--- a/rust/iroh-hairpin-repro/src/bin/client.rs
+++ b/rust/iroh-hairpin-repro/src/bin/client.rs
@@ -1,0 +1,102 @@
+//! The dialing side, run on a SECOND host behind the same NAT as the server.
+//! Each attempt binds a fresh endpoint, dials the ticket, opens the first
+//! bi-stream, writes, and waits 10 s for the server's reply — the shape of a
+//! first connection between two peers. Reports the selected path.
+//!
+//!   client <ticket> [attempts=5] [--lan-only]
+//!
+//! `--lan-only` strips the NAT-reflexive addresses from the ticket before
+//! dialing (keeps the relay and the private-range addresses): the workaround.
+
+#[path = "../common.rs"]
+mod common;
+
+use anyhow::{Context, Result};
+use common::{is_lan, stamp, ALPN};
+use iroh::{endpoint::presets, Endpoint, EndpointAddr};
+use iroh_tickets::endpoint::EndpointTicket;
+use std::time::{Duration, Instant};
+use tokio::time::timeout;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let ticket = args.get(1).context("usage: client <ticket> [attempts] [--lan-only]")?;
+    let attempts: u32 = args.iter().skip(2).find_map(|a| a.parse().ok()).unwrap_or(5);
+    let lan_only = args.iter().any(|a| a == "--lan-only");
+    let ticket: EndpointTicket = ticket.parse().context("not an EndpointTicket")?;
+    let full = ticket.endpoint_addr().clone();
+    let addr = if lan_only {
+        let mut a = EndpointAddr::new(full.id);
+        for r in full.relay_urls() {
+            a = a.with_relay_url(r.clone());
+        }
+        for ip in full.ip_addrs().filter(|s| is_lan(s)) {
+            a = a.with_ip_addr(*ip);
+        }
+        a
+    } else {
+        full.clone()
+    };
+    println!(
+        "dialing {} with relays [{}] and direct [{}]{}",
+        addr.id,
+        addr.relay_urls().map(|r| r.to_string()).collect::<Vec<_>>().join(" "),
+        addr.ip_addrs().map(|s| format!("{s}{}", if is_lan(s) { "" } else { "(reflexive)" })).collect::<Vec<_>>().join(" "),
+        if lan_only { "  [--lan-only]" } else { "" }
+    );
+
+    let mut stalls = 0;
+    for i in 1..=attempts {
+        let ep = Endpoint::builder(presets::N0).bind().await?;
+        let _ = timeout(Duration::from_secs(5), ep.online()).await;
+        let t0 = Instant::now();
+        let conn = match timeout(Duration::from_secs(25), ep.connect(addr.clone(), ALPN)).await {
+            Ok(Ok(c)) => c,
+            Ok(Err(e)) => {
+                println!("[{}] attempt {i}: connect failed after {:.1}s: {e}", stamp(), t0.elapsed().as_secs_f32());
+                ep.close().await;
+                continue;
+            }
+            Err(_) => {
+                println!("[{}] attempt {i}: connect timed out (25s)", stamp());
+                ep.close().await;
+                continue;
+            }
+        };
+        let connect_s = t0.elapsed().as_secs_f32();
+        let path = || {
+            conn.paths()
+                .iter()
+                .find(|p| p.is_selected())
+                .map(|p| if p.is_relay() { "relay" } else { "direct" })
+                .unwrap_or("none")
+        };
+        let (mut send, mut recv) = conn.open_bi().await?;
+        send.write_all(b"hello").await?;
+        send.finish()?;
+        match timeout(Duration::from_secs(10), recv.read_to_end(8)).await {
+            Ok(Ok(v)) if v == b"OK" => println!(
+                "[{}] attempt {i}: OK — connected in {connect_s:.2}s, reply in {:.2}s, selected path={}",
+                stamp(), t0.elapsed().as_secs_f32(), path()
+            ),
+            Ok(Ok(v)) => println!("[{}] attempt {i}: unexpected reply {v:?}", stamp()),
+            Ok(Err(e)) => {
+                stalls += 1;
+                println!("[{}] attempt {i}: STALL — connected in {connect_s:.2}s, then the stream died: {e}; selected path={}", stamp(), path());
+            }
+            Err(_) => {
+                stalls += 1;
+                println!(
+                    "[{}] attempt {i}: STALL — connected in {connect_s:.2}s, no reply to the first stream in 10s; selected path={}",
+                    stamp(), path()
+                );
+            }
+        }
+        conn.close(0u32.into(), b"done");
+        ep.close().await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+    println!("== {stalls} of {attempts} attempts stalled{}", if lan_only { " (LAN-only ticket)" } else { "" });
+    Ok(())
+}

--- a/rust/iroh-hairpin-repro/src/bin/server.rs
+++ b/rust/iroh-hairpin-repro/src/bin/server.rs
@@ -1,0 +1,96 @@
+//! The accepting side. Prints its ticket (the full EndpointAddr: relay +
+//! every direct address iroh knows, LAN and NAT-reflexive alike), then
+//! traces each incoming connection: when the QUIC handshake completes, where
+//! the packets come from, and whether the client's first stream ever arrives.
+//!
+//!   cargo run --release --bin server
+
+#[path = "../common.rs"]
+mod common;
+
+use anyhow::Result;
+use common::{is_lan, stamp, ALPN};
+use iroh::{endpoint::presets, Endpoint};
+use iroh_tickets::endpoint::EndpointTicket;
+use std::time::{Duration, Instant};
+use tokio::time::timeout;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let ep = Endpoint::builder(presets::N0)
+        .alpns(vec![ALPN.to_vec()])
+        .bind()
+        .await?;
+    let online = timeout(Duration::from_secs(10), ep.online()).await.is_ok();
+    let addr = ep.addr();
+    println!("endpoint id: {}", ep.id());
+    println!("online: {online}");
+    for r in addr.relay_urls() {
+        println!("relay: {r}");
+    }
+    for a in addr.ip_addrs() {
+        println!("direct: {a}  [{}]", if is_lan(a) { "LAN" } else { "NAT-reflexive" });
+    }
+    println!("TICKET={}", EndpointTicket::new(addr.clone()));
+    println!("[{}] accepting on {:?}", stamp(), String::from_utf8_lossy(ALPN));
+
+    while let Some(incoming) = ep.accept().await {
+        tokio::spawn(async move {
+            let t0 = Instant::now();
+            let from = format!("{:?}", incoming.remote_addr());
+            println!("[{}] incoming from {from}", stamp());
+            let connecting = match incoming.accept() {
+                Ok(c) => c,
+                Err(e) => {
+                    println!("[{}] accept error from {from}: {e}", stamp());
+                    return;
+                }
+            };
+            let conn = match timeout(Duration::from_secs(30), connecting).await {
+                Ok(Ok(c)) => c,
+                Ok(Err(e)) => {
+                    println!(
+                        "[{}] STALL: handshake from {from} failed after {:.1}s: {e}",
+                        stamp(),
+                        t0.elapsed().as_secs_f32()
+                    );
+                    return;
+                }
+                Err(_) => {
+                    println!("[{}] STALL: handshake from {from} not complete after 30s", stamp());
+                    return;
+                }
+            };
+            let paths: Vec<String> = conn
+                .paths()
+                .iter()
+                .map(|p| format!("{}{}", if p.is_relay() { "relay" } else { "direct" }, if p.is_selected() { "*" } else { "" }))
+                .collect();
+            println!(
+                "[{}] connected in {:.2}s from {from}: remote_id={} paths={}",
+                stamp(),
+                t0.elapsed().as_secs_f32(),
+                conn.remote_id(),
+                paths.join(",")
+            );
+            match timeout(Duration::from_secs(10), conn.accept_bi()).await {
+                Ok(Ok((mut send, mut recv))) => {
+                    let got = recv.read_to_end(64).await.unwrap_or_default();
+                    let _ = send.write_all(b"OK").await;
+                    let _ = send.finish();
+                    println!(
+                        "[{}] handshake OK in {:.2}s ({} bytes from the client)",
+                        stamp(),
+                        t0.elapsed().as_secs_f32(),
+                        got.len()
+                    );
+                }
+                Ok(Err(e)) => println!("[{}] stream error after {:.1}s: {e}", stamp(), t0.elapsed().as_secs_f32()),
+                Err(_) => println!("[{}] STALL: connected but no stream from the client within 10s", stamp()),
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            conn.close(0u32.into(), b"done");
+        });
+    }
+    Ok(())
+}

--- a/rust/iroh-hairpin-repro/src/common.rs
+++ b/rust/iroh-hairpin-repro/src/common.rs
@@ -1,0 +1,23 @@
+use std::net::{IpAddr, SocketAddr};
+
+pub const ALPN: &[u8] = b"iroh-hairpin-repro/1";
+
+/// Address on a private/link-local/loopback range — reachable on the LAN,
+/// as opposed to a NAT-reflexive public mapping learned through a relay.
+pub fn is_lan(addr: &SocketAddr) -> bool {
+    match addr.ip() {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local() || v4.is_loopback(),
+        IpAddr::V6(v6) => {
+            let seg = v6.segments();
+            v6.is_loopback() || (seg[0] & 0xffc0) == 0xfe80 || (seg[0] & 0xfe00) == 0xfc00
+        }
+    }
+}
+
+pub fn stamp() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let s = now.as_secs() % 86_400;
+    format!("{:02}:{:02}:{:02}.{:03}", s / 3600, (s / 60) % 60, s % 60, now.subsec_millis())
+}


### PR DESCRIPTION
# iroh: a same-NAT dialer selects a hairpinned reflexive path that only works one way

Two hosts behind one home router. The server's `EndpointAddr` (and so its
ticket) carries its LAN address **and** the NAT-reflexive public addresses
iroh learned through the relays. A dialer on the same LAN selects a "direct"
path to one of the reflexive addresses: the router hairpins the first packet
back in with its own LAN address as the source, the server's handshake flight
makes it back through that NAT state, the dialer's `connect()` resolves and it
opens its first stream — and nothing it sends after that reaches the server.
The server's `Connecting` never completes; the dialer sits on the dead path for
as long as it waits, with a working relay path available the whole time.

Galaxy S25 as the second host (cargo-ndk build through `adb shell`) against the Mac: **4 of 5** attempts stalled with the ticket as advertised, **0 of 5** with `--lan-only`, 0 of 3 from the same host. Full recipe, output and the two expectations for iroh in the crate's README; the issue text to file upstream is drafted alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)