### PR TITLE
fix(iroh): a spent app kick no longer cuts the next outage's first backoff short

### DIFF
--- a/rust/iroh_tunnel/README.md
+++ b/rust/iroh_tunnel/README.md
@@ -45,7 +45,7 @@ The surface is small (abi-version, start / stop / status / path-kind / network-c
 ```sh
 cd interop && npm install          # @number0/iroh 1.1.0 — the line the mStream server runs
 cd .. && cargo build               # builds the dev client binary
-node interop/harness.mjs           # Rust client ⇆ JS server; asserts JSON + Range + concurrency + reconnect + in-place kick + guest mode (federation ALPN, rejected token, in-place credential swap)
+node interop/harness.mjs           # Rust client ⇆ JS server; asserts JSON + Range + concurrency + reconnect + in-place kick + a spent kick not cutting the next backoff + guest mode (federation ALPN, rejected token, in-place credential swap)
 ```
 
 ## Build for Android

--- a/rust/iroh_tunnel/interop/harness.mjs
+++ b/rust/iroh_tunnel/interop/harness.mjs
@@ -97,6 +97,10 @@ async function main() {
   console.log(`[server] endpointId=${endpoint.id().toString()}`);
 
   const serverConns = []; // captured so the reconnect test can kill them
+  // While set, a connection accepted now never gets its handshake reply: the
+  // client's HANDSHAKE_TIMEOUT (10s) fails that attempt, which is the only way
+  // to make the supervisor sleep out a backoff against a live server.
+  let stallHandshake = false;
   (async () => {
     for (;;) {
       let incoming;
@@ -109,6 +113,7 @@ async function main() {
         const authBi = await conn.acceptBi();
         const sent = Buffer.from(await authBi.recv.readToEnd(HANDSHAKE_LIMIT));
         const ok = sent.length === connectSecret.length && crypto.timingSafeEqual(sent, connectSecret);
+        if (stallHandshake) await delay(12000); // past the client's 10s handshake timeout
         try { await authBi.send.writeAll(Array.from(Buffer.from(ok ? 'OK' : 'NO'))); await authBi.send.finish(); } catch { /* hung up */ }
         if (!ok) { try { conn.close(1n, Array.from(Buffer.from('unauthorized'))); } catch { /* noop */ } return; }
         for (;;) {
@@ -237,6 +242,30 @@ async function main() {
   check('same LOCAL_PORT answers after the kick', afterOk, afterOk ? `port ${port2.port} kept` : 'no answer');
   check('server accepted exactly one more connection for the kick', serverConns.length === connsBeforeKick + 2,
       `${connsBeforeKick} -> ${serverConns.length} (client2 first dial + re-dial)`);
+
+  // 7b) STALE KICK: the kick above landed while nothing was backing off (its
+  //     re-dial succeeded at once). The next outage that DOES back off must
+  //     not be cut short by that spent kick: drop client2's connection while
+  //     the server stalls the handshake, so attempt 1 times out (10s) and the
+  //     supervisor sleeps its first backoff, then let attempt 2 through. A
+  //     "backoff cut short: app kick" event before the reconnect is the bug.
+  console.log('\n=== STALE KICK TEST (a spent kick must not cut the next backoff) ===');
+  const mark = events2.length;
+  stallHandshake = true;
+  try { serverConns[serverConns.length - 1].close(0n, Array.from(Buffer.from('stale-kick test'))); } catch { /* noop */ }
+  await delay(5000); // attempt 1 is in flight and stalling; attempt 2 comes after the 10s timeout + backoff
+  stallHandshake = false;
+  let staleRec = false;
+  for (let i = 0; i < 30 && !staleRec; i++) {
+    await delay(1000);
+    staleRec = /reconnected: attempt [2-9]/.test(events2.slice(mark));
+  }
+  const since = events2.slice(mark);
+  check('attempt 1 failed on the stalled handshake', /attempt 1 failed .*handshake stalled/.test(since),
+      /attempt 1 failed/.test(since) ? 'seen' : 'no failed attempt (did the stall apply?)');
+  check('supervisor reconnected on a later attempt', staleRec, staleRec ? 'seen' : 'no "reconnected: attempt 2+" within 35s');
+  const spent = /backoff cut short: app kick/.test(since);
+  check('the spent kick did not cut the backoff short', !spent, spent ? 'stale "app kick" wake seen' : 'backoff slept');
   child2.kill();
 
   // 8) GUEST MODE: a federation endpoint (ALPN mstream/federation/1) whose
@@ -345,6 +374,6 @@ async function main() {
   process.exit(failures === 0 ? 0 : 1);
 }
 
-const guard = setTimeout(() => { console.error('[harness] TIMEOUT 180s'); process.exit(2); }, 180000);
+const guard = setTimeout(() => { console.error('[harness] TIMEOUT 240s'); process.exit(2); }, 240000);
 guard.unref();
 main().catch((e) => { console.error('[harness] ERROR', e); process.exit(3); });

--- a/rust/iroh_tunnel/src/lib.rs
+++ b/rust/iroh_tunnel/src/lib.rs
@@ -39,7 +39,7 @@ use iroh_tickets::Ticket as _;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{watch, Notify};
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
@@ -150,8 +150,13 @@ struct Shared {
     /// handshake, and a credential refresh spawns a fresh one on the same
     /// port ([`Tunnel::set_credential`]).
     supervisor: Mutex<Option<JoinHandle<()>>>,
-    /// App kick: wakes a supervisor that is sleeping out a backoff.
-    kick: Notify,
+    /// App kicks as a generation counter: a kick bumps it, and a backoff wait
+    /// ends early only when the generation moves past the value its attempt
+    /// started with ([`kick_after`]). A `Notify` used to sit here; it stored a
+    /// permit whenever a kick landed while nothing was backing off — the usual
+    /// case, since the re-dial succeeds at once — and that stale permit cut the
+    /// FIRST backoff of the next outage short with a spurious "app kick" event.
+    kick_gen: watch::Sender<u64>,
     /// Native events for the app's diagnostics log (drained by the status poll).
     events: Mutex<EventRing>,
     started: Instant,
@@ -238,6 +243,12 @@ impl Shared {
     }
     fn current_conn(&self) -> Connection {
         self.conn.lock().unwrap().clone()
+    }
+    /// Record an app kick (or a credential swap that should be tried at once):
+    /// a supervisor sleeping out a backoff, or failing the attempt in flight,
+    /// retries immediately. Kicks older than the current attempt are spent.
+    fn kick(&self) {
+        self.kick_gen.send_modify(|g| *g += 1);
     }
     /// Classify the live connection's *selected* path: direct (hole-punched),
     /// relayed, or unknown (no path selected yet / not connected). A snapshot.
@@ -377,7 +388,7 @@ impl Tunnel {
             }
             // No-op if the supervisor already saw this connection close.
             shared.current_conn().close(0u32.into(), b"app kick");
-            shared.kick.notify_one();
+            shared.kick();
         });
     }
 
@@ -436,7 +447,7 @@ impl Tunnel {
             }
             STATUS_RECONNECTING | STATUS_CONNECTING => {
                 shared.event("credential updated — cutting the backoff short");
-                shared.kick.notify_one();
+                shared.kick();
             }
             STATUS_DOWN => {
                 shared.event("credential updated, but the tunnel is down (listener lost) — a restart is needed");
@@ -579,6 +590,9 @@ async fn supervise(shared: Arc<Shared>) {
         loop {
             attempt += 1;
             let t0 = Instant::now();
+            // Kicks from here on — during this attempt or the backoff after it
+            // — cut that backoff short; anything older is already spent.
+            let kick_seen = *shared.kick_gen.borrow();
             // Re-warm a relay path before re-dialing (cheap if already online).
             let relay_online = tokio::time::timeout(ONLINE_TIMEOUT, shared.endpoint.online())
                 .await
@@ -619,7 +633,7 @@ async fn supervise(shared: Arc<Shared>) {
                         t0.elapsed().as_secs_f32(),
                         backoff.as_secs()
                     ));
-                    let woke = wait_backoff(&shared, backoff).await;
+                    let woke = wait_backoff(&shared, backoff, kick_seen).await;
                     backoff = next_backoff(backoff, woke);
                 }
             }
@@ -638,10 +652,24 @@ fn next_backoff(prev: Duration, woke: bool) -> Duration {
     }
 }
 
-/// Sleep `backoff`, returning early (true) on an app kick or on the home relay
-/// going from down to up. Only a DOWN→UP relay edge counts: a relay that was
-/// already up when the attempt failed says nothing about the next attempt.
-async fn wait_backoff(shared: &Shared, backoff: Duration) -> bool {
+/// Resolves once the kick generation has moved past `seen`: at once when it
+/// already has (a kick that landed during the attempt), else on the next kick.
+/// Never resolves for kicks older than `seen`. Unit-tested.
+async fn kick_after(kick_gen: &watch::Sender<u64>, seen: u64) {
+    let mut rx = kick_gen.subscribe();
+    // wait_for tests the current value first, even one already marked seen.
+    if rx.wait_for(|g| *g != seen).await.is_err() {
+        // The sender lives in Shared, so this cannot happen while a supervisor
+        // runs; if it ever did, no kick can come and the sleep should win.
+        std::future::pending::<()>().await;
+    }
+}
+
+/// Sleep `backoff`, returning early (true) on an app kick newer than
+/// `kick_seen` or on the home relay going from down to up. Only a DOWN→UP
+/// relay edge counts: a relay that was already up when the attempt failed says
+/// nothing about the next attempt.
+async fn wait_backoff(shared: &Shared, backoff: Duration, kick_seen: u64) -> bool {
     let mut relay = shared.endpoint.home_relay_status();
     let relay_was_up = relay.get().iter().any(|r| r.is_connected());
     let relay_back = async {
@@ -658,7 +686,7 @@ async fn wait_backoff(shared: &Shared, backoff: Duration) -> bool {
     };
     tokio::select! {
         _ = tokio::time::sleep(backoff) => false,
-        _ = shared.kick.notified() => {
+        _ = kick_after(&shared.kick_gen, kick_seen) => {
             shared.event("backoff cut short: app kick");
             true
         }
@@ -877,7 +905,7 @@ pub async fn connect_tunnel(code: &str, local_port: u16) -> Result<Tunnel> {
         local_port: bound_port,
         accept: Mutex::new(None),
         supervisor: Mutex::new(None),
-        kick: Notify::new(),
+        kick_gen: watch::channel(0u64).0,
         events: Mutex::new(EventRing::new()),
         started: Instant::now(),
         bridges_open_failed: AtomicU32::new(0),
@@ -1155,6 +1183,42 @@ mod tests {
         }
         assert_eq!(seen, vec![2, 4, 8, 10, 10, 10]);
         assert_eq!(next_backoff(Duration::from_secs(10), true).as_secs(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_spent_kick_does_not_wake_the_backoff() {
+        // Mirrors production: no receiver is kept, subscribers are created on demand.
+        let (tx, _) = watch::channel(0u64);
+        tx.send_modify(|g| *g += 1); // a kick from a previous connected period
+        let seen = *tx.borrow(); // the attempt starts after it
+        let woke = tokio::time::timeout(Duration::from_millis(50), kick_after(&tx, seen)).await;
+        assert!(
+            woke.is_err(),
+            "a kick older than the attempt must not cut its backoff"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_kick_during_or_after_the_attempt_wakes_the_backoff() {
+        let (tx, _) = watch::channel(0u64);
+        // During the attempt: the generation moved before the wait began.
+        let seen = *tx.borrow();
+        tx.send_modify(|g| *g += 1);
+        let woke = tokio::time::timeout(Duration::from_millis(50), kick_after(&tx, seen)).await;
+        assert!(
+            woke.is_ok(),
+            "a kick during the attempt cuts the backoff at once"
+        );
+        // While waiting: the kick lands mid-sleep.
+        let seen = *tx.borrow();
+        let (_, woke) = tokio::join!(
+            async {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                tx.send_modify(|g| *g += 1);
+            },
+            tokio::time::timeout(Duration::from_millis(500), kick_after(&tx, seen)),
+        );
+        assert!(woke.is_ok(), "a kick that lands mid-backoff wakes it");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #166, source only. A kick that landed while nothing was backing off (the normal case: the in-place re-dial succeeds immediately) left a `Notify` permit behind, and the **first backoff of the next outage** consumed it: the supervisor skipped its 1 s sleep and the events ring logged `backoff cut short: app kick` for a kick that happened minutes earlier. Recovery was unaffected; the diagnostics log was not.

The permit is replaced by a **generation counter** (`watch::Sender<u64>`): a kick bumps it, every attempt snapshots it, and the backoff wait wakes only when the generation moves past that snapshot. A kick during the attempt or the sleep still cuts the backoff short; one older than the attempt is spent. The drain suggested in the project notes was not used because it races `force_reconnect`, which closes the connection before it notifies.

## Evidence

- Two unit tests on `kick_after`: a kick older than the attempt never wakes the wait; one during or after it does (16/16 tests).
- New harness phase **STALE KICK**: after the in-place kick, client2's connection is dropped while the server stalls the handshake reply, so attempt 1 times out at 10 s and the supervisor sleeps its first backoff; then attempt 2 is let through. It asserts no `app kick` wake before the reconnect.
  - Pre-fix client (built from master): **fails** exactly there — `+14.0s attempt 1 failed … backoff 1s` → `+14.0s backoff cut short: app kick` → `reconnected: attempt 2 in 0.0s`.
  - This branch: **25/25**, `backoff slept`.
- `cargo build` clean, iOS release build compiles with 14 ABI exports.

## Not in this PR

The committed Android/iOS binaries are **not** refreshed for a log line, per the project's own rule; the change ships with the next native refresh. No Dart or ABI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
