### PR TITLE
feat(mirror): the mirror engine — planner, runner, transport interfaces

### DIFF
--- a/packages/library_mirror/lib/library_mirror.dart
+++ b/packages/library_mirror/lib/library_mirror.dart
@@ -3,4 +3,7 @@ library;
 
 export 'src/index_db.dart';
 export 'src/models.dart';
+export 'src/planner.dart';
+export 'src/runner.dart';
 export 'src/schema.dart' show kSchemaVersion;
+export 'src/transport.dart';

--- a/packages/library_mirror/lib/src/index_db.dart
+++ b/packages/library_mirror/lib/src/index_db.dart
@@ -283,6 +283,13 @@ class LibraryIndex {
   void upsertLocals(Iterable<LocalFile> files) =>
       transaction(() => files.forEach(upsertLocal));
 
+  /// Every local-copy row of [server] — the planner's input.
+  List<LocalFile> localFilesAll(String server) => [
+        for (final r in _db.select(
+            'SELECT * FROM local_files WHERE server = ? ORDER BY path', [server]))
+          LocalFile.fromRow(r)
+      ];
+
   void markState(String server, String path, String state,
           {String quality = 'original', String? error}) =>
       _db.execute(

--- a/packages/library_mirror/lib/src/planner.dart
+++ b/packages/library_mirror/lib/src/planner.dart
@@ -1,0 +1,172 @@
+import 'models.dart';
+
+/// Tunables. The defaults copy the server's own backup worker
+/// (`src/backup/worker.mjs`): a 2 s mtime window, with the ±1 h carve-out
+/// FAT volumes need after a DST change, and case-insensitive collision
+/// detection for the filesystems that fold case.
+class PlanOptions {
+  /// The server is mid-scan: rows can be transiently absent, so nothing is
+  /// trashed on this pass.
+  final bool scanning;
+
+  /// Trash mirror-owned files no enabled rule wants any more.
+  final bool trashUnwanted;
+  final int mtimeToleranceMs;
+  final int dstSkewMs;
+
+  const PlanOptions({
+    this.scanning = false,
+    this.trashUnwanted = true,
+    this.mtimeToleranceMs = 2000,
+    this.dstSkewMs = 3600 * 1000,
+  });
+}
+
+/// A local file the server now lists under a different path: moved, not
+/// re-downloaded.
+class Rename {
+  final LocalFile from;
+  final RemoteTrack to;
+  const Rename(this.from, this.to);
+}
+
+class Plan {
+  final List<RemoteTrack> downloads;
+  final List<RemoteTrack> replaces;
+  final List<Rename> renames;
+  final List<LocalFile> trashes;
+
+  /// Wanted paths that would collide on a case-folding filesystem. Skipped,
+  /// never clobbered.
+  final List<String> conflicts;
+  final int unchanged;
+
+  /// Bytes the transfers need, counting a replace's old copy too (it sits in
+  /// the trash until the sweep).
+  final int bytesNeeded;
+
+  const Plan({
+    required this.downloads,
+    required this.replaces,
+    required this.renames,
+    required this.trashes,
+    required this.conflicts,
+    required this.unchanged,
+    required this.bytesNeeded,
+  });
+
+  bool get hasWork =>
+      downloads.isNotEmpty ||
+      replaces.isNotEmpty ||
+      renames.isNotEmpty ||
+      trashes.isNotEmpty;
+}
+
+/// Whether a local mtime and the server's agree — within the tolerance, or
+/// off by exactly one hour (a FAT volume after a DST switch).
+bool mtimesAgree(int deltaMs, PlanOptions o) {
+  final d = deltaMs.abs();
+  return d < o.mtimeToleranceMs || (d - o.dstSkewMs).abs() < o.mtimeToleranceMs;
+}
+
+/// Decides what one sync run does. Pure over its inputs:
+///
+///  - [remote]: the server's current listing (the manifest rows);
+///  - [local]: every local-copy row of the server, any origin;
+///  - [wanted]: the paths the enabled rules pin.
+///
+/// Rules, per wanted path: a case-folded duplicate is a conflict; no usable
+/// local copy is a download — unless a mirror-owned file with the same
+/// content hash sits at a path the server no longer lists, which is a
+/// rename; a size or mtime disagreement is a replace; otherwise unchanged.
+/// Then, unless the server is scanning, mirror-owned rows the server dropped
+/// or no rule wants are trashed. Manual, auto and external copies are never
+/// trashed or moved — the mirror only ever removes what it created.
+Plan plan({
+  required Iterable<RemoteTrack> remote,
+  required Iterable<LocalFile> local,
+  required Set<String> wanted,
+  PlanOptions options = const PlanOptions(),
+}) {
+  final remoteByPath = {for (final t in remote) t.path: t};
+  final localByPath = {
+    for (final f in local)
+      if (f.quality == 'original') f.path: f,
+  };
+
+  final byFoldedKey = <String, List<String>>{};
+  for (final path in wanted) {
+    (byFoldedKey[path.toLowerCase()] ??= []).add(path);
+  }
+  final conflicts = <String>{
+    for (final group in byFoldedKey.values)
+      if (group.length > 1) ...group,
+  };
+
+  // Mirror-owned files the server no longer lists, by content hash: a wanted
+  // path with the same hash is that file under a new name.
+  final orphansByHash = <String, LocalFile>{};
+  for (final f in localByPath.values) {
+    if (f.origin != LocalOrigin.mirror || f.state != LocalState.ok) continue;
+    if (remoteByPath.containsKey(f.path) || f.hash == null) continue;
+    orphansByHash.putIfAbsent(f.hash!, () => f);
+  }
+
+  final downloads = <RemoteTrack>[];
+  final replaces = <RemoteTrack>[];
+  final renames = <Rename>[];
+  final claimed = <String>{};
+  var unchanged = 0;
+  var bytes = 0;
+
+  for (final path in wanted) {
+    if (conflicts.contains(path)) continue;
+    final r = remoteByPath[path];
+    if (r == null) continue; // pinned by a rule but gone from the server
+    final l = localByPath[path];
+    if (l == null || l.state != LocalState.ok) {
+      final orphan = r.hash == null ? null : orphansByHash[r.hash!];
+      if (orphan != null && claimed.add(orphan.path)) {
+        renames.add(Rename(orphan, r));
+      } else {
+        downloads.add(r);
+        bytes += r.size ?? 0;
+      }
+    } else if (_changed(r, l, options)) {
+      replaces.add(r);
+      bytes += (r.size ?? 0) + (l.size ?? 0);
+    } else {
+      unchanged++;
+    }
+  }
+
+  final trashes = <LocalFile>[];
+  if (!options.scanning) {
+    for (final f in localByPath.values) {
+      if (f.origin != LocalOrigin.mirror || claimed.contains(f.path)) continue;
+      final gone = !remoteByPath.containsKey(f.path);
+      final unwanted = options.trashUnwanted && !wanted.contains(f.path);
+      if (gone || unwanted) trashes.add(f);
+    }
+  }
+
+  return Plan(
+    downloads: downloads,
+    replaces: replaces,
+    renames: renames,
+    trashes: trashes,
+    conflicts: conflicts.toList()..sort(),
+    unchanged: unchanged,
+    bytesNeeded: bytes,
+  );
+}
+
+bool _changed(RemoteTrack r, LocalFile l, PlanOptions o) {
+  if (r.size != null && l.size != null && r.size != l.size) return true;
+  if (r.modified != null &&
+      l.mtime != null &&
+      !mtimesAgree(l.mtime! - r.modified!, o)) {
+    return true;
+  }
+  return false;
+}

--- a/packages/library_mirror/lib/src/runner.dart
+++ b/packages/library_mirror/lib/src/runner.dart
@@ -1,0 +1,381 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+
+import 'index_db.dart';
+import 'models.dart';
+import 'planner.dart';
+import 'transport.dart';
+
+/// Above this the server's `hash` is a sampled digest, not a whole-file MD5
+/// (`src/db/audio-hash.js`, hash_v 2) — size is the only byte-exact check.
+const int kFullHashMaxBytes = 25 * 1024 * 1024;
+
+/// Where one server's mirror lives. All three roots sit under the same
+/// download location so a finished temp file renames into place atomically
+/// and a trashed file is a move, not a copy. The trash and temp trees are
+/// siblings of `media/`, so the Local Files browser never lists them.
+class MirrorConfig {
+  final String server;
+  final String mediaRoot;
+  final String trashRoot;
+  final String tmpRoot;
+
+  /// Days a trashed file survives; 0 = keep forever.
+  final int retentionDays;
+  final bool wifiOnly;
+  final int concurrency;
+  final int pageSize;
+
+  const MirrorConfig({
+    required this.server,
+    required this.mediaRoot,
+    required this.trashRoot,
+    required this.tmpRoot,
+    this.retentionDays = 30,
+    this.wifiOnly = false,
+    this.concurrency = 3,
+    this.pageSize = 2000,
+  });
+
+  /// The standard layout under the app's download location:
+  /// `<downloadDir>/media/<server>` (the same tree manual downloads use),
+  /// `<downloadDir>/.mstream-trash/<server>`, `<downloadDir>/.mstream-tmp/<server>`.
+  factory MirrorConfig.under(String downloadDir, String server,
+          {int retentionDays = 30,
+          bool wifiOnly = false,
+          int concurrency = 3,
+          int pageSize = 2000}) =>
+      MirrorConfig(
+        server: server,
+        mediaRoot: p.join(downloadDir, 'media', server),
+        trashRoot: p.join(downloadDir, '.mstream-trash', server),
+        tmpRoot: p.join(downloadDir, '.mstream-tmp', server),
+        retentionDays: retentionDays,
+        wifiOnly: wifiOnly,
+        concurrency: concurrency,
+        pageSize: pageSize,
+      );
+
+  /// The on-disk file for a data path (`/<vpath>/<rel>`).
+  String localPathFor(String dataPath) =>
+      p.normalize(p.join(mediaRoot, dataPath.replaceFirst(RegExp(r'^/+'), '')));
+}
+
+class MirrorProgress {
+  final String phase;
+  final int done;
+  final int total;
+  final int failed;
+  const MirrorProgress(this.phase, this.done, this.total, this.failed);
+}
+
+/// One sync run for one server: refresh the manifest, expand the rules,
+/// plan, then apply — renames and trashes first (they free space), transfers
+/// through a small worker pool, each verified and stamped before it lands,
+/// and a trash sweep at the end. Every outcome is written to `sync_runs`;
+/// per-file failures are counted and recorded on the row, never fatal.
+///
+/// Runs for one server must not overlap; the app serialises them.
+class MirrorRunner {
+  final LibraryIndex index;
+  final ManifestClient manifest;
+  final Downloader downloader;
+
+  /// Free bytes on the volume holding [MirrorConfig.mediaRoot]; null (or a
+  /// null result) skips the preflight.
+  final Future<int?> Function(String dir)? freeSpace;
+  final DateTime Function() now;
+
+  MirrorRunner({
+    required this.index,
+    required this.manifest,
+    required this.downloader,
+    this.freeSpace,
+    DateTime Function()? now,
+  }) : now = now ?? DateTime.now;
+
+  Future<SyncRun> run(MirrorConfig c,
+      {String trigger = 'manual',
+      void Function(MirrorProgress)? onProgress,
+      bool Function()? isCancelled}) async {
+    final started = now().millisecondsSinceEpoch;
+    var downloaded = 0, replaced = 0, renamed = 0, trashed = 0, failed = 0;
+    var unchanged = 0, conflicts = 0, bytes = 0;
+    String? error;
+    bool cancelled() => isCancelled?.call() ?? false;
+
+    try {
+      onProgress?.call(const MirrorProgress('manifest', 0, 0, 0));
+      final scanning = await _refreshManifest(c);
+      final remote = index.remoteTracks(c.server);
+      final wanted = _expandSubscriptions(c, remote);
+      final pl = plan(
+        remote: remote,
+        local: index.localFilesAll(c.server),
+        wanted: wanted,
+        options: PlanOptions(scanning: scanning),
+      );
+      unchanged = pl.unchanged;
+      conflicts = pl.conflicts.length;
+      await _preflight(c, pl);
+
+      final bucket = _bucketName(now());
+      for (final r in pl.renames) {
+        if (cancelled()) break;
+        await _rename(c, r);
+        renamed++;
+      }
+      for (final f in pl.trashes) {
+        if (cancelled()) break;
+        await _trash(c, f, bucket);
+        trashed++;
+      }
+
+      final jobs = <(RemoteTrack, bool)>[
+        for (final t in pl.downloads) (t, false),
+        for (final t in pl.replaces) (t, true),
+      ];
+      var next = 0;
+      var done = 0;
+      Future<void> worker() async {
+        while (!cancelled()) {
+          final k = next++;
+          if (k >= jobs.length) return;
+          final (t, replace) = jobs[k];
+          try {
+            await _fetch(c, t, replace: replace, bucket: bucket);
+            if (replace) {
+              replaced++;
+            } else {
+              downloaded++;
+            }
+            bytes += t.size ?? 0;
+          } catch (_) {
+            failed++;
+          }
+          done++;
+          onProgress?.call(MirrorProgress('transfer', done, jobs.length, failed));
+        }
+      }
+
+      await Future.wait([for (var i = 0; i < c.concurrency; i++) worker()]);
+      await _sweepTrash(c);
+      await _purgeTmp(c);
+    } catch (e) {
+      error = '$e';
+    }
+
+    final run = SyncRun(
+      server: c.server,
+      started: started,
+      finished: now().millisecondsSinceEpoch,
+      trigger: trigger,
+      downloaded: downloaded,
+      replaced: replaced,
+      renamed: renamed,
+      trashed: trashed,
+      unchanged: unchanged,
+      failed: failed,
+      conflicts: conflicts,
+      bytes: bytes,
+      error: error,
+    );
+    index.recordRun(run);
+    onProgress?.call(MirrorProgress('done', downloaded + replaced, downloaded + replaced + failed, failed));
+    return run;
+  }
+
+  // ── manifest ──────────────────────────────────────────────────────────
+
+  /// Walks every page into the index and prunes what the server dropped.
+  /// Returns whether the server reported a scan in progress. A 304 on the
+  /// first page leaves the rows as they are — they are current.
+  Future<bool> _refreshManifest(MirrorConfig c) async {
+    final previous = index.meta(c.server, 'revision');
+    var page = await manifest.fetchPage(
+        limit: c.pageSize, ifNoneMatch: previous);
+    if (page == null) return false;
+    final rev = page.revision;
+    var scanning = page.scanning;
+    while (true) {
+      index.upsertTracks(c.server, page!.entries, rev);
+      final next = page.next;
+      if (next == null) break;
+      page = await manifest.fetchPage(cursor: next, limit: c.pageSize);
+      if (page == null) throw StateError('manifest: 304 mid-walk');
+      scanning = scanning || page.scanning;
+    }
+    // Rows are stamped with the FIRST page's revision even if a scan moved
+    // it mid-walk: the next run then sees a changed tag and re-walks.
+    index.pruneUnseen(c.server, rev);
+    index.setMeta(c.server, 'revision', rev);
+    return scanning;
+  }
+
+  // ── rules ─────────────────────────────────────────────────────────────
+
+  /// Expands the enabled rules to the paths they pin and rewrites their
+  /// required-by edges. A3 knows `library` (a whole vpath) and `folder` (a
+  /// data-path prefix); the entity kinds arrive with A6.
+  Set<String> _expandSubscriptions(MirrorConfig c, List<RemoteTrack> remote) {
+    final wanted = <String>{};
+    for (final s in index.subscriptionsFor(c.server)) {
+      final id = s.id;
+      if (id == null) continue;
+      final prefix = s.enabled ? _prefixFor(s) : null;
+      final paths = prefix == null
+          ? const <String>[]
+          : [for (final t in remote) if (t.path.startsWith(prefix)) t.path];
+      index.setSubscriptionFiles(id, c.server, paths);
+      wanted.addAll(paths);
+    }
+    return wanted;
+  }
+
+  static String? _prefixFor(Subscription s) => switch (s.kind) {
+        'library' => '/${s.key.replaceAll(RegExp(r'^/+|/+$'), '')}/',
+        'folder' => s.key.endsWith('/') ? s.key : '${s.key}/',
+        _ => null,
+      };
+
+  Future<void> _preflight(MirrorConfig c, Plan pl) async {
+    final probe = freeSpace;
+    if (probe == null || pl.bytesNeeded == 0) return;
+    await Directory(c.mediaRoot).create(recursive: true);
+    final free = await probe(c.mediaRoot);
+    if (free == null) return;
+    const headroom = 64 << 20;
+    if (free < pl.bytesNeeded + headroom) {
+      throw StateError('not enough free space: need ${pl.bytesNeeded + headroom} '
+          'bytes, have $free');
+    }
+  }
+
+  // ── apply ─────────────────────────────────────────────────────────────
+
+  Future<void> _rename(MirrorConfig c, Rename r) async {
+    final to = c.localPathFor(r.to.path);
+    await Directory(p.dirname(to)).create(recursive: true);
+    await _move(File(r.from.localPath), to);
+    index.removeLocal(c.server, r.from.path);
+    index.upsertLocal(_row(c, r.to, to, size: r.from.size, origin: LocalOrigin.mirror));
+  }
+
+  Future<void> _trash(MirrorConfig c, LocalFile f, String bucket) async {
+    final src = File(f.localPath);
+    if (await src.exists()) {
+      final dest = p.join(c.trashRoot, bucket, f.path.replaceFirst(RegExp(r'^/+'), ''));
+      await Directory(p.dirname(dest)).create(recursive: true);
+      await _move(src, dest);
+    }
+    index.removeLocal(c.server, f.path);
+  }
+
+  /// Download to a temp file, verify size (and the whole-file MD5 when the
+  /// server's hash is one), stamp the server's mtime, then rename into place
+  /// — the old copy of a replace goes to the trash first.
+  Future<void> _fetch(MirrorConfig c, RemoteTrack t,
+      {required bool replace, required String bucket}) async {
+    final dest = c.localPathFor(t.path);
+    final old = index.localFile(c.server, t.path);
+    await Directory(c.tmpRoot).create(recursive: true);
+    final tmp = p.join(c.tmpRoot, '${_randomId()}.part');
+    try {
+      await downloader.download(t.path, tmp, requiresWiFi: c.wifiOnly);
+      final f = File(tmp);
+      final size = await f.length();
+      if (t.size != null && size != t.size) {
+        throw StateError('size mismatch: got $size, expected ${t.size}');
+      }
+      if (t.hash != null && size < kFullHashMaxBytes) {
+        final digest = (await md5.bind(f.openRead()).first).toString();
+        if (digest != t.hash) throw StateError('checksum mismatch');
+      }
+      if (t.modified != null) {
+        await f.setLastModified(DateTime.fromMillisecondsSinceEpoch(t.modified!));
+      }
+      await Directory(p.dirname(dest)).create(recursive: true);
+      if (replace && old != null) {
+        await _trash(c, old, bucket);
+      } else if (await File(dest).exists()) {
+        await File(dest).delete();
+      }
+      await _move(f, dest);
+      index.upsertLocal(_row(c, t, dest,
+          size: size, origin: old?.origin ?? LocalOrigin.mirror));
+    } catch (e) {
+      try {
+        await File(tmp).delete();
+      } catch (_) {}
+      index.upsertLocal(LocalFile(
+        server: c.server,
+        path: t.path,
+        localPath: dest,
+        state: LocalState.failed,
+        origin: old?.origin ?? LocalOrigin.mirror,
+        size: old?.size,
+        mtime: old?.mtime,
+        hash: old?.hash,
+        error: '$e',
+        verifiedAt: now().millisecondsSinceEpoch,
+      ));
+      rethrow;
+    }
+  }
+
+  LocalFile _row(MirrorConfig c, RemoteTrack t, String localPath,
+          {int? size, required String origin}) =>
+      LocalFile(
+        server: c.server,
+        path: t.path,
+        localPath: localPath,
+        size: size ?? t.size,
+        mtime: t.modified,
+        hash: t.hash,
+        state: LocalState.ok,
+        origin: origin,
+        verifiedAt: now().millisecondsSinceEpoch,
+      );
+
+  /// rename(), with a copy + delete fallback for a target on another volume.
+  static Future<void> _move(File from, String to) async {
+    try {
+      await from.rename(to);
+    } on FileSystemException {
+      await from.copy(to);
+      await from.delete();
+    }
+  }
+
+  // ── housekeeping ──────────────────────────────────────────────────────
+
+  Future<void> _sweepTrash(MirrorConfig c) async {
+    if (c.retentionDays <= 0) return;
+    final root = Directory(c.trashRoot);
+    if (!await root.exists()) return;
+    final cutoff = now().subtract(Duration(days: c.retentionDays));
+    await for (final e in root.list()) {
+      if (e is! Directory) continue;
+      final day = DateTime.tryParse(p.basename(e.path));
+      if (day != null && day.isBefore(cutoff)) {
+        await e.delete(recursive: true);
+      }
+    }
+  }
+
+  Future<void> _purgeTmp(MirrorConfig c) async {
+    final root = Directory(c.tmpRoot);
+    if (await root.exists()) await root.delete(recursive: true);
+  }
+
+  static String _bucketName(DateTime t) =>
+      '${t.year.toString().padLeft(4, '0')}-${t.month.toString().padLeft(2, '0')}-'
+      '${t.day.toString().padLeft(2, '0')}';
+
+  static final Random _rng = Random.secure();
+  static String _randomId() =>
+      List.generate(12, (_) => _rng.nextInt(36).toRadixString(36)).join();
+}

--- a/packages/library_mirror/lib/src/transport.dart
+++ b/packages/library_mirror/lib/src/transport.dart
@@ -1,0 +1,41 @@
+import 'models.dart';
+
+/// One page of `POST /api/v1/sync/manifest` (mStream #984).
+class ManifestPage {
+  final String revision;
+  final bool scanning;
+  final int? next;
+  final List<RemoteTrack> entries;
+
+  const ManifestPage({
+    required this.revision,
+    required this.scanning,
+    required this.next,
+    required this.entries,
+  });
+
+  factory ManifestPage.fromJson(Map<String, dynamic> j) => ManifestPage(
+        revision: j['revision'] as String,
+        scanning: j['scanning'] == true,
+        next: (j['next'] as num?)?.toInt(),
+        entries: [
+          for (final e in (j['entries'] as List? ?? const []))
+            RemoteTrack.fromManifestEntry((e as Map).cast<String, dynamic>()),
+        ],
+      );
+}
+
+/// Fetches manifest pages. Returns null for a 304 — only possible on the
+/// first page, when [ifNoneMatch] carried the revision the server still has.
+abstract class ManifestClient {
+  Future<ManifestPage?> fetchPage(
+      {int? cursor, int limit = 2000, String? ifNoneMatch});
+}
+
+/// Moves one server file to [destination] (a temp path the runner owns) and
+/// completes once every byte is on disk; throws on failure. The app backs
+/// this with background_downloader, tests and the CLI with plain I/O.
+abstract class Downloader {
+  Future<void> download(String path, String destination,
+      {bool requiresWiFi = false});
+}

--- a/packages/library_mirror/pubspec.yaml
+++ b/packages/library_mirror/pubspec.yaml
@@ -17,6 +17,9 @@ dependencies:
   sqlite3: ^3.5.2
   path: ^1.9.0
   meta: ^1.16.0
+  # Whole-file MD5 verification of mirrored downloads (below the server's
+  # 25 MiB sampled-hash threshold).
+  crypto: ^3.0.6
 
 dev_dependencies:
   test: ^1.25.0

--- a/packages/library_mirror/test/planner_test.dart
+++ b/packages/library_mirror/test/planner_test.dart
@@ -1,0 +1,155 @@
+import 'package:library_mirror/library_mirror.dart';
+import 'package:test/test.dart';
+
+const t0 = 1700000000000;
+
+RemoteTrack rt(String path, {int? size = 1000, int? modified = t0, String? hash}) =>
+    RemoteTrack(id: path.hashCode & 0xffffff, path: path, size: size, modified: modified,
+        hash: hash ?? 'h$path');
+
+LocalFile lf(String path,
+        {String origin = LocalOrigin.mirror,
+        String state = LocalState.ok,
+        int? size = 1000,
+        int? mtime = t0,
+        String? hash,
+        String quality = 'original'}) =>
+    LocalFile(
+        server: 's', path: path, localPath: '/dl/media/s$path', state: state,
+        origin: origin, size: size, mtime: mtime, hash: hash ?? 'h$path', quality: quality);
+
+Plan run({List<RemoteTrack> remote = const [], List<LocalFile> local = const [],
+        Set<String>? wanted, PlanOptions options = const PlanOptions()}) =>
+    plan(remote: remote, local: local,
+        wanted: wanted ?? {for (final t in remote) t.path}, options: options);
+
+void main() {
+  group('plan', () {
+    test('missing → download, present and equal → unchanged', () {
+      final p = run(remote: [rt('/m/a'), rt('/m/b')], local: [lf('/m/a')]);
+      expect(p.downloads.map((t) => t.path), ['/m/b']);
+      expect(p.unchanged, 1);
+      expect(p.bytesNeeded, 1000);
+      expect(p.replaces, isEmpty);
+      expect(p.trashes, isEmpty);
+      expect(p.hasWork, isTrue);
+    });
+
+    test('a size or mtime difference is a replace, counted with headroom for both copies', () {
+      final p = run(
+          remote: [rt('/m/a', size: 1500), rt('/m/b', modified: t0 + 60 * 60 * 1000 * 5)],
+          local: [lf('/m/a'), lf('/m/b')]);
+      expect(p.replaces.map((t) => t.path), unorderedEquals(['/m/a', '/m/b']));
+      expect(p.bytesNeeded, 1500 + 1000 + 1000 + 1000);
+      expect(p.unchanged, 0);
+    });
+
+    test('mtime within 2 s, or exactly one hour off, still agrees (FAT / DST)', () {
+      final p = run(remote: [
+        rt('/m/a', modified: t0 + 1999),
+        rt('/m/b', modified: t0 + 3600 * 1000 + 500),
+        rt('/m/c', modified: t0 - 3600 * 1000),
+        rt('/m/d', modified: t0 + 2001),
+      ], local: [lf('/m/a'), lf('/m/b'), lf('/m/c'), lf('/m/d')]);
+      expect(p.unchanged, 3);
+      expect(p.replaces.single.path, '/m/d');
+    });
+
+    test('unknown sizes or mtimes on either side never force a replace', () {
+      final p = run(remote: [rt('/m/a', size: null, modified: null)],
+          local: [lf('/m/a', size: null, mtime: 5)]);
+      expect(p.unchanged, 1);
+    });
+
+    test('a failed or stale local row is fetched again', () {
+      final p = run(remote: [rt('/m/a'), rt('/m/b')],
+          local: [lf('/m/a', state: LocalState.failed), lf('/m/b', state: LocalState.stale)]);
+      expect(p.downloads.map((t) => t.path), unorderedEquals(['/m/a', '/m/b']));
+    });
+
+    test('rename: a mirror orphan with the same hash is moved, not downloaded', () {
+      final p = run(remote: [rt('/m/new', hash: 'X')], local: [lf('/m/old', hash: 'X')]);
+      expect(p.downloads, isEmpty);
+      expect(p.renames.single.from.path, '/m/old');
+      expect(p.renames.single.to.path, '/m/new');
+      expect(p.trashes, isEmpty, reason: 'the orphan was claimed by the rename');
+      expect(p.bytesNeeded, 0);
+    });
+
+    test('an orphan is claimed once; a second identical file downloads', () {
+      final p = run(remote: [rt('/m/n1', hash: 'X'), rt('/m/n2', hash: 'X')],
+          local: [lf('/m/old', hash: 'X')]);
+      expect(p.renames.length, 1);
+      expect(p.downloads.length, 1);
+    });
+
+    test('only mirror-owned orphans are renamed; a manual copy stays and the new path downloads', () {
+      final p = run(remote: [rt('/m/new', hash: 'X')],
+          local: [lf('/m/old', hash: 'X', origin: LocalOrigin.manual)]);
+      expect(p.renames, isEmpty);
+      expect(p.downloads.single.path, '/m/new');
+      expect(p.trashes, isEmpty);
+    });
+
+    test('server-dropped mirror rows are trashed; manual, auto and external never', () {
+      final p = run(remote: [rt('/m/keep')], local: [
+        lf('/m/keep'),
+        lf('/m/gone-mirror'),
+        lf('/m/gone-manual', origin: LocalOrigin.manual),
+        lf('/m/gone-auto', origin: LocalOrigin.auto),
+        lf('/m/gone-ext', origin: LocalOrigin.external),
+      ]);
+      expect(p.trashes.map((f) => f.path), ['/m/gone-mirror']);
+      expect(p.unchanged, 1);
+    });
+
+    test('mirror rows no rule wants are trashed, unless trashUnwanted is off', () {
+      final remote = [rt('/m/a'), rt('/m/b')];
+      final local = [lf('/m/a'), lf('/m/b')];
+      expect(run(remote: remote, local: local, wanted: {'/m/a'}).trashes.single.path, '/m/b');
+      expect(run(remote: remote, local: local, wanted: {'/m/a'},
+          options: const PlanOptions(trashUnwanted: false)).trashes, isEmpty);
+    });
+
+    test('scanning suppresses trashing but not transfers', () {
+      final p = run(remote: [rt('/m/a')], local: [lf('/m/gone')],
+          options: const PlanOptions(scanning: true));
+      expect(p.trashes, isEmpty);
+      expect(p.downloads.single.path, '/m/a');
+    });
+
+    test('case-folded duplicates are conflicts and skipped, both of them', () {
+      final p = run(remote: [rt('/m/Live.flac'), rt('/m/live.flac'), rt('/m/other')]);
+      expect(p.conflicts, ['/m/Live.flac', '/m/live.flac']);
+      expect(p.downloads.single.path, '/m/other');
+    });
+
+    test('a wanted path the server does not list is ignored', () {
+      final p = run(remote: [rt('/m/a')], wanted: {'/m/a', '/m/zzz'});
+      expect(p.downloads.single.path, '/m/a');
+    });
+
+    test('rows of another quality tier are invisible to the mirror', () {
+      final p = run(remote: [rt('/m/a')], local: [lf('/m/a', quality: 'mp3-192')]);
+      expect(p.downloads.single.path, '/m/a');
+      expect(p.trashes, isEmpty);
+    });
+
+    test('empty inputs plan nothing', () {
+      final p = run();
+      expect(p.hasWork, isFalse);
+      expect(p.unchanged, 0);
+    });
+  });
+
+  test('mtimesAgree', () {
+    const o = PlanOptions();
+    expect(mtimesAgree(0, o), isTrue);
+    expect(mtimesAgree(1999, o), isTrue);
+    expect(mtimesAgree(-1999, o), isTrue);
+    expect(mtimesAgree(2000, o), isFalse);
+    expect(mtimesAgree(3600 * 1000, o), isTrue);
+    expect(mtimesAgree(-3600 * 1000 + 1500, o), isTrue);
+    expect(mtimesAgree(3600 * 1000 + 2000, o), isFalse);
+  });
+}

--- a/packages/library_mirror/test/runner_test.dart
+++ b/packages/library_mirror/test/runner_test.dart
@@ -1,0 +1,330 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:library_mirror/library_mirror.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// A server library: data path → (bytes, mtime ms). The revision is whatever
+/// the test says it is, like the real one it only has to change when the
+/// library does.
+class FakeServer {
+  final Map<String, (List<int>, int)> files = {};
+  String revision = 'r1';
+  bool scanning = false;
+  int nextId = 1;
+  final Map<String, int> ids = {};
+
+  void put(String path, String body, {int mtime = 1700000000000}) {
+    files[path] = (utf8.encode(body), mtime);
+    ids.putIfAbsent(path, () => nextId++);
+  }
+
+  RemoteTrack entry(String path) {
+    final (bytes, mtime) = files[path]!;
+    return RemoteTrack(
+        id: ids[path]!, path: path, size: bytes.length, modified: mtime,
+        hash: md5.convert(bytes).toString(), hashV: 2, title: p.basename(path));
+  }
+}
+
+class FakeManifest implements ManifestClient {
+  final FakeServer server;
+  int calls = 0;
+  FakeManifest(this.server);
+
+  @override
+  Future<ManifestPage?> fetchPage({int? cursor, int limit = 2000, String? ifNoneMatch}) async {
+    calls++;
+    if (cursor == null && ifNoneMatch == server.revision) return null;
+    final all = (server.files.keys.map(server.entry).toList()..sort((a, b) => a.id.compareTo(b.id)));
+    final rows = all.where((t) => t.id > (cursor ?? 0)).take(limit).toList();
+    final more = all.any((t) => rows.isNotEmpty && t.id > rows.last.id);
+    return ManifestPage(revision: server.revision, scanning: server.scanning,
+        next: more ? rows.last.id : null, entries: rows);
+  }
+}
+
+class FakeDownloader implements Downloader {
+  final FakeServer server;
+  final List<String> calls = [];
+  final Set<String> failFor = {};
+  final Set<String> corruptFor = {};
+  FakeDownloader(this.server);
+
+  @override
+  Future<void> download(String path, String destination, {bool requiresWiFi = false}) async {
+    calls.add(path);
+    if (failFor.contains(path)) throw const SocketException('boom');
+    final (bytes, _) = server.files[path]!;
+    await File(destination).writeAsBytes(corruptFor.contains(path) ? [...bytes, 0] : bytes);
+  }
+}
+
+void main() {
+  late Directory tmp;
+  late LibraryIndex ix;
+  late FakeServer srv;
+  late FakeManifest manifest;
+  late FakeDownloader dl;
+  late MirrorConfig cfg;
+  DateTime clock = DateTime(2026, 9, 12, 12);
+
+  MirrorRunner runner({Future<int?> Function(String)? freeSpace}) => MirrorRunner(
+      index: ix, manifest: manifest, downloader: dl, freeSpace: freeSpace, now: () => clock);
+
+  String local(String path) => cfg.localPathFor(path);
+  String read(String path) => File(local(path)).readAsStringSync();
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('mirror_runner_');
+    ix = LibraryIndex.inMemory();
+    srv = FakeServer()
+      ..put('/music/A/1.mp3', 'one')
+      ..put('/music/A/2.mp3', 'two')
+      ..put('/music/B/3.mp3', 'three');
+    manifest = FakeManifest(srv);
+    dl = FakeDownloader(srv);
+    cfg = MirrorConfig.under(tmp.path, 's', concurrency: 2, pageSize: 2);
+    ix.addSubscription(const Subscription(server: 's', kind: 'library', key: 'music'));
+  });
+  tearDown(() {
+    ix.close();
+    try {
+      tmp.deleteSync(recursive: true);
+    } catch (_) {}
+  });
+
+  test('a first run mirrors the library: verified, stamped, indexed, recorded', () async {
+    final run = await runner().run(cfg, trigger: 'test');
+    expect(run.error, isNull);
+    expect(run.downloaded, 3);
+    expect(run.failed, 0);
+    expect(run.bytes, 3 + 3 + 5);
+    expect(read('/music/A/1.mp3'), 'one');
+    expect(read('/music/B/3.mp3'), 'three');
+    final row = ix.localFile('s', '/music/A/1.mp3')!;
+    expect(row.origin, LocalOrigin.mirror);
+    expect(row.state, LocalState.ok);
+    expect(row.hash, md5.convert(utf8.encode('one')).toString());
+    expect(row.size, 3);
+    expect(p.equals(row.localPath, local('/music/A/1.mp3')), isTrue);
+    final stamped = File(local('/music/A/1.mp3')).lastModifiedSync().millisecondsSinceEpoch;
+    expect((stamped - 1700000000000).abs(), lessThan(2000), reason: 'server mtime stamped');
+    expect(ix.meta('s', 'revision'), 'r1');
+    expect(ix.remoteCount('s'), 3);
+    expect(manifest.calls, 2, reason: 'two pages of two');
+    expect(ix.lastRun('s')!.trigger, 'test');
+    expect(ix.requiredBy('s', '/music/A/1.mp3'), 1);
+    expect(Directory(cfg.tmpRoot).existsSync(), isFalse, reason: 'temp tree purged');
+  });
+
+  test('an unchanged server is one 304 and no transfers; a new rule still acts on it', () async {
+    await runner().run(cfg);
+    dl.calls.clear();
+    final again = await runner().run(cfg);
+    expect(again.downloaded, 0);
+    expect(again.unchanged, 3);
+    expect(dl.calls, isEmpty);
+
+    // A folder rule for a path the library rule already covers changes nothing;
+    // drop the library rule and add a folder rule for /music/A only.
+    for (final s in ix.subscriptionsFor('s')) {
+      ix.removeSubscription(s.id!);
+    }
+    ix.addSubscription(const Subscription(server: 's', kind: 'folder', key: '/music/A'));
+    final narrowed = await runner().run(cfg);
+    expect(narrowed.trashed, 1, reason: '/music/B/3.mp3 is no longer wanted');
+    expect(File(local('/music/B/3.mp3')).existsSync(), isFalse);
+    expect(ix.localFile('s', '/music/B/3.mp3'), isNull);
+    expect(ix.localCount('s'), 2);
+  });
+
+  test('a server-side deletion lands in a dated trash bucket; a scan in progress defers it', () async {
+    await runner().run(cfg);
+    srv.files.remove('/music/A/2.mp3');
+    srv.revision = 'r2';
+    srv.scanning = true;
+    final deferred = await runner().run(cfg);
+    expect(deferred.trashed, 0);
+    expect(File(local('/music/A/2.mp3')).existsSync(), isTrue);
+
+    srv.scanning = false;
+    srv.revision = 'r3';
+    final run = await runner().run(cfg);
+    expect(run.trashed, 1);
+    expect(File(local('/music/A/2.mp3')).existsSync(), isFalse);
+    final trashed = File(p.join(cfg.trashRoot, '2026-09-12', 'music', 'A', '2.mp3'));
+    expect(trashed.existsSync(), isTrue);
+    expect(trashed.readAsStringSync(), 'two');
+    expect(ix.localFile('s', '/music/A/2.mp3'), isNull);
+    expect(ix.remoteCount('s'), 2);
+  });
+
+  test('a changed file is replaced; the old copy goes to the trash first', () async {
+    await runner().run(cfg);
+    srv.put('/music/A/1.mp3', 'one-v2', mtime: 1700000009000);
+    srv.revision = 'r2';
+    final run = await runner().run(cfg);
+    expect(run.replaced, 1);
+    expect(run.downloaded, 0);
+    expect(read('/music/A/1.mp3'), 'one-v2');
+    expect(File(p.join(cfg.trashRoot, '2026-09-12', 'music', 'A', '1.mp3')).readAsStringSync(), 'one');
+    expect(ix.localFile('s', '/music/A/1.mp3')!.size, 6);
+  });
+
+  test('a rename on the server is a local move, not a transfer', () async {
+    await runner().run(cfg);
+    final moved = srv.files.remove('/music/A/2.mp3')!;
+    srv.files['/music/C/2.mp3'] = moved;
+    srv.ids['/music/C/2.mp3'] = srv.nextId++;
+    srv.revision = 'r2';
+    dl.calls.clear();
+    final run = await runner().run(cfg);
+    expect(run.renamed, 1);
+    expect(dl.calls, isEmpty);
+    expect(read('/music/C/2.mp3'), 'two');
+    expect(File(local('/music/A/2.mp3')).existsSync(), isFalse);
+    expect(ix.localFile('s', '/music/A/2.mp3'), isNull);
+    expect(ix.localFile('s', '/music/C/2.mp3')!.origin, LocalOrigin.mirror);
+  });
+
+  test('a manual download is never trashed, and a matching one is not re-fetched', () async {
+    final manualPath = local('/music/A/1.mp3');
+    File(manualPath).createSync(recursive: true);
+    File(manualPath).writeAsStringSync('one');
+    ix.upsertLocal(LocalFile(server: 's', path: '/music/A/1.mp3', localPath: manualPath,
+        state: LocalState.ok, origin: LocalOrigin.manual, size: 3, mtime: 1700000000000));
+    ix.upsertLocal(LocalFile(server: 's', path: '/music/A/user.mp3',
+        localPath: local('/music/A/user.mp3'), state: LocalState.ok, origin: LocalOrigin.manual));
+    final run = await runner().run(cfg);
+    expect(run.downloaded, 2, reason: 'only the two the user did not already have');
+    expect(dl.calls, isNot(contains('/music/A/1.mp3')));
+    expect(run.trashed, 0);
+    expect(ix.localFile('s', '/music/A/user.mp3')!.origin, LocalOrigin.manual);
+  });
+
+  test('per-file failures are counted and recorded, never fatal; temp files are cleaned up', () async {
+    dl.failFor.add('/music/A/1.mp3');
+    dl.corruptFor.add('/music/A/2.mp3');
+    final run = await runner().run(cfg);
+    expect(run.error, isNull);
+    expect(run.failed, 2);
+    expect(run.downloaded, 1);
+    final f1 = ix.localFile('s', '/music/A/1.mp3')!;
+    expect(f1.state, LocalState.failed);
+    expect(f1.error, contains('boom'));
+    final f2 = ix.localFile('s', '/music/A/2.mp3')!;
+    expect(f2.state, LocalState.failed);
+    expect(f2.error, contains('size mismatch'));
+    expect(File(local('/music/A/2.mp3')).existsSync(), isFalse);
+    expect(Directory(cfg.tmpRoot).existsSync(), isFalse);
+
+    // The next run retries them.
+    dl.failFor.clear();
+    dl.corruptFor.clear();
+    final retry = await runner().run(cfg);
+    expect(retry.downloaded, 2);
+    expect(ix.localFile('s', '/music/A/1.mp3')!.state, LocalState.ok);
+  });
+
+  test('a checksum mismatch with the right size is caught', () async {
+    // Same length, different bytes: only the MD5 can tell.
+    srv.put('/music/A/1.mp3', 'one');
+    await runner().run(cfg);
+    srv.files['/music/A/1.mp3'] = (utf8.encode('uno'), 1700000000000);
+    // The manifest still advertises the OLD hash for this path (the server
+    // is lying / a mid-write race); the downloaded bytes will not match.
+    final lying = _LyingManifest(srv, '/music/A/1.mp3', md5.convert(utf8.encode('one')).toString());
+    srv.revision = 'r2';
+    final run = await MirrorRunner(index: ix, manifest: lying, downloader: dl, now: () => clock).run(cfg);
+    expect(run.failed, 0, reason: 'size and mtime agree with the row, so nothing is planned');
+    // Force a re-fetch by marking the row stale.
+    ix.markState('s', '/music/A/1.mp3', LocalState.stale);
+    final refetch = await MirrorRunner(index: ix, manifest: lying, downloader: dl, now: () => clock).run(cfg);
+    expect(refetch.failed, 1);
+    expect(ix.localFile('s', '/music/A/1.mp3')!.error, contains('checksum'));
+  });
+
+  test('trash buckets older than the retention are swept; 0 keeps forever', () async {
+    final old = Directory(p.join(cfg.trashRoot, '2026-08-01'))..createSync(recursive: true);
+    final recent = Directory(p.join(cfg.trashRoot, '2026-09-01'))..createSync(recursive: true);
+    final junk = Directory(p.join(cfg.trashRoot, 'not-a-date'))..createSync(recursive: true);
+    await runner().run(cfg);
+    expect(old.existsSync(), isFalse);
+    expect(recent.existsSync(), isTrue);
+    expect(junk.existsSync(), isTrue);
+
+    final forever = MirrorConfig.under(tmp.path, 's', retentionDays: 0);
+    Directory(p.join(forever.trashRoot, '2020-01-01')).createSync(recursive: true);
+    await runner().run(forever);
+    expect(Directory(p.join(forever.trashRoot, '2020-01-01')).existsSync(), isTrue);
+  });
+
+  test('cancellation stops between files', () async {
+    var stop = false;
+    final run = await runner().run(cfg, isCancelled: () => stop, onProgress: (pr) {
+      if (pr.phase == 'transfer') stop = true;
+    });
+    expect(run.error, isNull);
+    expect(run.downloaded, lessThan(3));
+    expect(run.downloaded, greaterThan(0));
+  });
+
+  test('preflight refuses a run that will not fit', () async {
+    final run = await runner(freeSpace: (_) async => 10).run(cfg);
+    expect(run.error, contains('free space'));
+    expect(run.downloaded, 0);
+    expect(dl.calls, isEmpty);
+    final ok = await runner(freeSpace: (_) async => 1 << 30).run(cfg);
+    expect(ok.downloaded, 3);
+  });
+
+  test('a disabled rule pins nothing and its edges are cleared', () async {
+    await runner().run(cfg);
+    final s = ix.subscriptionsFor('s').single;
+    ix.removeSubscription(s.id!);
+    final run = await runner().run(cfg);
+    expect(run.trashed, 3);
+    expect(ix.wantedPaths('s'), isEmpty);
+  });
+
+  test('ManifestPage.fromJson reads the shipped shape', () {
+    final page = ManifestPage.fromJson({
+      'revision': '1:9:9:1:0',
+      'scanning': false,
+      'next': 5,
+      'entries': [
+        {'filepath': 'music/a.mp3', 'id': 5, 'file-size': 10, 'modified': 1, 'hash': 'h',
+          'metadata': {'title': 'A', 'genres': []}},
+      ],
+    });
+    expect(page.revision, '1:9:9:1:0');
+    expect(page.next, 5);
+    expect(page.entries.single.path, '/music/a.mp3');
+    expect(page.entries.single.title, 'A');
+    expect(ManifestPage.fromJson({'revision': 'x', 'next': null}).entries, isEmpty);
+  });
+}
+
+/// Serves the fake server's manifest but keeps advertising [hash] for
+/// [path] — the client's checksum check must catch the mismatch.
+class _LyingManifest extends FakeManifest {
+  final String path;
+  final String hash;
+  _LyingManifest(super.server, this.path, this.hash);
+
+  @override
+  Future<ManifestPage?> fetchPage({int? cursor, int limit = 2000, String? ifNoneMatch}) async {
+    final page = await super.fetchPage(cursor: cursor, limit: limit, ifNoneMatch: ifNoneMatch);
+    if (page == null) return null;
+    return ManifestPage(revision: page.revision, scanning: page.scanning, next: page.next,
+        entries: [
+          for (final t in page.entries)
+            t.path == path
+                ? RemoteTrack(id: t.id, path: t.path, size: t.size, modified: t.modified, hash: hash, hashV: t.hashV)
+                : t,
+        ]);
+  }
+}


