### PR TITLE
feat(offline): playlists, rated, recent and search from the index; outbox for offline writes (A5)

### DIFF
--- a/BACKUP_SYNC_IMPLEMENTATION.md
+++ b/BACKUP_SYNC_IMPLEMENTATION.md
@@ -33,7 +33,7 @@ tests + one device smoke); no repo-wide format.
 | A2 | app | `packages/library_mirror`: index DB + import of existing downloads — **[#174](https://github.com/IrosTheBeggar/mstream_music/pull/174)** (`package:sqlite3` 3.x build hook, no flutter-libs package) | — | no | 🟡 2–3d |
 | A3 | app | Mirror engine + "Keep a full copy" — **[#176](https://github.com/IrosTheBeggar/mstream_music/pull/176)** (engine) + **[#177](https://github.com/IrosTheBeggar/mstream_music/pull/177)** (MirrorManager, adapters, Library copy screen; adoption of pre-existing copies) | S1, A2 | yes (Manage Servers ⋮ → Library copy) | 🔴 5–7d |
 | A4 | app | Offline browsing: albums, artists, album songs, art cache — **[#178](https://github.com/IrosTheBeggar/mstream_music/pull/178)** (`LibrarySource`, `ArtCache`, auto/manual offline flag) | A3 | yes (offline chip) | 🟡 3–4d |
-| A5 | app | Offline: playlists, rated, genres, recent, search (FTS5) | A4 | yes (search offline) | 🟡 3–4d |
+| A5 | app | Offline: playlists, rated, genres, recent, search (FTS5) — **[#179](https://github.com/IrosTheBeggar/mstream_music/pull/179)** (schema v2 outbox, `LibrarySource` lists, `OutboxManager` replay) | A4 | yes (search offline) | 🟡 3–4d |
 | A6a | app | Rules: album / artist "Keep offline" | A3 | yes | 🟡 2–3d |
 | A6b | app | Rules: playlist + rated | A6a, A5 | yes | 🟡 1–2d |
 | A7 | app | Transcoded quality tier for entity rules | A6a | yes (quality picker) | 🟡 2–3d |

--- a/lib/screens/browser.dart
+++ b/lib/screens/browser.dart
@@ -4,6 +4,7 @@ import 'package:mstream_music/singletons/file_explorer.dart';
 import '../l10n/app_localizations.dart';
 import '../l10n/enum_labels.dart';
 import '../singletons/browser_list.dart';
+import '../singletons/server_list.dart';
 import '../singletons/api.dart';
 import '../singletons/settings.dart';
 import '../objects/display_item.dart';
@@ -1123,7 +1124,9 @@ class _BrowserState extends State<Browser> {
       builder: (context, _) {
         final term = BrowserManager().currentSearchTerm;
         if (term != null) {
-          return _subheaderStrip(Icons.search, l.searchSubheaderResults(term));
+          final offline = ServerManager().currentServer?.browseOffline == true;
+          return _subheaderStrip(Icons.search, l.searchSubheaderResults(term),
+              badge: offline ? l.offlineChip : null);
         }
         final path = BrowserManager().currentPath;
         if (path != null) {
@@ -1180,7 +1183,8 @@ class _BrowserState extends State<Browser> {
     );
   }
 
-  Widget _subheaderStrip(IconData icon, String text, {bool mono = false}) {
+  Widget _subheaderStrip(IconData icon, String text,
+      {bool mono = false, String? badge}) {
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.fromLTRB(14, 4, 12, 5),
@@ -1204,6 +1208,23 @@ class _BrowserState extends State<Browser> {
               ),
             ),
           ),
+          // Results from the library copy on this device (A5): the same pill
+          // the app bar wears while the server is browsed offline.
+          if (badge != null) ...[
+            const SizedBox(width: 6),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+              decoration: BoxDecoration(
+                color: VelvetColors.warning.withValues(alpha: 0.18),
+                borderRadius: BorderRadius.circular(VelvetColors.radiusSmall),
+              ),
+              child: Text(badge,
+                  style: TextStyle(
+                      fontSize: 10,
+                      color: VelvetColors.warning,
+                      fontWeight: FontWeight.w600)),
+            ),
+          ],
         ],
       ),
     );

--- a/lib/screens/library_copy_screen.dart
+++ b/lib/screens/library_copy_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:material_ui/material_ui.dart';
@@ -7,6 +8,7 @@ import '../objects/server.dart';
 import '../singletons/browser_list.dart';
 import '../singletons/library_index.dart';
 import '../singletons/mirror_manager.dart';
+import '../singletons/outbox.dart';
 import '../singletons/server_list.dart';
 import '../theme/velvet_theme.dart';
 import '../util/format_bytes.dart';
@@ -168,6 +170,8 @@ class _LibraryCopyScreenState extends State<LibraryCopyScreen> {
                 });
                 ServerManager().notifyServerChanged();
                 BrowserManager().goToNavScreen();
+                // Back online by choice: send what was written meanwhile.
+                if (!v) unawaited(OutboxManager().replay(server));
               },
       ),
     ]);

--- a/lib/singletons/api.dart
+++ b/lib/singletons/api.dart
@@ -6,9 +6,9 @@ import './server_list.dart';
 import './browser_list.dart';
 import './app_messenger.dart';
 import './log_manager.dart';
-import './settings.dart';
 import './library_index.dart';
 import './library_source.dart';
+import './outbox.dart';
 import '../objects/server.dart';
 import '../util/local_copy.dart';
 import 'auto_dj_manager.dart';
