### PR TITLE
fix(l10n): grey screen on every non-English device since v0.36.0

### DIFF
--- a/integration_test/helpers/test_helpers.dart
+++ b/integration_test/helpers/test_helpers.dart
@@ -35,11 +35,12 @@ import 'package:path_provider/path_provider.dart';
 
 import 'package:mstream_music/main.dart';
 import 'package:mstream_music/l10n/app_localizations.dart';
+import 'package:mstream_music/l10n/localizations_delegates.dart';
 import 'package:mstream_music/singletons/server_list.dart';
 import 'package:mstream_music/singletons/browser_list.dart';
 
 Widget testApp() => MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      localizationsDelegates: appLocalizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: MStreamApp(),
     );

--- a/integration_test/server_edit_jwt_test.dart
+++ b/integration_test/server_edit_jwt_test.dart
@@ -20,6 +20,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'package:mstream_music/l10n/app_localizations.dart';
+import 'package:mstream_music/l10n/localizations_delegates.dart';
 import 'package:mstream_music/objects/server.dart';
 import 'package:mstream_music/screens/add_server.dart';
 import 'package:mstream_music/singletons/server_list.dart';
@@ -44,7 +45,7 @@ void main() {
 
   Future<void> pumpEditScreen(WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      localizationsDelegates: appLocalizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: const Scaffold(body: SizedBox()),
     ));

--- a/lib/l10n/localizations_delegates.dart
+++ b/lib/l10n/localizations_delegates.dart
@@ -1,0 +1,25 @@
+// Hand-written (NOT gen-l10n output): the delegate list every MaterialApp in
+// the app mounts. Use this, never AppLocalizations.localizationsDelegates on
+// its own.
+//
+// The generated list carries flutter_localizations' delegates, which serve
+// package:flutter/material's MaterialLocalizations. The UI is built on
+// package:material_ui, whose MaterialLocalizations is a DIFFERENT type with
+// its own global delegate. Without it, material_ui's MaterialApp falls back to
+// DefaultMaterialLocalizations — English only — so on any other device
+// language every MaterialLocalizations.of(context) lookup (the drawer tooltip,
+// TextField, TabBar, dialogs…) threw "No MaterialLocalizations found": the
+// release-build grey screen of #169. cupertino_ui has the same split for the
+// CupertinoLocalizations its adaptive widgets read on iOS.
+import 'package:cupertino_ui/cupertino_ui.dart'
+    show GlobalCupertinoLocalizations;
+import 'package:flutter/widgets.dart';
+import 'package:material_ui/material_ui.dart' show GlobalMaterialLocalizations;
+
+import 'app_localizations.dart';
+
+const List<LocalizationsDelegate<dynamic>> appLocalizationsDelegates = [
+  ...AppLocalizations.localizationsDelegates,
+  GlobalMaterialLocalizations.delegate,
+  GlobalCupertinoLocalizations.delegate,
+];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,6 +52,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'native/iroh_tunnel.dart';
 import 'widgets/iroh_repair_sheet.dart';
 import 'l10n/app_localizations.dart';
+import 'l10n/localizations_delegates.dart';
 import 'widgets/player_panel.dart';
 import 'widgets/server_version_line.dart';
 import 'widgets/browser_toolbar.dart';
