### PR TITLE
feat(mirror): mstream_mirror, the headless copy (A11)

### DIFF
--- a/BACKUP_SYNC_IMPLEMENTATION.md
+++ b/BACKUP_SYNC_IMPLEMENTATION.md
@@ -42,7 +42,7 @@ tests + one device smoke); no repo-wide format.
 | A9 | app | Consume deltas | S2, A3 | no | 🟢 1d |
 | S3 | mStream | Device upload libraries | — | admin toggle | 🟡 2d |
 | A10 | app | Back up a desktop folder *to* the server | S3, A2 | yes | 🟡 3–5d |
-| A11 | app | Headless `mstream_mirror` CLI | A3 | no | 🟡 2–3d |
+| A11 | app | Headless `mstream_mirror` CLI — **[#182](https://github.com/IrosTheBeggar/mstream_music/pull/182)** (`bin/mstream_mirror.dart`, pure-Dart HTTP transports) | A3 | no | 🟡 2–3d |
 
 Critical path: **S1 ∥ A2 → A3 → A4 → A5.** A1 is independent and the
 cheapest visible win. A8, S2/A9, S3/A10 and A11 are optional and can trail

--- a/packages/library_mirror/README.md
+++ b/packages/library_mirror/README.md
@@ -13,3 +13,24 @@ Design: `BACKUP_SYNC_PLAN.md` §4.1, work packages A2–A4 in
 dart pub get
 dart test
 ```
+
+## Headless copy (`mstream_mirror`)
+
+The same engine from the command line, for a NAS, a desktop without the app
+open, or a scheduled task (A11):
+
+```
+dart run library_mirror:mstream_mirror --server http://nas:3000 --dest D:\Music --keep library:music
+dart run library_mirror:mstream_mirror --server http://nas:3000 --dest D:\Music        # later runs
+dart compile exe bin/mstream_mirror.dart -o mstream_mirror.exe                            # one binary
+```
+
+`--keep kind:key` adds a rule (`library:music`, `folder:/music/Live`,
+`album:Name`, `artist:Name`, `playlist:Name`, `rated:8`), `--drop` removes
+one, `--list-rules` shows them; rules live in the index next to the copy
+(`<dest>/.mstream-index.db`), so a bare run repeats the last set. Sign in
+with `--user`/`--password` or pass `--token`; public-mode servers need
+neither. Exit codes: 0 ok, 1 fatal, 2 some files failed (retried next run).
+The copy lands in `<dest>/media/<name>/`, deletions in
+`<dest>/.mstream-trash/<name>/<date>/` for `--retention-days` (30).
+

--- a/packages/library_mirror/bin/mstream_mirror.dart
+++ b/packages/library_mirror/bin/mstream_mirror.dart
@@ -1,0 +1,8 @@
+import 'dart:io';
+
+import 'package:library_mirror/library_mirror.dart';
+
+/// Headless library copy: `dart run library_mirror:mstream_mirror --server
+/// http://nas:3000 --dest D:\Music --keep library:music`, or compile it once
+/// with `dart compile exe bin/mstream_mirror.dart`. See README.md.
+Future<void> main(List<String> args) async => exit(await runCli(args));

--- a/packages/library_mirror/lib/library_mirror.dart
+++ b/packages/library_mirror/lib/library_mirror.dart
@@ -1,6 +1,8 @@
 /// Local library index for mStream Music — see README.md.
 library;
 
+export 'src/cli.dart';
+export 'src/http_transport.dart';
 export 'src/index_db.dart';
 export 'src/models.dart';
 export 'src/planner.dart';

--- a/packages/library_mirror/lib/src/cli.dart
+++ b/packages/library_mirror/lib/src/cli.dart
@@ -1,0 +1,183 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+
+import 'http_transport.dart';
+import 'index_db.dart';
+import 'models.dart';
+import 'runner.dart';
+
+/// Exit codes, after the server's own backup worker: 0 ok, 1 fatal (bad
+/// arguments, no sign-in, server unreachable), 2 = the run completed but
+/// some files failed (they are retried next run).
+abstract final class CliExit {
+  static const int ok = 0;
+  static const int fatal = 1;
+  static const int partial = 2;
+}
+
+ArgParser buildParser() => ArgParser()
+  ..addOption('server', abbr: 's', help: 'Server URL, e.g. http://nas:3000')
+  ..addOption('dest',
+      abbr: 'd', help: 'Folder that holds the copy (media/<name>/ underneath)')
+  ..addOption('name',
+      abbr: 'n', help: 'Local name of the server (default: its host)')
+  ..addOption('token',
+      abbr: 't', help: 'Token from a previous sign-in (public mode: omit)')
+  ..addOption('user', abbr: 'u', help: 'Sign in as this user (with --password)')
+  ..addOption('password')
+  ..addOption('index', help: 'Index database (default: <dest>/.mstream-index.db)')
+  ..addMultiOption('keep',
+      abbr: 'k',
+      splitCommas: false,
+      help: 'Add a rule, kind:key — library:music, folder:/music/Live, '
+          'album:Name, artist:Name, playlist:Name, rated:8 (0–10)')
+  ..addMultiOption('drop',
+      splitCommas: false, help: 'Remove a rule, kind:key')
+  ..addFlag('list-rules', negatable: false, help: 'Print the rules and exit')
+  ..addOption('retention-days',
+      defaultsTo: '30', help: 'Days a trashed file is kept (0 = forever)')
+  ..addOption('concurrency', defaultsTo: '3')
+  ..addOption('page-size', defaultsTo: '2000')
+  ..addFlag('quiet', abbr: 'q', negatable: false, help: 'Only the summary')
+  ..addFlag('help', abbr: 'h', negatable: false);
+
+const Set<String> _kinds = {
+  RuleKind.library,
+  RuleKind.folder,
+  RuleKind.album,
+  RuleKind.artist,
+  RuleKind.playlist,
+  RuleKind.rated,
+};
+
+/// A `kind:key` rule spec.
+({String kind, String key}) parseRule(String spec) {
+  final i = spec.indexOf(':');
+  if (i <= 0 || i == spec.length - 1) {
+    throw FormatException('a rule is kind:key, not "$spec"');
+  }
+  final kind = spec.substring(0, i).trim();
+  if (!_kinds.contains(kind)) {
+    throw FormatException('unknown rule kind "$kind" (${_kinds.join(', ')})');
+  }
+  return (kind: kind, key: spec.substring(i + 1).trim());
+}
+
+/// One line for a finished run, in the app's own words.
+String summarize(SyncRun run) => run.error != null
+    ? 'failed: ${run.error}'
+    : 'ok — ${run.downloaded} new, ${run.replaced} replaced, '
+        '${run.renamed} renamed, ${run.trashed} trashed, '
+        '${run.failed} failed, ${run.unchanged} unchanged';
+
+/// Runs the headless mirror once and returns the exit code. Rules live in
+/// the index next to the copy, so `--keep` is needed once; every later
+/// invocation is just `--server … --dest …`. [client], [out] and [err] are
+/// for tests.
+Future<int> runCli(List<String> args,
+    {http.Client? client, StringSink? out, StringSink? err}) async {
+  final o = out ?? stdout;
+  final e = err ?? stderr;
+  final parser = buildParser();
+  final ArgResults r;
+  try {
+    r = parser.parse(args);
+  } on FormatException catch (x) {
+    e.writeln(x.message);
+    e.writeln(parser.usage);
+    return CliExit.fatal;
+  }
+  if (r['help'] as bool) {
+    o.writeln('mstream_mirror — keep a folder in sync with an mStream server');
+    o.writeln(parser.usage);
+    return CliExit.ok;
+  }
+  final base = r['server'] as String?;
+  final dest = r['dest'] as String?;
+  if (base == null || dest == null) {
+    e.writeln('--server and --dest are required');
+    e.writeln(parser.usage);
+    return CliExit.fatal;
+  }
+  final name = (r['name'] as String?) ?? (Uri.tryParse(base)?.host ?? 'server');
+  final indexPath = (r['index'] as String?) ?? p.join(dest, '.mstream-index.db');
+  final quiet = r['quiet'] as bool;
+
+  final c = client ?? http.Client();
+  final LibraryIndex index;
+  try {
+    await Directory(dest).create(recursive: true);
+    index = LibraryIndex.open(indexPath);
+  } catch (x) {
+    e.writeln('cannot open the index at $indexPath: $x');
+    if (client == null) c.close();
+    return CliExit.fatal;
+  }
+  try {
+    for (final spec in r['keep'] as List<String>) {
+      final rule = parseRule(spec);
+      index.addSubscription(
+          Subscription(server: name, kind: rule.kind, key: rule.key));
+    }
+    for (final spec in r['drop'] as List<String>) {
+      final rule = parseRule(spec);
+      for (final s in index.subscriptionsFor(name)) {
+        if (s.kind == rule.kind && s.key == rule.key && s.id != null) {
+          index.removeSubscription(s.id!);
+        }
+      }
+    }
+    final rules = index.subscriptionsFor(name);
+    if (r['list-rules'] as bool) {
+      for (final s in rules) {
+        o.writeln('${s.kind}:${s.key}${s.enabled ? '' : ' (disabled)'}');
+      }
+      return CliExit.ok;
+    }
+    if (rules.isEmpty && !quiet) {
+      o.writeln('no rules yet: this run refreshes the index only '
+          '(add one with --keep kind:key)');
+    }
+
+    final user = r['user'] as String?;
+    final server = user != null
+        ? await MirrorServer.login(base, user, (r['password'] as String?) ?? '',
+            client: c)
+        : MirrorServer(base, token: r['token'] as String?);
+
+    final cfg = MirrorConfig.under(dest, name,
+        artRoot: p.join(dest, 'art', name),
+        retentionDays: int.parse(r['retention-days'] as String),
+        concurrency: int.parse(r['concurrency'] as String),
+        pageSize: int.parse(r['page-size'] as String));
+    final runner = MirrorRunner(
+      index: index,
+      manifest: HttpManifestClient(server, c),
+      downloader: HttpDownloader(server, c),
+      lists: HttpListsClient(server, c),
+      art: HttpArtClient(server, c),
+    );
+    if (!quiet) o.writeln('checking $base …');
+    final run = await runner.run(cfg, trigger: 'cli', onProgress: (pr) {
+      if (quiet || pr.phase != 'transfer' || pr.total == 0) return;
+      o.writeln('  ${pr.done}/${pr.total}'
+          '${pr.failed > 0 ? ' (${pr.failed} failed)' : ''}');
+    });
+    o.writeln(summarize(run));
+    if (run.error != null) return CliExit.fatal;
+    return run.failed > 0 ? CliExit.partial : CliExit.ok;
+  } on FormatException catch (x) {
+    e.writeln(x.message);
+    return CliExit.fatal;
+  } on Exception catch (x) {
+    e.writeln('$x');
+    return CliExit.fatal;
+  } finally {
+    index.close();
+    if (client == null) c.close();
+  }
+}

--- a/packages/library_mirror/lib/src/http_transport.dart
+++ b/packages/library_mirror/lib/src/http_transport.dart
@@ -1,0 +1,227 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+import 'models.dart';
+import 'transport.dart';
+
+/// One mStream server as the headless transports see it: the base URL
+/// (scheme, host, port, optional path prefix) and the token from
+/// `POST /api/v1/auth/login` — or none in public mode. The URL shapes match
+/// the app's (`buildServerDownloadUrl`, `buildAlbumArtUrl`) so a copy made
+/// by the CLI and one made by the app are the same files.
+class MirrorServer {
+  final String base;
+  final String? token;
+
+  MirrorServer(String base, {this.token})
+      : base = base.replaceFirst(RegExp(r'/+$'), '');
+
+  Uri api(String location) => Uri.parse('$base$location');
+
+  Map<String, String> get headers => {'x-access-token': token ?? ''};
+
+  Map<String, String> get jsonHeaders =>
+      {...headers, 'Content-Type': 'application/json'};
+
+  /// The file behind a data path (`/<vpath>/<rel>`).
+  Uri media(String dataPath) => Uri.parse(
+      '$base/media${encodeDataPath(dataPath)}${token == null ? '' : '?token=$token'}');
+
+  /// A cover by its content-addressed name, at the list-row size.
+  Uri art(String artFile, {String compress = 'm'}) => Uri.parse(Uri.encodeFull(
+      '$base/album-art/$artFile?compress=$compress${token == null ? '' : '&token=$token'}'));
+
+  /// Each path segment percent-encoded, leading slash kept.
+  static String encodeDataPath(String dataPath) => [
+        for (final e in dataPath.split('/'))
+          if (e.isNotEmpty) '/${Uri.encodeComponent(e)}'
+      ].join();
+
+  /// Signs in and returns the server bound to its token.
+  static Future<MirrorServer> login(
+      String base, String username, String password,
+      {http.Client? client}) async {
+    final c = client ?? http.Client();
+    try {
+      final s = MirrorServer(base);
+      final res = await c
+          .post(s.api('/api/v1/auth/login'),
+              body: {'username': username, 'password': password})
+          .timeout(const Duration(seconds: 30));
+      if (res.statusCode != 200) {
+        throw HttpException('login: HTTP ${res.statusCode}');
+      }
+      final token = (jsonDecode(res.body) as Map)['token'];
+      if (token is! String || token.isEmpty) {
+        throw const HttpException('login: no token in the reply');
+      }
+      return MirrorServer(base, token: token);
+    } finally {
+      if (client == null) c.close();
+    }
+  }
+}
+
+const Duration _timeout = Duration(seconds: 60);
+
+Future<dynamic> _json(Future<http.Response> send, String what) async {
+  final res = await send.timeout(_timeout);
+  if (res.statusCode != 200) throw HttpException('$what: HTTP ${res.statusCode}');
+  return jsonDecode(res.body);
+}
+
+/// `POST /api/v1/sync/manifest`, one page at a time, with the revision
+/// ETag so an unchanged library is a 304.
+class HttpManifestClient implements ManifestClient {
+  final MirrorServer server;
+  final http.Client client;
+  HttpManifestClient(this.server, this.client);
+
+  @override
+  Future<ManifestPage?> fetchPage(
+      {int? cursor, int limit = 2000, String? ifNoneMatch}) async {
+    final headers = {...server.jsonHeaders};
+    if (ifNoneMatch != null) headers['If-None-Match'] = '"$ifNoneMatch"';
+    final res = await client
+        .post(server.api('/api/v1/sync/manifest'),
+            headers: headers,
+            body: jsonEncode({'cursor': ?cursor, 'limit': limit}))
+        .timeout(_timeout);
+    if (res.statusCode == 304) return null;
+    if (res.statusCode != 200) {
+      throw HttpException('manifest: HTTP ${res.statusCode}');
+    }
+    return ManifestPage.fromJson(
+        (jsonDecode(res.body) as Map).cast<String, dynamic>());
+  }
+}
+
+/// Streams `/media/<path>` straight to the destination file.
+class HttpDownloader implements Downloader {
+  final MirrorServer server;
+  final http.Client client;
+  HttpDownloader(this.server, this.client);
+
+  @override
+  Future<void> download(String path, String destination,
+      {bool requiresWiFi = false}) async {
+    final res = await client
+        .send(http.Request('GET', server.media(path)))
+        .timeout(_timeout);
+    if (res.statusCode != 200) {
+      await res.stream.drain<void>();
+      throw HttpException('media$path: HTTP ${res.statusCode}');
+    }
+    final sink = File(destination).openWrite();
+    try {
+      await sink.addStream(res.stream);
+    } finally {
+      await sink.close();
+    }
+  }
+}
+
+/// The browse lists the index keeps for offline use.
+class HttpListsClient implements LibraryListsClient {
+  final MirrorServer server;
+  final http.Client client;
+  HttpListsClient(this.server, this.client);
+
+  Future<dynamic> _get(String location) =>
+      _json(client.get(server.api(location), headers: server.headers), location);
+
+  Future<dynamic> _post(String location, Map<String, dynamic> body) => _json(
+      client.post(server.api(location),
+          headers: server.jsonHeaders, body: jsonEncode(body)),
+      location);
+
+  static String _dataPath(String fp) => fp.startsWith('/') ? fp : '/$fp';
+
+  @override
+  Future<List<AlbumRow>> albums() async {
+    final res = await _get('/api/v1/db/albums');
+    return [
+      for (final e in (res['albums'] as List? ?? const []))
+        if (e is Map && e['name'] is String)
+          AlbumRow(
+            name: e['name'] as String,
+            albumArtist: (e['album_artist'] ?? e['albumArtist'] ?? e['artist'])
+                ?.toString(),
+            year: (e['year'] as num?)?.toInt(),
+            art: e['album_art_file'] as String?,
+          ),
+    ];
+  }
+
+  @override
+  Future<List<String>> artists() async {
+    final res = await _get('/api/v1/db/artists');
+    return [
+      for (final e in (res['artists'] as List? ?? const []))
+        if (e is String)
+          e
+        else if (e is Map && e['name'] is String)
+          e['name'] as String,
+    ];
+  }
+
+  @override
+  Future<Map<String, int>> genres() async {
+    final res = await _post('/api/v1/db/genres', {});
+    return {
+      for (final e in (res['genres'] as List? ?? const []))
+        if (e is Map && e['name'] is String)
+          e['name'] as String: (e['track_count'] as num?)?.toInt() ?? 0,
+    };
+  }
+
+  @override
+  Future<List<PlaylistRow>> playlists() async {
+    final names = await _get('/api/v1/playlist/getall');
+    final out = <PlaylistRow>[];
+    for (final e in (names as List? ?? const [])) {
+      final name = e is Map ? e['name'] : null;
+      if (name is! String) continue;
+      final items =
+          await _post('/api/v1/playlist/load', {'playlistname': name});
+      out.add(PlaylistRow(id: name, name: name, paths: [
+        for (final t in (items as List? ?? const []))
+          if (t is Map && t['filepath'] is String)
+            _dataPath(t['filepath'] as String),
+      ]));
+    }
+    return out;
+  }
+
+  @override
+  Future<Map<String, int>> rated() async {
+    final res = await _get('/api/v1/db/rated');
+    return {
+      for (final e in (res as List? ?? const []))
+        if (e is Map &&
+            e['filepath'] is String &&
+            (e['metadata'] as Map?)?['rating'] is num)
+          _dataPath(e['filepath'] as String):
+              ((e['metadata'] as Map)['rating'] as num).toInt(),
+    };
+  }
+}
+
+/// Album art by its content-addressed name.
+class HttpArtClient implements ArtClient {
+  final MirrorServer server;
+  final http.Client client;
+  HttpArtClient(this.server, this.client);
+
+  @override
+  Future<void> fetchArt(String artFile, String destination) async {
+    final res = await client.get(server.art(artFile)).timeout(_timeout);
+    if (res.statusCode != 200) {
+      throw HttpException('album-art/$artFile: HTTP ${res.statusCode}');
+    }
+    await File(destination).writeAsBytes(res.bodyBytes, flush: true);
+  }
+}

--- a/packages/library_mirror/pubspec.yaml
+++ b/packages/library_mirror/pubspec.yaml
@@ -20,6 +20,9 @@ dependencies:
   # Whole-file MD5 verification of mirrored downloads (below the server's
   # 25 MiB sampled-hash threshold).
   crypto: ^3.0.6
+  # The headless CLI's transports (A11); the app keeps its own clients.
+  http: ^1.2.0
+  args: ^2.6.0
 
 dev_dependencies:
   test: ^1.25.0

--- a/packages/library_mirror/test/cli_test.dart
+++ b/packages/library_mirror/test/cli_test.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:library_mirror/library_mirror.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// A tiny mStream: one library with two files, no art, empty lists.
+class FakeMStream {
+  final Map<String, List<int>> files = {
+    '/music/a.mp3': utf8.encode('abc'),
+    '/music/b.mp3': utf8.encode('defg'),
+  };
+  String revision = 'r1';
+  int manifestCalls = 0;
+  int mediaCalls = 0;
+
+  Future<http.Response> handle(http.Request r) async {
+    final path = Uri.decodeComponent(r.url.path);
+    if (path.endsWith('/sync/manifest')) {
+      manifestCalls++;
+      if (r.headers['If-None-Match'] == '"$revision"') {
+        return http.Response('', 304);
+      }
+      var id = 0;
+      return http.Response(
+          jsonEncode({
+            'revision': revision,
+            'scanning': false,
+            'next': null,
+            'entries': [
+              for (final e in files.entries)
+                {
+                  'filepath': e.key.substring(1),
+                  'id': ++id,
+                  'file-size': e.value.length,
+                  'modified': 1700000000000,
+                  'hash': md5.convert(e.value).toString(),
+                  'hash-v': 2,
+                  'metadata': {'title': p.basename(e.key)},
+                }
+            ],
+          }),
+          200);
+    }
+    if (path.startsWith('/media/')) {
+      mediaCalls++;
+      final bytes = files[path.substring('/media'.length)];
+      return bytes == null
+          ? http.Response('nope', 404)
+          : http.Response.bytes(bytes, 200);
+    }
+    if (path.endsWith('/db/albums')) return http.Response('{"albums":[]}', 200);
+    if (path.endsWith('/db/artists')) return http.Response('{"artists":[]}', 200);
+    if (path.endsWith('/db/genres')) return http.Response('{"genres":[]}', 200);
+    if (path.endsWith('/playlist/getall')) return http.Response('[]', 200);
+    if (path.endsWith('/db/rated')) return http.Response('[]', 200);
+    return http.Response('unknown $path', 404);
+  }
+}
+
+void main() {
+  test('parseRule accepts kind:key and rejects the rest', () {
+    expect(parseRule('library:music'), (kind: 'library', key: 'music'));
+    expect(parseRule('album:Be Somebody'), (kind: 'album', key: 'Be Somebody'));
+    expect(parseRule('folder:/music/Live: 1999'),
+        (kind: 'folder', key: '/music/Live: 1999'));
+    expect(() => parseRule('music'), throwsFormatException);
+    expect(() => parseRule('genre:Rock'), throwsFormatException);
+    expect(() => parseRule('album:'), throwsFormatException);
+  });
+
+  test('--help and missing arguments', () async {
+    final out = StringBuffer();
+    final err = StringBuffer();
+    expect(await runCli(['--help'], out: out, err: err), CliExit.ok);
+    expect(out.toString(), contains('--server'));
+    expect(await runCli(['--dest', 'x'], out: out, err: err), CliExit.fatal);
+    expect(err.toString(), contains('--server and --dest are required'));
+  });
+
+  test('a copy from the command line: first run, 304 run, a dropped rule', () async {
+    final tmp = Directory.systemTemp.createTempSync('cli_');
+    addTearDown(() => tmp.deleteSync(recursive: true));
+    final srv = FakeMStream();
+    final client = MockClient(srv.handle);
+    final base = ['--server', 'http://h:3000', '--dest', tmp.path, '--name', 's', '--quiet'];
+    final out = StringBuffer();
+    final err = StringBuffer();
+
+    expect(await runCli([...base, '--keep', 'library:music'], client: client, out: out, err: err),
+        CliExit.ok, reason: err.toString());
+    expect(out.toString(), contains('2 new'));
+    expect(File(p.join(tmp.path, 'media', 's', 'music', 'a.mp3')).readAsStringSync(), 'abc');
+    expect(File(p.join(tmp.path, 'media', 's', 'music', 'b.mp3')).readAsStringSync(), 'defg');
+    expect(File(p.join(tmp.path, '.mstream-index.db')).existsSync(), isTrue);
+    expect(srv.mediaCalls, 2);
+
+    // The rule lives in the index: a bare second run is one 304 and nothing else.
+    out.clear();
+    expect(await runCli(base, client: client, out: out, err: err), CliExit.ok);
+    expect(out.toString(), contains('0 new'));
+    expect(out.toString(), contains('2 unchanged'));
+    expect(srv.mediaCalls, 2);
+
+    out.clear();
+    expect(await runCli([...base, '--list-rules'], client: client, out: out, err: err), CliExit.ok);
+    expect(out.toString().trim(), 'library:music');
+
+    // Dropping the rule trashes the copy, into the dated bucket.
+    out.clear();
+    expect(await runCli([...base, '--drop', 'library:music'], client: client, out: out, err: err), CliExit.ok);
+    expect(out.toString(), contains('2 trashed'));
+    expect(File(p.join(tmp.path, 'media', 's', 'music', 'a.mp3')).existsSync(), isFalse);
+    expect(Directory(p.join(tmp.path, '.mstream-trash', 's')).listSync(), isNotEmpty);
+  });
+
+  test('an unreachable server is a fatal exit with the reason on stderr', () async {
+    final tmp = Directory.systemTemp.createTempSync('cli_');
+    addTearDown(() => tmp.deleteSync(recursive: true));
+    final client = MockClient((_) async => throw const SocketException('down'));
+    final out = StringBuffer();
+    final err = StringBuffer();
+    expect(await runCli(['--server', 'http://h', '--dest', tmp.path, '--quiet'],
+        client: client, out: out, err: err), CliExit.fatal);
+    expect(out.toString(), contains('failed:'));
+  });
+}

--- a/packages/library_mirror/test/http_transport_test.dart
+++ b/packages/library_mirror/test/http_transport_test.dart
@@ -1,0 +1,128 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:library_mirror/library_mirror.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  final server = MirrorServer('http://h:3000/', token: 'tok');
+
+  test('MirrorServer: trailing slash trimmed, paths encoded, token carried', () {
+    expect(server.base, 'http://h:3000');
+    expect(server.api('/api/v1/ping').toString(), 'http://h:3000/api/v1/ping');
+    expect(server.media('/music/A B/1 #2.mp3').toString(),
+        'http://h:3000/media/music/A%20B/1%20%232.mp3?token=tok');
+    expect(MirrorServer('http://h').media('/m/x.mp3').toString(),
+        'http://h/media/m/x.mp3');
+    expect(server.art('aa.jpeg').toString(),
+        'http://h:3000/album-art/aa.jpeg?compress=m&token=tok');
+    expect(server.headers, {'x-access-token': 'tok'});
+  });
+
+  test('login returns a server bound to the token; a refusal throws', () async {
+    late http.Request seen;
+    final ok = MockClient((r) async {
+      seen = r;
+      return http.Response(jsonEncode({'token': 'jwt'}), 200);
+    });
+    final s = await MirrorServer.login('http://h/', 'paul', 'pw', client: ok);
+    expect(s.token, 'jwt');
+    expect(seen.url.toString(), 'http://h/api/v1/auth/login');
+    expect(seen.bodyFields, {'username': 'paul', 'password': 'pw'});
+    final bad = MockClient((_) async => http.Response('no', 401));
+    expect(MirrorServer.login('http://h', 'x', 'y', client: bad),
+        throwsA(isA<HttpException>()));
+  });
+
+  test('manifest: cursor and limit in the body, quoted ETag, 304 → null', () async {
+    final seen = <http.Request>[];
+    final c = MockClient((r) async {
+      seen.add(r);
+      if (r.headers['If-None-Match'] == '"r1"') return http.Response('', 304);
+      return http.Response(
+          jsonEncode({
+            'revision': 'r1',
+            'scanning': false,
+            'next': null,
+            'entries': [
+              {'filepath': 'music/a.mp3', 'id': 1, 'file-size': 3, 'modified': 1,
+                'hash': 'h', 'metadata': {'title': 'A'}},
+            ],
+          }),
+          200);
+    });
+    final m = HttpManifestClient(server, c);
+    final page = await m.fetchPage(cursor: 5, limit: 10);
+    expect(page!.entries.single.path, '/music/a.mp3');
+    expect(jsonDecode(seen.first.body), {'cursor': 5, 'limit': 10});
+    expect(seen.first.headers['x-access-token'], 'tok');
+    expect(await m.fetchPage(ifNoneMatch: 'r1'), isNull);
+    expect(jsonDecode(seen.last.body), {'limit': 2000});
+    final down = HttpManifestClient(server, MockClient((_) async => http.Response('x', 500)));
+    expect(down.fetchPage(), throwsA(isA<HttpException>()));
+  });
+
+  test('downloader streams the media to the file; a refusal leaves none', () async {
+    final tmp = Directory.systemTemp.createTempSync('http_dl_');
+    addTearDown(() => tmp.deleteSync(recursive: true));
+    final c = MockClient((r) async => r.url.path.endsWith('/1.mp3')
+        ? http.Response.bytes([1, 2, 3], 200)
+        : http.Response('nope', 404));
+    final d = HttpDownloader(server, c);
+    final dest = p.join(tmp.path, 'out.part');
+    await d.download('/music/1.mp3', dest);
+    expect(File(dest).readAsBytesSync(), [1, 2, 3]);
+    expect(d.download('/music/2.mp3', p.join(tmp.path, 'none.part')),
+        throwsA(isA<HttpException>()));
+  });
+
+  test('lists: albums, artists, genres, playlists (getall + load), rated', () async {
+    final c = MockClient((r) async {
+      final path = r.url.path;
+      Object body;
+      if (path.endsWith('/db/albums')) {
+        body = {'albums': [{'name': 'Alpha', 'album_artist': 'Ann', 'year': 2001, 'album_art_file': 'aa.jpeg'}]};
+      } else if (path.endsWith('/db/artists')) {
+        body = {'artists': ['Ann', {'name': 'Bob'}]};
+      } else if (path.endsWith('/db/genres')) {
+        body = {'genres': [{'name': 'Rock', 'track_count': 2}]};
+      } else if (path.endsWith('/playlist/getall')) {
+        body = [{'name': 'Mix'}];
+      } else if (path.endsWith('/playlist/load')) {
+        expect(jsonDecode(r.body), {'playlistname': 'Mix'});
+        body = [{'filepath': 'music/a.mp3', 'metadata': {}}];
+      } else if (path.endsWith('/db/rated')) {
+        body = [{'filepath': 'music/b.mp3', 'metadata': {'rating': 8}}, {'filepath': 'music/c.mp3', 'metadata': {}}];
+      } else {
+        return http.Response('?', 404);
+      }
+      return http.Response(jsonEncode(body), 200);
+    });
+    final l = HttpListsClient(server, c);
+    final albums = await l.albums();
+    expect(albums.single.name, 'Alpha');
+    expect(albums.single.albumArtist, 'Ann');
+    expect(albums.single.art, 'aa.jpeg');
+    expect(await l.artists(), ['Ann', 'Bob']);
+    expect(await l.genres(), {'Rock': 2});
+    final pls = await l.playlists();
+    expect(pls.single.name, 'Mix');
+    expect(pls.single.paths, ['/music/a.mp3']);
+    expect(await l.rated(), {'/music/b.mp3': 8});
+  });
+
+  test('art is written to the destination', () async {
+    final tmp = Directory.systemTemp.createTempSync('http_art_');
+    addTearDown(() => tmp.deleteSync(recursive: true));
+    final c = MockClient((r) async {
+      expect(r.url.toString(), 'http://h:3000/album-art/aa.jpeg?compress=m&token=tok');
+      return http.Response.bytes([9, 9], 200);
+    });
+    final dest = p.join(tmp.path, 'aa.jpeg');
+    await HttpArtClient(server, c).fetchArt('aa.jpeg', dest);
+    expect(File(dest).readAsBytesSync(), [9, 9]);
+  });
+}