### PR DESCRIPTION
## Summary

First half of A3 (`BACKUP_SYNC_IMPLEMENTATION.md` §4.1–4.2): the **mirror engine**, entirely inside `packages/library_mirror`. No app changes — the wiring and the "Keep a full copy" section follow in the second PR.

- **Planner** (`planner.dart`, pure): given the manifest rows, every local-copy row and the paths the rules pin, decides `downloads / replaces / renames / trashes / conflicts`. Rules in order: case-folded duplicates are conflicts (skipped, never clobbered); no usable copy → download, unless a *mirror-owned* file with the same content hash sits at a path the server no longer lists → rename; size or mtime disagreement → replace (2 s window + the ±1 h DST carve-out, both copied from `src/backup/worker.mjs`); otherwise unchanged. Then, unless the server is mid-scan, mirror-owned rows the server dropped or no rule wants are trashed. Manual, auto and external copies are never moved or trashed — the mirror only removes what it created.
- **Runner** (`runner.dart`): refresh the manifest (`If-None-Match` → 304 keeps the rows; pages walked by cursor; `pruneUnseen`; revision stored), expand rules (`library` = whole vpath, `folder` = data-path prefix; entity kinds come with A6) and rewrite their required-by edges, plan, preflight free space (injectable), then apply: renames and trashes first, transfers through a worker pool, each verified (size, and whole-file MD5 below the server's 25 MiB sampled-hash threshold), stamped with the server mtime, and renamed into place from a temp tree — a replace moves the old copy to the trash first. Dated trash buckets (`.mstream-trash/<server>/<yyyy-mm-dd>/…`) swept past the retention (0 = forever); temp tree purged. Per-file failures are counted and recorded on the row with the error; only manifest/preflight failures are fatal. Every run lands in `sync_runs`.
- **Layout**: `<downloadDir>/media/<server>` is the mirror (the same tree manual downloads already use, so playback and the badge need no new code), with `.mstream-trash/<server>` and `.mstream-tmp/<server>` as siblings — outside `media/`, so the Local Files browser never lists them, and on the same volume so every landing is an atomic rename.
- **Transport interfaces** (`transport.dart`): `ManifestClient` (with `ManifestPage.fromJson` for the shipped shape) and `Downloader`; the app backs them with the API client and background_downloader, tests and the future CLI with plain I/O.

## Test plan

- [x] `dart analyze` clean; `dart test` **52/52** — 15 planner cases (each rule, DST skew, failed/stale re-fetch, rename claimed once, manual orphan not renamed, origins never trashed, unwanted vs `trashUnwanted`, scanning, case conflicts, stale wanted paths, other quality tiers, empty) and 14 runner cases on a real temp directory with a fake server (first run verified/stamped/indexed/recorded across two pages; 304 + a narrowed rule trashes the unwanted file; deletion → dated bucket, deferred while scanning; replace → old copy in trash; rename → local move with zero transfers; manual copies untouched and not re-fetched; per-file failures recorded and retried, temp files cleaned; checksum mismatch at equal size caught; retention sweep incl. 0 = forever; cancellation; preflight refusal; disabled rule clears edges; `ManifestPage.fromJson`).
- [x] `flutter analyze` at the app root unchanged (the package is analysed through the path dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