@@ -165,7 +166,9 @@ Future<void> _startApp() async {
         home: MStreamApp(),
         theme: buildAppTheme(palette),
         locale: locale,
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        // The shared list, not the generated one alone: material_ui needs its own
+        // global delegates or every non-English device gets a grey screen (#169).
+        localizationsDelegates: appLocalizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         debugShowCheckedModeBanner: false,
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -210,7 +210,7 @@ packages:
     source: hosted
     version: "1.0.9"
   cupertino_ui:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: cupertino_ui
       sha256: "2137c0d41f3b62cc4d3d2495e6c354bd6b6133cd21c6bb155736cc31dbd49a11"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,6 +89,9 @@ dependencies:
   viz_decoder_native:
     path: packages/viz_decoder_native
   material_ui: ^1.1.0
+  # Direct dependency (material_ui already pulls it in) for its
+  # GlobalCupertinoLocalizations - see lib/l10n/localizations_delegates.dart.
+  cupertino_ui: ^1.0.1
   flutter_local_notifications: ^22.3.0
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/test/iroh_login_screen_test.dart
+++ b/test/iroh_login_screen_test.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:mstream_music/l10n/app_localizations.dart';
+import 'package:mstream_music/l10n/localizations_delegates.dart';
 import 'package:mstream_music/screens/iroh_login_screen.dart';
 
 void main() {
@@ -16,7 +17,7 @@ void main() {
     Future<String?> Function(String, String)? validate,
   }) async {
     await tester.pumpWidget(MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      localizationsDelegates: appLocalizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: IrohLoginScreen(
         title: 'Sign in',

--- a/test/localizations_delegates_test.dart
+++ b/test/localizations_delegates_test.dart
@@ -1,0 +1,71 @@
+// Regression test for #169 (grey screen on any non-English device language).
+//
+// The UI is built on package:material_ui, whose MaterialLocalizations is a
+// different type from package:flutter/material's. The generated
+// AppLocalizations.localizationsDelegates only carries flutter_localizations'
+// delegates (the flutter/material type), so on its own it leaves material_ui
+// widgets with English-only DefaultMaterialLocalizations — every lookup on a
+// German/French/… device threw, and in release the screen became the grey
+// ErrorWidget. appLocalizationsDelegates adds the material_ui + cupertino_ui
+// global delegates; every MaterialApp in the app and the tests must use it.
+import 'package:cupertino_ui/cupertino_ui.dart' show CupertinoLocalizations;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:mstream_music/l10n/app_localizations.dart';
+import 'package:mstream_music/l10n/localizations_delegates.dart';
+
+void main() {
+  // The same lookups the real screens make: the drawer tooltip (main.dart),
+  // what TextField / TabBar / dialogs read internally, and the app's own
+  // strings — rendered so a failure surfaces as a build exception.
+  Widget probe(Locale locale, List<LocalizationsDelegate<dynamic>> delegates) =>
+      MaterialApp(
+        locale: locale,
+        localizationsDelegates: delegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => Text(
+            '${MaterialLocalizations.of(context).openAppDrawerTooltip}|'
+            '${CupertinoLocalizations.of(context).pasteButtonLabel}|'
+            '${AppLocalizations.of(context).addServerTitle}',
+          ),
+        ),
+      );
+
+  for (final locale in AppLocalizations.supportedLocales) {
+    testWidgets('material_ui + cupertino_ui localizations resolve for $locale',
+        (tester) async {
+      await tester.pumpWidget(probe(locale, appLocalizationsDelegates));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      expect(find.byType(Text), findsOneWidget);
+    });
+  }
+
+  testWidgets('a non-English locale gets translated material strings',
+      (tester) async {
+    await tester.pumpWidget(probe(const Locale('de'), appLocalizationsDelegates));
+    await tester.pumpAndSettle();
+    final tooltip = tester.widget<Text>(find.byType(Text)).data!.split('|').first;
+    expect(tooltip, isNotEmpty);
+    expect(tooltip, isNot('Open navigation menu'));
+  });
+
+  testWidgets('the generated list alone is NOT enough for a non-English locale',
+      (tester) async {
+    // Two errors are reported: WidgetsApp's debug warning that the locale is
+    // not supported by every delegate, then the real assertion. The test
+    // binding collapses two into a generic "multiple exceptions" note, so
+    // capture them at the source instead of via takeException().
+    final reported = <String>[];
+    final previous = FlutterError.onError;
+    FlutterError.onError = (details) => reported.add(details.exceptionAsString());
+    try {
+      await tester.pumpWidget(
+          probe(const Locale('de'), AppLocalizations.localizationsDelegates));
+    } finally {
+      FlutterError.onError = previous;
+    }
+    expect(reported.join(' '), contains('No MaterialLocalizations found'));
+  });
+}


### PR DESCRIPTION
## Summary
Since v0.36.0 the app shows a grey screen on the home and Add Server screens for every device whose language is not English (#169, reported on a German Nothing Phone running Android 16). It is not an Android 16 or Nothing OS problem; v0.35.0 is unaffected.

## Root cause
PR #126 moved the UI to `package:material_ui`, whose `MaterialLocalizations` is a different Dart type from `package:flutter/material`'s. The generated `AppLocalizations.localizationsDelegates` only carries the flutter_localizations delegates (the flutter/material type), so material_ui widgets were left with `DefaultMaterialLocalizations`, which supports only `en`. The app declares de/es/fr/it/ja/pl/pt/ru/zh as supported locales, so a German phone resolves to `de`, Flutter loads no material_ui `MaterialLocalizations` for it, and every `MaterialLocalizations.of(context)` throws: the drawer tooltip on the home screen, `TextField`/`TabBar` on Add Server, the language `DropdownButton` on Welcome. In release that exception renders as the grey `ErrorWidget`. Unsupported device languages fall back to the first supported locale, which is `de`, so they were hit as well. Only English devices escaped.

## Fix
- `lib/l10n/localizations_delegates.dart`: `appLocalizationsDelegates` = the generated list + material_ui's `GlobalMaterialLocalizations.delegate` + cupertino_ui's `GlobalCupertinoLocalizations.delegate` (cupertino_ui becomes a direct dependency for the import).
- Every `MaterialApp` (`main.dart`, `test/`, `integration_test/`) uses that list.
- `test/localizations_delegates_test.dart` resolves all ten supported locales and keeps a negative control proving the generated-only list fails for `de`.

## Verification
- `flutter analyze` clean on the touched files; the full `flutter test` suite passes (622 tests).
- Reproduced with a debug build on Pixel_4_API_31 (app language `de`) and Pixel_6_API_36 (Android 16, per-app locale `de-DE`): red "No MaterialLocalizations found" on exactly the screens in the report. With the fix, home and Add Server render in German on both, no exceptions in logcat.
- Release-mode smoke on the Android 16 emulator (`de-DE`, an unsupported `nl-NL`, and `en-US`): running now, results posted as a comment before merge.

Thanks to @elixs-de for the report and the screen recording. It caught this before the build reached Google Play.

Fixes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
