### PR TITLE
docs: backup & library sync design + implementation plan

### DIFF
--- a/BACKUP_SYNC_IMPLEMENTATION.md
+++ b/BACKUP_SYNC_IMPLEMENTATION.md
@@ -29,8 +29,8 @@ tests + one device smoke); no repo-wide format.
 | ID | Repo | Title | Depends on | Ships UI? | Size |
 |---|---|---|---|---|---|
 | S1 | mStream | `sync/manifest` endpoint + `sync` ping flag — **[mStream #984](https://github.com/IrosTheBeggar/mStream/pull/984)** | — | no | 🟢 2d |
-| A1 | app | Mirror root per server (Tier A) | — | yes (picker row) | 🟢 1–2d |
-| A2 | app | `packages/library_mirror`: index DB + import of existing downloads | — | no | 🟡 2–3d |
+| A1 | app | Mirror root per server (Tier A) — **[#173](https://github.com/IrosTheBeggar/mstream_music/pull/173)** | — | yes (picker row) | 🟢 1–2d |
+| A2 | app | `packages/library_mirror`: index DB + import of existing downloads — **[#174](https://github.com/IrosTheBeggar/mstream_music/pull/174)** (`package:sqlite3` 3.x build hook, no flutter-libs package) | — | no | 🟡 2–3d |
 | A3 | app | Mirror engine + "Keep a full copy" in Manage Server | S1, A2 | yes (one section) | 🔴 5–7d |
 | A4 | app | Offline browsing: albums, artists, album songs, art cache | A3 | yes (offline chip) | 🟡 3–4d |
 | A5 | app | Offline: playlists, rated, genres, recent, search (FTS5) | A4 | yes (search offline) | 🟡 3–4d |

--- a/BACKUP_SYNC_IMPLEMENTATION.md
+++ b/BACKUP_SYNC_IMPLEMENTATION.md
@@ -1,0 +1,543 @@
+# Backup & sync — implementation plan (Syncthing excluded)
+
+Work packages for `BACKUP_SYNC_PLAN.md` §4.1–4.3, §4.5, §5 and phases 0–4,
+6, 7. **Excluded:** §4.4 Tier B/C (Syncthing detection, events, pairing) =
+phase 5. Tier A (the per-server *mirror root*) is kept because it contains no
+Syncthing code — it is a folder any tool can fill; drop A1 if that is not
+wanted.
+
+Conventions assumed throughout: one worktree per PR off `master` (server PRs
+in `mStream`); one visual change per PR; a capability is a ping flag, never a
+probe; new strings land in all nine ARB files; lean verification (analyzer +
+tests + one device smoke); no repo-wide format.
+
+**Two decisions this doc makes that the design doc left open**
+
+1. **`package:sqlite3` + `sqlite3_flutter_libs`, not drift.** The repo has no
+   codegen pipeline (no build_runner), the schema is small, and the server
+   side already lives in raw SQL. drift can be layered on the same file later.
+2. **The manifest carries the lite metadata block + genres, not only hashes.**
+   Offline lists need title/artist/album for every row, and fetching them via
+   `db/metadata/batch` would be thousands of calls. ~350 B/row → 25k tracks ≈
+   9 MB raw / ~2 MB gzipped per full pull, and a 304 when nothing changed.
+   This supersedes the entry list in design §5.1.
+
+---
+
+## 0. PR map
+
+| ID | Repo | Title | Depends on | Ships UI? | Size |
+|---|---|---|---|---|---|
+| S1 | mStream | `sync/manifest` endpoint + `sync` ping flag — **[mStream #984](https://github.com/IrosTheBeggar/mStream/pull/984)** | — | no | 🟢 2d |
+| A1 | app | Mirror root per server (Tier A) | — | yes (picker row) | 🟢 1–2d |
+| A2 | app | `packages/library_mirror`: index DB + import of existing downloads | — | no | 🟡 2–3d |
+| A3 | app | Mirror engine + "Keep a full copy" in Manage Server | S1, A2 | yes (one section) | 🔴 5–7d |
+| A4 | app | Offline browsing: albums, artists, album songs, art cache | A3 | yes (offline chip) | 🟡 3–4d |
+| A5 | app | Offline: playlists, rated, genres, recent, search (FTS5) | A4 | yes (search offline) | 🟡 3–4d |
+| A6a | app | Rules: album / artist "Keep offline" | A3 | yes | 🟡 2–3d |
+| A6b | app | Rules: playlist + rated | A6a, A5 | yes | 🟡 1–2d |
+| A7 | app | Transcoded quality tier for entity rules | A6a | yes (quality picker) | 🟡 2–3d |
+| A8 | app | Fold the keep-queue-offline ledger into the index | A3 | no | 🟡 1–2d |
+| S2 | mStream | Tombstones + `since` deltas | S1 | no | 🟡 2–3d |
+| A9 | app | Consume deltas | S2, A3 | no | 🟢 1d |
+| S3 | mStream | Device upload libraries | — | admin toggle | 🟡 2d |
+| A10 | app | Back up a desktop folder *to* the server | S3, A2 | yes | 🟡 3–5d |
+| A11 | app | Headless `mstream_mirror` CLI | A3 | no | 🟡 2–3d |
+
+Critical path: **S1 ∥ A2 → A3 → A4 → A5.** A1 is independent and the
+cheapest visible win. A8, S2/A9, S3/A10 and A11 are optional and can trail
+indefinitely. The server release with S1 precedes the app release with A3
+(the app gates strictly on the flag; an older server simply shows no
+"Library copy" section).
+
+---
+
+## 1. S1 — server: `POST /api/v1/sync/manifest`
+
+**Files**
+
+- new `src/db/sync-manifest.js` — the SQL as pure functions over a db handle
+  (testable with `node:sqlite` + `test/helpers/apply-migrations.mjs`).
+- new `src/api/sync.js` — `setup(mstream)`: Joi validation, ETag / 304, JSON.
+- `src/server.js` — import + `syncApi.setup(mstream)` next to `dbApi`.
+- `src/api/playlist.js` (home of the `/api/v1/ping` handler) — `sync: true`
+  beside `discoveryP2p`.
+- `docs/openapi.yaml`, `CHANGELOG.md`, tests. **Not** `federation-auth.js`.
+
+**Contract (as shipped in mStream #984 — the app implements against this)**
+
+```
+POST /api/v1/sync/manifest
+{ "cursor": 0, "limit": 2000, "ignoreVPaths": [] }          // all optional
+If-None-Match: "<revision>"                                  // optional; honoured on the first page only
+
+200 { "revision": "…", "scanning": false, "next": 4812 | null,
+      "entries": [ { "filepath": "music/Artist/Album/01.flac",
+                     "metadata": { …the lite block: title, artist, album, album-art,
+                                   year, track, disk, duration, rating, bpm,
+                                   musical-key, genres, has-lyrics,
+                                   has-synced-lyrics, replaygain-track },
+                     "id": 4812, "file-size": 31337, "modified": 1725000000000,
+                     "hash": "…", "audio-hash": "…", "hash-v": 2, "format": "flac",
+                     "album-id": 12, "artist-id": 7,
+                     "created-at": "2026-08-01 10:00:00" } ] }
+304 (empty body)  when If-None-Match equals the current revision and no cursor was sent
+```
+
+- Entry = the same `{filepath, metadata}` row every list endpoint returns
+  (`toLiteMetadata(renderMetadataObj(row))`, genres via the batched
+  `enrichRowsWithGenres`), so the app parses `metadata` with the existing
+  `MusicMetadata.fromServerMap`; the sync identity fields sit beside it,
+  kebab-cased like the rest of the wire vocabulary. Album artist is not per
+  track — it comes from `db/albums` (keyed by name), which A4 fetches anyway.
+- `rating` in the lite block is the caller's own (user_metadata join), so
+  offline "rated" lists need no separate call — but rating changes do not
+  move the revision (see below).
+- Scope: `libraryFilter(req.user, ignoreVPaths)`, exactly like `db/*`.
+- Page query: `trackQuery(userId) WHERE <filter> AND t.id > ? ORDER BY t.id
+  LIMIT limit + 1` — the extra row says whether a next page exists, no COUNT.
+  `filepath = <vpath>/<rel>` with `\` → `/`. `next` = last id, `null` on the
+  last page (a full last page still ends with `null`). `limit` 1..5000,
+  default 2000.
+- Revision: one indexed pass `COUNT(*), MAX(id), MAX(modified),
+  COUNT(album_art_file)` over the visible set, prefixed with the library ids
+  → `"<ids>:<n>:<maxId>:<maxModified>:<withArt>"`. Sent as the `ETag` on every
+  response (304 included) and as `revision` in the body; compared only when
+  `cursor` is absent. Moves on add / delete / mtime change / art backfill /
+  scope change; returns to its old value when the set is restored. Covers
+  library content only — never per-user ratings or play counts.
+- `scanning: dbQueue.isScanning()` — the client downloads but never trashes
+  while true (rows can be transiently absent mid-scan).
+- The flag is `sync: true` in `buildFeatures()` (`src/api/server-info.js`):
+  under `features` on `GET /api/` (what the app reads) and flat on
+  `/api/v1/ping`.
+- Compression: the existing middleware covers it; nothing to add.
+
+**Tests** (`test/db/sync-manifest.test.mjs`): stable paging with inserts
+mid-walk; filter scope + `ignoreVPaths`; path rendering for nested dirs and
+backslashes; revision changes on insert / delete / mtime bump and not on a
+no-op; empty visibility (`1=0`) → empty page; genres present; lite fields
+equal `toLiteMetadata`. Validation errors (limit 0 / 5001, non-integer cursor).
+
+**Acceptance:** full pull of 25k rows < 1 s locally; 304 path < 5 ms; no
+other route changes.
+
+---
+
+## 2. A1 — app: mirror root (Tier A)
+
+Folder contract: `<mirrorRoot>/<vpath>/<relative path>` — the download tree's
+shape minus the `media/<localname>` prefix, so `mirrorRoot + item.data` is the
+candidate (`data` already begins with `/<vpath>/`).
+
+**Files**
+
+- `lib/objects/server.dart` — `String? mirrorRoot;` persisted in JSON;
+  round-trip case in `test/objects/server_test.dart`.
+- `lib/singletons/file_explorer.dart` — `Future<List<String>>
+  localCandidates(Server s, String dataPath)` → `[<downloadDir>/media/<localname><data>,
+  <mirrorRoot><data>]` (mirror root only when set and the directory exists),
+  separators normalised for Windows. The one place that knows both shapes.
+- `lib/util/queue_actions.dart` `_buildServerFileMediaItemWithDir` and
+  `lib/objects/display_item.dart` `recheckDownloadedIn` — first existing
+  candidate wins. `lib/singletons/browser_list.dart` `_resolveDownloadBadges`
+  groups by `(storageMode, storageBasePath, mirrorRoot)`.
+- `lib/singletons/downloads.dart` `downloadOneFile` — the "already on disk"
+  check uses the candidates, so a mirrored file is not re-downloaded into the
+  app tree.
+- `lib/screens/add_server.dart` — one row under the storage-mode picker:
+  "Local copy folder (optional)" via `file_selector.getDirectoryPath`. Shown
+  on desktop always, on Android only when `!isPlayBuild` and all-files access
+  is granted (same gate as `permanent`), never on iOS.
+- l10n: 3 strings × 9 ARBs.
+
+**Tests:** candidate-path builder (Windows separators, missing root, unset
+root) — pure, in `test/singletons/`.
+**Smoke:** Windows release build with a robocopy'd library folder → rows show
+the downloaded badge and playback logs a `file://` source; S25 `--flavor
+full` with a folder under `/sdcard/Music`.
+
+---
+
+## 3. A2 — app: `packages/library_mirror` (index only, no UI)
+
+Pure Dart package (`publish_to: none`, path dependency like
+`wifi_lock_shim`); deps `sqlite3`, `path`, `crypto`, `meta`. The app adds
+`sqlite3_flutter_libs` (bundles SQLite with FTS5 on Android / iOS / macOS /
+Windows / Linux; ships armeabi-v7a, matching `ndk.abiFilters`).
+
+**Layout**
+
+```
+packages/library_mirror/
+  lib/library_mirror.dart        exports
+  lib/src/schema.dart            DDL + PRAGMA user_version migrations
+  lib/src/index_db.dart          LibraryIndex: open/close, upserts, queries
+  lib/src/models.dart            RemoteTrack, LocalFile, Subscription, SyncRun, PlanAction
+  lib/src/planner.dart           (A3) pure plan()
+  lib/src/runner.dart            (A3) MirrorRunner
+  lib/src/transport.dart         (A3) ManifestClient + Downloader interfaces
+  bin/mstream_mirror.dart        (A11)
+  test/…
+```
+
+**Schema v1.** Every table carries `server` = `Server.localname`; albums and
+artists are keyed by **name** because that is how `db/albums`, `db/artists`,
+`db/album-songs` and `db/artists-albums` identify them (no ids on the wire).
+`album_id` / `artist_id` from the manifest are kept for exact grouping.
+
+```sql
+PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;
+
+CREATE TABLE meta(server TEXT, key TEXT, value TEXT, PRIMARY KEY(server, key));  -- revision, last_run, imported
+CREATE TABLE remote_tracks(
+  server TEXT, id INTEGER, path TEXT NOT NULL, size INTEGER, modified INTEGER,
+  hash TEXT, audio_hash TEXT, hash_v INTEGER, album_id INTEGER, artist_id INTEGER, art TEXT,
+  created_at TEXT, title TEXT, artist TEXT, album TEXT, album_artist TEXT,
+  track INTEGER, disc INTEGER, year INTEGER, duration REAL, format TEXT,
+  genres TEXT,            -- JSON array
+  seen_rev TEXT,
+  PRIMARY KEY(server, id));
+CREATE UNIQUE INDEX rt_path   ON remote_tracks(server, path);
+CREATE INDEX rt_album         ON remote_tracks(server, album);
+CREATE INDEX rt_artist        ON remote_tracks(server, artist);
+CREATE INDEX rt_audio_hash    ON remote_tracks(server, audio_hash);
+CREATE INDEX rt_created       ON remote_tracks(server, created_at);
+CREATE TABLE remote_albums(server TEXT, name TEXT, album_artist TEXT, year INTEGER, art TEXT, PRIMARY KEY(server, name));
+CREATE TABLE remote_artists(server TEXT, name TEXT, PRIMARY KEY(server, name));
+CREATE TABLE remote_genres(server TEXT, name TEXT, track_count INTEGER, PRIMARY KEY(server, name));
+CREATE TABLE remote_playlists(server TEXT, id TEXT, name TEXT, PRIMARY KEY(server, id));
+CREATE TABLE remote_playlist_items(server TEXT, playlist_id TEXT, pos INTEGER, path TEXT, PRIMARY KEY(server, playlist_id, pos));
+CREATE TABLE remote_rated(server TEXT, path TEXT, rating INTEGER, PRIMARY KEY(server, path));
+CREATE TABLE local_files(
+  server TEXT, path TEXT, local_path TEXT NOT NULL, size INTEGER, mtime INTEGER, hash TEXT,
+  state TEXT NOT NULL,                        -- pending | downloading | ok | stale | trashed | failed
+  origin TEXT NOT NULL,                       -- mirror | manual | auto | external
+  quality TEXT NOT NULL DEFAULT 'original',
+  verified_at INTEGER, error TEXT,
+  PRIMARY KEY(server, path, quality));
+CREATE TABLE subscriptions(
+  id INTEGER PRIMARY KEY, server TEXT, kind TEXT, key TEXT, quality TEXT DEFAULT 'original',
+  wifi_only INTEGER DEFAULT 0, enabled INTEGER DEFAULT 1, last_run INTEGER,
+  UNIQUE(server, kind, key, quality));
+CREATE TABLE subscription_files(                -- required-by edges
+  subscription_id INTEGER REFERENCES subscriptions(id) ON DELETE CASCADE,
+  server TEXT, path TEXT, PRIMARY KEY(subscription_id, server, path));
+CREATE TABLE sync_runs(
+  id INTEGER PRIMARY KEY, server TEXT, started INTEGER, finished INTEGER, trigger TEXT,
+  downloaded INTEGER, replaced INTEGER, renamed INTEGER, trashed INTEGER, unchanged INTEGER,
+  failed INTEGER, conflicts INTEGER, bytes INTEGER, error TEXT);
+CREATE VIRTUAL TABLE tracks_fts USING fts5(title, artist, album, path,
+  content='remote_tracks', content_rowid='rowid');
+-- plus the three content-sync triggers on remote_tracks (insert / delete / update)
+```
+
+`remote_tracks` keeps an implicit rowid despite the composite PK; that rowid is
+the FTS content rowid.
+
+**API surface (`LibraryIndex`)** — `open(path)`, `upsertTracks(server, rows,
+rev)` (one transaction per manifest page), `pruneUnseen(server, rev)` →
+deleted paths, `localFile(server, path)`, `localStates(server, paths)`,
+`upsertLocal(...)`, `markState(...)`, `subscriptionsFor(server)`,
+`requiredBy(server, path)`, `recordRun(SyncRun)`, `albums(server)`,
+`artists(server)`, `albumSongs(server, name)`, `search(server, q)`,
+`removeServer(server)`.
+
+**App side**
+
+- `lib/singletons/library_index.dart` — singleton opening
+  `<appDataDir>/library_index.db` (next to `servers.json`: documents dir on
+  mobile, App Support on the desktop branch) at boot right after
+  `SettingsManager().load()`. One main-isolate connection for reads; sync runs
+  open their own connection inside `Isolate.run`.
+- First run: import existing downloads — walk `<downloadDir>/media/<localname>`
+  per server, stat only, insert `origin=manual, state=ok, hash=NULL` inside
+  `Isolate.run`. Idempotent behind `meta.imported`.
+- `ServerManager.removeServer` (`lib/singletons/server_list.dart:2056`) calls
+  `removeServer`.
+- Failure policy: if the native library fails to load, the index is disabled
+  for the session and everything falls back to today's `existsSync` path.
+
+**Tests:** package `dart test` on `sqlite3.openInMemory()`: schema creation
++ migration from an older `user_version`; upsert idempotence; `pruneUnseen`;
+FTS results after insert / update / delete; required-by counting;
+`removeServer` cascade. App: the import walk against a temp dir.
+
+---
+
+## 4. A3 — app: mirror engine + "Keep a full copy of this library"
+
+### 4.1 Planner (`planner.dart`, pure, exhaustively unit-tested)
+
+```dart
+Plan plan({required List<RemoteTrack> remote, required Map<String, LocalFile> local,
+           required Set<String> wanted, required PlanOptions o});
+class Plan { downloads, replaces, renames, trashes, conflicts, unchanged, bytesNeeded }
+```
+
+Rules (design §4.2 step 2), evaluated per path in this order:
+
+1. Case-insensitive / NFC-normalised duplicate among `wanted` → `conflict`
+   (skip both).
+2. No local row, or `state != ok` → `download`.
+3. `size` differs, or `|mtime − modified|` outside 2000 ms **and** not within
+   2000 ms of ±3600 s → `replace` (constants copied from `worker.mjs`).
+4. A local file with the same `audio_hash` (fallback `hash`) at a path absent
+   from `remote` → `rename`.
+5. `origin == mirror` and path absent from `remote` → `trash`, unless
+   `o.scanning`.
+6. `origin == mirror`, path not in `wanted`, `o.trashUnwanted` → `trash`.
+
+`bytesNeeded` = Σ sizes of downloads + replaces (old + new for a replace).
+Test matrix: each rule; DST skew; sampled-hash rows (`hashV ≥ 2` and size ≥
+25 MB → size only); manual / external never trashed; scanning suppresses
+trash; rename beats download; conflict pair; empty inputs.
+
+### 4.2 Runner (`runner.dart`)
+
+`MirrorRunner(index, ManifestClient, Downloader, Fs)` —
+`Future<SyncRun> run(server, {trigger})`:
+
+1. Manifest pages with `If-None-Match` → 304 ⇒ record `unchanged` and
+   return; else upsert per page, then `pruneUnseen`.
+2. Expand subscriptions → `wanted` (A3: `library` kind only — every manifest
+   path under that vpath).
+3. `plan()`; preflight `bytesNeeded` against free space (Windows
+   `GetDiskFreeSpaceExW` and POSIX `statvfs` through the existing `ffi` dep,
+   or the `disk_space_plus` package if simpler); abort with `error` when
+   short.
+4. Renames + trashes first (frees space). Trash = `rename()` into
+   `<root>/.mstream-trash/<YYYY-MM-DD>/<path>`, copy + delete fallback across
+   volumes.
+5. Downloads / replaces via `Downloader.enqueue(DownloadJob)` → completion
+   stream. On completion: size check; MD5 via `crypto` when `hashV` means
+   full (< 25 MB); `File.setLastModified(modified)`; atomic rename from
+   `.mstream-tmp-<rand>` (replace: old file to trash first); `local_files`
+   `state=ok, origin=mirror`. Mismatch → `failed` + error, tmp removed.
+6. Sweep trash buckets older than retention; purge stray `.mstream-tmp-*`;
+   write `sync_runs`; art (A4).
+
+Runs are serialised per server (in-memory lock); a trigger arriving mid-run
+is skipped with a log line, like the server's after-scan policy.
+
+### 4.3 App adapters
+
+- `lib/singletons/mirror_manager.dart` — `MirrorManager` singleton: a
+  `MirrorRunner` per server; schedules (2 min after start when online, every
+  6 h while running, `syncNow(server)`); `Stream<MirrorStatus>` for the UI;
+  defers on `connectivity_plus` "none".
+- `ManifestClient` over `ApiManager.makeServerCall`, which treats any status
+  > 299 as failure — add an `allow304` parameter (or a sibling call) so a 304
+  returns cleanly.
+- `Downloader` in `lib/singletons/downloads.dart`: `enqueueMirror(server,
+  path, tmpDest, {requiresWiFi})` → `DownloadTask(group: 'mirror',
+  allowPause: true, retries: 5, priority: low, headers: {'x-access-token':
+  …})` (header auth for the JWT; the iroh loopback `__lt` param stays on the
+  URL as today). `_onUpdate` routes `group == 'mirror'` to the runner's
+  completion sink instead of the queue-patch path.
+  `FileDownloader().configure([(Config.holdingQueue, (null, null, 3))])`
+  caps the mirror group at three concurrent transfers without starving
+  manual downloads; `(Config.checkAvailableSpace, 500)` backs up the
+  preflight. The iroh tunnel proxies full HTTP semantics including Range
+  (`rust/iroh_tunnel/src/lib.rs`), so pause / resume works unchanged.
+- `Server` gains `int mirrorRetentionDays = 30` (persisted); subscriptions
+  live in the index.
+- The play-time resolver from A1 additionally consults `local_files` when the
+  index is open — one indexed lookup instead of `existsSync` per row —
+  and `_resolveDownloadBadges` batches through `localStates(server, paths)`.
+
+### 4.4 UI — one section in Manage Server (`lib/screens/manage_server.dart`)
+
+"Library copy": per vpath a switch "Keep a full copy on this device"; a
+status line (`Last synced 12 min ago · 4,812 files · 31 GB · 2 errors`);
+"Sync now"; retention dropdown (7 / 30 / 90 days / keep forever); on mobile
+a "Wi-Fi only" switch (hidden on desktop). Tapping the error count opens a
+plain list from `sync_runs.error` + failed `local_files`. The Downloads
+screen is untouched. l10n: ~10 strings × 9 ARBs.
+
+### 4.5 Verification
+
+`flutter analyze`, `flutter test`, `dart test` in the package. Smoke against
+the local test server (`storage.dbDirectory` set, two vpaths, ~200 files):
+full run → files under `media/<localname>/…` carrying server mtimes; delete
+a server file + rescan → local file lands in `.mstream-trash/<date>/`; edit a
+tag + rescan → replaced; rename on the server + rescan → local rename with
+zero bytes downloaded (`sync_runs.renamed == 1`); kill the app mid-run →
+relaunch resumes without duplicates; a 260+ character path on Windows.
+Devices: Windows release build; S25 `--flavor full`; Pixel_4_API_31
+`--flavor play` (mirror works in app storage, no folder picker).
+
+---
+
+## 5. A4 — offline browsing: albums, artists, album songs, art
+
+**Refactor first, behaviour-neutral.** `lib/singletons/library_source.dart`:
+
+```dart
+abstract class LibrarySource {
+  Future<List<DisplayItem>> albums(Server s);
+  Future<List<DisplayItem>> artists(Server s);
+  Future<List<DisplayItem>> artistAlbums(Server s, String artist);
+  Future<List<DisplayItem>> albumSongs(Server s, String? album);
+  // A5: genres, genreSongs, playlists, playlistContents, rated, recentlyAdded, search
+}
+```
+
+`HttpLibrarySource` = the mapping bodies lifted verbatim from
+`ApiManager.getAlbums / getArtists / getArtistAlbums / fetchAlbumSongs`; the
+`ApiManager` methods shrink to `source(s).albums(s)` + label +
+`addListToStack`. `LocalLibrarySource` maps index rows to the same
+`DisplayItem` shapes (`type 'album'` + `altAlbumArt`; `type 'file'` with `data
+'/<path>'` and a `MusicMetadata` built by a new `MusicMetadata.fromIndexRow`).
+Artist → albums is `SELECT DISTINCT album FROM remote_tracks WHERE artist = ?
+OR album_artist = ?` — close to `db/artists-albums`, not identical; accepted
+and labelled by the offline chip.
+
+**Index population:** runner step 1b fetches `db/albums` and `db/artists`
+(two whole-library calls) into `remote_albums` / `remote_artists` on every
+non-304 run.
+
+**Art cache:** runner step 6 downloads `album-art/<file>?compress=m` for every
+distinct `art` of mirrored tracks into `<appData>/art/<server>/<file>`
+(content-addressed names → no invalidation). `DisplayItem.getImage /
+getAlbumThumb` and the `queueExtras` art URL prefer the cached file when
+present, via `ArtCache.pathFor(server, file)` backed by an in-memory set
+loaded at boot — no per-row stat.
+
+**Switch policy:** a runtime `offline` flag on the current server, set by a
+"Browse offline copy" toggle in the browser toolbar overflow and automatically
+when the `getServerPaths` ping fails while the index has rows for that server;
+cleared on a successful ping. `LibrarySource source(Server s) => s.offline ?
+local : http`. The visual change is the offline chip in the toolbar; every
+list looks identical.
+
+**Tests:** `LocalLibrarySource` over an in-memory index — row shapes equal the
+HTTP mapping for a fixture response; existing capability tests unchanged.
+
+---
+
+## 6. A5 — offline: playlists, rated, genres, recent, search
+
+- Runner fetches `playlist/getall` then `playlist/load` per playlist,
+  `db/rated`, `db/genres` (all small) on non-304 runs. Recent = `ORDER BY
+  created_at DESC LIMIT 100` over `remote_tracks`.
+- Search: `tracks_fts MATCH ?` with prefix tokens (`"term"*`), grouped like
+  the online search screen; rows carry full metadata (no `partialMetadata`
+  refetch offline).
+- Offline writes: `outbox(server, op, payload, created)`; `rateSong` and
+  playlist edits enqueue when offline and replay after the next successful
+  ping (last-writer-wins; failures logged). Split into A5b if it grows.
+- Visual change: search works offline (badge on the results header).
+
+---
+
+## 7. A6a / A6b — rules
+
+Expansion is local SQL now that the index holds everything:
+
+| kind | expansion |
+|---|---|
+| `album` | `remote_tracks WHERE album = key` |
+| `artist` | `… WHERE artist = key OR album_artist = key` |
+| `genre` | `… WHERE genres LIKE '%"key"%'` (a `remote_track_genres` table if it ever matters) |
+| `playlist` | `remote_playlist_items WHERE playlist_id = key` (refreshed each run) |
+| `rated` | `remote_rated WHERE rating >= key` |
+| `library` / `folder` | path prefix |
+
+`subscription_files` is rewritten per run; a path is `wanted` when any
+enabled subscription references it; removing a rule re-plans and trashes only
+paths with no remaining edge. UI — A6a: "Keep offline" switch in the album
+detail toolbar (`lib/screens/album_detail_view.dart` /
+`lib/widgets/browser_toolbar.dart`) and in the artist row's actions sheet;
+A6b: playlist row action in `lib/widgets/more_actions_sheet.dart` + "Keep
+rated ≥ N" in Manage Server. Mobile rules default `wifi_only` from the
+existing `offlineQueueWifiOnly` setting.
+
+---
+
+## 8. A7 — transcoded tier
+
+Rule `quality = 'mp3-192'` etc.: destination
+`media-transcoded/<codec>-<kbps>/<localname>/<path>` with the extension
+swapped; URL from `buildServerStreamUrl` with transcode params; no Range and
+no verify (size unknown → completion = ok); `local_files.quality`
+distinguishes rows; the resolver prefers `original`, then transcoded; the
+planner ignores transcoded rows entirely. Quality picker on the "Keep
+offline" sheet, hidden when `transcodeAvailable == false`.
+
+---
+
+## 9. A8 — fold keep-queue-offline into the index
+
+`AutoDownloadLedger` becomes a thin façade over `local_files WHERE
+origin='auto'` ordered by `verified_at`; `selectEvictions` keeps its signature
+and its tests (`test/singletons/auto_download_cap_test.dart`,
+`auto_download_test.dart`). Migration: import `auto_downloads.json` once,
+then delete it. No UI.
+
+---
+
+## 10. S2 + A9 — deltas (only when full pulls hurt: >100k tracks, or phones on cellular)
+
+Server: a migration adds `track_tombstones(library_id, filepath, deleted_at)`,
+written at the two delete sites — the `DELETE FROM tracks WHERE (id,
+filepath) IN …` batch in `src/db/orphan-cleanup.js` and its twin in
+`rust-parser/src/main.rs` — plus vpath removal; swept after 180 days. The
+manifest accepts `since: {maxId, maxModified, at}` and returns `entries`
+(`id > maxId OR modified > maxModified`) + `deleted: [paths]` from tombstones
+with `deleted_at > at`, or `full: true` when the tombstone window has been
+swept. Ping flag `syncDelta`.
+App: the runner sends `since` when the flag is set; any inconsistency
+(unknown path in `deleted`, count mismatch) forces a full pull.
+
+---
+
+## 11. S3 + A10 — back up a desktop folder *to* the server
+
+Server: admin toggle `allowDeviceLibraries`; `POST /api/v1/sync/upload-library
+{deviceName}` idempotently creates library `uploads-<user>-<device>` under a
+configured parent and returns its vpath. Upload stays
+`POST /api/v1/file-explorer/upload` (busboy, `data-location` header), gated by
+`allow_upload`. After a batch the client calls a user-scoped
+`POST /api/v1/sync/upload-library/scan` that queues a scan of that vpath only
+(the admin scan routes stay admin).
+App: Manage Server → "Back up a folder to this server": pick a folder,
+`Directory.watch` on desktop plus a stat walk per run, upload new / changed
+by size + mtime, never delete remotely, progress in the same status section.
+Needs a product decision first: who may create libraries.
+
+---
+
+## 12. A11 — headless CLI
+
+`packages/library_mirror/bin/mstream_mirror.dart`: `--server URL --token T
+--dest DIR [--rules rules.json] [--index path]`; a `Downloader` over
+`package:http` streaming to file with Range resume; `dart compile exe`; exit
+codes mirror the server worker (0 ok, 1 fatal, per-file errors counted).
+Launcher scheduling is a separate mStream ticket.
+
+---
+
+## 13. Release checklist
+
+- S1 released and deployed before the app release containing A3.
+- App PRs: `flutter analyze`, `flutter test`, package `dart test`, the §4.5
+  smoke, one screenshot of the single visual change.
+- Server PRs: `npm test`, `npm run lint`, `docs/openapi.yaml`, CHANGELOG line.
+- Retarget stacked PR bases before merging (A6b on A6a, A9 on A3).
+
+---
+
+## 14. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| 32-bit Android device without the SQLite native lib | `ndk.abiFilters` packages armeabi-v7a and `sqlite3_flutter_libs` ships it; still catch the load failure and disable the index for the session |
+| Two SQLite connections (UI isolate + run isolate) | WAL + `busy_timeout` 5 s; writes come from the run isolate except tiny UI writes (subscriptions) |
+| Manifest size on big libraries | ~2 MB gzipped at 25k; S2 deltas when it hurts; smaller pages on cellular |
+| Case-insensitive collisions on Windows / macOS | planner `conflicts`, surfaced in the status errors list |
+| Windows `MAX_PATH` | `longPathAware` in `windows/runner/runner.exe.manifest` on the desktop branch; smoke with a 260+ char path |
+| Trash needs headroom for replaces | preflight counts old + new; "keep forever" shows trash size in the status line |
+| App closed = no sync on desktop | say so in the status line; A11 for a scheduled headless run |
+| `makeServerCall` treats 304 as failure | `allow304` on the manifest call |
+| Album / artist identity by name | mirrors the API exactly; exact grouping stays available via `album_id` / `artist_id` if a screen ever needs it |

--- a/BACKUP_SYNC_PLAN.md
+++ b/BACKUP_SYNC_PLAN.md
@@ -1,0 +1,426 @@
+# Backup & library sync plan (desktop first, Plus on mobile)
+
+Design notes for keeping a local copy of a server's library in sync — as a
+backup, and for offline browsing/playback — and for letting external tools
+such as Syncthing do the transfer where the user prefers. Research + proposal
+only; nothing here is implemented.
+
+**Branches:** the desktop shell lives on `feat/windows-desktop` (PR #84); this
+plan assumes it lands first. Server repo: `mStream`. Prior-art sources are
+linked in §2.
+
+---
+
+## 0. TL;DR
+
+- **Server stays the source of truth.** The desktop keeps a **one-way mirror**
+  (pull). Server-side deletions move the local file into a dated trash with
+  retention — the same convention the server's own backup worker uses. No
+  two-way merge in v1; "backup my folder to the server" is a later, separate
+  direction (§4.5).
+- Three building blocks, each shippable on its own:
+  1. **Local library index** — SQLite (drift) caching the server's entities
+     (tracks/albums/artists/genres/playlists/ratings) keyed by server ids, plus
+     local-file state. Drives offline browse, FTS search and local playback.
+  2. **Mirror engine** — pure Dart package under `packages/` that diffs a server
+     **manifest** against the index, transfers with resume + verify through the
+     existing `background_downloader` stack, and reconciles (trash, rename
+     detection by `audio_hash`).
+  3. **External-sync bridge** — a per-server *mirror root* so a folder kept by
+     Syncthing / rclone / a NAS share is recognised as local copies, plus
+     optional Syncthing REST integration (status, events, one-tap pairing).
+- **Server needs one new endpoint for v1** (`POST /api/v1/sync/manifest`).
+  Everything else the engine needs already exists. Deltas with tombstones and a
+  Syncthing pairing endpoint come later.
+- **Don't bundle Syncthing; detect it.** On Android only the `full`/Plus flavor
+  can read a Syncthing folder (all-files access). The official Syncthing
+  Android app was discontinued in 2024; Syncthing-Fork is maintained.
+
+---
+
+## 1. What exists today
+
+### 1.1 App
+
+| Piece | Where | Notes |
+|---|---|---|
+| Download manager | `lib/singletons/downloads.dart` | `background_downloader` 9.5.5 (supports iOS/Android/macOS/Windows/Linux, pause/resume, Wi-Fi constraint). Layout is `<base>/media/<serverLocalname>/<dataPath>` — a path mirror per server. Dedupe key = `serverName+filepath`. Iroh re-resolve on tunnel rotation. |
+| Storage location | `lib/singletons/file_explorer.dart` `getDownloadDir` | Per-server `storageMode`: `appLocal` / `appExternal` / `sdCardApp` / `permanent` / `sdCard`. Desktop branch: `permanent` = user-chosen folder, else App Support. FAT-name checks (`hasFatIllegalChars`, `isFatLikeDir`) already exist and double as NTFS reserved-name checks. |
+| Keep-queue-offline | `lib/singletons/auto_download_ledger.dart`, `DownloadTracker.auto` | Auto-downloads the queue, FIFO cap eviction, manual downloads never evicted. This is already the "auto vs pinned" split every music app ends up with. |
+| Local playback | `lib/media/local_playback_backend.dart`, `lib/singletons/api.dart:257-299`, `lib/util/queue_actions.dart:59-70` | Queue items carry `extras.localPath`; existence is re-checked at play time and playback falls back to streaming. Resolution is a `File.existsSync()` on the derived path — no index. |
+| Local browsing | `FileExplorer.getLocalFiles` | Walks the filesystem: folders + files only. No albums/artists/search offline. |
+| Persistence | `servers.json`, `queue.json` (`lib/singletons/queue_store.dart`), `auto_downloads.json`, settings | Single-JSON-file pattern with `WriteChain`. No database in the app. |
+| Plus flavor | `lib/build_variant.dart`, `PLAY_COMPLIANCE.md` | `full` = `mstream.music.plus`: all-files access, self-signed SSL. The Play flavor can only use app-scoped storage. |
+
+### 1.2 Server
+
+| Piece | Where | Notes |
+|---|---|---|
+| Track identity | `src/db/schema.js` `tracks` | `file_size`, `modified` (mtime ms), `file_hash` (MD5 <25MB, sampled above), `audio_hash` (payload-only, stable across tag edits), `hash_v`, `created_at`. Both already reach clients via the metadata object (`hash`, `audio-hash`, `modified`, `file-size`, `created-at`) in `src/api/db.js`. |
+| Media | `src/server.js:725` `/media/:vpath` | `express.static` per library → `Range` and `HEAD` work for free (resume, cheap size check). `/transcode` deliberately has no `Accept-Ranges`. |
+| Listings | `POST /api/v1/file-explorer/recursive` | Paths only (no size/mtime) — usable as a fallback manifest for old servers, at the cost of a `db/metadata/batch` round-trip. |
+| Bulk download | `src/api/download.js` | Zip streaming with `downloadSizeLimit`. Fine for one-off exports, wrong tool for a mirror (no per-file resume, no verify). |
+| Server-side backup | `src/backup/manager.js`, `src/backup/worker.mjs`, `src/api/backup.js` | Admin-only, same-host mirror of a library to a `dest_path`: sorted merge-walk (rsync-style), `.mstream-trash/<YYYY-MM-DD>/` soft delete with `retention_days`, resume for ≥16MB files, mtime tolerance (2s + DST skew), after-scan / daily triggers, task-queue mutex with scans, history rows. **This is the algorithm the client engine should copy, not reinvent.** |
+| Export pattern | `src/db/discovery-export.js` | Builds an allowlisted SQLite snapshot + `manifest.json` (row count, sha256). Precedent for handing a client a ready-made SQLite file. |
+| Change signal | `GET /api/v1/db/status`, `GET /api/v1/scan/status` | Count + `locked`; no revision, no changes-since feed, no tombstones (orphan cleanup deletes rows outright, in both scanners). |
+| Transport | `src/api/iroh.js`, app `rust/iroh_tunnel` | Iroh **core only** — no `iroh-blobs`. Downloads already flow through the tunnel via the loopback proxy. |
+
+---
+
+## 2. Prior art — what desktop apps do, and what to borrow
+
+### 2.1 General file sync
+
+| Tool | Mechanism | Borrow |
+|---|---|---|
+| **Syncthing** ([2.0, Aug 2025](https://github.com/syncthing/syncthing/releases/tag/v2.0.0)) | Block Exchange Protocol between device IDs; each side keeps an index (SQLite since 2.0, [LWN](https://lwn.net/Articles/1033634/)) and exchanges index deltas; variable block size; folder types `sendonly` / `receiveonly` / `sendreceive` / `receiveencrypted`; versioning (trash-can, staggered); `.stignore`; relays for NAT; [REST API](https://docs.syncthing.net/dev/rest.html) on `127.0.0.1:8384` with `X-API-Key` (`/rest/config/folders`, `/rest/db/completion`, `/rest/db/status`, `/rest/events` long-poll). Deleted items are forgotten after six months by default in 2.0. | The **index-exchange model** (client holds a manifest, diffs, pulls); `sendonly` on the server ↔ `receiveonly` on the client is exactly our one-way mirror; the REST/events surface is what the app integrates with (§4.4). |
+| **Nextcloud / ownCloud desktop client** | Sync journal in a local SQLite; tree discovery by **ETag propagation** (a changed file changes its parent folder ETags, so unchanged subtrees are skipped); selective sync; **virtual files / files-on-demand** placeholders. | Cheap "did anything change?" check (a per-library revision ETag, §5); files-on-demand is the mental model for the browser: show everything, hydrate on play. |
+| **Dropbox** | `list_folder` + `list_folder/continue` cursor (delta feed), `longpoll`; 4MB block hashes; Smart Sync placeholders. | The **cursor-based delta feed** is the phase-2 shape of the manifest endpoint. |
+| **rclone** | `sync` one-way (size+modtime or `--checksum`), `--backup-dir` (moved/overwritten files go to a dir — same as `.mstream-trash`), `--track-renames` (hash-based rename detection), `--modify-window`, `bisync` two-way with listing snapshots. | `--track-renames` via `audio_hash`; `--backup-dir` semantics; keep two-way out of v1 (bisync needs snapshots of both sides and conflict rules). |
+| **robocopy /MIR, rsync** | Merge-walk of two sorted trees. | The server's `worker.mjs` already implements this; the client engine mirrors it. |
+
+### 2.2 Backup tools
+
+| Tool | Mechanism | Verdict |
+|---|---|---|
+| **restic / kopia / borg / Duplicati** | Content-defined chunking, dedup, encryption, immutable snapshots in a repository; restore is a separate step. | Not a fit: the copy must stay a playable folder. But the "manifest + content-addressed verify" idea carries over (album art is already content-addressed on the server — MD5 stem since V50). |
+| **Time Machine / File History** | Mirror + versions with retention. | Retention UI: "keep deleted files for N days" (server default 30). |
+| **mStream's own backup destinations** | Server pushes a library to a same-host path. | Complementary zero-code route: mount the desktop (SMB) on the server host and add it as a destination. Worth documenting in the app's help text. |
+
+### 2.3 Music apps
+
+| App | What it does | Borrow |
+|---|---|---|
+| **iTunes / Music.app** | Sync to device by selection: playlists, artists, albums, genres; "Consolidate files" into the managed folder; library DB kept outside the media tree. | The **selection model** (§4.3) — users think in playlists/artists/albums, not paths. |
+| **Plexamp** | Per-album/playlist/artist downloads at a chosen quality (server transcodes on download); a Downloads section; server keeps the download job list. | "Quality" as a per-rule setting: *original* for the mirror/backup, *transcoded* for pocket copies. Never mix them in one tree. |
+| **Finamp** (Jellyfin) | Download system rebuilt on a local DB: collections → items → files as a graph with "required by" edges, so deleting a playlist doesn't remove tracks an album still pins; **sync** re-fetches each collection and adds/removes; full offline mode browses the local DB. | The **required-by graph** for subscriptions (§4.3) and the offline-mode source switch (§4.1). |
+| **Symfonium** | Keeps a **full local SQLite copy of the library metadata** for every provider (browsing is always local; incremental sync where the provider supports it), plus an offline cache with rules (sync playlists/albums/filters, size cap, transcode). | The local index is the foundation, the file mirror sits on top — same layering as here. |
+| **DSub / Tempo / Ultrasonic** | Pinned vs cached tracks, cache size cap with LRU, "keep playlist synced". | We already have this split (manual vs auto ledger). Reuse, don't duplicate. |
+| **Spotify / Apple Music** | Per-album/playlist download toggles, playlists keep their downloads updated, Wi-Fi-only, storage cap, "Remove all downloads". | The UX vocabulary: a single "Keep offline" switch per entity, with the rule list under Manage Server. |
+| **Calibre / beets / Lightroom** | Library = a folder with the DB inside it (Calibre `metadata.db`, beets' SQLite, Lightroom catalog). Calibre explicitly warns that syncing that folder with Dropbox/Syncthing corrupts the DB. | **Never put the app's SQLite inside a synced folder.** Sync media only; the index is per-device and rebuilt from the server. |
+
+Android note: the official Syncthing Android app was
+[archived in 2024](https://forum.syncthing.net/t/syncthing-android-public-archived/23360);
+[Syncthing-Fork](https://f-droid.org/packages/com.github.catfriend1.syncthingfork/)
+continues under a new maintainer (2.1.x on F-Droid, Aug 2026). iOS has no
+first-party Syncthing at all.
+
+---
+
+## 3. Semantics: "backup" and "sync" pull in opposite directions
+
+A mirror propagates deletions, which is what "stay synced" means but not what
+"backup" means. Every tool above resolves this the same way: **mirror + dated
+trash + retention**. Adopt the server's convention verbatim:
+
+- Deleted-on-server → move local file to `<root>/.mstream-trash/<YYYY-MM-DD>/<same relative path>`.
+- Sweep buckets older than `retention_days` (default 30, `0` = keep forever = true backup).
+- Never delete a file the mirror didn't create (ownership is recorded in the index — files that arrived via Syncthing or a manual download are `external`/`manual` and untouched).
+- Modified-on-server (size/mtime/hash differ) → download to `.mstream-tmp-*`, atomic rename over the old file, old file to trash.
+
+Direction for v1: **pull only**. The client never writes into the server's
+library. Uploading a desktop folder is §4.5 and lands in its own library, which
+sidesteps merge conflicts entirely.
+
+---
+
+## 4. Architecture
+
+### 4.1 Local library index (SQLite via drift)
+
+Why a DB now: the app resolves local copies by `existsSync` on a derived path
+and browses local files by walking the disk. A mirror of 25k files needs a
+diffable table, and offline browsing needs albums/artists/search — neither is
+JSON-file shaped.
+
+**Choice: `drift`** (`sqlite3_flutter_libs` bundles SQLite with FTS5 on all six
+platforms; typed queries; migrations; runs in an isolate). Not isar (v3
+maintenance stalled), not sqflite (desktop only via FFI shim, untyped). The
+server is SQLite too, so schema knowledge transfers.
+
+**Principle: the index is a cache of server responses keyed by server ids, not
+a re-derivation.** Album/artist grouping, compilations, album_artist rules and
+the V51 cascades live on the server; the client must not re-implement them.
+Store what `db/albums`, `db/artists`, `db/genres`, `playlist/getall`, `db/rated`
+and the manifest return, as-is.
+
+Tables (all keyed by `server` = localname):
+
+| Table | Purpose |
+|---|---|
+| `remote_tracks` | id, path, size, modified, hash, audio_hash, hash_v, album_id, artist_id, title, artist, album, album_artist, track, disc, year, duration, format, art, created_at, `seen_rev` |
+| `remote_albums`, `remote_artists`, `remote_genres` | as served; `track_count`, art |
+| `remote_playlists`, `remote_playlist_items`, `remote_rated` | user state, for offline lists |
+| `local_files` | server, path, local_path, size, mtime, hash, `state` (pending / downloading / ok / stale / trashed), `origin` (mirror / manual / auto / external), verified_at |
+| `subscriptions` | server, kind, key, quality, wifi_only, enabled, last_run (§4.3) |
+| `sync_runs` | per-run counters + errors (mirrors the server's history rows) |
+| `tracks_fts` | FTS5 over title/artist/album/path for offline search |
+| `outbox` | queued offline writes (rating, playlist edit) replayed when online — phase 3 |
+
+**Offline browsing = a source switch in the API layer.** `Api().getAlbums()`,
+`getArtists()`, `getAlbumSongs()`, `getPlaylists()`, `searchServer()` etc. all
+end in `BrowserManager().addListToStack(List<DisplayItem>)`. Add a
+`LibrarySource` with two implementations — HTTP (today) and Local (SQL) — that
+produce the same `DisplayItem` rows. Screens don't change. Select Local when
+the server ping fails, the user flips an "Offline" toggle, or the subscription
+is "browse offline library". Rows whose `local_files.state == ok` get the
+existing local badge; the rest stay visible and greyed (files-on-demand).
+
+**Playback:** `buildServerFileMediaItem` consults the index instead of
+`existsSync` on a guessed path — one lookup, and it also finds files under the
+mirror root (§4.4). Keep the existence re-check at play time (the backend
+already falls back to streaming).
+
+Migration: leave `auto_downloads.json` and `queue.json` alone in phase 2. Import
+existing `media/<localname>/` files into `local_files` as `origin=manual` on
+first run (walk once, stat only; hash lazily).
+
+### 4.2 Mirror engine (`packages/library_mirror`, pure Dart)
+
+Pure Dart with no Flutter imports so the same code can later run headless
+(`dart compile exe` → an `mstream-mirror` CLI, or inside the launcher). The
+app is a pure client on desktop with no background service, so "backup runs
+while the app is closed" needs that path eventually.
+
+Pipeline per server, per run (one run at a time per server, like the server's
+task queue):
+
+1. **Fetch manifest** — `POST /api/v1/sync/manifest` (§5), paged. Send the last
+   `revision` as `If-None-Match`; a 304 ends the run in one round-trip.
+   Upsert into `remote_tracks`, stamp `seen_rev`. Rows not seen at the new
+   revision are deletions.
+   *Fallback for servers without the endpoint:* `file-explorer/recursive` per
+   library + `db/metadata/batch` in chunks. Slower, no 304, still correct.
+2. **Plan** — join `remote_tracks ⋈ local_files` for every path a subscription
+   covers:
+   - missing locally → `download`
+   - size or mtime differ (server tolerance: 2s, DST ±1h skew — copy the
+     constants from `worker.mjs`) → `download` (replace)
+   - hash matches a local file at another path → `rename` (rclone
+     `--track-renames`; `audio_hash` survives tag edits, `hash` doesn't)
+   - gone from manifest, `origin=mirror` → `trash`
+   - covered by no subscription any more → `trash` (or keep, per setting)
+   Preflight: sum bytes vs free space (per-platform free-space query) and
+   refuse to start a run that can't fit.
+3. **Transfer** — hand the plan to `DownloadManager` in a dedicated
+   `background_downloader` group (`mirror`) so it doesn't fight manual/auto
+   downloads for the concurrency budget; `allowPause: true` (Range resume via
+   `express.static`); `requiresWiFi` from the rule on mobile; a bandwidth cap
+   on desktop (throttle setting — the server has no per-user QoS). Destination
+   is the existing `<base>/media/<localname>/<path>` tree so today's local
+   playback and FileExplorer keep working unchanged.
+4. **Verify + stamp** — compare size; for rows with `hash_v` meaning
+   full-MD5 (below the 25MB threshold) verify MD5; above it, size only (or
+   port the sampled scheme from `audio-hash.js` later). Then
+   `File.setLastModified(server modified)` so rclone/Syncthing/robocopy see
+   consistent times if the user layers them on top.
+5. **Reconcile** — apply `rename` / `trash`, write `sync_runs`, sweep trash
+   buckets past retention, purge `.mstream-tmp-*` orphans.
+6. **Art** — album art files are content-addressed (`<md5>.<ext>`); fetch the
+   set referenced by mirrored tracks into an art cache keyed by filename.
+   Cheap, dedups across albums, and offline album grids need it.
+
+Triggers: app start (after N minutes online), every 6h while running, manual
+"Sync now", and — cheap and decisive — a `db/status.totalFileCount` or
+manifest-revision change observed on any browse. Over iroh nothing changes:
+the manifest is an API call and `/media` already proxies through the tunnel.
+
+### 4.3 Subscriptions — what to keep
+
+Rules, not paths. Each rule expands to a path set at plan time:
+
+| Kind | Expands via | Quality options |
+|---|---|---|
+| `library` (whole vpath) | manifest filter | original |
+| `folder` | manifest prefix | original |
+| `album` / `artist` / `genre` | `db/album-songs`, `db/artists-albums`, `db/genre-songs` | original / transcoded |
+| `playlist` | `playlist/load` on each run (keeps synced, like Spotify) | original / transcoded |
+| `rated` (≥ N stars) | `db/rated` | original / transcoded |
+| `queue` | existing keep-queue-offline sweep, unchanged | as today |
+
+A track pinned by several rules has several "required by" edges (Finamp's
+model): removing a rule only trashes files no other rule needs. Transcoded
+copies live under `media-transcoded/<codec>-<bitrate>/…`, never in the mirror
+tree, because the mirror's contract is byte-identical originals.
+
+**Desktop backup = one `library` rule per library, quality original, retention
+30 days.** That is the whole "backup" feature from the user's point of view.
+
+### 4.4 External-sync bridge, and where Syncthing fits
+
+Three tiers; each is useful without the next.
+
+**Tier A — Mirror root (no Syncthing code at all).** Add `mirrorRoot` to
+`Server` (a folder that already contains `<library>/<path>` from any source).
+`local_files` gains `origin=external` rows from a periodic stat walk (or a
+`Directory.watch` on desktop) and the play-time resolver checks it. Result:
+whatever keeps that folder current — Syncthing, rclone, robocopy, a NAS the
+user already mirrors — makes the app play locally and browse offline. On
+Android this needs all-files access → Plus flavor only (the Play flavor can't
+take a `File` path outside app storage; SAF tree URIs don't fit the
+`File`-based player path).
+
+**Tier B — Syncthing status/events (desktop, read-only integration).** If
+`127.0.0.1:8384` answers, read the API key from Syncthing's `config.xml`
+(standard per-OS path) or let the user paste it. Then: list folders whose
+path equals the mirror root, show `/rest/db/completion` progress and
+`/rest/db/status` state in Manage Server, and long-poll
+`/rest/events?events=ItemFinished,FolderCompletion` to refresh `local_files`
+incrementally instead of re-walking. Zero transfer code, immediate value for
+people who already run Syncthing.
+
+**Tier C — One-tap pairing via the server.** Admin toggles "Share this library
+with Syncthing" in mStream: the server talks to the Syncthing daemon on *its*
+host (REST, same API-key discovery), creates a `sendonly` folder for the
+library's `root_path`, and exposes `{deviceId, folderId, folderLabel}` at
+`GET /api/v1/sync/syncthing`. The desktop app then adds the server's device
+and accepts the folder as `receiveonly` at the mirror root through its local
+Syncthing REST API; the server side auto-accepts the app's device ID via the
+same endpoint (`POST` with the client's `myID` from `/rest/system/status`).
+Device IDs travel over mStream's authenticated API, so no QR/manual ID
+exchange. Docker and the launcher can ship Syncthing as a sidecar; nothing in
+mStream depends on it being present.
+
+Why not bundle Syncthing in the app: it's a Go daemon with its own updater,
+GUI and open port; the app just became a pure client (server management moved
+to the launcher) and bundling would reverse that. Detect and integrate.
+
+Syncthing vs the native engine: Syncthing gives NAT traversal, block-level
+resume, versioning and a mature two-way story for free, but it syncs
+*folders*, not *subscriptions* (no "just this playlist"), needs a daemon on
+both ends, is Plus-only on Android and unavailable on iOS. The native engine
+covers every platform and every rule but only moves originals over HTTP.
+Ship both: Tier A + the native engine first; Tier B/C once the mirror root
+exists.
+
+**iroh-blobs** is the third option — content-addressed, verified, resumable
+transfer over the tunnel the app already has — but the shim deliberately
+compiles iroh core only to keep the Android `.so` small, and the server uses
+`@number0/iroh`. Revisit only if HTTP-over-tunnel resume proves inadequate.
+
+### 4.5 Reverse direction — backup a desktop folder *to* the server
+
+Later phase, and deliberately not a merge: the desktop folder becomes its own
+library on the server ("Uploads from <device>"), populated by
+`POST /api/v1/file-explorer/upload` (respecting `noupload` / `allow_upload`),
+then scanned. Because that library has one writer, there's no conflict
+resolution. With Syncthing present it's the mirror image of Tier C
+(`sendonly` on the desktop, `receiveonly` on the server host). Requires a
+"create library" call for non-admins or an admin pre-creating the vpath.
+
+---
+
+## 5. Server API additions
+
+### 5.1 `POST /api/v1/sync/manifest` (v1, required)
+
+> Superseded in detail by `BACKUP_SYNC_IMPLEMENTATION.md` §1: entries also
+> carry the lite metadata block (title / artist / album / album artist /
+> track / disc / year / duration / format) and `genres`, so offline lists
+> never need a per-track metadata fetch. The shape below is the minimum.
+
+```
+POST /api/v1/sync/manifest
+{ "cursor": "<opaque or absent>", "limit": 5000, "ignoreVPaths": ["…"] }
+→ 200 { "revision": "<string>",
+        "entries": [ { "id", "path", "size", "modified", "hash", "audioHash",
+                       "hashV", "albumId", "artistId", "art", "createdAt" } ],
+        "next": "<cursor>|null" }
+→ 304 when If-None-Match matches the current revision
+```
+
+- Scope = `libraryFilter(req.user, …)` like every `db/*` route; paths are
+  `vpath/relative` exactly as `file-explorer/recursive` renders them.
+- Order by `t.id`, cursor = last id → stable paging under concurrent scans.
+- `revision` = `<visible-library-ids>:<count>:<max(id)>:<max(modified)>`
+  computed per request (one indexed query) — no schema change. Bump-on-scan
+  via `task-queue`'s `onScanComplete` hook can replace it later.
+- ~150 bytes/entry → 25k tracks ≈ 3.7MB uncompressed, well under 1MB gzipped.
+  A full pull on every run is fine for a desktop; deltas are an optimisation.
+- Add to the federation allowlist only if peer mirrors are ever wanted
+  (currently not).
+
+### 5.2 Later
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/v1/sync/manifest` with `since: <revision>` | Delta: changed rows + tombstones. Needs a `track_tombstones(library_id, filepath, deleted_at)` table written by **both** scanners' delete paths and orphan cleanup, with its own retention (Syncthing 2.0 chose six months). |
+| `GET /api/v1/sync/snapshot` | Discovery-export-style SQLite snapshot of the visible library. Only worth it if the JSON path proves slow on phones; couples client to server schema. |
+| `GET/POST /api/v1/sync/syncthing` | Tier C pairing (§4.4). Admin toggle in `/api/v1/admin/config/*`. |
+| Ping flag `sync` (+ `syncthing`) | House rule: flags, never probes. |
+
+Nothing else: `/media` already does `Range` + `HEAD`; metadata, albums,
+artists, playlists and ratings endpoints are reused as-is.
+
+---
+
+## 6. Phasing (one visual change per PR, per the usual rule)
+
+| Phase | Scope | Platforms | Effort |
+|---|---|---|---|
+| **0 — Mirror root** | `Server.mirrorRoot` + picker in Manage Server (desktop form; Plus on Android), resolver checks it, local badge appears for externally-synced files. | desktop, Plus | 🟢 1–2d |
+| **1 — Manifest endpoint** | `sync/manifest` + ping flag + tests (server PR). | server | 🟢 1–2d |
+| **2 — Index + engine** | drift DB, `packages/library_mirror`, `library` rule only, Manage Server: "Keep a full copy" toggle, status line, Sync now, retention. Import of existing downloads. | desktop first, then all | 🔴 6–9d |
+| **3 — Offline browsing** | `LibrarySource` switch, Local implementation for albums/artists/genres/playlists/rated/search (FTS5), offline toggle + auto-fallback, art cache. | all | 🟡 4–6d |
+| **4 — Rules** | album/artist/playlist/genre/rated subscriptions, required-by edges, transcoded quality tier, "Keep offline" on entity rows. Fold keep-queue-offline into the same ledger. | all | 🟡 3–5d |
+| **5 — Syncthing B/C** | detect + status/events; server toggle + pairing endpoint; docker/launcher sidecar docs. | desktop (+server) | 🟡 3–5d |
+| **6 — Upload direction** | per-device upload library, folder watch, Syncthing mirror image. | desktop | 🟡 3–5d |
+| **7 — Headless** | `mstream-mirror` CLI from the engine package; launcher integration. | desktop | 🟡 2–3d |
+
+Phase 2 is the only one that can't be split further; its PR should land the
+package with unit tests around the planner (pure functions over manifest +
+local rows, same style as `AutoDownloadLedger.selectEvictions`) before any
+UI.
+
+---
+
+## 7. Gotchas (found now, so they don't cost a release later)
+
+- **SQLite in a synced folder corrupts** (Calibre's lesson). The index lives in
+  App Support, never under the mirror root.
+- **Case-insensitive targets.** Windows/macOS/FAT fold case; a Linux server
+  can hold `Live.flac` and `live.flac`. Detect collisions in the plan step
+  (NFC + lowercase key) and skip with a per-file error rather than clobber —
+  Syncthing reports the same as "case conflicts".
+- **Unicode normalisation.** HFS+/APFS return NFD names; compare NFC keys
+  (`worker.mjs` already does).
+- **Windows paths.** Reserved names and `<>:"|?*` — reuse `hasFatIllegalChars`
+  for Windows targets; enable long-path awareness in the Windows runner
+  manifest or `\\?\`-prefix, or a 300-char classical path fails on
+  `MAX_PATH`.
+- **mtime tolerance.** 2s window + ±1h DST carve-out from `worker.mjs`; without
+  it a FAT mirror re-downloads everything twice a year.
+- **Big-file hashes are sampled** (≥25MB, `hash_v` 2). Size is the only
+  byte-exact check there unless the sampled scheme is ported.
+- **Transcode is not mirror.** `/transcode` has no `Accept-Ranges`, no
+  `Content-Length`, and a different byte stream every time — keep transcoded
+  copies in their own tree and never verify them against `hash`.
+- **Trash headroom.** A replace needs old + new on disk briefly; the preflight
+  must count that, and "retention 0 = forever" needs a visible size.
+- **Desktop has no background service.** Runs happen while the app is open;
+  say so in the UI until phase 7. `background_downloader` on desktop is
+  in-process.
+- **Tokens in URLs.** Downloads use `?token=`; tasks persisted by the
+  downloader across restarts carry it — same as today, but a mirror queue
+  is larger and lives longer. Prefer the header form if the downloader group
+  is long-lived.
+- **Play flavor.** Native mirror works (app-scoped storage); Tier A/Syncthing
+  do not. Gate the picker on `!isPlayBuild`, as the storage modes already are.
+- **Android downloads time out at 9 minutes** unless `allowPause`/foreground
+  is set — set `allowPause: true` for the mirror group.
+
+---
+
+## 8. Open questions
+
+1. Direction confirmed as **pull-only first**? (§3) The upload direction is
+   a different feature with different permissions.
+2. Should "Keep a full copy of this library" default to **original quality
+   only** (true backup), with transcoded tiers reserved for entity rules?
+3. Where does the desktop index live for multiple servers — one DB with a
+   `server` column (proposed) or one DB per server (simpler deletes when a
+   server is removed)?
+4. Syncthing on the server host: sidecar in `docker-mstream` and the launcher,
+   or documentation only?
+5. Is a headless mirror (phase 7) wanted in the launcher, or is "app must be
+   open" acceptable for the first release?


### PR DESCRIPTION
The two planning documents behind the library-sync work, so they ride the `feat/library-sync` integration branch alongside the code:

- `BACKUP_SYNC_PLAN.md` — prior-art survey, the pull-only mirror + dated-trash decision, the local index, the external-sync bridge (mirror root / Syncthing tiers).
- `BACKUP_SYNC_IMPLEMENTATION.md` — the PR-sized work packages with files, schema, tests and order; Syncthing tiers excluded. Links S1 (mStream #984), A1 (#173) and A2 (#174).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)