@@ -63,6 +63,14 @@ class ApiManager {
   }) async {
     final server = useThisServer ?? ServerManager().currentServer;
     if (server == null) throw Exception('No server selected');
+    // Browsing the library copy: the counts the last run stored.
+    final local = _localSource(server);
+    if (local != null) {
+      return [
+        for (final g in local.index.genres(server.localname))
+          {'name': g.name, 'track_count': g.trackCount},
+      ];
+    }
 
     final body = <String, dynamic>{};
     if (ignoreVPaths != null && ignoreVPaths.isNotEmpty) {
@@ -322,26 +330,12 @@ class ApiManager {
     }
   }
 
-  // Builds 'playlist' DisplayItems from a getall response.
-  List<DisplayItem> _playlistItems(dynamic res, Server? server) {
-    final List<DisplayItem> newList = [];
-    res.forEach((e) {
-      newList.add(DisplayItem(server, e['name'], 'playlist', e['name'],
-          Icon(Icons.queue_music, color: VelvetColors.textSecondary), null));
-    });
-    return newList;
-  }
-
   Future<void> getPlaylists({Server? useThisServer}) async {
-    // Parsing runs INSIDE the try (here and in the other browse fetches): a
-    // response-shape surprise (error object with a 2xx, older server) used to
-    // throw NoSuchMethodError past the guard and abort the browse silently.
     try {
-      final res = await makeServerCall(
-          useThisServer, '/api/v1/playlist/getall', {}, 'GET');
-
+      final server = _browseServer(useThisServer);
+      final list = await _sourceFor(server).playlists(server);
       BrowserManager().setBrowserLabel('Playlists');
-      BrowserManager().addListToStack(_playlistItems(res, useThisServer));
+      BrowserManager().addListToStack(list);
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getPlaylists failed: $err');
@@ -353,10 +347,8 @@ class ApiManager {
   /// without pushing a navigation entry.
   Future<void> refreshPlaylists() async {
     try {
-      final res =
-          await makeServerCall(null, '/api/v1/playlist/getall', {}, 'GET');
-      BrowserManager()
-          .replaceTop(_playlistItems(res, ServerManager().currentServer));
+      final server = _browseServer(null);
+      BrowserManager().replaceTop(await _sourceFor(server).playlists(server));
     } catch (err) {
       appLog('[api] refreshPlaylists failed: $err');
     }
@@ -365,8 +357,17 @@ class ApiManager {
   /// Creates an empty playlist (POST /playlist/new). Throws on failure (e.g. the
   /// server's 400 when the name already exists) so the caller can surface it.
   Future<void> createPlaylist(String title) async {
-    await makeServerCall(null, '/api/v1/playlist/new', {'title': title}, 'POST',
-        cancelable: false);
+    final server = _browseServer(null);
+    final payload = {'title': title};
+    if (server.browseOffline) {
+      if (!OutboxManager().enqueue(server, OutboxOp.playlistNew, payload)) {
+        throw Exception('Playlist create failed (offline, no index)');
+      }
+    } else {
+      await makeServerCall(server, '/api/v1/playlist/new', payload, 'POST',
+          cancelable: false);
+      OutboxManager().applyLocally(server, OutboxOp.playlistNew, payload);
+    }
     await refreshPlaylists();
   }
 
@@ -380,6 +381,13 @@ class ApiManager {
   Future<void> addSongToPlaylist(
       Server server, String playlist, String filepath) async {
     final fp = filepath.startsWith('/') ? filepath.substring(1) : filepath;
+    final payload = {'playlist': playlist, 'song': fp};
+    if (server.browseOffline) {
+      if (!OutboxManager().enqueue(server, OutboxOp.playlistAdd, payload)) {
+        throw Exception('Add to playlist failed (offline, no index)');
+      }
+      return;
+    }
     final response = await http
         .post(
           server.apiUri('/api/v1/playlist/add-song'),
@@ -393,6 +401,7 @@ class ApiManager {
     if (response.statusCode > 299) {
       throw Exception('Add to playlist failed (HTTP ${response.statusCode})');
     }
+    OutboxManager().applyLocally(server, OutboxOp.playlistAdd, payload);
   }
 
   /// POST /api/v1/playlist/save — create-or-OVERWRITE [playlist] on
@@ -404,6 +413,13 @@ class ApiManager {
     final songs = [
       for (final f in filepaths) f.startsWith('/') ? f.substring(1) : f,
     ];
+    final payload = {'title': playlist, 'songs': songs};
+    if (server.browseOffline) {
+      if (!OutboxManager().enqueue(server, OutboxOp.playlistSave, payload)) {
+        throw Exception('Playlist save failed (offline, no index)');
+      }
+      return;
+    }
     final response = await http
         .post(
           server.apiUri('/api/v1/playlist/save'),
@@ -417,159 +433,57 @@ class ApiManager {
     if (response.statusCode > 299) {
       throw Exception('Playlist save failed (HTTP ${response.statusCode})');
     }
+    OutboxManager().applyLocally(server, OutboxOp.playlistSave, payload);
   }
 
   /// Renames a playlist (POST /playlist/rename). Throws on failure.
   Future<void> renamePlaylist(String oldName, String newName) async {
-    await makeServerCall(null, '/api/v1/playlist/rename',
-        {'oldName': oldName, 'newName': newName}, 'POST', cancelable: false);
+    final server = _browseServer(null);
+    final payload = {'oldName': oldName, 'newName': newName};
+    if (server.browseOffline) {
+      if (!OutboxManager().enqueue(server, OutboxOp.playlistRename, payload)) {
+        throw Exception('Playlist rename failed (offline, no index)');
+      }
+    } else {
+      await makeServerCall(server, '/api/v1/playlist/rename', payload, 'POST',
+          cancelable: false);
+      OutboxManager().applyLocally(server, OutboxOp.playlistRename, payload);
+    }
     await refreshPlaylists();
   }
 
   Future<void> removePlaylist(String playlistId,
       {Server? useThisServer}) async {
-    try {
-      await makeServerCall(useThisServer, '/api/v1/playlist/delete',
-          {'playlistname': playlistId}, 'POST', cancelable: false);
-    } catch (err) {
-      // TODO: Handle Errors
-      appLog('[api] removePlaylist failed: $err');
-      return;
+    final server = _browseServer(useThisServer);
+    final payload = {'playlistname': playlistId};
+    if (server.browseOffline) {
+      if (!OutboxManager().enqueue(server, OutboxOp.playlistDelete, payload)) {
+        appLog('[api] removePlaylist failed: offline, no index');
+        return;
+      }
+    } else {
+      try {
+        await makeServerCall(server, '/api/v1/playlist/delete', payload, 'POST',
+            cancelable: false);
+      } catch (err) {
+        // TODO: Handle Errors
+        appLog('[api] removePlaylist failed: $err');
+        return;
+      }
+      OutboxManager().applyLocally(server, OutboxOp.playlistDelete, payload);
     }
 
-    BrowserManager().removeAll(playlistId, useThisServer!, 'playlist');
+    BrowserManager().removeAll(playlistId, server, 'playlist');
   }
 
   Future<void> searchServer(String search) async {
     try {
-      // The user's ticked search categories map 1:1 onto the endpoint's five
-      // `no*` flags — the server only does the work that's asked. The default
-      // set (artists+albums+songs) reproduces mStream's classic search.
-      final cats = SettingsManager().searchCategories;
-      // noLyrics is the only one of the five worth gating: the other four
-      // date to 4.7.0, below the support floor, so no server we still talk to
-      // can reject them. noLyrics arrived at 6.13.1, and one unknown key 400s
-      // the whole search — losing artists and albums too, over a category the
-      // server cannot do either way. Dropping it just lets the server apply
-      // its default, which on those versions is "no lyrics search exists".
-      //
-      // Pre-filter only, no learn-and-retry: makeServerCall discards the
-      // response body on an error, so there is nothing here to read the
-      // rejected key out of. Widening that shared error contract is a bigger
-      // change than this one parameter justifies.
-      final server = ServerManager().currentServer;
-      final searchPayload = <String, dynamic>{
-        'search': search,
-        'noArtists': !cats.contains(SearchCategory.artists),
-        'noAlbums': !cats.contains(SearchCategory.albums),
-        'noTitles': !cats.contains(SearchCategory.songs),
-        'noFiles': !cats.contains(SearchCategory.files),
-        'noLyrics': !cats.contains(SearchCategory.lyrics),
-      };
-      final searchBody = server == null
-          ? searchPayload
-          : ServerCapabilities().filter(server, searchPayload).body;
-      var res =
-          await makeServerCall(null, '/api/v1/db/search', searchBody, 'POST');
-
+      final server = _browseServer(null);
+      final list = await _sourceFor(server).search(server, search);
       BrowserManager().setBrowserLabel('Search');
-      List<DisplayItem> newList = [];
-      res['artists'].forEach((e) {
-        DisplayItem newItem = DisplayItem(
-            ServerManager().currentServer,
-            e['name'],
-            'artist',
-            e['name'],
-            Icon(Icons.library_music, color: VelvetColors.textSecondary),
-            'artist');
-        newItem.altAlbumArt = e['album_art_file'];
-        newList.add(newItem);
-      });
-
-      res['albums'].forEach((e) {
-        DisplayItem newItem = DisplayItem(
-            ServerManager().currentServer,
-            e['name'],
-            'album',
-            e['name'],
-            Icon(Icons.library_music, color: VelvetColors.textSecondary),
-            'album');
-        newItem.altAlbumArt = e['album_art_file'];
-        newList.add(newItem);
-      });
-
-      // Track hits carry the LITE metadata subset (PR #685, same kebab-case keys
-      // as the full block, so fromServerMap parses it directly). Attach it so the
-      // row renders a real card (title / artist) and flag it partial so the queue
-      // refetches the full block (fidelity / counts) on enqueue. Older servers
-      // omit the key → metadata stays null (still partial → still fetched). With
-      // metadata the artist is the subtitle, so the 'song' type hint only matters
-      // on the metadata-less path.
-      res['title'].forEach((e) {
-        final md = e['metadata'];
-        final meta = md is Map ? MusicMetadata.fromServerMap(md) : null;
-        DisplayItem newItem = DisplayItem(
-            ServerManager().currentServer,
-            e['name'],
-            'file',
-            '/${e['filepath']}',
-            Icon(Icons.music_note, color: VelvetColors.accent),
-            meta != null ? null : 'song');
-        newItem.altAlbumArt = e['album_art_file'];
-        newItem.metadata = meta;
-        newItem.partialMetadata = true;
-        newList.add(newItem);
-      });
-
-      // Files (filepath matches) — only populated when the scope is `files`.
-      // Carries the lite metadata block too (PR #685); `?.` because older servers
-      // may omit the `files` key entirely. We keep the folder as the subtitle (the
-      // match context — getSubText shows an explicit subtext over the metadata
-      // artist); getText shows the title once metadata is attached, the filename
-      // otherwise. Flagged partial so the queue refetches the full block.
-      res['files']?.forEach((e) {
-        final String fp = e['filepath'];
-        final int slash = fp.lastIndexOf('/');
-        final md = e['metadata'];
-        DisplayItem newItem = DisplayItem(
-            ServerManager().currentServer,
-            e['name'],
-            'file',
-            '/$fp',
-            Icon(Icons.insert_drive_file, color: VelvetColors.accent),
-            slash > 0 ? fp.substring(0, slash) : null);
-        newItem.altAlbumArt = e['album_art_file'];
-        if (md is Map) newItem.metadata = MusicMetadata.fromServerMap(md);
-        newItem.partialMetadata = true;
-        newList.add(newItem);
-      });
-
-      // Lyric matches (only when the `lyrics` category is ticked; `?.` since
-      // older servers omit the key). Carries the lite metadata block (PR #685)
-      // plus a `snippet` excerpt. We keep the snippet as the subtitle so the user
-      // sees WHY it matched (getSubText prefers an explicit subtext over the
-      // metadata artist); getText shows the real title once metadata is attached.
-      // `snippet` is null on the LIKE / non-FTS path → plain label. Flagged
-      // partial so the queue refetches the full block.
-      res['lyrics']?.forEach((e) {
-        final snippet = (e['snippet'] as String?)?.trim();
-        final md = e['metadata'];
-        DisplayItem newItem = DisplayItem(
-            ServerManager().currentServer,
-            e['name'],
-            'file',
-            '/${e['filepath']}',
-            Icon(Icons.lyrics, color: VelvetColors.accent),
-            snippet != null && snippet.isNotEmpty ? snippet : 'lyrics');
-        newItem.altAlbumArt = e['album_art_file'];
-        if (md is Map) newItem.metadata = MusicMetadata.fromServerMap(md);
-        newItem.partialMetadata = true;
-        newList.add(newItem);
-      });
-
       // Stash the query on the frame so the results view shows a "Results for
       // …" subheader (and it reverts on back-nav, like the file-explorer path).
-      BrowserManager().addListToStack(newList, searchTerm: search);
+      BrowserManager().addListToStack(list, searchTerm: search);
     } catch (err) {
       appLog('[api] searchServer failed: $err');
     }
@@ -628,28 +542,10 @@ class ApiManager {
 
   Future<void> getRecentlyAdded({Server? useThisServer}) async {
     try {
-      final res = await makeServerCall(
-          useThisServer, '/api/v1/db/recent/added', {'limit': 100}, 'POST');
-
+      final server = _browseServer(useThisServer);
+      final list = await _sourceFor(server).recent(server);
       BrowserManager().setBrowserLabel('Recent');
-
-      List<DisplayItem> newList = [];
-      res.forEach((e) {
-        MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
-
-        DisplayItem newItem = DisplayItem(
-            useThisServer,
-            e['filepath'],
-            'file',
-            '/${e['filepath']}',
-            Icon(Icons.music_note, color: VelvetColors.accent),
-            null);
-
-        newItem.metadata = m;
-
-        newList.add(newItem);
-      });
-      BrowserManager().addListToStack(newList);
+      BrowserManager().addListToStack(list);
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getRecentlyAdded failed: $err');
@@ -658,28 +554,10 @@ class ApiManager {
 
   Future<void> getRated({Server? useThisServer}) async {
     try {
-      final res =
-          await makeServerCall(useThisServer, '/api/v1/db/rated', {}, 'GET');
-
+      final server = _browseServer(useThisServer);
+      final list = await _sourceFor(server).rated(server);
       BrowserManager().setBrowserLabel('Rated');
-
-      List<DisplayItem> newList = [];
-      res.forEach((e) {
-        MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
-
-        DisplayItem newItem = DisplayItem(
-            useThisServer,
-            e['filepath'],
-            'file',
-            '/${e['filepath']}',
-            Icon(Icons.music_note, color: VelvetColors.accent),
-            m.artist);
-
-        newItem.metadata = m;
-
-        newList.add(newItem);
-      });
-      BrowserManager().addListToStack(newList);
+      BrowserManager().addListToStack(list);
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getRated failed: $err');
@@ -694,6 +572,14 @@ class ApiManager {
   /// a leading "/").
   Future<void> rateSong(Server server, String filepath, int? rating) async {
     final fp = filepath.startsWith('/') ? filepath.substring(1) : filepath;
+    final payload = {'filepath': fp, 'rating': rating};
+    // Browsing the library copy: queued, replayed after the next good ping.
+    if (server.browseOffline) {
+      if (!OutboxManager().enqueue(server, OutboxOp.rate, payload)) {
+        throw Exception('Rating failed (offline, no index)');
+      }
+      return;
+    }
     // Timeout matters here: the star-rating UI updates optimistically and its
     // catch is the ONLY revert path — an unbounded hang against a black-holed
     // server left a rating showing that the server never received.
@@ -710,6 +596,7 @@ class ApiManager {
     if (response.statusCode > 299) {
       throw Exception('Rating failed (HTTP ${response.statusCode})');
     }
+    OutboxManager().applyLocally(server, OutboxOp.rate, payload);
   }
 
   /// POST /api/v1/db/metadata/batch — the full metadata block for many tracks
@@ -1222,29 +1109,13 @@ class ApiManager {
   Future<void> getPlaylistContents(String playlistName,
       {Server? useThisServer}) async {
     try {
-      final res = await makeServerCall(useThisServer, '/api/v1/playlist/load',
-          {'playlistname': playlistName}, 'POST');
-
-      List<DisplayItem> newList = [];
-      res.forEach((e) {
-        MusicMetadata m = MusicMetadata.fromServerMap(e['metadata']);
-
-        DisplayItem newItem = DisplayItem(
-            useThisServer,
-            e['filepath'],
-            'file',
-            '/${e['filepath']}',
-            Icon(Icons.music_note, color: VelvetColors.accent),
-            null);
-
-        newItem.metadata = m;
-        newList.add(newItem);
-      });
-
+      final server = _browseServer(useThisServer);
+      final list =
+          await _sourceFor(server).playlistContents(server, playlistName);
       // Name the frame so the subheader can label it, the toolbar can offer
       // the album-style controls, and an empty result reads as "playlist is
       // empty" rather than a blank list.
-      BrowserManager().addListToStack(newList, playlist: playlistName);
+      BrowserManager().addListToStack(list, playlist: playlistName);
     } catch (err) {
       // TODO: Handle Errors
       appLog('[api] getPlaylistContents failed: $err');

--- a/lib/singletons/library_source.dart
+++ b/lib/singletons/library_source.dart
@@ -8,6 +8,7 @@ import '../objects/server.dart';
 import '../theme/velvet_theme.dart';
 import '../util/media_format.dart';
 import 'api.dart';
+import 'server_capabilities.dart';
 import 'settings.dart';
 
 /// One level of the file explorer: the server's own path for the header and
@@ -29,6 +30,11 @@ abstract class LibrarySource {
   Future<List<DisplayItem>> artistAlbums(Server s, String artist);
   Future<List<DisplayItem>> albumSongs(Server s, String? album);
   Future<FileListing> fileList(Server s, String directory);
+  Future<List<DisplayItem>> playlists(Server s);
+  Future<List<DisplayItem>> playlistContents(Server s, String playlist);
+  Future<List<DisplayItem>> rated(Server s);
+  Future<List<DisplayItem>> recent(Server s);
+  Future<List<DisplayItem>> search(Server s, String term);
 }
 
 /// The server, over the same calls the browser always made.
@@ -105,6 +111,125 @@ class HttpLibrarySource implements LibrarySource {
       newList.add(newItem);
     });
     return newList;
+  }
+
+  @override
+  Future<List<DisplayItem>> playlists(Server s) async {
+    final res = await api.makeServerCall(s, '/api/v1/playlist/getall', {}, 'GET');
+    return [
+      for (final e in res as List)
+        DisplayItem(s, e['name'], 'playlist', e['name'],
+            Icon(Icons.queue_music, color: VelvetColors.textSecondary), null),
+    ];
+  }
+
+  @override
+  Future<List<DisplayItem>> playlistContents(Server s, String playlist) async {
+    final res = await api.makeServerCall(
+        s, '/api/v1/playlist/load', {'playlistname': playlist}, 'POST');
+    return _trackRows(s, res, subtitle: (_) => null);
+  }
+
+  @override
+  Future<List<DisplayItem>> rated(Server s) async {
+    final res = await api.makeServerCall(s, '/api/v1/db/rated', {}, 'GET');
+    return _trackRows(s, res, subtitle: (m) => m.artist);
+  }
+
+  @override
+  Future<List<DisplayItem>> recent(Server s) async {
+    final res = await api.makeServerCall(
+        s, '/api/v1/db/recent/added', {'limit': 100}, 'POST');
+    return _trackRows(s, res, subtitle: (_) => null);
+  }
+
+  /// The `[{filepath, metadata}]` rows the playlist, rated and recent
+  /// endpoints share.
+  List<DisplayItem> _trackRows(Server s, dynamic res,
+      {required String? Function(MusicMetadata) subtitle}) {
+    final List<DisplayItem> out = [];
+    for (final e in res as List) {
+      final m = MusicMetadata.fromServerMap(e['metadata']);
+      out.add(DisplayItem(s, e['filepath'], 'file', '/${e['filepath']}',
+          Icon(Icons.music_note, color: VelvetColors.accent), subtitle(m))
+        ..metadata = m);
+    }
+    return out;
+  }
+
+  /// The server's grouped search: artists, albums, tracks, then file and
+  /// lyric hits when those categories are ticked. The ticked categories map
+  /// 1:1 onto the endpoint's five `no*` flags, so the server only does the
+  /// work that is asked for. `noLyrics` (6.13.1) is the one flag worth
+  /// gating through the capability filter: an unknown key 400s the whole
+  /// search on an older server, and the other four predate the support
+  /// floor.
+  @override
+  Future<List<DisplayItem>> search(Server s, String term) async {
+    final cats = SettingsManager().searchCategories;
+    final payload = <String, dynamic>{
+      'search': term,
+      'noArtists': !cats.contains(SearchCategory.artists),
+      'noAlbums': !cats.contains(SearchCategory.albums),
+      'noTitles': !cats.contains(SearchCategory.songs),
+      'noFiles': !cats.contains(SearchCategory.files),
+      'noLyrics': !cats.contains(SearchCategory.lyrics),
+    };
+    final res = await api.makeServerCall(s, '/api/v1/db/search',
+        ServerCapabilities().filter(s, payload).body, 'POST');
+    final List<DisplayItem> out = [];
+    res['artists'].forEach((e) {
+      out.add(DisplayItem(s, e['name'], 'artist', e['name'],
+          Icon(Icons.library_music, color: VelvetColors.textSecondary), 'artist')
+        ..altAlbumArt = e['album_art_file']);
+    });
+    res['albums'].forEach((e) {
+      out.add(DisplayItem(s, e['name'], 'album', e['name'],
+          Icon(Icons.library_music, color: VelvetColors.textSecondary), 'album')
+        ..altAlbumArt = e['album_art_file']);
+    });
+    // Track hits carry the LITE metadata subset (PR #685, same kebab-case
+    // keys as the full block). Attached so the row renders a real card and
+    // flagged partial so the queue refetches the full block on enqueue; an
+    // older server omits the key → metadata stays null (still partial).
+    res['title'].forEach((e) {
+      final md = e['metadata'];
+      final meta = md is Map ? MusicMetadata.fromServerMap(md) : null;
+      out.add(DisplayItem(s, e['name'], 'file', '/${e['filepath']}',
+          Icon(Icons.music_note, color: VelvetColors.accent),
+          meta != null ? null : 'song')
+        ..altAlbumArt = e['album_art_file']
+        ..metadata = meta
+        ..partialMetadata = true);
+    });
+    // File (path) matches keep the folder as the subtitle — the match
+    // context; `?.` because older servers omit the key entirely.
+    res['files']?.forEach((e) {
+      final String fp = e['filepath'];
+      final int slash = fp.lastIndexOf('/');
+      final md = e['metadata'];
+      final item = DisplayItem(s, e['name'], 'file', '/$fp',
+          Icon(Icons.insert_drive_file, color: VelvetColors.accent),
+          slash > 0 ? fp.substring(0, slash) : null)
+        ..altAlbumArt = e['album_art_file']
+        ..partialMetadata = true;
+      if (md is Map) item.metadata = MusicMetadata.fromServerMap(md);
+      out.add(item);
+    });
+    // Lyric matches keep the snippet as the subtitle so the user sees WHY it
+    // matched; null on the LIKE / non-FTS path → plain label.
+    res['lyrics']?.forEach((e) {
+      final snippet = (e['snippet'] as String?)?.trim();
+      final md = e['metadata'];
+      final item = DisplayItem(s, e['name'], 'file', '/${e['filepath']}',
+          Icon(Icons.lyrics, color: VelvetColors.accent),
+          snippet != null && snippet.isNotEmpty ? snippet : 'lyrics')
+        ..altAlbumArt = e['album_art_file']
+        ..partialMetadata = true;
+      if (md is Map) item.metadata = MusicMetadata.fromServerMap(md);
+      out.add(item);
+    });
+    return out;
   }
 
   @override
@@ -224,6 +349,60 @@ class LocalLibrarySource implements LibrarySource {
     ]);
   }
 
+  @override
+  Future<List<DisplayItem>> playlists(Server s) async => [
+        for (final p in index.playlists(s.localname))
+          DisplayItem(s, p.name, 'playlist', p.name,
+              Icon(Icons.queue_music, color: VelvetColors.textSecondary), null),
+      ];
+
+  /// A slot whose file the manifest no longer lists keeps its place with
+  /// no metadata, as the server's own answer does.
+  @override
+  Future<List<DisplayItem>> playlistContents(Server s, String playlist) async => [
+        for (final i in index.playlistItems(s.localname, playlist))
+          i.track != null
+              ? _track(s, i.track!)
+              : DisplayItem(s, i.path.substring(1), 'file', i.path,
+                  Icon(Icons.music_note, color: VelvetColors.accent), null),
+      ];
+
+  @override
+  Future<List<DisplayItem>> rated(Server s) async => [
+        for (final t in index.rated(s.localname)) _track(s, t, subtitle: t.artist),
+      ];
+
+  @override
+  Future<List<DisplayItem>> recent(Server s) async => [
+        for (final t in index.recent(s.localname)) _track(s, t),
+      ];
+
+  /// The grouped search over the index — artists, albums, then tracks by
+  /// title / artist / album / path prefix — honouring the same category
+  /// switches as the server search. Lyrics are not indexed. Track rows
+  /// carry full metadata, so nothing is refetched on enqueue.
+  @override
+  Future<List<DisplayItem>> search(Server s, String term) async {
+    final cats = SettingsManager().searchCategories;
+    final n = s.localname;
+    return [
+      if (cats.contains(SearchCategory.artists))
+        for (final a in index.artistsMatching(n, term))
+          DisplayItem(s, a, 'artist', a,
+              Icon(Icons.library_music, color: VelvetColors.textSecondary),
+              'artist'),
+      if (cats.contains(SearchCategory.albums))
+        for (final a in index.albumsMatching(n, term))
+          DisplayItem(s, a.name, 'album', a.name,
+              Icon(Icons.library_music, color: VelvetColors.textSecondary),
+              'album')
+            ..altAlbumArt = a.art,
+      if (cats.contains(SearchCategory.songs) ||
+          cats.contains(SearchCategory.files))
+        for (final t in index.search(n, term)) _track(s, t),
+    ];
+  }
+
   /// Every track under [directory]: the paths plus their metadata keyed the
   /// way the batch endpoint keys it (no leading slash), for "play all".
   Future<(List<String>, Map<String, MusicMetadata>)> recursiveTracks(
@@ -235,14 +414,15 @@ class LocalLibrarySource implements LibrarySource {
     );
   }
 
-  DisplayItem _track(Server s, RemoteTrack t) => DisplayItem(
-      s,
-      t.path.substring(1),
-      'file',
-      t.path,
-      Icon(Icons.music_note, color: VelvetColors.accent),
-      null)
-    ..metadata = metadataOf(t);
+  DisplayItem _track(Server s, RemoteTrack t, {String? subtitle}) =>
+      DisplayItem(
+          s,
+          t.path.substring(1),
+          'file',
+          t.path,
+          Icon(Icons.music_note, color: VelvetColors.accent),
+          subtitle)
+        ..metadata = metadataOf(t);
 
   /// The index row as the server's metadata map, so the one parser the app
   /// already has builds the object — same keys, same kebab-casing.

--- a/lib/singletons/mirror_manager.dart
+++ b/lib/singletons/mirror_manager.dart
@@ -308,6 +308,71 @@ class ServerListsClient implements LibraryListsClient {
     }
   }
 
+  Future<dynamic> _post(String location, Map<String, dynamic> body) async {
+    final client = _newClient();
+    try {
+      final res = await client
+          .post(server.apiUri(location),
+              body: jsonEncode(body),
+              headers: {
+                'Content-Type': 'application/json',
+                'x-access-token': server.authToken ?? ''
+              })
+          .timeout(const Duration(seconds: 60));
+      if (res.statusCode != 200) {
+        throw HttpException('$location: HTTP ${res.statusCode}');
+      }
+      return await decodeJsonBody(res.body);
+    } finally {
+      client.close();
+    }
+  }
+
+  static String _dataPath(String fp) => fp.startsWith('/') ? fp : '/$fp';
+
+  @override
+  Future<Map<String, int>> genres() async {
+    final res = await _post('/api/v1/db/genres', {});
+    return {
+      for (final e in (res['genres'] as List? ?? const []))
+        if (e is Map && e['name'] is String)
+          e['name'] as String: (e['track_count'] as num?)?.toInt() ?? 0,
+    };
+  }
+
+  /// Every playlist with its tracks: `getall` names them, `load` lists
+  /// each. Paths get the leading slash the manifest uses.
+  @override
+  Future<List<PlaylistRow>> playlists() async {
+    final names = await _get('/api/v1/playlist/getall');
+    final out = <PlaylistRow>[];
+    for (final e in (names as List? ?? const [])) {
+      final name = e is Map ? e['name'] : null;
+      if (name is! String) continue;
+      final items =
+          await _post('/api/v1/playlist/load', {'playlistname': name});
+      out.add(PlaylistRow(id: name, name: name, paths: [
+        for (final t in (items as List? ?? const []))
+          if (t is Map && t['filepath'] is String)
+            _dataPath(t['filepath'] as String),
+      ]));
+    }
+    return out;
+  }
+
+  @override
+  Future<Map<String, int>> rated() async {
+    final res = await _get('/api/v1/db/rated');
+    return {
+      for (final e in (res as List? ?? const []))
+        if (e is Map &&
+            e['filepath'] is String &&
+            (e['metadata'] as Map?)?['rating'] is num)
+          _dataPath(e['filepath'] as String):
+              ((e['metadata'] as Map)['rating'] as num).toInt(),
+    };
+  }
+
   @override
   Future<List<AlbumRow>> albums() async {
     final res = await _get('/api/v1/db/albums');

--- a/lib/singletons/outbox.dart
+++ b/lib/singletons/outbox.dart
@@ -1,0 +1,163 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:library_mirror/library_mirror.dart';
+
+import '../objects/server.dart';
+import 'library_index.dart';
+import 'log_manager.dart';
+
+/// The queued write kinds and the endpoint each replays to. A payload is
+/// the request body exactly as the online call sends it.
+abstract final class OutboxOp {
+  static const String rate = 'rate';
+  static const String playlistAdd = 'playlist-add';
+  static const String playlistNew = 'playlist-new';
+  static const String playlistSave = 'playlist-save';
+  static const String playlistRename = 'playlist-rename';
+  static const String playlistDelete = 'playlist-delete';
+
+  static const Map<String, String> endpoints = {
+    rate: '/api/v1/db/rate-song',
+    playlistAdd: '/api/v1/playlist/add-song',
+    playlistNew: '/api/v1/playlist/new',
+    playlistSave: '/api/v1/playlist/save',
+    playlistRename: '/api/v1/playlist/rename',
+    playlistDelete: '/api/v1/playlist/delete',
+  };
+}
+
+/// The server refused a queued write for good — a 4xx that is not an auth,
+/// timeout or rate-limit hiccup — so retrying would fail the same way.
+class OutboxRejected implements Exception {
+  final int status;
+  const OutboxRejected(this.status);
+  @override
+  String toString() => 'OutboxRejected($status)';
+}
+
+/// Writes made while a server is browsed offline (A5 of
+/// BACKUP_SYNC_IMPLEMENTATION.md): a rating, a playlist edit. Each is
+/// applied to the index at once, so the offline lists show it, and queued
+/// with its request body; the queue replays in order after the next
+/// successful ping. Last writer wins. A write the server rejects is logged
+/// and dropped; a network failure stops the replay until the next ping.
+class OutboxManager {
+  OutboxManager._();
+  static final OutboxManager _instance = OutboxManager._();
+  factory OutboxManager() => _instance;
+
+  /// Sends one queued entry — replaced in tests.
+  Future<void> Function(Server server, OutboxEntry entry) sender = post;
+  DateTime Function() now = DateTime.now;
+  final Set<String> _replaying = {};
+
+  LibraryIndex? get _ix => LibraryIndexManager().index;
+
+  /// Writes waiting for [s].
+  int pending(Server s) => _ix?.outboxCount(s.localname) ?? 0;
+
+  /// Queues [op] for replay and mirrors it into the index. False when there
+  /// is no index to hold it — the caller then reports the write as failed.
+  bool enqueue(Server s, String op, Map<String, dynamic> payload) {
+    final ix = _ix;
+    if (ix == null) return false;
+    ix.enqueue(s.localname, op, payload,
+        created: now().millisecondsSinceEpoch);
+    applyLocally(s, op, payload);
+    appLog('[outbox] ${s.localname}: queued $op');
+    return true;
+  }
+
+  /// Mirrors a write into the index — queued, or just made online — so the
+  /// offline copy agrees with the server without waiting for a run.
+  void applyLocally(Server s, String op, Map<String, dynamic> payload) {
+    final ix = _ix;
+    if (ix == null) return;
+    final n = s.localname;
+    try {
+      switch (op) {
+        case OutboxOp.rate:
+          ix.setRating(n, _dataPath(payload['filepath']),
+              (payload['rating'] as num?)?.toInt());
+        case OutboxOp.playlistAdd:
+          ix.addPlaylistItem(
+              n, '${payload['playlist']}', _dataPath(payload['song']));
+        case OutboxOp.playlistNew:
+          ix.createPlaylist(n, '${payload['title']}');
+        case OutboxOp.playlistSave:
+          ix.savePlaylist(n, '${payload['title']}', [
+            for (final f in (payload['songs'] as List? ?? const []))
+              _dataPath(f)
+          ]);
+        case OutboxOp.playlistRename:
+          ix.renamePlaylist(
+              n, '${payload['oldName']}', '${payload['newName']}');
+        case OutboxOp.playlistDelete:
+          ix.deletePlaylist(n, '${payload['playlistname']}');
+      }
+    } catch (e) {
+      appLog('[outbox] $n: could not mirror $op: $e');
+    }
+  }
+
+  /// Sends what is queued for [s], oldest first. Stops at the first network
+  /// failure (the next ping tries again); drops what the server rejects.
+  Future<void> replay(Server s) async {
+    final ix = _ix;
+    final n = s.localname;
+    if (ix == null || !_replaying.add(n)) return;
+    try {
+      final entries = ix.outbox(n);
+      if (entries.isEmpty) return;
+      var sent = 0, done = 0;
+      for (final e in entries) {
+        try {
+          await sender(s, e);
+          ix.outboxDone(e.id);
+          sent++;
+          done++;
+        } on OutboxRejected catch (err) {
+          appLog('[outbox] $n: ${e.op} rejected (HTTP ${err.status}) — dropped');
+          ix.outboxDone(e.id);
+          done++;
+        } catch (err) {
+          ix.outboxFailed(e.id, '$err');
+          appLog('[outbox] $n: ${e.op} failed ($err); '
+              '${entries.length - done} left for the next ping');
+          break;
+        }
+      }
+      if (sent > 0) appLog('[outbox] $n: replayed $sent change(s)');
+    } finally {
+      _replaying.remove(n);
+    }
+  }
+
+  /// The default sender: the entry's endpoint with the server's token.
+  static Future<void> post(Server s, OutboxEntry e) async {
+    final location = OutboxOp.endpoints[e.op];
+    if (location == null) throw const OutboxRejected(0);
+    final res = await http
+        .post(s.apiUri(location),
+            body: jsonEncode(e.payload),
+            headers: {
+              'Content-Type': 'application/json',
+              'x-access-token': s.authToken ?? '',
+            })
+        .timeout(const Duration(seconds: 15));
+    final code = res.statusCode;
+    if (code >= 200 && code < 300) return;
+    if (code >= 400 && code < 500 && code != 401 && code != 408 && code != 429) {
+      throw OutboxRejected(code);
+    }
+    throw HttpException('$location: HTTP $code');
+  }
+
+  /// The app's data path for a server filepath (leading slash).
+  static String _dataPath(Object? fp) {
+    final f = '$fp';
+    return f.startsWith('/') ? f : '/$f';
+  }
+}

--- a/lib/singletons/server_list.dart
+++ b/lib/singletons/server_list.dart
@@ -12,6 +12,7 @@ import './browser_list.dart';
 import './federation_inbox_alerts.dart';
 import './log_manager.dart';
 import './library_index.dart';
+import './outbox.dart';
 import '../build_variant.dart';
 import '../util/insecure_tls_channel.dart';
 import '../util/server_version.dart';
@@ -352,6 +353,8 @@ class ServerManager {
       // allowlist and 403s a peer key.
       final info = await _fetchServerInfo(server);
       _clearAutoOffline(server);
+      // Reachable: send what was written while it was not.
+      unawaited(OutboxManager().replay(server));
 
       final bool? prevAvail = server.transcodeAvailable;
       final String? prevCodec = server.transcodeDefaultCodec;

--- a/packages/library_mirror/lib/src/index_db.dart
+++ b/packages/library_mirror/lib/src/index_db.dart
@@ -42,10 +42,8 @@ class LibraryIndex {
     if (v == kSchemaVersion) return;
     db.execute('BEGIN');
     try {
-      if (v < 1) {
-        for (final s in schemaStatements()) {
-          db.execute(s);
-        }
+      for (final s in upgradeStatements(v)) {
+        db.execute(s);
       }
       db.execute('PRAGMA user_version = $kSchemaVersion');
       db.execute('COMMIT');
@@ -545,6 +543,197 @@ class LibraryIndex {
       .map((t) => '"${t.replaceAll('"', '""')}"*')
       .join(' ');
 
+  // ── the other lists (A5) ──────────────────────────────────────────────
+
+  List<GenreRow> genres(String server) => [
+        for (final r in _db.select(
+            'SELECT name, track_count FROM remote_genres WHERE server = ? '
+            'ORDER BY name COLLATE NOCASE',
+            [server]))
+          GenreRow(
+              name: r['name'] as String,
+              trackCount: (r['track_count'] as int?) ?? 0)
+      ];
+
+  /// The playlists by name, without their tracks.
+  List<PlaylistRow> playlists(String server) => [
+        for (final r in _db.select(
+            'SELECT id, name FROM remote_playlists WHERE server = ? '
+            'ORDER BY name COLLATE NOCASE',
+            [server]))
+          PlaylistRow(id: r['id'] as String, name: r['name'] as String)
+      ];
+
+  /// The slots of playlist [id] in order, each with its track when the
+  /// manifest knows the path — the shape `playlist/load` returns.
+  List<PlaylistItem> playlistItems(String server, String id) => [
+        for (final r in _db.select(
+            'SELECT i.pos AS item_pos, i.path AS item_path, rt.* '
+            'FROM remote_playlist_items i '
+            'LEFT JOIN remote_tracks rt ON rt.server = i.server AND rt.path = i.path '
+            'WHERE i.server = ? AND i.playlist_id = ? ORDER BY i.pos',
+            [server, id]))
+          (
+            pos: r['item_pos'] as int,
+            path: r['item_path'] as String,
+            track: r['rt_id'] == null ? null : RemoteTrack.fromRow(r),
+          )
+      ];
+
+  /// The tracks the caller rated, best first — `db/rated`'s order. The
+  /// rating comes from the rated list, which is fresher than the manifest's
+  /// lite block.
+  List<RemoteTrack> rated(String server) => [
+        for (final r in _db.select(
+            'SELECT rt.*, rr.rating AS user_rating FROM remote_rated rr '
+            'JOIN remote_tracks rt ON rt.server = rr.server AND rt.path = rr.path '
+            'WHERE rr.server = ? AND rr.rating > 0 '
+            'ORDER BY rr.rating DESC, rt.path',
+            [server]))
+          RemoteTrack.fromRow(r).withRating(r['user_rating'] as int?)
+      ];
+
+  /// The newest additions — `db/recent/added`'s order.
+  List<RemoteTrack> recent(String server, {int limit = 100}) => [
+        for (final r in _db.select(
+            'SELECT * FROM remote_tracks WHERE server = ? '
+            'ORDER BY created_at DESC, id DESC LIMIT ?',
+            [server, limit]))
+          RemoteTrack.fromRow(r)
+      ];
+
+  /// Artists whose name contains [query] (case-insensitive), for the
+  /// grouped search offline. [albumsMatching] is the same over albums.
+  List<String> artistsMatching(String server, String query,
+          {int limit = 50}) =>
+      [
+        for (final r in _db.select(
+            "SELECT name FROM remote_artists WHERE server = ? "
+            "AND name LIKE ? ESCAPE '\\' ORDER BY name COLLATE NOCASE LIMIT ?",
+            [server, _like(query), limit]))
+          r['name'] as String
+      ];
+
+  List<AlbumRow> albumsMatching(String server, String query,
+          {int limit = 50}) =>
+      [
+        for (final r in _db.select(
+            "SELECT * FROM remote_albums WHERE server = ? "
+            "AND name LIKE ? ESCAPE '\\' ORDER BY name COLLATE NOCASE LIMIT ?",
+            [server, _like(query), limit]))
+          AlbumRow.fromRow(r)
+      ];
+
+  static String _like(String q) =>
+      '%${q.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_')}%';
+
+  // ── the caller's own writes (mirrored so the offline copy shows them) ──
+
+  /// Records the caller's rating for [path] in the rated list and on the
+  /// track's row; null or 0 clears it.
+  void setRating(String server, String path, int? rating) => transaction(() {
+        final r = rating == null || rating <= 0 ? null : rating;
+        if (r == null) {
+          _db.execute('DELETE FROM remote_rated WHERE server = ? AND path = ?',
+              [server, path]);
+        } else {
+          _db.execute(
+              'INSERT OR REPLACE INTO remote_rated (server, path, rating) '
+              'VALUES (?, ?, ?)',
+              [server, path, r]);
+        }
+        _db.execute(
+            'UPDATE remote_tracks SET rating = ? WHERE server = ? AND path = ?',
+            [r, server, path]);
+      });
+
+  /// Creates playlist [name] when it does not exist. Playlists are keyed by
+  /// name: the server puts no id on the wire.
+  void createPlaylist(String server, String name) => _db.execute(
+      'INSERT OR IGNORE INTO remote_playlists (server, id, name) VALUES (?, ?, ?)',
+      [server, name, name]);
+
+  /// Appends [path] to playlist [name], creating it first like
+  /// `playlist/add-song` does.
+  void addPlaylistItem(String server, String name, String path) =>
+      transaction(() {
+        createPlaylist(server, name);
+        final next = _db.select(
+            'SELECT COALESCE(MAX(pos), -1) + 1 AS n FROM remote_playlist_items '
+            'WHERE server = ? AND playlist_id = ?',
+            [server, name]).first['n'] as int;
+        _db.execute(
+            'INSERT INTO remote_playlist_items (server, playlist_id, pos, path) '
+            'VALUES (?, ?, ?, ?)',
+            [server, name, next, path]);
+      });
+
+  /// Replaces the tracks of playlist [name] (`playlist/save`).
+  void savePlaylist(String server, String name, List<String> paths) =>
+      transaction(() {
+        createPlaylist(server, name);
+        _db.execute(
+            'DELETE FROM remote_playlist_items WHERE server = ? AND playlist_id = ?',
+            [server, name]);
+        final ins = _db.prepare(
+            'INSERT INTO remote_playlist_items (server, playlist_id, pos, path) '
+            'VALUES (?, ?, ?, ?)');
+        try {
+          for (var i = 0; i < paths.length; i++) {
+            ins.execute([server, name, i, paths[i]]);
+          }
+        } finally {
+          ins.close();
+        }
+      });
+
+  void renamePlaylist(String server, String oldName, String newName) =>
+      transaction(() {
+        _db.execute(
+            'UPDATE remote_playlists SET id = ?, name = ? WHERE server = ? AND id = ?',
+            [newName, newName, server, oldName]);
+        _db.execute(
+            'UPDATE remote_playlist_items SET playlist_id = ? '
+            'WHERE server = ? AND playlist_id = ?',
+            [newName, server, oldName]);
+      });
+
+  void deletePlaylist(String server, String name) => transaction(() {
+        _db.execute(
+            'DELETE FROM remote_playlist_items WHERE server = ? AND playlist_id = ?',
+            [server, name]);
+        _db.execute('DELETE FROM remote_playlists WHERE server = ? AND id = ?',
+            [server, name]);
+      });
+
+  // ── outbox ────────────────────────────────────────────────────────────
+
+  /// Queues a write for replay; returns its id. Entries replay in id order,
+  /// so a later write to the same thing wins.
+  int enqueue(String server, String op, Map<String, dynamic> payload,
+      {required int created}) {
+    _db.execute(
+        'INSERT INTO outbox (server, op, payload, created) VALUES (?, ?, ?, ?)',
+        [server, op, jsonEncode(payload), created]);
+    return _db.lastInsertRowId;
+  }
+
+  List<OutboxEntry> outbox(String server) => [
+        for (final r in _db.select(
+            'SELECT * FROM outbox WHERE server = ? ORDER BY id', [server]))
+          OutboxEntry.fromRow(r)
+      ];
+
+  int outboxCount(String server) => _db.select(
+      'SELECT COUNT(*) AS n FROM outbox WHERE server = ?',
+      [server]).first['n'] as int;
+
+  void outboxDone(int id) => _db.execute('DELETE FROM outbox WHERE id = ?', [id]);
+
+  void outboxFailed(int id, String error) => _db.execute(
+      'UPDATE outbox SET attempts = attempts + 1, last_error = ? WHERE id = ?',
+      [error, id]);
+
   // ── server removal ────────────────────────────────────────────────────
 
   /// Drops everything the index knows about [server]. Files on disk are the
@@ -554,7 +743,7 @@ class LibraryIndex {
           'subscription_files', 'subscriptions', 'sync_runs', 'local_files',
           'remote_rated', 'remote_playlist_items', 'remote_playlists',
           'remote_genres', 'remote_artists', 'remote_albums', 'remote_tracks',
-          'meta',
+          'outbox', 'meta',
         ]) {
           _db.execute('DELETE FROM $t WHERE server = ?', [server]);
         }

--- a/packages/library_mirror/lib/src/models.dart
+++ b/packages/library_mirror/lib/src/models.dart
@@ -58,6 +58,16 @@ class RemoteTrack {
     this.rating,
   });
 
+  /// The same row with the caller's [rating] (the rated list is fresher
+  /// than the manifest's lite block).
+  RemoteTrack withRating(int? rating) => RemoteTrack(
+        id: id, path: path, size: size, modified: modified, hash: hash,
+        audioHash: audioHash, hashV: hashV, albumId: albumId, artistId: artistId,
+        art: art, createdAt: createdAt, title: title, artist: artist, album: album,
+        track: track, disc: disc, year: year, duration: duration, format: format,
+        genres: genres, rating: rating,
+      );
+
   /// Parses one `entries[]` element of `POST /api/v1/sync/manifest`: the lite
   /// `{filepath, metadata}` row every list endpoint returns, plus the
   /// kebab-cased sync fields beside it (mStream #984).
@@ -282,4 +292,49 @@ class PlaylistRow {
   final String name;
   final List<String> paths;
   const PlaylistRow({required this.id, required this.name, this.paths = const []});
+}
+
+/// A genre and how many tracks carry it (`db/genres`).
+@immutable
+class GenreRow {
+  final String name;
+  final int trackCount;
+  const GenreRow({required this.name, required this.trackCount});
+}
+
+/// One slot of a playlist: its position, the data path and — when the
+/// manifest knows the path — the track. A slot whose file is gone stays
+/// (the server keeps such entries too, with empty metadata).
+typedef PlaylistItem = ({int pos, String path, RemoteTrack? track});
+
+/// A write made while the server was unreachable, waiting to be replayed:
+/// [op] names the endpoint, [payload] is the body as it will be sent.
+@immutable
+class OutboxEntry {
+  final int id;
+  final String server;
+  final String op;
+  final Map<String, dynamic> payload;
+  final int created;
+  final int attempts;
+  final String? lastError;
+  const OutboxEntry({
+    required this.id,
+    required this.server,
+    required this.op,
+    required this.payload,
+    required this.created,
+    this.attempts = 0,
+    this.lastError,
+  });
+
+  factory OutboxEntry.fromRow(Map<String, Object?> r) => OutboxEntry(
+        id: r['id'] as int,
+        server: r['server'] as String,
+        op: r['op'] as String,
+        payload: (jsonDecode(r['payload'] as String) as Map).cast<String, dynamic>(),
+        created: r['created'] as int,
+        attempts: (r['attempts'] as int?) ?? 0,
+        lastError: _str(r['last_error']),
+      );
 }

--- a/packages/library_mirror/lib/src/runner.dart
+++ b/packages/library_mirror/lib/src/runner.dart
@@ -127,7 +127,7 @@ class MirrorRunner {
     try {
       onProgress?.call(const MirrorProgress('manifest', 0, 0, 0));
       final refreshed = await _refreshManifest(c);
-      if (refreshed.changed) await _refreshLists(c);
+      await _refreshLists(c, manifestChanged: refreshed.changed);
       final scanning = refreshed.scanning;
       final remote = index.remoteTracks(c.server);
       final wanted = _expandSubscriptions(c, remote);
@@ -248,16 +248,29 @@ class MirrorRunner {
 
   /// The album / artist lists, replaced wholesale whenever the manifest
   /// moved. Best-effort: a failure leaves the previous lists in place.
-  Future<void> _refreshLists(MirrorConfig c) async {
+  /// The browse lists for offline use — a convenience the mirror itself
+  /// does not depend on, so each is fetched on its own and a failure leaves
+  /// the others as they were. Albums and artists follow the manifest (same
+  /// source), so they are refetched only when it moved; the caller's
+  /// playlists and ratings and the genre counts change on their own, so
+  /// those are refreshed every run.
+  Future<void> _refreshLists(MirrorConfig c,
+      {required bool manifestChanged}) async {
     final client = lists;
     if (client == null) return;
-    try {
-      index.replaceAlbums(c.server, await client.albums());
-      index.replaceArtists(c.server, await client.artists());
-    } catch (_) {
-      // The lists are a convenience for offline browsing; the mirror itself
-      // does not depend on them.
+    Future<void> attempt(Future<void> Function() fetch) async {
+      try {
+        await fetch();
+      } catch (_) {}
     }
+
+    if (manifestChanged) {
+      await attempt(() async => index.replaceAlbums(c.server, await client.albums()));
+      await attempt(() async => index.replaceArtists(c.server, await client.artists()));
+    }
+    await attempt(() async => index.replaceGenres(c.server, await client.genres()));
+    await attempt(() async => index.replacePlaylists(c.server, await client.playlists()));
+    await attempt(() async => index.replaceRated(c.server, await client.rated()));
   }
 
   /// Album art for [tracks], one fetch per distinct file not yet cached.

--- a/packages/library_mirror/lib/src/schema.dart
+++ b/packages/library_mirror/lib/src/schema.dart
@@ -12,7 +12,7 @@
 /// composite key: the FTS5 external-content table addresses rows by it, and an
 /// implicit rowid on a WITHOUT-INTEGER-PRIMARY-KEY table may change on VACUUM,
 /// which would silently desync the search index.
-const int kSchemaVersion = 1;
+const int kSchemaVersion = 2;
 
 const List<String> _v1 = [
   '''
@@ -180,5 +180,30 @@ const List<String> _v1 = [
   END''',
 ];
 
+/// v2 (A5): the offline outbox — writes made while the server was
+/// unreachable (a rating, a playlist edit), replayed in order after the
+/// next successful ping.
+const List<String> _v2 = [
+  '''
+  CREATE TABLE outbox (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    server     TEXT NOT NULL,
+    op         TEXT NOT NULL,          -- rate | playlist-add | playlist-new | ...
+    payload    TEXT NOT NULL,          -- JSON: the request body as it will be sent
+    created    INTEGER NOT NULL,       -- epoch ms
+    attempts   INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT
+  )''',
+  'CREATE INDEX ob_server ON outbox (server, id)',
+];
+
+/// Statements that take an index at schema [from] to [to] (default: the
+/// current version). `from` 0 is an empty database.
+List<String> upgradeStatements(int from, {int to = kSchemaVersion}) =>
+    List.unmodifiable([
+      if (from < 1 && to >= 1) ..._v1,
+      if (from < 2 && to >= 2) ..._v2,
+    ]);
+
 /// Statements that take an empty database to [kSchemaVersion].
-List<String> schemaStatements() => List.unmodifiable(_v1);
+List<String> schemaStatements() => upgradeStatements(0);

--- a/packages/library_mirror/lib/src/transport.dart
+++ b/packages/library_mirror/lib/src/transport.dart
@@ -45,6 +45,16 @@ abstract class Downloader {
 abstract class LibraryListsClient {
   Future<List<AlbumRow>> albums();
   Future<List<String>> artists();
+
+  /// `db/genres`: name → track count.
+  Future<Map<String, int>> genres();
+
+  /// `playlist/getall` and `playlist/load` for each: the playlists with
+  /// their tracks' data paths (leading slash, like the manifest).
+  Future<List<PlaylistRow>> playlists();
+
+  /// `db/rated`: data path → the caller's rating.
+  Future<Map<String, int>> rated();
 }
 
 /// Fetches one album-art file (its content-addressed name on the server) to

--- a/packages/library_mirror/test/lists_outbox_test.dart
+++ b/packages/library_mirror/test/lists_outbox_test.dart
@@ -1,0 +1,144 @@
+import 'package:library_mirror/library_mirror.dart';
+import 'package:library_mirror/src/schema.dart' show upgradeStatements;
+import 'package:sqlite3/sqlite3.dart';
+import 'package:test/test.dart';
+
+RemoteTrack rt(int id, String path,
+        {String? title,
+        String? artist,
+        String? album,
+        int? rating,
+        String? createdAt}) =>
+    RemoteTrack(
+        id: id,
+        path: path,
+        size: 1,
+        modified: 1,
+        hash: 'h$id',
+        title: title,
+        artist: artist,
+        album: album,
+        rating: rating,
+        createdAt: createdAt);
+
+void main() {
+  late LibraryIndex ix;
+  setUp(() => ix = LibraryIndex.inMemory());
+  tearDown(() => ix.close());
+
+  test('a v1 index gains the outbox on open', () {
+    final db = sqlite3.openInMemory();
+    for (final s in upgradeStatements(0, to: 1)) {
+      db.execute(s);
+    }
+    db.execute('PRAGMA user_version = 1');
+    expect(db.select("SELECT 1 FROM sqlite_master WHERE name = 'outbox'"), isEmpty);
+    LibraryIndex.migrate(db);
+    expect(db.select('PRAGMA user_version').first.columnAt(0), 2);
+    expect(db.select("SELECT 1 FROM sqlite_master WHERE name = 'outbox'"), isNotEmpty);
+    db.close();
+  });
+
+  group('lists', () {
+    setUp(() {
+      ix.upsertTracks('s', [
+        rt(1, '/m/a.mp3', title: 'A', artist: 'Ann', album: 'One', rating: 4,
+            createdAt: '2026-01-01T00:00:00Z'),
+        rt(2, '/m/b.mp3', title: 'B', artist: 'Bob', album: 'Two',
+            createdAt: '2026-03-01T00:00:00Z'),
+        rt(3, '/m/c.mp3', title: 'C', artist: 'Ann', album: 'One',
+            createdAt: '2026-02-01T00:00:00Z'),
+      ], 'r1');
+      ix.replaceArtists('s', ['Ann', 'Bob', 'Annie %']);
+      ix.replaceAlbums('s', const [
+        AlbumRow(name: 'One'),
+        AlbumRow(name: 'Two'),
+        AlbumRow(name: 'one_x'),
+      ]);
+    });
+
+    test('genres, playlists and their slots (an unknown path keeps its slot)',
+        () {
+      ix.replaceGenres('s', {'Rock': 2, 'Ambient': 1});
+      expect(ix.genres('s').map((g) => (g.name, g.trackCount)),
+          [('Ambient', 1), ('Rock', 2)]);
+      ix.replacePlaylists('s', const [
+        PlaylistRow(
+            id: 'Mix', name: 'Mix', paths: ['/m/b.mp3', '/m/gone.mp3', '/m/a.mp3']),
+        PlaylistRow(id: 'Empty', name: 'Empty'),
+      ]);
+      expect(ix.playlists('s').map((p) => p.name), ['Empty', 'Mix']);
+      final items = ix.playlistItems('s', 'Mix');
+      expect(items.map((i) => i.path), ['/m/b.mp3', '/m/gone.mp3', '/m/a.mp3']);
+      expect(items[0].track!.title, 'B');
+      expect(items[1].track, isNull);
+      expect(items[2].pos, 2);
+      expect(ix.playlistItems('s', 'Empty'), isEmpty);
+    });
+
+    test('rated: best first, the rated list wins over the lite block', () {
+      ix.replaceRated('s', {'/m/a.mp3': 8, '/m/c.mp3': 10, '/m/zzz.mp3': 6});
+      final rows = ix.rated('s');
+      expect(rows.map((t) => t.path), ['/m/c.mp3', '/m/a.mp3']);
+      expect(rows.last.rating, 8, reason: "not the manifest's 4");
+    });
+
+    test('recent: newest first by created_at then id', () {
+      expect(ix.recent('s').map((t) => t.path), ['/m/b.mp3', '/m/c.mp3', '/m/a.mp3']);
+      expect(ix.recent('s', limit: 1).single.path, '/m/b.mp3');
+    });
+
+    test('artists / albums matching a substring, LIKE wildcards escaped', () {
+      expect(ix.artistsMatching('s', 'an'), ['Ann', 'Annie %']);
+      expect(ix.artistsMatching('s', '%'), ['Annie %']);
+      expect(ix.albumsMatching('s', 'one').map((a) => a.name), ['One', 'one_x']);
+      expect(ix.albumsMatching('s', '_x').map((a) => a.name), ['one_x']);
+      expect(ix.albumsMatching('s', 't_o'), isEmpty, reason: '_ is literal, so no Two');
+    });
+
+    test("the caller's own writes: rating and playlist edits", () {
+      ix.setRating('s', '/m/b.mp3', 9);
+      expect(ix.rated('s').single.path, '/m/b.mp3');
+      expect(ix.remoteTrack('s', '/m/b.mp3')!.rating, 9);
+      ix.setRating('s', '/m/b.mp3', 0);
+      expect(ix.rated('s'), isEmpty);
+      expect(ix.remoteTrack('s', '/m/b.mp3')!.rating, isNull);
+
+      ix.addPlaylistItem('s', 'New', '/m/a.mp3');
+      ix.addPlaylistItem('s', 'New', '/m/b.mp3');
+      expect(ix.playlists('s').single.name, 'New');
+      expect(ix.playlistItems('s', 'New').map((i) => i.path),
+          ['/m/a.mp3', '/m/b.mp3']);
+      ix.savePlaylist('s', 'New', ['/m/c.mp3']);
+      expect(ix.playlistItems('s', 'New').map((i) => i.path), ['/m/c.mp3']);
+      ix.renamePlaylist('s', 'New', 'Newer');
+      expect(ix.playlists('s').single.id, 'Newer');
+      expect(ix.playlistItems('s', 'Newer').single.path, '/m/c.mp3');
+      ix.createPlaylist('s', 'Newer'); // already there: no-op
+      ix.deletePlaylist('s', 'Newer');
+      expect(ix.playlists('s'), isEmpty);
+      expect(ix.playlistItems('s', 'Newer'), isEmpty);
+    });
+  });
+
+  test('outbox: in order, done removes, failed counts, removeServer clears', () {
+    final a = ix.enqueue('s', 'rate', {'filepath': 'm/a.mp3', 'rating': 8},
+        created: 1);
+    final b = ix.enqueue('s', 'playlist-add', {'playlist': 'Mix', 'song': 'm/b.mp3'},
+        created: 2);
+    ix.enqueue('other', 'rate', {'filepath': 'x', 'rating': 1}, created: 3);
+    expect(ix.outboxCount('s'), 2);
+    final rows = ix.outbox('s');
+    expect(rows.map((e) => e.id), [a, b]);
+    expect(rows.first.payload, {'filepath': 'm/a.mp3', 'rating': 8});
+    expect(rows.first.created, 1);
+    ix.outboxFailed(b, 'boom');
+    expect(ix.outbox('s').last.attempts, 1);
+    expect(ix.outbox('s').last.lastError, 'boom');
+    ix.outboxDone(a);
+    expect(ix.outbox('s').map((e) => e.op), ['playlist-add']);
+    ix.removeServer('s');
+    expect(ix.outboxCount('s'), 0);
+    expect(ix.outboxCount('other'), 1);
+  });
+}

--- a/packages/library_mirror/test/runner_test.dart
+++ b/packages/library_mirror/test/runner_test.dart
@@ -343,9 +343,17 @@ void main() {
 
     // 304: lists untouched, cached art not re-fetched.
     art.calls.clear();
+    lists.failPlaylists = true;
     await r().run(withArt);
     expect(lists.calls, 1);
     expect(art.calls, isEmpty);
+    // The caller's lists are refreshed on every run, each on its own: the
+    // failed playlist fetch left the previous playlists in place.
+    expect(lists.userListCalls, 2);
+    expect(ix.genres('s').single.name, 'Rock');
+    expect(ix.playlists('s').single.name, 'Mix');
+    expect(ix.rated('s').single.path, '/music/A/2.mp3');
+    lists.failPlaylists = false;
 
     // A failing art fetch is not a run error and leaves nothing behind.
     art.failFor.add('cc.jpeg');
@@ -377,6 +385,8 @@ void main() {
 
 class _FakeLists implements LibraryListsClient {
   int calls = 0;
+  int userListCalls = 0;
+  bool failPlaylists = false;
   @override
   Future<List<AlbumRow>> albums() async {
     calls++;
@@ -385,6 +395,21 @@ class _FakeLists implements LibraryListsClient {
 
   @override
   Future<List<String>> artists() async => const ['Zed'];
+
+  @override
+  Future<Map<String, int>> genres() async {
+    userListCalls++;
+    return const {'Rock': 2};
+  }
+
+  @override
+  Future<List<PlaylistRow>> playlists() async {
+    if (failPlaylists) throw const SocketException('no playlists');
+    return const [PlaylistRow(id: 'Mix', name: 'Mix', paths: ['/music/A/1.mp3'])];
+  }
+
+  @override
+  Future<Map<String, int>> rated() async => const {'/music/A/2.mp3': 8};
 }
 
 class _FakeArt implements ArtClient {

--- a/test/singletons/library_source_test.dart
+++ b/test/singletons/library_source_test.dart
@@ -4,6 +4,7 @@ import 'package:material_ui/material_ui.dart' show Icons;
 
 import 'package:mstream_music/objects/server.dart';
 import 'package:mstream_music/singletons/library_source.dart';
+import 'package:mstream_music/singletons/settings.dart';
 
 RemoteTrack rt(int id, String path,
         {String? title, String? artist, String? album, int? track, int? disc,
@@ -104,5 +105,68 @@ void main() {
     expect(LocalLibrarySource.dirPath(''), '/');
     expect(LocalLibrarySource.dirPath('/a'), '/a/');
     expect(LocalLibrarySource.dirPath('/a/'), '/a/');
+  });
+
+  test("playlists, and a playlist's slots (a gone file keeps its slot)", () async {
+    ix.replacePlaylists('home', const [
+      PlaylistRow(id: 'Mix', name: 'Mix',
+          paths: ['/music/Bob/Other/x.mp3', '/music/gone.mp3']),
+    ]);
+    final lists = await src.playlists(server);
+    expect(lists.single.type, 'playlist');
+    expect(lists.single.data, 'Mix');
+    expect(lists.single.icon!.icon, Icons.queue_music);
+    final rows = await src.playlistContents(server, 'Mix');
+    expect(rows.map((r) => (r.type, r.data)),
+        [('file', '/music/Bob/Other/x.mp3'), ('file', '/music/gone.mp3')]);
+    expect(rows.first.metadata!.title, 'X');
+    expect(rows.last.metadata, isNull);
+    expect(rows.last.name, 'music/gone.mp3');
+    expect(await src.playlistContents(server, 'nope'), isEmpty);
+  });
+
+  test('rated rows: best first, artist as the subtitle', () async {
+    ix.replaceRated('home',
+        {'/music/Alice/First/02.flac': 6, '/music/Bob/Other/x.mp3': 9});
+    final rows = await src.rated(server);
+    expect(rows.map((r) => r.data),
+        ['/music/Bob/Other/x.mp3', '/music/Alice/First/02.flac']);
+    expect(rows.first.subtext, 'Bob');
+    expect(rows.first.metadata!.rating, 9);
+  });
+
+  test('recent lists the newest additions first (id order without dates)',
+      () async {
+    final rows = await src.recent(server);
+    expect(rows.map((r) => r.data).first, '/music/Bob/Other/list.m3u');
+    expect(rows, hasLength(4));
+    expect(rows.first.metadata!.title, 'L');
+  });
+
+  test('search groups artists, albums and tracks per the ticked categories',
+      () async {
+    final before = SettingsManager().searchCategories;
+    try {
+      SettingsManager().searchCategories = {
+        SearchCategory.artists, SearchCategory.albums, SearchCategory.songs,
+      };
+      final rows = await src.search(server, 'ali');
+      expect(rows.first.type, 'artist');
+      expect(rows.first.data, 'Alice');
+      expect(rows.skip(1).map((r) => r.data), unorderedEquals(
+          ['/music/Alice/First/01.flac', '/music/Alice/First/02.flac']));
+      expect(rows.last.metadata!.title, isNotNull, reason: 'full metadata');
+      expect(rows.last.partialMetadata, isFalse);
+
+      final byAlbum = await src.search(server, 'fir');
+      expect(byAlbum.first.type, 'album');
+      expect(byAlbum.first.data, 'First');
+      expect(byAlbum.first.altAlbumArt, 'aa.jpeg');
+
+      SettingsManager().searchCategories = {SearchCategory.albums};
+      expect(await src.search(server, 'ali'), isEmpty);
+    } finally {
+      SettingsManager().searchCategories = before;
+    }
   });
 }

--- a/test/singletons/outbox_test.dart
+++ b/test/singletons/outbox_test.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:library_mirror/library_mirror.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:mstream_music/objects/server.dart';
+import 'package:mstream_music/singletons/library_index.dart';
+import 'package:mstream_music/singletons/outbox.dart';
+
+void main() {
+  late Directory tmp;
+  final server = Server('http://h', null, null, null, 'home');
+  final ob = OutboxManager();
+
+  setUp(() async {
+    tmp = Directory.systemTemp.createTempSync('outbox_');
+    LibraryIndexManager().close();
+    await LibraryIndexManager().open(path: p.join(tmp.path, 'index.db'));
+    LibraryIndexManager().index!.upsertTracks('home', const [
+      RemoteTrack(id: 1, path: '/music/a.mp3', title: 'A', artist: 'Ann'),
+      RemoteTrack(id: 2, path: '/music/b.mp3', title: 'B', artist: 'Bob'),
+    ], 'r1');
+    ob.now = () => DateTime.fromMillisecondsSinceEpoch(1000);
+  });
+  tearDown(() {
+    LibraryIndexManager().close();
+    ob.sender = OutboxManager.post;
+    try {
+      tmp.deleteSync(recursive: true);
+    } catch (_) {}
+  });
+
+  test('enqueue mirrors the write into the index and counts as pending', () {
+    expect(ob.enqueue(server, OutboxOp.rate, {'filepath': 'music/a.mp3', 'rating': 8}),
+        isTrue);
+    expect(ob.enqueue(server, OutboxOp.playlistAdd, {'playlist': 'Mix', 'song': 'music/b.mp3'}),
+        isTrue);
+    final ix = LibraryIndexManager().index!;
+    expect(ix.rated('home').single.path, '/music/a.mp3');
+    expect(ix.rated('home').single.rating, 8);
+    expect(ix.playlistItems('home', 'Mix').single.path, '/music/b.mp3');
+    expect(ob.pending(server), 2);
+    expect(ix.outbox('home').first.created, 1000);
+    expect(ix.outbox('home').first.payload, {'filepath': 'music/a.mp3', 'rating': 8});
+  });
+
+  test('replay: in order, a rejected write is dropped, a network failure stops it',
+      () async {
+    ob.enqueue(server, OutboxOp.rate, {'filepath': 'music/a.mp3', 'rating': 8});
+    ob.enqueue(server, OutboxOp.playlistNew, {'title': 'Bad'});
+    ob.enqueue(server, OutboxOp.playlistRename, {'oldName': 'Bad', 'newName': 'Good'});
+    ob.enqueue(server, OutboxOp.playlistDelete, {'playlistname': 'Good'});
+    final sent = <String>[];
+    ob.sender = (s, e) async {
+      sent.add(e.op);
+      if (e.op == OutboxOp.playlistNew) throw const OutboxRejected(400);
+      if (e.op == OutboxOp.playlistRename) throw const SocketException('down');
+    };
+    await ob.replay(server);
+    expect(sent, [OutboxOp.rate, OutboxOp.playlistNew, OutboxOp.playlistRename]);
+    final left = LibraryIndexManager().index!.outbox('home');
+    expect(left.map((e) => e.op), [OutboxOp.playlistRename, OutboxOp.playlistDelete]);
+    expect(left.first.attempts, 1);
+    expect(left.first.lastError, contains('down'));
+
+    // The next ping resumes from the failed one.
+    sent.clear();
+    ob.sender = (s, e) async => sent.add(e.op);
+    await ob.replay(server);
+    expect(sent, [OutboxOp.playlistRename, OutboxOp.playlistDelete]);
+    expect(ob.pending(server), 0);
+  });
+
+  test('applyLocally mirrors an online write without queueing it', () {
+    ob.applyLocally(server, OutboxOp.playlistSave, {'title': 'S', 'songs': ['music/a.mp3', 'music/b.mp3']});
+    final ix = LibraryIndexManager().index!;
+    expect(ix.playlistItems('home', 'S').map((i) => i.path), ['/music/a.mp3', '/music/b.mp3']);
+    expect(ob.pending(server), 0);
+  });
+
+  test('no index: nothing is queued and the caller hears about it', () {
+    LibraryIndexManager().close();
+    expect(ob.enqueue(server, OutboxOp.rate, {'filepath': 'x', 'rating': 1}), isFalse);
+    expect(ob.pending(server), 0);
+  });
+}


### PR DESCRIPTION
## Summary

A5 of `BACKUP_SYNC_IMPLEMENTATION.md`: **playlists, rated, recent and search offline**, and an **outbox** for the writes made meanwhile.

- **Index (schema v2)**: `outbox` table; queries for playlists and their slots, the rated list (the rated list's rating wins over the manifest's lite block), recent by `created_at`, artists / albums matching a substring for the grouped search; the caller's own writes mirrored locally (rating, playlist add / save / rename / delete). The runner refreshes the user's lists (genres, playlists, rated) **every run**, each on its own so one failing leaves the others; albums and artists still follow the manifest.
- **`LibrarySource`** grows `playlists / playlistContents / rated / recent / search`. `HttpLibrarySource` is the mapping code moved out of `ApiManager` (including the search categories → `no*` flags and the capability filter); `LocalLibrarySource` builds the same rows from the index — a playlist slot whose file is gone keeps its place with no metadata as the server's answer does, search groups artists, albums, then tracks (FTS5 prefix over title / artist / album / path) per the ticked categories, and track rows carry full metadata so nothing is refetched on enqueue. `getGenres` (AutoDJ picker) answers from the index offline.
- **Outbox** (`lib/singletons/outbox.dart`): while a server is browsed offline, `rateSong`, `addSongToPlaylist`, `savePlaylist`, `createPlaylist`, `renamePlaylist` and `removePlaylist` mirror the change into the index at once and queue the exact request body. After the next successful ping (and when the manual offline switch is turned off) the queue replays in order — last writer wins, a 4xx the server means is logged and dropped, a network failure stops the replay until the next ping. Online writes are mirrored into the index too, so the offline copy never lags the user's own edits.
- **The one visual change**: the search results strip wears the same "Offline copy" pill as the app bar while the results come from the index. No new strings.

Not in this PR: rules for playlists / rated (A6b), now-playing art from the cache, lyric search offline (not indexed).

## Test plan

- [x] Package `dart test` 65/65 (v1 → v2 migration adds the outbox; playlist slots incl. a gone file; rated order + override; recent order; LIKE wildcard escaping; local edits; outbox order / done / failed; the runner refreshes the user's lists on a 304 run and a failing fetch leaves the previous list).
- [x] `flutter analyze` at the 21-issue baseline; `flutter test` incl. `library_source_test.dart` (the five lists' row shapes) and `outbox_test.dart` (enqueue mirrors + counts; replay order, rejected dropped, network failure stops and resumes on the next replay; no index → caller told).
- [x] Emulator smoke on Pixel_4_API_31 (results in the comment below): sync fills playlists / rated / genres; offline Playlists, a playlist's slots, Bewertet, Neueste and search (with the pill) from the index; rate + add-to-playlist offline mirrored at once and replayed on the next ping, verified on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