### PR DESCRIPTION
## Summary

A11 of `BACKUP_SYNC_IMPLEMENTATION.md`: **`mstream_mirror`, the headless copy** — the same engine from the command line, for a NAS, a desktop without the app open, or a scheduled task. Package-only: nothing in the app changes.

- **`lib/src/http_transport.dart`**: pure-Dart transports over `package:http` — `MirrorServer` (base URL + token, `login` via `POST /api/v1/auth/login`), `HttpManifestClient` (paged, quoted ETag → 304), `HttpDownloader` (streams `/media/<path>` to the file), `HttpListsClient` (albums / artists / genres / playlists / rated), `HttpArtClient`. The URL shapes match the app's builders, so a copy made by the CLI and one made by the app are the same files in the same tree.
- **`lib/src/cli.dart` + `bin/mstream_mirror.dart`**: `--server`, `--dest`, `--name`, `--token` or `--user`/`--password`, `--index`, `--keep kind:key` / `--drop kind:key` / `--list-rules`, `--retention-days`, `--concurrency`, `--page-size`, `--quiet`. Rules live in the index next to the copy, so `--keep` is needed once and a bare run repeats the last set. Progress lines during transfers, the app's own summary line at the end. Exit codes mirror the server's backup worker: 0 ok, 1 fatal (arguments, sign-in, server), 2 some files failed (retried next run). `dart compile exe bin/mstream_mirror.dart` makes one binary; README has the recipe.
- Dependencies added to the package: `http`, `args`.

Not in this PR: launcher scheduling (a separate mStream ticket per the plan), Range resume on interrupted downloads (a failed file is retried whole next run), a transcoded tier (A7).

## Test plan

- [x] Package `dart test` 78/78 incl. `http_transport_test.dart` (URL shapes and encoding, login, manifest cursor / ETag / 304 / error, streamed download, all five lists, art) and `cli_test.dart` (rule parsing, help / missing args, an end-to-end copy against a mocked server: first run → 2 files, bare run → 304 and 2 unchanged, `--list-rules`, `--drop` → 2 trashed into the dated bucket; unreachable server → exit 1).
- [x] `dart analyze` clean; `flutter analyze` at the 21-issue baseline.
- [x] Smoke against the local mStream 6.27.0 (public mode): `--keep library:music` → `9 new` with progress; bare run → `9 unchanged`; cover cached under `art/<name>/`; `--list-rules` → `library:music`; `--drop library:music` → `9 trashed`, media folder empty, nine files in `.mstream-trash/<name>/<date>/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
