### PR TITLE
feat(servers): a federated peer sits directly under its parent, drawn as a branch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,7 @@ import 'singletons/queue_store.dart';
 import 'singletons/log_manager.dart';
 import 'app_version.dart';
 import 'build_variant.dart';
+import 'util/server_tree.dart';
 import 'util/self_signed_overrides.dart';
 import 'singletons/playlists.dart';
 import 'singletons/settings.dart';
@@ -870,9 +871,10 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
   // over the browser ↔ album-detail body. It sits BELOW the player overlay and
   // the outer Scaffold's drawer in build()'s Stack, so an open drawer dims it
   // like any other content.
-  // One row of the server picker. A federated peer is indented under the
-  // server it is reached through and names it, since a peer has no URL of its
-  // own to be identified by — only a name its parent reports.
+  // One row of the server picker. A federated peer sits directly under the
+  // server it is reached through (see serversGrouped), drawn as a branch off
+  // that row, and names it, since a peer has no URL of its own to be
+  // identified by — only a name its parent reports.
   Widget _serverPickerRow(AppLocalizations l, Server server) {
     final selected = server == ServerManager().currentServer;
     final color = selected ? VelvetColors.primary : VelvetColors.textPrimary;
@@ -881,8 +883,11 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
     }
     final parent = server.parentServer?.displayName ?? server.federationParent;
     return Padding(
-      padding: const EdgeInsets.only(left: 16),
+      padding: const EdgeInsets.only(left: 8),
       child: Row(mainAxisSize: MainAxisSize.min, children: [
+        Text(kPeerBranch,
+            style: TextStyle(color: VelvetColors.textSecondary, fontSize: 16)),
+        const SizedBox(width: 6),
         Icon(Icons.hub_outlined, size: 16, color: VelvetColors.textSecondary),
         const SizedBox(width: 8),
         Flexible(
@@ -1023,7 +1028,10 @@ class _MStreamAppState extends State<MStreamApp> with WidgetsBindingObserver {
                       itemBuilder: (BuildContext context) {
                         final servers = ServerManager().serverList;
                         return <PopupMenuEntry<int>>[
-                          for (final server in servers)
+                          // Display order: a peer directly under the server
+                          // it is reached through (serversGrouped); the
+                          // value stays the index into the STORED list.
+                          for (final server in serversGrouped(servers))
                             // A peer its parent no longer lists (or one the
                             // user hid) stays in the list so queued and
                             // downloaded tracks keep resolving, but is not

--- a/lib/screens/auto_dj.dart
+++ b/lib/screens/auto_dj.dart
@@ -27,6 +27,7 @@ import '../singletons/auto_dj_manager.dart';
 import '../singletons/media.dart';
 import '../singletons/server_list.dart';
 import '../util/fan_out_readout.dart';
+import '../util/server_tree.dart';
 import '../util/server_version.dart';
 import '../theme/velvet_theme.dart';
 import '../widgets/queue_list.dart' show toggleAutoDJ;
@@ -192,8 +193,14 @@ class _AutoDJScreenState extends State<AutoDJScreen> {
   /// The servers this mode is about: everything the picker may offer. A
   /// federated peer counts — it takes part like any other server — but not
   /// one the user hid or its parent stopped listing.
-  List<Server> get _servers =>
-      ServerManager().serverList.where((s) => s.isSelectable).toList();
+  List<Server> get _servers => serversGrouped(ServerManager().serverList)
+      .where((s) => s.isSelectable)
+      .toList();
+
+  /// A dropdown label: a peer is drawn as a branch off its parent, which
+  /// [serversGrouped] places right above it.
+  String _serverLabel(Server s) =>
+      s.isFederated ? '$kPeerBranch ${s.displayName}' : s.displayName;
 
   /// The server whose own settings the bottom section edits. Falls back to
   /// the panel's server so the section is never empty, and re-resolves if the
@@ -392,7 +399,7 @@ class _AutoDJScreenState extends State<AutoDJScreen> {
                       value: s,
                       // A peer has no URL of its own; its name is what the
                       // rest of the app shows for it.
-                      child: Text(s.displayName,
+                      child: Text(_serverLabel(s),
                           overflow: TextOverflow.ellipsis,
                           style:
                               TextStyle(color: VelvetColors.textPrimary)),
@@ -948,8 +955,9 @@ class _AutoDJScreenState extends State<AutoDJScreen> {
     // A federated peer hosts the DJ like any other server (random-songs is
     // on the federation allowlist since mStream #946); only one the user
     // hid, or its parent stopped listing, stays out.
-    final servers =
-        ServerManager().serverList.where((s) => s.isSelectable).toList();
+    final servers = serversGrouped(ServerManager().serverList)
+        .where((s) => s.isSelectable)
+        .toList();
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
       child: DropdownButton<Server>(
@@ -965,7 +973,7 @@ class _AutoDJScreenState extends State<AutoDJScreen> {
         items: servers
             .map((s) => DropdownMenuItem(
                   value: s,
-                  child: Text(s.displayName,
+                  child: Text(_serverLabel(s),
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(color: VelvetColors.textPrimary)),
                 ))

--- a/lib/screens/manage_server.dart
+++ b/lib/screens/manage_server.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import '../l10n/app_localizations.dart';
 import '../objects/server.dart';
 import '../singletons/server_list.dart';
+import '../util/server_tree.dart';
 import '../native/iroh_tunnel.dart';
 import '../singletons/log_manager.dart';
 import '../theme/velvet_theme.dart';
@@ -216,6 +217,14 @@ class ManageServersScreen extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(12, 10, 4, 10),
           child: Row(
             children: [
+              // A peer is a branch off the parent's row above it.
+              if (server.isFederated)
+                Padding(
+                  padding: const EdgeInsets.only(left: 8, right: 10),
+                  child: Text(kPeerBranch,
+                      style: TextStyle(
+                          color: VelvetColors.textSecondary, fontSize: 18)),
+                ),
               Container(
                 width: 44,
                 height: 44,
@@ -324,11 +333,15 @@ class ManageServersScreen extends StatelessWidget {
                 ),
               );
             }
+            // Display order: a peer directly under the server it is reached
+            // through (serversGrouped); every action keys on the index into
+            // the STORED list, so that is what each row is handed.
+            final ordered = serversGrouped(cServerList);
             return ListView.builder(
               physics: const AlwaysScrollableScrollPhysics(),
-              itemCount: cServerList.length,
-              itemBuilder: (BuildContext context, int index) =>
-                  _serverRow(context, cServerList[index], index),
+              itemCount: ordered.length,
+              itemBuilder: (BuildContext context, int index) => _serverRow(
+                  context, ordered[index], cServerList.indexOf(ordered[index])),
             );
           },
         ),

--- a/lib/util/server_tree.dart
+++ b/lib/util/server_tree.dart
@@ -1,0 +1,31 @@
+import '../objects/server.dart';
+
+/// The server list in display order: every server in its stored order, with
+/// each federated peer moved to sit directly under the parent it is reached
+/// through. The stored list appends peers as the reconcile finds them, so
+/// without this a peer lands after servers that have nothing to do with it
+/// and the relationship is only legible from its "via" line. A peer whose
+/// parent is not in the list at all (a record that outlived its parent)
+/// keeps its place at the end. Pure; unit-tested.
+List<Server> serversGrouped(List<Server> stored) {
+  final out = <Server>[];
+  final placed = <Server>{};
+  for (final s in stored) {
+    if (s.isFederated) continue;
+    out.add(s);
+    placed.add(s);
+    for (final p in stored) {
+      if (p.isFederated && p.federationParent == s.localname) {
+        out.add(p);
+        placed.add(p);
+      }
+    }
+  }
+  for (final s in stored) {
+    if (!placed.contains(s)) out.add(s);
+  }
+  return out;
+}
+
+/// The glyph that draws a peer as a branch off the row above it.
+const String kPeerBranch = '\u2514';

--- a/smoke/android/autodj-multi-server.sh
+++ b/smoke/android/autodj-multi-server.sh
@@ -227,7 +227,7 @@ PY
 app_stop; cfg_write auto_dj.json "$RIG/auto_dj.json"; logcat_clear; wake; app_start
 wait_for_log '\[app\] default server ready' 30 || fail "phase 1b: default never published"
 wait_for_log '\[autodj\] restored on peer-rig-peer-a' 15 && pass "phase 1b: DJ restored armed on the peer" || fail "phase 1b: DJ not restored on the peer"
-N=$(cfg_read servers.json | python3 -c "import sys,json; print(len(json.load(sys.stdin)))"); PEER_Y=$((222 + 144 * (N - 1)))
+PEER_Y=366  # picker rows 222, 366, …: the peer sits directly under its parent, which is row 1
 tap $PICKER; sleep 1.5; shot p1b-picker; tap 639 $PEER_Y; sleep 3
 wait_for_log '\[srv\] switched to peer-rig-peer-a' 5 && pass "phase 1b: peer selected from the picker" || fail "phase 1b: no switch to the peer"
 tap $PEER_ALBUMS; sleep 4; shot p1b-albums; tap $ALBUM1; sleep 3; tap $TRACK1; sleep 6

--- a/smoke/android/federation-rig.sh
+++ b/smoke/android/federation-rig.sh
@@ -28,7 +28,7 @@
 # node_modules symlinked), node, a music folder (SMOKE_RIG_MUSIC, default
 # ~/code/mstream-demo-music, ~10 albums), the phone on the Mac's LAN
 # (SMOKE_RIG_HOST, default en0's address). Taps use the Galaxy S25 coordinates
-# and assume the picker lists the parent first and the peer last.
+# and assume the parent is the first picker row, with the peer directly under it.
 #
 # Everything it creates is torn down: both servers, their scratch dirs, the
 # phone's server list (cfg_restore) and the peer's download folder.
@@ -139,8 +139,9 @@ for i in $(seq 1 $RECON); do
   cfg_read servers.json | python3 -c "import sys,json; sys.exit(0 if any(s.get('federationParent')=='$PARENT' for s in json.load(sys.stdin)) else 1)" && break; sleep 1
 done
 [ "$i" -lt "$RECON" ] && pass "peer reconciled under $PARENT in ${i}s" || { save_applog rig-launch; fail "no peer entry after ${RECON}s"; summary; exit 1; }
-N=$(cfg_read servers.json | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
-PEER_Y=$((222 + 144 * (N - 1))) # picker rows: 222, 366, 510, … — the peer is listed last
+# Picker rows: 222, 366, 510, … — a peer sits directly under its parent,
+# and the parent is planted first, so the peer is row 2.
+PEER_Y=366
 tap $PICKER; sleep 1.5; shot picker; tap 639 $PEER_Y; sleep 3
 wait_for_log '\[srv\] switched to peer-rig-peer-a' 5 && pass "peer selected from the picker" || fail "no switch to the peer"
 shot peer-nav

--- a/test/util/server_tree_test.dart
+++ b/test/util/server_tree_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/util/server_tree.dart';
+
+// The server lists' display order: a peer directly under its parent.
+
+Server _own(String n) => Server('https://$n.example.com', 'u', 'p', 'J', n);
+Server _peer(String n, String parent, int id) =>
+    Server('federated://$parent/$id', null, null, null, n)
+      ..federationParent = parent
+      ..federationPeerId = id;
+
+List<String> _names(List<Server> l) => l.map((s) => s.localname).toList();
+
+void main() {
+  test('own servers keep their stored order', () {
+    expect(_names(serversGrouped([_own('a'), _own('b')])), ['a', 'b']);
+  });
+
+  test('a peer moves from the end of the list to under its parent', () {
+    // The reconcile appends peers after every stored server.
+    final l = [_own('home'), _own('other'), _peer('peer-x', 'home', 3)];
+    expect(_names(serversGrouped(l)), ['home', 'peer-x', 'other']);
+  });
+
+  test('several peers keep their own order under the parent; parents keep '
+      'theirs', () {
+    final l = [
+      _own('b'),
+      _own('a'),
+      _peer('a-2', 'a', 2),
+      _peer('b-1', 'b', 1),
+      _peer('a-1', 'a', 1),
+    ];
+    expect(_names(serversGrouped(l)), ['b', 'b-1', 'a', 'a-2', 'a-1']);
+  });
+
+  test('a peer whose parent is gone stays at the end', () {
+    final l = [_peer('orphan', 'gone', 9), _own('a')];
+    expect(_names(serversGrouped(l)), ['a', 'orphan']);
+  });
+
+  test('every server appears exactly once', () {
+    final l = [_own('a'), _peer('a-1', 'a', 1), _own('b'), _peer('x', 'z', 1)];
+    final g = serversGrouped(l);
+    expect(g.length, l.length);
+    expect(g.toSet().length, l.length);
+  });
+}


### PR DESCRIPTION
Every server list now shows a federated peer directly under the server it is reached through, opening with a `└` branch glyph — the app-bar picker, Manage Servers and both Auto DJ dropdowns. The stored list appends peers as the reconcile finds them, so a peer used to land after servers that had nothing to do with it, and the relationship was only legible from its *via* line.

`serversGrouped` (`lib/util/server_tree.dart`, pure, unit-tested) orders a list for display: each own server in its stored order, its peers directly under it, a peer whose parent is gone at the end. Every action still keys on the index into the stored list, so defaults, edits, deletes and `changeCurrentServer` are unchanged.

The smoke scripts' peer-row math follows: with the parent planted first, the peer is now row 2 rather than the last row.

`flutter analyze` at the baseline; `flutter test` 554/554 (5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)